### PR TITLE
fix: remoteEntry chunk may have css files which need to be exclude

### DIFF
--- a/.changeset/quick-dodos-tie.md
+++ b/.changeset/quick-dodos-tie.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/manifest': patch
+---
+
+fix: remoteEntry chunk may have css files which need to be exclude

--- a/packages/manifest/src/StatsManager.ts
+++ b/packages/manifest/src/StatsManager.ts
@@ -84,7 +84,7 @@ class StatsManager {
 
       assert(remoteEntryNameChunk, 'Can not get remoteEntry chunk!');
       const files = Array.from(remoteEntryNameChunk.files).filter(
-        (f) => !f.includes(HOT_UPDATE_SUFFIX),
+        (f) => !f.includes(HOT_UPDATE_SUFFIX) && !f.endsWith('.css'),
       );
       assert(
         files.length === 1,


### PR DESCRIPTION
## Description

remoteEntry chunk may have css files which need to be exclude

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
