### PR TITLE
fix: tsup config join

### DIFF
--- a/.changeset/two-files-jog.md
+++ b/.changeset/two-files-jog.md
@@ -1,0 +1,8 @@
+---
+'@module-federation/native-federation-typescript': patch
+'@module-federation/third-party-dts-extractor': patch
+'@module-federation/native-federation-tests': patch
+'@module-federation/dts-plugin': patch
+---
+
+fix: tsup configuration

--- a/packages/dts-plugin/tsup.config.ts
+++ b/packages/dts-plugin/tsup.config.ts
@@ -1,5 +1,5 @@
-import type { Options } from 'tsup';
 import { join } from 'path';
+import type { Options } from 'tsup';
 
 function generateConfigurations(
   options: Array<[string[] | Record<string, string>, Options]>,
@@ -11,7 +11,7 @@ function generateConfigurations(
       clean: true,
       dts: true,
       legacyOutput: true,
-      outDir: 'packages/dts-plugin/dist',
+      outDir: join('packages', 'dts-plugin', 'dist'),
       external: [join(__dirname, 'package.json')],
       ...config,
     };
@@ -21,11 +21,11 @@ function generateConfigurations(
 export const tsup: Options[] = generateConfigurations([
   [
     {
-      index: join(__dirname, 'src/index.ts'),
-      core: join(__dirname, 'src/core/index.ts'),
-      forkDevWorker: join(__dirname, 'src/dev-worker/forkDevWorker.ts'),
-      startBroker: join(__dirname, 'src/server/broker/startBroker.ts'),
-      forkGenerateDts: join(__dirname, 'src/core/lib/forkGenerateDts.ts'),
+      index: join(__dirname, 'src', 'index.ts'),
+      core: join(__dirname, 'src', 'core', 'index.ts'),
+      forkDevWorker: join(__dirname, 'src', 'dev-worker', 'forkDevWorker.ts'),
+      startBroker: join(__dirname, 'src', 'server', 'broker', 'startBroker.ts'),
+      forkGenerateDts: join(__dirname, 'src', 'core', 'lib', 'forkGenerateDts.ts'),
     },
     {
       format: ['cjs'],
@@ -33,7 +33,7 @@ export const tsup: Options[] = generateConfigurations([
   ],
   [
     {
-      'launch-web-client': join(__dirname, 'src/server/launchWebClient.ts'),
+      'launch-web-client': join(__dirname, 'src', 'server', 'launchWebClient.ts'),
     },
     {
       format: ['iife'],

--- a/packages/dts-plugin/tsup.config.ts
+++ b/packages/dts-plugin/tsup.config.ts
@@ -25,7 +25,13 @@ export const tsup: Options[] = generateConfigurations([
       core: join(__dirname, 'src', 'core', 'index.ts'),
       forkDevWorker: join(__dirname, 'src', 'dev-worker', 'forkDevWorker.ts'),
       startBroker: join(__dirname, 'src', 'server', 'broker', 'startBroker.ts'),
-      forkGenerateDts: join(__dirname, 'src', 'core', 'lib', 'forkGenerateDts.ts'),
+      forkGenerateDts: join(
+        __dirname,
+        'src',
+        'core',
+        'lib',
+        'forkGenerateDts.ts',
+      ),
     },
     {
       format: ['cjs'],
@@ -33,7 +39,12 @@ export const tsup: Options[] = generateConfigurations([
   ],
   [
     {
-      'launch-web-client': join(__dirname, 'src', 'server', 'launchWebClient.ts'),
+      'launch-web-client': join(
+        __dirname,
+        'src',
+        'server',
+        'launchWebClient.ts',
+      ),
     },
     {
       format: ['iife'],

--- a/packages/native-federation-tests/tsup.config.ts
+++ b/packages/native-federation-tests/tsup.config.ts
@@ -22,6 +22,6 @@ export default defineConfig({
   clean: true,
   minify: true,
   format: ['cjs', 'esm'],
-  outDir: 'packages/native-federation-tests/dist',
+  outDir: join('packages', 'native-federation-tests', 'dist'),
   external: [join(__dirname, 'package.json')],
 });

--- a/packages/native-federation-typescript/tsup.config.ts
+++ b/packages/native-federation-typescript/tsup.config.ts
@@ -22,6 +22,6 @@ export default defineConfig({
   clean: true,
   minify: true,
   format: ['cjs', 'esm'],
-  outDir: 'packages/native-federation-typescript/dist',
+  outDir: join('packages', 'native-federation-typescript', 'dist'),
   external: [join(__dirname, 'package.json')],
 });

--- a/packages/third-party-dts-extractor/tsup.config.ts
+++ b/packages/third-party-dts-extractor/tsup.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   splitting: true,
   clean: true,
   format: ['cjs', 'esm'],
-  outDir: 'packages/third-party-dts-extractor/dist',
+  outDir: join('packages', 'third-party-dts-extractor', 'dist'),
   external: [join(__dirname, 'package.json')],
 });


### PR DESCRIPTION
To enable testing also on windows in the future, it would be better to not hardcode path separator