### PR TITLE
disable `experiments.lazyCompilation` in sidecar

### DIFF
--- a/lib/with-federated-sidecar.js
+++ b/lib/with-federated-sidecar.js
@@ -128,6 +128,10 @@ const withModuleFederation =
           runtimeChunk: false,
           splitChunks: undefined,
         },
+        experiments: {
+          ...compilation.experiments,
+          lazyCompilation: false,
+        },
       };
 
       if (typeof webpackOptions.output.chunkFilename === "string") {


### PR DESCRIPTION
This feature doesn't work well with MF. Compiler hangs and not serving the chunks.