### PR TITLE
fix(nextjs-mf): Do not attach runtime to api runtime chunks

### DIFF
--- a/.changeset/sharp-dryers-sparkle.md
+++ b/.changeset/sharp-dryers-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/enhanced': patch
+---
+
+Wrap require of federation runtime module in conditional so that async boundary plugin doesnt crash runtimes who do not implement federation

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,26 +46,26 @@ jobs:
       - name: Run Affected Test
         run: npx nx affected -t test --parallel=3 --exclude='*,!tag:type:pkg'
 
-      # - name: E2E Test for Next.js Dev
-      #   run: |
-      #     pnpm run app:next:dev &
-      #     sleep 1 &&
-      #     npx wait-on tcp:3001 &&
-      #     npx wait-on tcp:3002 &&
-      #     npx wait-on tcp:3000 &&
-      #     npx nx run-many --target=test:e2e --projects=3000-home,3001-shop,3002-checkout --parallel=2 &&
-      #     lsof -ti tcp:3000,3001,3002 | xargs kill
+      - name: E2E Test for Next.js Dev
+        run: |
+          pnpm run app:next:dev > /dev/null 2>&1 &
+          sleep 1 &&
+          npx wait-on tcp:3001 &&
+          npx wait-on tcp:3002 &&
+          npx wait-on tcp:3000 &&
+          npx nx run-many --target=test:e2e --projects=3000-home,3001-shop,3002-checkout --parallel=3 &&
+          lsof -ti tcp:3000,3001,3002 | xargs kill
 
-      # - name: E2E Test for Next.js Prod
-      #   run: |
-      #     pnpm run --filter @module-federation/3002-checkout --filter @module-federation/3000-home --filter @module-federation/3001-shop build &&
-      #     pnpm run app:next:prod &
-      #     sleep 2 &&
-      #     npx wait-on tcp:3001 &&
-      #     npx wait-on tcp:3002 &&
-      #     npx wait-on tcp:3000 &&
-      #     npx nx run-many --target=test:e2e --projects=3000-home,3001-shop,3002-checkout --parallel=1 &&
-      #     lsof -ti tcp:3000,3001,3002 | xargs kill
+      - name: E2E Test for Next.js Prod
+        run: |
+          pnpm run --filter @module-federation/3002-checkout --filter @module-federation/3000-home --filter @module-federation/3001-shop build &&
+          pnpm run app:next:prod &
+          sleep 2 &&
+          npx wait-on tcp:3001 &&
+          npx wait-on tcp:3002 &&
+          npx wait-on tcp:3000 &&
+          npx nx run-many --target=test:e2e --projects=3000-home,3001-shop,3002-checkout --parallel=1 &&
+          lsof -ti tcp:3000,3001,3002 | xargs kill
 
       - name: E2E Test for ModernJS
         run: npx nx run-many --target=test:e2e --projects=modernjs --parallel=1 && lsof -ti tcp:4001 | xargs kill

--- a/packages/enhanced/src/lib/container/AsyncBoundaryPlugin.ts
+++ b/packages/enhanced/src/lib/container/AsyncBoundaryPlugin.ts
@@ -314,7 +314,11 @@ class AsyncEntryStartupPlugin {
 
         if (shouldInclude) {
           initialEntryModules.push(
-            `__webpack_require__(${JSON.stringify(entryModuleID)});`,
+            `if(__webpack_require__.m[${JSON.stringify(entryModuleID)}]) {
+              __webpack_require__(${JSON.stringify(entryModuleID)});
+            } else {
+              console.warn('Federation Runtime Module not found. In the current runtime');
+            }`,
           );
         }
       }

--- a/packages/nextjs-mf/src/plugins/container/InvertedContainerRuntimeModule.ts
+++ b/packages/nextjs-mf/src/plugins/container/InvertedContainerRuntimeModule.ts
@@ -31,6 +31,9 @@ class InvertedContainerRuntimeModule extends RuntimeModule {
       return '';
     }
 
+    if (this.chunk.runtime === 'webpack-api-runtime') {
+      return '';
+    }
     const { name } = this.options;
     const containerEntryModule = this.findEntryModuleOfContainer() as
       | Module


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
If a specific runtime chunk does not implement federation and async boundary is used on the build, it will crash that runtime
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/module-federation/core/issues/2559

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
