### PR TITLE
fix(runtime): resolve the problem that static resource preload is not reused

### DIFF
--- a/.changeset/unlucky-teachers-yawn.md
+++ b/.changeset/unlucky-teachers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/sdk': patch
+---
+
+fix: Resolve the problem that static resource preload is not reused

--- a/packages/sdk/src/dom.ts
+++ b/packages/sdk/src/dom.ts
@@ -140,6 +140,7 @@ export function createLink(
   if (!link) {
     link = document.createElement('link');
     link.setAttribute('href', url);
+    link.setAttribute('crossorigin', 'anonymous');
 
     if (createLinkHook) {
       const createLinkRes = createLinkHook(url);


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

fix(runtime): resolve the problem that static resource preload is not reused

## Related Issue

![image](https://github.com/module-federation/core/assets/27547179/20c27565-8307-482d-80b1-fd631acdfc29)


<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
