### PR TITLE
fix: avoid shared module will be compiled in wrong target compiler

### DIFF
--- a/.changeset/dirty-mayflies-bake.md
+++ b/.changeset/dirty-mayflies-bake.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/enhanced': patch
+---
+
+fix: avoid shared module will be compiled in wrong target compiler

--- a/packages/enhanced/src/lib/sharing/ProvideSharedPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/ProvideSharedPlugin.ts
@@ -113,7 +113,7 @@ class ProvideSharedPlugin {
     const compilationData: WeakMap<Compilation, ResolvedProvideMap> =
       new WeakMap();
 
-    compiler.hooks.compilation.tap(
+    compiler.hooks.thisCompilation.tap(
       'ProvideSharedPlugin',
       (compilation: Compilation, { normalModuleFactory }) => {
         const resolvedProvideMap: ResolvedProvideMap = new Map();
@@ -254,7 +254,7 @@ class ProvideSharedPlugin {
       },
     );
 
-    compiler.hooks.compilation.tap(
+    compiler.hooks.thisCompilation.tap(
       'ProvideSharedPlugin',
       (compilation: Compilation, { normalModuleFactory }) => {
         compilation.dependencyFactories.set(


### PR DESCRIPTION
## Description
* avoid shared module will be compiled in wrong target compiler

`html-webpack-plugin` will use childCompiler which loader target is [node](https://github.com/jantimon/html-webpack-plugin/blob/main/lib/child-compiler.js#L103) to compile . And it will output the asset if the shared set a file path like this:

```ts
shared: {
  'shared-config': {
     import: './src/shared-config'
    }
},
```


html-webpack-plugin asset: 

![image](https://github.com/module-federation/universe/assets/41466093/42fe31cf-238e-4463-b241-6b3c929ecdcb)

default target(browser) asset: 

![image](https://github.com/module-federation/universe/assets/41466093/fbbc84c4-0959-49a0-b77d-9abe1c961496)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x ] I have updated the documentation.
