### PR TITLE
feat(dts-plugin): decode encoded remote name

### DIFF
--- a/.changeset/dull-berries-judge.md
+++ b/.changeset/dull-berries-judge.md
@@ -1,0 +1,7 @@
+---
+'@module-federation/webpack-bundler-runtime': patch
+'@module-federation/dts-plugin': patch
+'@module-federation/sdk': patch
+---
+
+fix: support decode encode remote name

--- a/packages/dts-plugin/src/core/configurations/hostPlugin.ts
+++ b/packages/dts-plugin/src/core/configurations/hostPlugin.ts
@@ -1,4 +1,9 @@
-import { MANIFEST_EXT, parseEntry } from '@module-federation/sdk';
+import {
+  MANIFEST_EXT,
+  parseEntry,
+  ENCODE_NAME_PREFIX,
+  decodeName,
+} from '@module-federation/sdk';
 import { utils } from '@module-federation/managers';
 import { HostOptions, RemoteInfo } from '../interfaces/HostOptions';
 import { validateOptions } from '../lib/utils';
@@ -39,14 +44,18 @@ export const retrieveRemoteInfo = (options: {
   remote: string;
 }): RemoteInfo => {
   const { hostOptions, remoteAlias, remote } = options;
+  let decodeRemote = remote;
+  if (remote.startsWith(ENCODE_NAME_PREFIX)) {
+    decodeRemote = decodeName(remote, ENCODE_NAME_PREFIX);
+  }
 
-  const parsedInfo = parseEntry(remote, undefined, '@');
+  const parsedInfo = parseEntry(decodeRemote, undefined, '@');
 
   const url =
     'entry' in parsedInfo
       ? parsedInfo.entry
-      : parsedInfo.name === remote
-      ? remote
+      : parsedInfo.name === decodeRemote
+      ? decodeRemote
       : '';
 
   const zipUrl = url ? buildZipUrl(hostOptions, url) : '';

--- a/packages/dts-plugin/src/core/configurations/hostPlugin.ts
+++ b/packages/dts-plugin/src/core/configurations/hostPlugin.ts
@@ -44,18 +44,18 @@ export const retrieveRemoteInfo = (options: {
   remote: string;
 }): RemoteInfo => {
   const { hostOptions, remoteAlias, remote } = options;
-  let decodeRemote = remote;
-  if (remote.startsWith(ENCODE_NAME_PREFIX)) {
-    decodeRemote = decodeName(remote, ENCODE_NAME_PREFIX);
+  let decodedRemote = remote;
+  if (decodedRemote.startsWith(ENCODE_NAME_PREFIX)) {
+    decodedRemote = decodeName(decodedRemote, ENCODE_NAME_PREFIX);
   }
 
-  const parsedInfo = parseEntry(decodeRemote, undefined, '@');
+  const parsedInfo = parseEntry(decodedRemote, undefined, '@');
 
   const url =
     'entry' in parsedInfo
       ? parsedInfo.entry
-      : parsedInfo.name === decodeRemote
-      ? decodeRemote
+      : parsedInfo.name === decodedRemote
+      ? decodedRemote
       : '';
 
   const zipUrl = url ? buildZipUrl(hostOptions, url) : '';

--- a/packages/sdk/src/constant.ts
+++ b/packages/sdk/src/constant.ts
@@ -32,3 +32,4 @@ export const MFModuleType = {
 };
 
 export const MODULE_DEVTOOL_IDENTIFIER = '__MF_DEVTOOLS_MODULE_INFO__';
+export const ENCODE_NAME_PREFIX = 'ENCODE_NAME_PREFIX';

--- a/packages/webpack-bundler-runtime/src/constant.ts
+++ b/packages/webpack-bundler-runtime/src/constant.ts
@@ -1,1 +1,2 @@
 export const FEDERATION_SUPPORTED_TYPES = ['script'];
+export { ENCODE_NAME_PREFIX } from '@module-federation/sdk';

--- a/packages/webpack-bundler-runtime/src/constant.ts
+++ b/packages/webpack-bundler-runtime/src/constant.ts
@@ -1,2 +1,1 @@
-export const ENCODE_NAME_PREFIX = 'ENCODE_NAME_PREFIX';
 export const FEDERATION_SUPPORTED_TYPES = ['script'];

--- a/packages/webpack-bundler-runtime/src/remotes.ts
+++ b/packages/webpack-bundler-runtime/src/remotes.ts
@@ -1,8 +1,7 @@
 import { attachShareScopeMap } from './attachShareScopeMap';
 import type { RemoteEntryExports } from './types';
 import { RemotesOptions } from './types';
-import { decodeName } from '@module-federation/sdk';
-import { ENCODE_NAME_PREFIX } from './constant';
+import { decodeName, ENCODE_NAME_PREFIX } from '@module-federation/sdk';
 
 export function remotes(options: RemotesOptions) {
   const {


### PR DESCRIPTION
## Description

if remote name start with `ENCODE_NAME_PREFIX` , it will be decoded. 

This feature is used to support remote name which has `@` and other characters which can not be used in var `globalObject` , and the name have to transformed. 

take examples:
```js
    new ModuleFederationPlugin({
       name:'@scope/button'
    });

encodeName('@scope/button',ENCODE_NAME_PREFIX) === 'ENCODE_NAME_PREFIXscope_scope__button'
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
