### PR TITLE
Release v0.1.16

### DIFF
--- a/.changeset/bright-items-draw.md
+++ b/.changeset/bright-items-draw.md
@@ -1,5 +1,0 @@
----
-'@module-federation/runtime': patch
----
-
-fix types for beforePreloadRemote args hook

--- a/.changeset/large-suits-sit.md
+++ b/.changeset/large-suits-sit.md
@@ -1,5 +1,0 @@
----
-'@module-federation/managers': patch
----
-
-chore: support normalize shared.import option

--- a/.changeset/popular-fishes-speak.md
+++ b/.changeset/popular-fishes-speak.md
@@ -1,5 +1,0 @@
----
-'@module-federation/runtime': patch
----
-
-fix: only delete can be configurable descriptor

--- a/.changeset/silly-ants-visit.md
+++ b/.changeset/silly-ants-visit.md
@@ -1,6 +1,0 @@
----
-'@module-federation/native-federation-typescript': patch
-'@module-federation/dts-plugin': patch
----
-
-optional vue-tsc

--- a/.changeset/unlucky-teachers-yawn.md
+++ b/.changeset/unlucky-teachers-yawn.md
@@ -1,5 +1,0 @@
----
-'@module-federation/sdk': patch
----
-
-fix: Resolve the problem that static resource preload is not reused

--- a/apps/modernjs/CHANGELOG.md
+++ b/apps/modernjs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/modernjs
 
+## 0.1.21
+
+### Patch Changes
+
+- @module-federation/enhanced@0.1.16
+
 ## 0.1.20
 
 ### Patch Changes

--- a/apps/modernjs/package.json
+++ b/apps/modernjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@module-federation/modernjs",
   "private": true,
-  "version": "0.1.20",
+  "version": "0.1.21",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/node-dynamic-remote-new-version/CHANGELOG.md
+++ b/apps/node-dynamic-remote-new-version/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Patch Changes
 
+- @module-federation/node@2.2.7
+
+## null
+
+### Patch Changes
+
 - @module-federation/node@2.2.6
 
 ## null

--- a/apps/node-dynamic-remote/CHANGELOG.md
+++ b/apps/node-dynamic-remote/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Patch Changes
 
+- @module-federation/node@2.2.7
+
+## null
+
+### Patch Changes
+
 - @module-federation/node@2.2.6
 
 ## null

--- a/apps/runtime-demo/3008-runtime-remote/CHANGELOG.md
+++ b/apps/runtime-demo/3008-runtime-remote/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 3008-runtime-remote
 
+## 1.0.5
+
+### Patch Changes
+
+- @module-federation/enhanced@0.1.16
+
 ## 1.0.4
 
 ### Patch Changes

