### PR TITLE
fix: don't modify loaded tag

### DIFF
--- a/.changeset/sixty-bugs-turn.md
+++ b/.changeset/sixty-bugs-turn.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/sdk': patch
+---
+
+fix: don't modify loaded tag

--- a/packages/sdk/src/dom.ts
+++ b/packages/sdk/src/dom.ts
@@ -64,19 +64,19 @@ export function createScript(info: {
         if (createScriptRes.timeout) timeout = createScriptRes.timeout;
       }
     }
-  }
 
-  const attrs = info.attrs;
-  if (attrs) {
-    Object.keys(attrs).forEach((name) => {
-      if (script) {
-        if (name === 'async' || name === 'defer') {
-          script[name] = attrs[name];
-        } else {
-          script.setAttribute(name, attrs[name]);
+    const attrs = info.attrs;
+    if (attrs) {
+      Object.keys(attrs).forEach((name) => {
+        if (script) {
+          if (name === 'async' || name === 'defer') {
+            script[name] = attrs[name];
+          } else {
+            script.setAttribute(name, attrs[name]);
+          }
         }
-      }
-    });
+      });
+    }
   }
 
   const onScriptComplete = (
@@ -156,15 +156,15 @@ export function createLink(info: {
         link = createLinkRes;
       }
     }
-  }
 
-  const attrs = info.attrs;
-  if (attrs) {
-    Object.keys(attrs).forEach((name) => {
-      if (link) {
-        link.setAttribute(name, attrs[name]);
-      }
-    });
+    const attrs = info.attrs;
+    if (attrs) {
+      Object.keys(attrs).forEach((name) => {
+        if (link) {
+          link.setAttribute(name, attrs[name]);
+        }
+      });
+    }
   }
 
   const onLinkComplete = (


### PR DESCRIPTION
## Description

when tag is loaded , don't modify attr . Otherwise, the ssr will throw warning: html content not match server html content

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
