### PR TITLE
fix(nextjs-mf): fix react/jsx-runtime required version warning

### DIFF
--- a/.changeset/plenty-shoes-grab.md
+++ b/.changeset/plenty-shoes-grab.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/nextjs-mf': patch
+---
+
+Prevent react/jsx-runtime warnings from appearing

--- a/apps/website-new/docs/en/guide/framework/nextjs.mdx
+++ b/apps/website-new/docs/en/guide/framework/nextjs.mdx
@@ -247,70 +247,80 @@ You do not need to share these packages, sharing next internals yourself will ca
 ```ts
 export const DEFAULT_SHARE_SCOPE: SharedObject = {
   'next/dynamic': {
-    eager: false,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/head': {
-    eager: false,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/link': {
-    eager: true,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/router': {
     requiredVersion: false,
     singleton: true,
-    import: false,
-    eager: false,
+    import: undefined,
   },
-  'next/script': {
-    requiredVersion: false,
+  'next/image': {
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
-    eager: false,
+  },
+  'next/script': {
+    requiredVersion: undefined,
+    singleton: true,
+    import: undefined,
   },
   react: {
     singleton: true,
     requiredVersion: false,
-    eager: false,
+    import: false,
+  },
+  'react/': {
+    singleton: true,
+    requiredVersion: false,
+    import: false,
+  },
+  'react-dom/': {
+    singleton: true,
+    requiredVersion: false,
     import: false,
   },
   'react-dom': {
     singleton: true,
     requiredVersion: false,
-    eager: false,
     import: false,
   },
   'react/jsx-dev-runtime': {
     singleton: true,
     requiredVersion: false,
-    import: undefined,
-    eager: false,
   },
   'react/jsx-runtime': {
     singleton: true,
     requiredVersion: false,
-    eager: false,
-    import: false,
   },
   'styled-jsx': {
-    requiredVersion: false,
     singleton: true,
     import: undefined,
-    eager: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
   },
   'styled-jsx/style': {
-    requiredVersion: false,
+    singleton: true,
+    import: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
+  },
+  'styled-jsx/css': {
     singleton: true,
     import: undefined,
-    eager: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
   },
 };
 ```

--- a/apps/website-new/docs/en/practice/frameworks/next/presets.mdx
+++ b/apps/website-new/docs/en/practice/frameworks/next/presets.mdx
@@ -23,70 +23,80 @@ It's important to note that manually sharing these internals can lead to errors,
 ```ts
 export const DEFAULT_SHARE_SCOPE: SharedObject = {
   'next/dynamic': {
-    eager: false,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/head': {
-    eager: false,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/link': {
-    eager: true,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/router': {
     requiredVersion: false,
     singleton: true,
-    import: false,
-    eager: false,
+    import: undefined,
   },
-  'next/script': {
-    requiredVersion: false,
+  'next/image': {
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
-    eager: false,
+  },
+  'next/script': {
+    requiredVersion: undefined,
+    singleton: true,
+    import: undefined,
   },
   react: {
     singleton: true,
     requiredVersion: false,
-    eager: false,
+    import: false,
+  },
+  'react/': {
+    singleton: true,
+    requiredVersion: false,
+    import: false,
+  },
+  'react-dom/': {
+    singleton: true,
+    requiredVersion: false,
     import: false,
   },
   'react-dom': {
     singleton: true,
     requiredVersion: false,
-    eager: false,
     import: false,
   },
   'react/jsx-dev-runtime': {
     singleton: true,
     requiredVersion: false,
-    import: undefined,
-    eager: false,
   },
   'react/jsx-runtime': {
     singleton: true,
     requiredVersion: false,
-    eager: false,
-    import: false,
   },
   'styled-jsx': {
-    requiredVersion: false,
     singleton: true,
     import: undefined,
-    eager: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
   },
   'styled-jsx/style': {
-    requiredVersion: false,
+    singleton: true,
+    import: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
+  },
+  'styled-jsx/css': {
     singleton: true,
     import: undefined,
-    eager: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
   },
 };
 ```

--- a/apps/website-new/docs/zh/guide/framework/nextjs.mdx
+++ b/apps/website-new/docs/zh/guide/framework/nextjs.mdx
@@ -23,70 +23,80 @@
 ```ts
 export const DEFAULT_SHARE_SCOPE: SharedObject = {
   'next/dynamic': {
-    eager: false,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/head': {
-    eager: false,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/link': {
-    eager: true,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/router': {
     requiredVersion: false,
     singleton: true,
-    import: false,
-    eager: false,
+    import: undefined,
   },
-  'next/script': {
-    requiredVersion: false,
+  'next/image': {
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
-    eager: false,
+  },
+  'next/script': {
+    requiredVersion: undefined,
+    singleton: true,
+    import: undefined,
   },
   react: {
     singleton: true,
     requiredVersion: false,
-    eager: false,
+    import: false,
+  },
+  'react/': {
+    singleton: true,
+    requiredVersion: false,
+    import: false,
+  },
+  'react-dom/': {
+    singleton: true,
+    requiredVersion: false,
     import: false,
   },
   'react-dom': {
     singleton: true,
     requiredVersion: false,
-    eager: false,
     import: false,
   },
   'react/jsx-dev-runtime': {
     singleton: true,
     requiredVersion: false,
-    import: undefined,
-    eager: false,
   },
   'react/jsx-runtime': {
     singleton: true,
     requiredVersion: false,
-    eager: false,
-    import: false,
   },
   'styled-jsx': {
-    requiredVersion: false,
     singleton: true,
     import: undefined,
-    eager: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
   },
   'styled-jsx/style': {
-    requiredVersion: false,
+    singleton: true,
+    import: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
+  },
+  'styled-jsx/css': {
     singleton: true,
     import: undefined,
-    eager: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
   },
 };
 ```

