### PR TITLE
fix(sdk): fix auto public path

### DIFF
--- a/.changeset/mighty-vans-rescue.md
+++ b/.changeset/mighty-vans-rescue.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/sdk': patch
+---
+
+fix auto public path

--- a/packages/sdk/__tests__/inferAutoPublicPath.spec.ts
+++ b/packages/sdk/__tests__/inferAutoPublicPath.spec.ts
@@ -8,5 +8,16 @@ describe('inferAutoPublicPath', () => {
     expect(inferAutoPublicPath('http://localhost:3009/remoteEntry.js')).toEqual(
       'http://localhost:3009/',
     );
+
+    expect(
+      inferAutoPublicPath(
+        'http://localhost:3009/_next/static/chunks/mf-stats.json',
+      ),
+    ).toEqual('http://localhost:3009/');
+    expect(
+      inferAutoPublicPath(
+        'http://localhost:3009/_next/static/chunks/remoteEntry.js',
+      ),
+    ).toEqual('http://localhost:3009/');
   });
 });

--- a/packages/sdk/src/generateSnapshotFromManifest.ts
+++ b/packages/sdk/src/generateSnapshotFromManifest.ts
@@ -49,6 +49,14 @@ export const simpleJoinRemoteEntry = (rPath: string, rName: string): string => {
 };
 
 export function inferAutoPublicPath(url: string): string {
+  if (url.includes('/_next/')) {
+    return url
+      .split('_next/')[0]
+      .replace(/#.*$/, '')
+      .replace(/\?.*$/, '')
+      .replace(/\/[^\/]+$/, '/');
+  }
+
   return url
     .replace(/#.*$/, '')
     .replace(/\?.*$/, '')


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

The publicPath value returned by the `inferAutoPublicPath` function cannot be properly used in @module-federation/nextjs-mf.

As you know, when the address "http://localhost:3009/_next/static/chunks/mf-stats.json" is returned via the `inferAutoPublicPath` function, it returns "http://localhost:3009/_next/static/chunks/". This allows the auto-setting of publicPath.

In this case, @module-federation/nextjs-mf works as follows:
When publicPath is set to auto, it combines "http://localhost:3009/_next/static/chunks/" with the filename.
If the filename value is passed as 'static/chunks/remoteEntry.js', it combines to
"http://localhost:3009/_next/static/chunks/" + "static/chunks/remoteEntry.js",
resulting in an incorrect URL.

![스크린샷 2024-05-17 오후 10 38 33](https://github.com/module-federation/core/assets/18302025/14fbe7f4-ca2a-4f74-9e41-504c0b761959)

https://github.com/module-federation/core/blob/10e6f5acb3f7431c01ee598865bf2aee82a520cc/apps/3001-shop/next.config.js#L18-L21

On the other hand, if you set the filename to 'remoteEntry.js' instead of 'static/chunks/remoteEntry.js',
a 404 error occurs in nextjs when accessing "http://localhost:3009/_next/static/chunks/remoteEntry.js".

Due to this, I tried modifying it as below, and would like your opinion.
I was contemplating where to make the adjustments, and ended up making these changes. If there is a better solution, I would like to hear your suggestions.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