--- a/apps/runtime-demo/3008-runtime-remote/package.json
+++ b/apps/runtime-demo/3008-runtime-remote/package.json
@@ -1,7 +1,7 @@
 {
   "name": "3008-runtime-remote",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/packages/chrome-devtools/CHANGELOG.md
+++ b/packages/chrome-devtools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/devtools
 
+## 0.1.16
+
+### Patch Changes
+
+- Updated dependencies [364f2bc]
+  - @module-federation/sdk@0.1.16
+
 ## 0.1.15
 
 ### Patch Changes

--- a/packages/chrome-devtools/package.json
+++ b/packages/chrome-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/devtools",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "scripts": {
     "build:storybook": "storybook build",
     "storybook": "storybook dev -p 6006",

--- a/packages/dts-plugin/CHANGELOG.md
+++ b/packages/dts-plugin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @module-federation/dts-plugin
 
+## 0.1.16
+
+### Patch Changes
+
+- ea34795: optional vue-tsc
+- Updated dependencies [cce5404]
+- Updated dependencies [364f2bc]
+  - @module-federation/managers@0.1.16
+  - @module-federation/sdk@0.1.16
+  - @module-federation/third-party-dts-extractor@0.1.16
+
 ## 0.1.15
 
 ### Patch Changes

--- a/packages/dts-plugin/package.json
+++ b/packages/dts-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/dts-plugin",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "author": "hanric <hanric.zhang@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,5 +1,19 @@
 # [0.2.0-canary.5](https://github.com/module-federation/core/compare/enhanced-0.2.0-canary.4...enhanced-0.2.0-canary.5) (2023-11-20)
 
+## 0.1.16
+
+### Patch Changes
+
+- Updated dependencies [cce5404]
+- Updated dependencies [ea34795]
+- Updated dependencies [364f2bc]
+  - @module-federation/managers@0.1.16
+  - @module-federation/dts-plugin@0.1.16
+  - @module-federation/sdk@0.1.16
+  - @module-federation/runtime-tools@0.1.16
+  - @module-federation/manifest@0.1.16
+  - @module-federation/rspack@0.1.16
+
 ## 0.1.15
 
 ### Patch Changes

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/enhanced",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "files": [

--- a/packages/managers/CHANGELOG.md
+++ b/packages/managers/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/managers
 
+## 0.1.16
+
+### Patch Changes
+
+- cce5404: chore: support normalize shared.import option
+- Updated dependencies [364f2bc]
+  - @module-federation/sdk@0.1.16
+
 ## 0.1.15
 
 ### Patch Changes

--- a/packages/managers/package.json
+++ b/packages/managers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/managers",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "MIT",
   "description": "Provide managers for helping handle mf data .",
   "keywords": [

--- a/packages/manifest/CHANGELOG.md
+++ b/packages/manifest/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @module-federation/manifest
 
+## 0.1.16
+
+### Patch Changes
+
+- Updated dependencies [cce5404]
+- Updated dependencies [ea34795]
+- Updated dependencies [364f2bc]
+  - @module-federation/managers@0.1.16
+  - @module-federation/dts-plugin@0.1.16
+  - @module-federation/sdk@0.1.16
+
 ## 0.1.15
 
 ### Patch Changes

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/manifest",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "MIT",
   "description": "Provide manifest/stats for webpack/rspack MF project .",
   "keywords": [

--- a/packages/native-federation-typescript/CHANGELOG.md
+++ b/packages/native-federation-typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [1.0.0-canary.1](https://github.com/module-federation/core/compare/native-federation-typescript-0.2.6...native-federation-typescript-1.0.0-canary.1) (2023-11-06)
 
+## 0.5.1
+
+### Patch Changes
+
+- ea34795: optional vue-tsc
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/native-federation-typescript/package.json
+++ b/packages/native-federation-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/native-federation-typescript",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Bundler agnostic unplugin to share federated types",
   "keywords": [
     "module federation",

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -1,5 +1,18 @@
 # [8.1.0-canary.7](https://github.com/module-federation/core/compare/nextjs-mf-8.1.0-canary.6...nextjs-mf-8.1.0-canary.7) (2023-11-21)
 
+## 8.3.17
+
+### Patch Changes
+
+- Updated dependencies [103cd07]
+- Updated dependencies [425fc9d]
+- Updated dependencies [364f2bc]
+  - @module-federation/runtime@0.1.16
+  - @module-federation/sdk@0.1.16
+  - @module-federation/node@2.2.7
+  - @module-federation/enhanced@0.1.16
+  - @module-federation/utilities@3.0.21
+
 ## 8.3.16
 
 ### Patch Changes

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "8.3.16",
+  "version": "8.3.17",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,17 @@
 # [2.1.0-canary.6](https://github.com/module-federation/core/compare/node-2.1.0-canary.5...node-2.1.0-canary.6) (2023-11-21)
 
+## 2.2.7
+
+### Patch Changes
+
+- Updated dependencies [103cd07]
+- Updated dependencies [425fc9d]
+- Updated dependencies [364f2bc]
+  - @module-federation/runtime@0.1.16
+  - @module-federation/sdk@0.1.16
+  - @module-federation/enhanced@0.1.16
+  - @module-federation/utilities@3.0.21
+
 ## 2.2.6
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "exports": {

--- a/packages/rspack/CHANGELOG.md
+++ b/packages/rspack/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @module-federation/rspack
 
+## 0.1.16
+
+### Patch Changes
+
+- Updated dependencies [cce5404]
+- Updated dependencies [ea34795]
+- Updated dependencies [364f2bc]
+  - @module-federation/managers@0.1.16
+  - @module-federation/dts-plugin@0.1.16
+  - @module-federation/sdk@0.1.16
+  - @module-federation/runtime-tools@0.1.16
+  - @module-federation/manifest@0.1.16
+
 ## 0.1.15
 
 ### Patch Changes

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rspack",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "MIT",
   "keywords": [
     "Module Federation",

--- a/packages/runtime-tools/CHANGELOG.md
+++ b/packages/runtime-tools/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [1.0.1-canary.1](https://github.com/module-federation/core/compare/runtime-1.0.0...runtime-1.0.1-canary.1) (2023-12-06)
 
+## 0.1.16
+
+### Patch Changes
+
+- Updated dependencies [103cd07]
+- Updated dependencies [425fc9d]
+  - @module-federation/runtime@0.1.16
+  - @module-federation/webpack-bundler-runtime@0.1.16
+
 ## 0.1.15
 
 ### Patch Changes

--- a/packages/runtime-tools/package.json
+++ b/packages/runtime-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-tools",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/runtime
 
+## 0.1.16
+
+### Patch Changes
+
+- 103cd07: fix types for beforePreloadRemote args hook
+- 425fc9d: fix: only delete can be configurable descriptor
+- Updated dependencies [364f2bc]
+  - @module-federation/sdk@0.1.16
+
 ## 0.1.15
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [1.1.0-canary.1](https://github.com/module-federation/core/compare/sdk-1.0.0...sdk-1.1.0-canary.1) (2023-12-05)
 
+## 0.1.16
+
+### Patch Changes
+
+- 364f2bc: fix: Resolve the problem that static resource preload is not reused
+
 ## 0.1.15
 
 ## 0.1.14

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/sdk",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "MIT",
   "description": "A sdk for support module federation",
   "keywords": [

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -47,7 +47,7 @@
     "@storybook/node-logger": "^6.5.16 || ^7.0.0",
     "webpack": "^5.75.0",
     "webpack-virtual-modules": "^0.5.0 || ^0.6.0",
-    "@module-federation/utilities": "^3.0.20",
+    "@module-federation/utilities": "^3.0.21",
     "@nx/react": "~16.0.0 || ~17.0.0 || ~17.2.0",
     "@nx/webpack": "~16.0.0 || ~17.0.0 || ~17.2.0"
   }

--- a/packages/third-party-dts-extractor/CHANGELOG.md
+++ b/packages/third-party-dts-extractor/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/third-party-dts-extractor
 
+## 0.1.16
+
 ## 0.1.15
 
 ## 0.1.14

--- a/packages/third-party-dts-extractor/package.json
+++ b/packages/third-party-dts-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/third-party-dts-extractor",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "files": [
     "dist/",
     "README.md"

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [3.1.0](https://github.com/module-federation/core/compare/utils-3.0.2...utils-3.1.0) (2023-10-26)
 
+## 3.0.21
+
+### Patch Changes
+
+- Updated dependencies [364f2bc]
+  - @module-federation/sdk@0.1.16
+
 ## 3.0.20
 
 ### Patch Changes

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/utilities",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "type": "commonjs",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.cjs.d.ts",

--- a/packages/webpack-bundler-runtime/CHANGELOG.md
+++ b/packages/webpack-bundler-runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # [1.0.0-canary.3](https://github.com/module-federation/core/compare/webpack-bundler-runtime-1.0.0-canary.2...webpack-bundler-runtime-1.0.0-canary.3) (2023-11-23)
 
+## 0.1.16
+
+### Patch Changes
+
+- Updated dependencies [103cd07]
+- Updated dependencies [425fc9d]
+- Updated dependencies [364f2bc]
+  - @module-federation/runtime@0.1.16
+  - @module-federation/sdk@0.1.16
+
 ## 0.1.15
 
 ### Patch Changes

--- a/packages/webpack-bundler-runtime/package.json
+++ b/packages/webpack-bundler-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/webpack-bundler-runtime",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "MIT",
   "description": "Module Federation Runtime for webpack",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v0.1.16 -->

## What's Changed
### Bug Fixes 🐞
* fix(runtime): correct type structure for preload remote hook by @ScriptedAlchemy in https://github.com/module-federation/core/pull/2515
* fix(runtime): resolve the problem that static resource preload is not reused by @zhoushaw in https://github.com/module-federation/core/pull/2531
* fix: only delete can be configurable descriptor by @2heal1 in https://github.com/module-federation/core/pull/2518
### Document 📖
* docs: fixes parameter name typo by @konclave in https://github.com/module-federation/core/pull/2533
* docs: format rsbuild zh chapter by @9aoy in https://github.com/module-federation/core/pull/2532
### Other Changes
* Release v0.1.15 by @zhoushaw in https://github.com/module-federation/core/pull/2520
* Fix/optional peer deps by @crutch12 in https://github.com/module-federation/core/pull/2538
* chore: support normalize shared.import option by @2heal1 in https://github.com/module-federation/core/pull/2535
* chore(deps-dev): bump esbuild from 0.20.2 to 0.21.4 by @dependabot in https://github.com/module-federation/core/pull/2548
* chore(deps): bump ws and @types/ws by @dependabot in https://github.com/module-federation/core/pull/2547
* chore: removed ts-ignore on ContainerEntryModule by @ilteoood in https://github.com/module-federation/core/pull/2542
* chore(deps-dev): bump @modern-js/eslint-config from 2.46.1 to 2.50.0 by @dependabot in https://github.com/module-federation/core/pull/2544
* chore(deps-dev): bump qwik-nx from 1.1.1 to 2.3.0 by @dependabot in https://github.com/module-federation/core/pull/2546

## New Contributors
* @konclave made their first contribution in https://github.com/module-federation/core/pull/2533
* @9aoy made their first contribution in https://github.com/module-federation/core/pull/2532

**Full Changelog**: https://github.com/module-federation/core/compare/v0.1.15...v0.1.16