### PR TITLE
feat: support pass shareScopeMap

### DIFF
--- a/.changeset/silver-dolphins-relate.md
+++ b/.changeset/silver-dolphins-relate.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/webpack-bundler-runtime': patch
+'@module-federation/runtime': patch
+---
+
+feat: support pass shareScopeMap

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -204,8 +204,13 @@ export class FederationHost {
   initShareScopeMap(
     scopeName: string,
     shareScope: ShareScopeMap[string],
+    hostShareScopeMap?: ShareScopeMap,
   ): void {
-    this.sharedHandler.initShareScopeMap(scopeName, shareScope);
+    this.sharedHandler.initShareScopeMap(
+      scopeName,
+      shareScope,
+      hostShareScopeMap,
+    );
   }
 
   private formatOptions(

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -204,13 +204,9 @@ export class FederationHost {
   initShareScopeMap(
     scopeName: string,
     shareScope: ShareScopeMap[string],
-    hostShareScopeMap?: ShareScopeMap,
+    extraOptions: { hostShareScopeMap?: ShareScopeMap } = {},
   ): void {
-    this.sharedHandler.initShareScopeMap(
-      scopeName,
-      shareScope,
-      hostShareScopeMap,
-    );
+    this.sharedHandler.initShareScopeMap(scopeName, shareScope, extraOptions);
   }
 
   private formatOptions(

--- a/packages/runtime/src/module/index.ts
+++ b/packages/runtime/src/module/index.ts
@@ -84,8 +84,8 @@ class Module {
       };
 
       // Help to find host instance
-      Object.defineProperty(remoteEntryInitOptions, 'hostId', {
-        value: this.host.options.id || this.host.name,
+      Object.defineProperty(remoteEntryInitOptions, 'shareScopeMap', {
+        value: localShareScopeMap,
         // remoteEntryInitOptions will be traversed and assigned during container init, ,so this attribute is not allowed to be traversed
         enumerable: false,
       });
@@ -93,7 +93,7 @@ class Module {
       const initContainerOptions =
         await this.host.hooks.lifecycle.beforeInitContainer.emit({
           shareScope,
-          // @ts-ignore hostId will be set by Object.defineProperty
+          // @ts-ignore shareScopeMap will be set by Object.defineProperty
           remoteEntryInitOptions,
           initScope,
           remoteInfo: this.remoteInfo,

--- a/packages/runtime/src/shared/index.ts
+++ b/packages/runtime/src/shared/index.ts
@@ -50,6 +50,7 @@ export class SharedHandler {
       shareScope: ShareScopeMap[string];
       options: Options;
       origin: FederationHost;
+      hostShareScopeMap?: ShareScopeMap;
     }>('initContainer'),
   });
 
@@ -414,6 +415,7 @@ export class SharedHandler {
   initShareScopeMap(
     scopeName: string,
     shareScope: ShareScopeMap[string],
+    hostShareScopeMap?: ShareScopeMap,
   ): void {
     const { host } = this;
     this.shareScopeMap[scopeName] = shareScope;
@@ -421,6 +423,7 @@ export class SharedHandler {
       shareScope,
       options: host.options,
       origin: host,
+      hostShareScopeMap,
     });
   }
 

--- a/packages/runtime/src/shared/index.ts
+++ b/packages/runtime/src/shared/index.ts
@@ -46,12 +46,12 @@ export class SharedHandler {
       resolver: () => Shared | undefined;
     }>('resolveShare'),
     // maybe will change, temporarily for internal use only
-    initContainerShareScopeMap: new AsyncWaterfallHook<{
+    initContainerShareScopeMap: new SyncWaterfallHook<{
       shareScope: ShareScopeMap[string];
       options: Options;
       origin: FederationHost;
       hostShareScopeMap?: ShareScopeMap;
-    }>('initContainer'),
+    }>('initContainerShareScopeMap'),
   });
 
   constructor(host: FederationHost) {

--- a/packages/runtime/src/shared/index.ts
+++ b/packages/runtime/src/shared/index.ts
@@ -50,6 +50,7 @@ export class SharedHandler {
       shareScope: ShareScopeMap[string];
       options: Options;
       origin: FederationHost;
+      scopeName: string;
       hostShareScopeMap?: ShareScopeMap;
     }>('initContainerShareScopeMap'),
   });
@@ -423,6 +424,7 @@ export class SharedHandler {
       shareScope,
       options: host.options,
       origin: host,
+      scopeName,
       hostShareScopeMap,
     });
   }

--- a/packages/runtime/src/shared/index.ts
+++ b/packages/runtime/src/shared/index.ts
@@ -416,7 +416,7 @@ export class SharedHandler {
   initShareScopeMap(
     scopeName: string,
     shareScope: ShareScopeMap[string],
-    hostShareScopeMap?: ShareScopeMap,
+    extraOptions: { hostShareScopeMap?: ShareScopeMap } = {},
   ): void {
     const { host } = this;
     this.shareScopeMap[scopeName] = shareScope;
@@ -425,7 +425,7 @@ export class SharedHandler {
       options: host.options,
       origin: host,
       scopeName,
-      hostShareScopeMap,
+      hostShareScopeMap: extraOptions.hostShareScopeMap,
     });
   }
 

--- a/packages/runtime/src/type/config.ts
+++ b/packages/runtime/src/type/config.ts
@@ -125,7 +125,7 @@ export type LoadModuleOptions = {
 // Only for legacy federation provider
 export type RemoteEntryInitOptions = {
   version: string;
-  hostId: string;
+  shareScopeMap: ShareScopeMap;
 };
 
 export type InitScope = Array<Record<string, never>>;

--- a/packages/webpack-bundler-runtime/src/initContainerEntry.ts
+++ b/packages/webpack-bundler-runtime/src/initContainerEntry.ts
@@ -26,7 +26,11 @@ export function initContainerEntry(
     ...remoteEntryInitOptions,
   });
 
-  federationInstance.initShareScopeMap(name, shareScope);
+  federationInstance.initShareScopeMap(
+    name,
+    shareScope,
+    remoteEntryInitOptions?.shareScopeMap,
+  );
 
   if (webpackRequire.federation.attachShareScopeMap) {
     webpackRequire.federation.attachShareScopeMap(webpackRequire);

--- a/packages/webpack-bundler-runtime/src/initContainerEntry.ts
+++ b/packages/webpack-bundler-runtime/src/initContainerEntry.ts
@@ -27,7 +27,7 @@ export function initContainerEntry(
   });
 
   federationInstance.initShareScopeMap(name, shareScope, {
-    shareScopeMap: remoteEntryInitOptions?.shareScopeMap,
+    hostShareScopeMap: remoteEntryInitOptions?.shareScopeMap || {},
   });
 
   if (webpackRequire.federation.attachShareScopeMap) {

--- a/packages/webpack-bundler-runtime/src/initContainerEntry.ts
+++ b/packages/webpack-bundler-runtime/src/initContainerEntry.ts
@@ -26,11 +26,9 @@ export function initContainerEntry(
     ...remoteEntryInitOptions,
   });
 
-  federationInstance.initShareScopeMap(
-    name,
-    shareScope,
-    remoteEntryInitOptions?.shareScopeMap,
-  );
+  federationInstance.initShareScopeMap(name, shareScope, {
+    shareScopeMap: remoteEntryInitOptions?.shareScopeMap,
+  });
 
   if (webpackRequire.federation.attachShareScopeMap) {
     webpackRequire.federation.attachShareScopeMap(webpackRequire);


### PR DESCRIPTION
## Description

pass shareScopeMap to container which allow remote sync host's all shareScope 

users can write runtime plugin to sync multiple shareScope 
```js
function multipleShareScopePlugin() {
  return {
    name: "multiple-share-scope",
    initContainerShareScopeMap(args) {
      try {
        const { hostShareScopeMap, origin, scopeName } = args;
        if (hostShareScopeMap) {
          Object.keys(hostShareScopeMap).forEach((hostShareScopeName) => {
            if (hostShareScopeName === scopeName) {
              return;
            }
            const hostShareScope = hostShareScopeMap[hostShareScopeName];
            origin.shareScopeMap[hostShareScopeName] = hostShareScope;
          });
        }
      } catch (err) {
        console.error(new Error(err));
      }
      return args;
    }
  };
}
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
