### PR TITLE
fix: no delete exist types if fetch new types failed

### DIFF
--- a/.changeset/mighty-goats-hang.md
+++ b/.changeset/mighty-goats-hang.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+fix: no delete exist types if fetch new types failed

--- a/packages/dts-plugin/src/core/lib/DTSManager.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.spec.ts
@@ -185,20 +185,8 @@ describe('DTSManager', () => {
     });
   });
 
-  it('correct consumeTypes', async () => {
-    const distFolder = join(projectRoot, 'dist', typesFolder);
-    const zip = new AdmZip();
-    await zip.addLocalFolderPromise(distFolder, {});
-    axios.get = vi.fn().mockResolvedValueOnce({ data: zip.toBuffer() });
-
-    await dtsManager.consumeTypes();
-
-    const targetFolder = join(projectRoot, hostOptions.typesFolder);
-    expect(
-      dirTree(targetFolder, {
-        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
-      }),
-    ).toMatchObject({
+  describe('consumeTypes', async () => {
+    const expectedStructure = {
       name: '@mf-types-dts-test-consume-types',
       children: [
         {
@@ -318,6 +306,31 @@ describe('DTSManager', () => {
           name: 'remotes',
         },
       ],
+    };
+    const targetFolder = join(projectRoot, hostOptions.typesFolder);
+    it('correct consumeTypes', async () => {
+      const distFolder = join(projectRoot, 'dist', typesFolder);
+      const zip = new AdmZip();
+      await zip.addLocalFolderPromise(distFolder, {});
+      axios.get = vi.fn().mockResolvedValueOnce({ data: zip.toBuffer() });
+
+      await dtsManager.consumeTypes();
+
+      expect(
+        dirTree(targetFolder, {
+          exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
+        }),
+      ).toMatchObject(expectedStructure);
+    });
+
+    it('no delete exist remote types if fetch new remote types failed', async () => {
+      axios.get = vi.fn().mockRejectedValue(new Error('error'));
+      await dtsManager.consumeTypes();
+      expect(
+        dirTree(targetFolder, {
+          exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
+        }),
+      ).toMatchObject(expectedStructure);
     });
   });
 

--- a/packages/dts-plugin/src/core/lib/DTSManager.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.ts
@@ -341,18 +341,6 @@ class DTSManager {
 
   async consumeArchiveTypes(options: HostOptions) {
     const { hostOptions, mapRemotesToDownload } = retrieveHostConfig(options);
-    if (hostOptions.deleteTypesFolder) {
-      await rm(hostOptions.typesFolder, {
-        recursive: true,
-        force: true,
-      }).catch((error) =>
-        fileLog(
-          `Unable to remove types folder, ${error}`,
-          'consumeArchiveTypes',
-          'error',
-        ),
-      );
-    }
 
     const downloadPromises = Object.entries(mapRemotesToDownload).map(
       async (item) => {

--- a/packages/dts-plugin/src/core/lib/archiveHandler.ts
+++ b/packages/dts-plugin/src/core/lib/archiveHandler.ts
@@ -1,5 +1,6 @@
 import AdmZip from 'adm-zip';
 import { resolve, join } from 'path';
+import { rm } from 'fs/promises';
 import typescript from 'typescript';
 
 import { HostOptions } from '../interfaces/HostOptions';
@@ -62,6 +63,21 @@ export const downloadTypesArchive = (hostOptions: Required<HostOptions>) => {
         const response = await axiosGet(url, {
           responseType: 'arraybuffer',
         }).catch(downloadErrorLogger(destinationFolder, url));
+
+        try {
+          if (hostOptions.deleteTypesFolder) {
+            await rm(destinationPath, {
+              recursive: true,
+              force: true,
+            });
+          }
+        } catch (error) {
+          fileLog(
+            `Unable to remove types folder, ${error}`,
+            'downloadTypesArchive',
+            'error',
+          );
+        }
 
         const zip = new AdmZip(Buffer.from(response.data));
         zip.extractAllTo(destinationPath, true);

--- a/packages/dts-plugin/vite.config.ts
+++ b/packages/dts-plugin/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 
 export default defineConfig({
-  cacheDir: '../../node_modules/.vite/native-federation-tests',
+  cacheDir: '../../node_modules/.vite/dts-plugin',
 
   plugins: [nxViteTsPaths()],
 


### PR DESCRIPTION
## Description

no delete exist types if fetch new types failed

## Related Issue
#2489 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
