### PR TITLE
docs: fixes parameter name typo

### DIFF
--- a/apps/website-new/docs/en/configure/index.mdx
+++ b/apps/website-new/docs/en/configure/index.mdx
@@ -11,7 +11,7 @@ type ModuleFederationOptions = {
   // Configuration for remote modules and entry information in module federation
   remotes?: Array<RemoteInfo>;
   // module federation expose module information
-  expose?: PluginExposesOptions;
+  exposes?: PluginExposesOptions;
   // Shared dependency configuration
   shared?: ShareInfos;
   // Dynamic publicPath


### PR DESCRIPTION
## Description

`ModuleFederationOptions` had a typo in the `exposes` property name

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
