### PR TITLE
fix(nextjs-mf): enable manifest generation on clientside when setting publicPath

### DIFF
--- a/.changeset/gorgeous-boats-grab.md
+++ b/.changeset/gorgeous-boats-grab.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/nextjs-mf': patch
+---
+
+enable manifest to be generated on client-side when setting publicPath

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-client-plugins.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-client-plugins.ts
@@ -33,8 +33,10 @@ export function applyClientPlugins(
 ): void {
   const { webpack } = compiler;
   const { remotes, name } = options;
-  //@ts-ignore
-  compiler.options.output.publicPath = 'auto';
+
+  if (compiler.options.output.publicPath === '/_next/') {
+    compiler.options.output.publicPath = 'auto';
+  }
   // Build will hang without this. Likely something in my plugin
   compiler.options.optimization.splitChunks = undefined;
 

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
@@ -6,7 +6,6 @@
 'use strict';
 
 import type {
-  ModuleFederationPluginOptions,
   NextFederationPluginExtraOptions,
   NextFederationPluginOptions,
 } from '@module-federation/utilities';
@@ -141,7 +140,7 @@ export class NextFederationPlugin {
   private getNormalFederationPluginOptions(
     compiler: Compiler,
     isServer: boolean,
-  ): ModuleFederationPluginOptions {
+  ): moduleFederationPlugin.ModuleFederationPluginOptions {
     const defaultShared = this._extraOptions.skipSharingNextInternals
       ? {}
       : retrieveDefaultShared(isServer);
@@ -178,6 +177,7 @@ export class NextFederationPlugin {
         ...defaultShared,
         ...this._options.shared,
       },
+      ...(isServer ? {} : { manifest: { filePath: '/static/chunks' } }),
       // nextjs project needs to add config.watchOptions = ['**/node_modules/**', '**/@mf-types/**'] to prevent loop types update
       dts: this._options.dts ?? false,
     };


### PR DESCRIPTION
## Description

- Allow `publicPath` to be modified for the client side.
- Fixed the typing for the ModuleFederationPlugin base options for the NextFederationPlugin.
- Specified manifest export directory to fit Next.js client static folder.

## Related Issue

[[nextjs-mf] Manifest is not being generated for the client](https://github.com/module-federation/universe/issues/2294)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
