### PR TITLE
fix: use endsWith to detect .js/.mjs file paths

### DIFF
--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -99,7 +99,7 @@ class RemoveRRRuntimePlugin {
           },
           (assets) => {
             Object.keys(assets).forEach((filename) => {
-              if (filename.includes('.js') || filename.includes('.mjs')) {
+              if (filename.endsWith('.js') || filename.endsWith('.mjs')) {
                 const asset = compilation.getAsset(filename);
                 const newSource = asset.source
                   .source()


### PR DESCRIPTION
`.includes('.js')` also includes `.json` files. With a custom loader, 
```js
          {
            test: /\.geo\.json$/,
            type: 'asset/resource',
          },
```

The `getAsset(..).source.source()` is a `Buffer` and not a string, so it doesn't have `.replace`.