### PR TITLE
fix(dts-plugin): avoid the generation type order being affected by the loading timing so that every type occurs

### DIFF
--- a/.changeset/popular-mayflies-chew.md
+++ b/.changeset/popular-mayflies-chew.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+fix: Avoid the generation type order being affected by the loading timing so that every type occurs

--- a/packages/dts-plugin/src/core/lib/DTSManager.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.ts
@@ -267,6 +267,7 @@ class DTSManager {
     const remoteKeys: string[] = [];
 
     const importTypeStr = this.loadedRemoteAPIAlias
+      .sort()
       .map((alias, index) => {
         const remoteKey = `RemoteKeys_${index}`;
         const packageType = `PackageType_${index}`;


### PR DESCRIPTION

## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

fix(dts-plugin): avoid the generation type order being affected by the loading timing so that every type occurs

![image](https://github.com/module-federation/core/assets/27547179/db05d39c-a2ea-4171-8ae1-6e47141e0c75)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

None
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