--- a/apps/website-new/docs/zh/practice/frameworks/next/presets.mdx
+++ b/apps/website-new/docs/zh/practice/frameworks/next/presets.mdx
@@ -23,70 +23,80 @@
 ```ts
 export const DEFAULT_SHARE_SCOPE: SharedObject = {
   'next/dynamic': {
-    eager: false,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/head': {
-    eager: false,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/link': {
-    eager: true,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/router': {
     requiredVersion: false,
     singleton: true,
-    import: false,
-    eager: false,
+    import: undefined,
   },
-  'next/script': {
-    requiredVersion: false,
+  'next/image': {
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
-    eager: false,
+  },
+  'next/script': {
+    requiredVersion: undefined,
+    singleton: true,
+    import: undefined,
   },
   react: {
     singleton: true,
     requiredVersion: false,
-    eager: false,
+    import: false,
+  },
+  'react/': {
+    singleton: true,
+    requiredVersion: false,
+    import: false,
+  },
+  'react-dom/': {
+    singleton: true,
+    requiredVersion: false,
     import: false,
   },
   'react-dom': {
     singleton: true,
     requiredVersion: false,
-    eager: false,
     import: false,
   },
   'react/jsx-dev-runtime': {
     singleton: true,
     requiredVersion: false,
-    import: undefined,
-    eager: false,
   },
   'react/jsx-runtime': {
     singleton: true,
     requiredVersion: false,
-    eager: false,
-    import: false,
   },
   'styled-jsx': {
-    requiredVersion: false,
     singleton: true,
     import: undefined,
-    eager: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
   },
   'styled-jsx/style': {
-    requiredVersion: false,
+    singleton: true,
+    import: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
+  },
+  'styled-jsx/css': {
     singleton: true,
     import: undefined,
-    eager: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
   },
 };
 ```

--- a/packages/nextjs-mf/README.md
+++ b/packages/nextjs-mf/README.md
@@ -47,70 +47,80 @@ You do not need to share these packages, sharing next internals yourself will ca
 ```ts
 export const DEFAULT_SHARE_SCOPE: SharedObject = {
   'next/dynamic': {
-    eager: false,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/head': {
-    eager: false,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/link': {
-    eager: true,
-    requiredVersion: false,
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
   },
   'next/router': {
     requiredVersion: false,
     singleton: true,
-    import: false,
-    eager: false,
+    import: undefined,
   },
-  'next/script': {
-    requiredVersion: false,
+  'next/image': {
+    requiredVersion: undefined,
     singleton: true,
     import: undefined,
-    eager: false,
+  },
+  'next/script': {
+    requiredVersion: undefined,
+    singleton: true,
+    import: undefined,
   },
   react: {
     singleton: true,
     requiredVersion: false,
-    eager: false,
+    import: false,
+  },
+  'react/': {
+    singleton: true,
+    requiredVersion: false,
+    import: false,
+  },
+  'react-dom/': {
+    singleton: true,
+    requiredVersion: false,
     import: false,
   },
   'react-dom': {
     singleton: true,
     requiredVersion: false,
-    eager: false,
     import: false,
   },
   'react/jsx-dev-runtime': {
     singleton: true,
     requiredVersion: false,
-    import: undefined,
-    eager: false,
   },
   'react/jsx-runtime': {
     singleton: true,
     requiredVersion: false,
-    eager: false,
-    import: false,
   },
   'styled-jsx': {
-    requiredVersion: false,
     singleton: true,
     import: undefined,
-    eager: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
   },
   'styled-jsx/style': {
-    requiredVersion: false,
+    singleton: true,
+    import: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
+  },
+  'styled-jsx/css': {
     singleton: true,
     import: undefined,
-    eager: false,
+    version: require('styled-jsx/package.json').version,
+    requiredVersion: '^' + require('styled-jsx/package.json').version,
   },
 };
 ```

--- a/packages/nextjs-mf/src/internal.ts
+++ b/packages/nextjs-mf/src/internal.ts
@@ -62,11 +62,11 @@ export const DEFAULT_SHARE_SCOPE: SharedObject = {
   },
   'react/jsx-dev-runtime': {
     singleton: true,
-    requiredVersion: undefined,
+    requiredVersion: false,
   },
   'react/jsx-runtime': {
     singleton: true,
-    requiredVersion: undefined,
+    requiredVersion: false,
   },
   'styled-jsx': {
     singleton: true,


### PR DESCRIPTION
## Description

Sets `requiredVersion` to `false` in the default share scope.  This fixes a warning I've been seeing in my project with `react.jsx-runtime`


> shared module react/jsx-runtime
> No required version specified and unable to automatically determine one. Unable to find required version for "react" in description file (...)

I believe this setting should match the config in the `react` share scope?

I've also synced the readme/docs share scope snippet.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
