### PR TITLE
fix(sdk): the returned properties are used by default when create script and create link hook

### DIFF
--- a/.changeset/strange-bottles-confess.md
+++ b/.changeset/strange-bottles-confess.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/sdk': patch
+---
+
+fix: The returned properties are used by default when create script and create link hook

--- a/packages/sdk/__tests__/dom.spec.ts
+++ b/packages/sdk/__tests__/dom.spec.ts
@@ -123,6 +123,32 @@ describe('createScript', () => {
 
       expect(clearTimeout).toHaveBeenCalled();
     });
+
+    it('should set section attributes on the script element', () => {
+      const url = 'https://example.com/script.js';
+      const cb = jest.fn();
+      const attrs = {
+        async: true,
+        'data-test': 'test',
+        crossOrigin: 'anonymous',
+      };
+      const { script } = createScript({
+        url,
+        cb,
+        attrs,
+        createScriptHook: (url) => {
+          const scriptEle = document.createElement('script');
+          scriptEle.src = url;
+          scriptEle.crossOrigin = 'use-credentials';
+          scriptEle.async = false;
+          return scriptEle;
+        },
+      });
+
+      expect(script.async).toBe(true);
+      expect(script.crossOrigin).toBe('use-credentials');
+      expect(script.getAttribute('data-test')).toBe('test');
+    });
   });
 });
 
@@ -171,6 +197,33 @@ describe('createLink', () => {
     const { link } = createLink({ url, cb, attrs });
 
     expect(link.rel).toBe('preload');
+    expect(link.getAttribute('as')).toBe('script');
+    expect(link.getAttribute('data-test')).toBe('test');
+  });
+
+  it('should set section attributes on the link element', () => {
+    const url = 'https://example.com/script.js';
+    const cb = jest.fn();
+    const attrs = {
+      rel: 'preload',
+      as: 'script',
+      'data-test': 'test',
+      crossOrigin: 'anonymous',
+    };
+    const { link } = createLink({
+      url,
+      cb,
+      attrs,
+      createLinkHook: (url) => {
+        const linkEle = document.createElement('link');
+        linkEle.href = url;
+        linkEle.crossOrigin = 'use-credentials';
+        return linkEle;
+      },
+    });
+
+    expect(link.rel).toBe('preload');
+    expect(link.crossOrigin).toBe('use-credentials');
     expect(link.getAttribute('as')).toBe('script');
     expect(link.getAttribute('data-test')).toBe('test');
   });

--- a/packages/sdk/src/dom.ts
+++ b/packages/sdk/src/dom.ts
@@ -71,7 +71,8 @@ export function createScript(info: {
         if (script) {
           if (name === 'async' || name === 'defer') {
             script[name] = attrs[name];
-          } else {
+            // Attributes that do not exist are considered overridden
+          } else if (!script.getAttribute(name)) {
             script.setAttribute(name, attrs[name]);
           }
         }
@@ -160,7 +161,7 @@ export function createLink(info: {
     const attrs = info.attrs;
     if (attrs) {
       Object.keys(attrs).forEach((name) => {
-        if (link) {
+        if (link && !link.getAttribute(name)) {
           link.setAttribute(name, attrs[name]);
         }
       });


### PR DESCRIPTION

## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
fix(sdk): the returned properties are used by default when create script and create link hook

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
