### PR TITLE
fix: rspack splitChunk.chunks should use function to prevent wrong be…

### DIFF
--- a/.changeset/shy-pears-raise.md
+++ b/.changeset/shy-pears-raise.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rspack': patch
+---
+
+fix: rspack splitChunk.chunks should use function to prevent wrong behavior

--- a/packages/rspack/src/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/ModuleFederationPlugin.ts
@@ -143,7 +143,10 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
 
           if (cacheGroup.chunks === 'all') {
             cacheGroup.chunks = (chunk) => {
-              if (chunk.name && chunk.name === name) {
+              if (
+                chunk.name &&
+                (chunk.name === name || chunk.name === name + '_partial')
+              ) {
                 return false;
               }
               return true;

--- a/packages/rspack/src/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/ModuleFederationPlugin.ts
@@ -142,10 +142,12 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
           }
 
           if (cacheGroup.chunks === 'all') {
-            cacheGroup.chunks = new RegExp(
-              `^(?!.*(${name}|${name}_partial)).*$`,
-              'g',
-            );
+            cacheGroup.chunks = (chunk) => {
+              if (chunk.name && chunk.name === name) {
+                return false;
+              }
+              return true;
+            };
             break;
           }
           if (cacheGroup.chunks === 'initial') {


### PR DESCRIPTION
## Description
![img_v3_02bh_b3ac439f-8cec-4f9d-96d2-aa10f698765g](https://github.com/module-federation/core/assets/41466093/c55a9c55-833a-4efb-8de1-57fb2284f76e)

Rspack chunk may not have name , and it will return false if no chunk name.
When MFPlugin patch the chuknSplit.chunks as RegExp , it will have wrong splitChunk behaviour which increase assets limit

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
