### PR TITLE
fix(node): missing variable in runtime plugin error call

### DIFF
--- a/.changeset/funny-parents-sneeze.md
+++ b/.changeset/funny-parents-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/node': patch
+---
+
+missing variable in runtime plugin error call

--- a/packages/node/src/runtimePlugin.ts
+++ b/packages/node/src/runtimePlugin.ts
@@ -183,7 +183,7 @@ export default function () {
                 )(chunk, __non_webpack_require__, urlDirname, chunkName);
                 callback(null, chunk);
               } catch (e) {
-                callback(err, null);
+                callback(e, null);
               }
             });
             res.on('error', function (err) {


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
fixing bad var in error callback of runtime plugin
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
