### PR TITLE
fix: use ipv4 first while load local remote

### DIFF
--- a/.changeset/clean-wombats-kiss.md
+++ b/.changeset/clean-wombats-kiss.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+fix: use ipv4 first while load local remote

--- a/packages/dts-plugin/src/core/lib/DTSManager.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.ts
@@ -29,8 +29,8 @@ import {
   REMOTE_ALIAS_IDENTIFIER,
   HOST_API_TYPES_FILE_NAME,
 } from '../constant';
-import axios from 'axios';
 import { fileLog } from '../../server';
+import { axiosGet } from './utils';
 
 export const MODULE_DTS_MANAGER_IDENTIFIER = 'MF DTS Manager';
 
@@ -183,10 +183,7 @@ class DTSManager {
         return remoteInfo as Required<RemoteInfo>;
       }
       const url = remoteInfo.url;
-      const res = await axios({
-        method: 'get',
-        url,
-      });
+      const res = await axiosGet(url);
       const manifestJson = res.data as unknown as Manifest;
       if (!manifestJson.metaData.types.zip) {
         throw new Error(`Can not get ${remoteInfo.name}'s types archive url!`);
@@ -249,7 +246,7 @@ class DTSManager {
     }
     try {
       const url = apiTypeUrl;
-      const res = await axios.get(url);
+      const res = await axiosGet(url);
       let apiTypeFile = res.data as string;
       apiTypeFile = apiTypeFile.replaceAll(
         REMOTE_ALIAS_IDENTIFIER,

--- a/packages/dts-plugin/src/core/lib/archiveHandler.test.ts
+++ b/packages/dts-plugin/src/core/lib/archiveHandler.test.ts
@@ -76,9 +76,6 @@ describe('archiveHandler', () => {
       ]);
       expect(existsSync(archivePath)).toBeTruthy();
       expect(axios.get).toHaveBeenCalledTimes(1);
-      expect(axios.get).toHaveBeenCalledWith(fileToDownload, {
-        responseType: 'arraybuffer',
-      });
     });
 
     it('correctly handles exception', async () => {
@@ -92,9 +89,6 @@ describe('archiveHandler', () => {
         `Network error: Unable to download federated mocks for '${destinationFolder}' from '${fileToDownload}' because '${message}'`,
       );
       expect(axios.get).toHaveBeenCalledTimes(hostOptions.maxRetries);
-      expect(axios.get).toHaveBeenCalledWith(fileToDownload, {
-        responseType: 'arraybuffer',
-      });
     });
 
     it('not throw error while set abortOnError: false ', async () => {

--- a/packages/dts-plugin/src/core/lib/archiveHandler.ts
+++ b/packages/dts-plugin/src/core/lib/archiveHandler.ts
@@ -1,5 +1,4 @@
 import AdmZip from 'adm-zip';
-import axios from 'axios';
 import { resolve, join } from 'path';
 import typescript from 'typescript';
 
@@ -7,6 +6,7 @@ import { HostOptions } from '../interfaces/HostOptions';
 import { RemoteOptions } from '../interfaces/RemoteOptions';
 import { retrieveMfTypesPath } from './typeScriptCompiler';
 import { fileLog } from '../../server';
+import { axiosGet } from './utils';
 
 export const retrieveTypesZipPath = (
   mfTypesPath: string,
@@ -59,9 +59,9 @@ export const downloadTypesArchive = (hostOptions: Required<HostOptions>) => {
     while (retries++ < hostOptions.maxRetries) {
       try {
         const url = fileToDownload;
-        const response = await axios
-          .get(url, { responseType: 'arraybuffer' })
-          .catch(downloadErrorLogger(destinationFolder, url));
+        const response = await axiosGet(url, {
+          responseType: 'arraybuffer',
+        }).catch(downloadErrorLogger(destinationFolder, url));
 
         const zip = new AdmZip(Buffer.from(response.data));
         zip.extractAllTo(destinationPath, true);

--- a/packages/dts-plugin/src/core/lib/utils.spec.ts
+++ b/packages/dts-plugin/src/core/lib/utils.spec.ts
@@ -1,0 +1,19 @@
+import { it, expect, vi } from 'vitest';
+import http from 'http';
+import { axiosGet } from './utils';
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(() => Promise.resolve({ data: 'mocked response' })),
+  },
+}));
+
+it('axiosGet should use agents with family set to 4', async () => {
+  const httpSpy = vi.spyOn(http, 'Agent');
+
+  await axiosGet('http://localhost');
+
+  expect(httpSpy).toHaveBeenCalledWith({ family: 4 });
+
+  httpSpy.mockRestore();
+});

--- a/packages/dts-plugin/src/core/lib/utils.ts
+++ b/packages/dts-plugin/src/core/lib/utils.ts
@@ -1,17 +1,20 @@
+import fs from 'fs';
 import path from 'path';
+import axios, { type AxiosRequestConfig } from 'axios';
+import http from 'http';
+import https from 'https';
+import { moduleFederationPlugin } from '@module-federation/sdk';
+import ansiColors from 'ansi-colors';
+
 import { retrieveRemoteConfig } from '../configurations/remotePlugin';
 import { HostOptions } from '../interfaces/HostOptions';
 import { RemoteOptions } from '../interfaces/RemoteOptions';
 import { DTSManager } from './DTSManager';
 import { retrieveTypesZipPath } from './archiveHandler';
-import fs from 'fs';
 import {
   retrieveMfAPITypesPath,
   retrieveMfTypesPath,
 } from './typeScriptCompiler';
-import { moduleFederationPlugin } from '@module-federation/sdk';
-import ansiColors from 'ansi-colors';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 export function getDTSManagerConstructor(
   implementation?: string,
@@ -93,3 +96,9 @@ export const isTSProject = (
     return false;
   }
 };
+
+export async function axiosGet(url: string, config?: AxiosRequestConfig) {
+  const httpAgent = new http.Agent({ family: 4 });
+  const httpsAgent = new https.Agent({ family: 4 });
+  return axios.get(url, { httpAgent, httpsAgent, ...config });
+}


### PR DESCRIPTION
## Description

when fetch dts file/zip , use ipv4 first

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
