### PR TITLE
fix: remove plugins from child compiler

### DIFF
--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -275,11 +275,9 @@ class ChildFederation {
         'DropClientPage',
         'ReactFreshWebpackPlugin',
       ];
-      
+
       childCompiler.options.plugins = childCompiler.options.plugins.filter(
-        (plugin) => {
-          return !removePlugins.includes(plugin.constructor.name);
-        }
+        (plugin) => !removePlugins.includes(plugin.constructor.name)
       );
 
       if (MiniCss) {


### PR DESCRIPTION
`.forEach` and `.splice` don't work - `splice` mutates the array and the indices shift every removal. `filter` is better.
Another approach is to loop backwards and `splice`. Or even simply `arr.slice().forEach` so the loop is on a copy. I chose to `filter` because it's clearer and I don't think there's a real benefit of maintaining the same plugins array - it seems like webpack is creating a new array for the child compiler anyway?