### PR TITLE
fix: only delete can be configurable descriptor

### DIFF
--- a/.changeset/popular-fishes-speak.md
+++ b/.changeset/popular-fishes-speak.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+fix: only delete can be configurable descriptor

--- a/packages/runtime/src/remote/index.ts
+++ b/packages/runtime/src/remote/index.ts
@@ -406,7 +406,10 @@ export class RemoteHandler {
       const remoteInfo = loadedModule.remoteInfo;
       const key = remoteInfo.entryGlobalName as keyof typeof globalThis;
 
-      if (globalThis[key]) {
+      if (
+        globalThis[key] &&
+        Object.getOwnPropertyDescriptor(globalThis, key)?.configurable
+      ) {
         delete globalThis[key];
       }
       const remoteEntryUniqueKey = getRemoteEntryUniqueKey(


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

fix: only delete can be configurable descriptor

## Related Issue
#2436
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
