### PR TITLE
fix: download api types when types refresh

### DIFF
--- a/.changeset/nervous-cougars-switch.md
+++ b/.changeset/nervous-cougars-switch.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+fix: download api types when types refresh

--- a/packages/dts-plugin/src/core/lib/DTSManager.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.ts
@@ -444,6 +444,16 @@ class DTSManager {
           (i) => i.name === remoteName,
         );
 
+        const consumeTypes = async (
+          requiredRemoteInfo: Required<RemoteInfo>,
+        ) => {
+          const [_alias, destinationPath] = await this.consumeTargetRemotes(
+            hostOptions,
+            requiredRemoteInfo,
+          );
+          await this.downloadAPITypes(requiredRemoteInfo, destinationPath);
+        };
+
         if (!loadedRemoteInfo) {
           const remoteInfo = Object.values(mapRemotesToDownload).find(
             (item) => {
@@ -456,20 +466,11 @@ class DTSManager {
                 await this.requestRemoteManifest(remoteInfo);
               this.remoteAliasMap[remoteInfo.alias] = requiredRemoteInfo;
             }
-            await this.consumeTargetRemotes(
-              hostOptions,
-              this.remoteAliasMap[remoteInfo.alias],
-            );
+            await consumeTypes(this.remoteAliasMap[remoteInfo.alias]);
           } else if (updatedRemoteInfo) {
             const consumeDynamicRemoteTypes = async () => {
-              const [_destinationFolder, destinationPath] =
-                await this.consumeTargetRemotes(
-                  hostOptions,
-                  this.updatedRemoteInfos[updatedRemoteInfo.name],
-                );
-              await this.downloadAPITypes(
+              await consumeTypes(
                 this.updatedRemoteInfos[updatedRemoteInfo.name],
-                destinationPath,
               );
               this.consumeAPITypes(hostOptions);
             };
@@ -498,7 +499,7 @@ class DTSManager {
             }
           }
         } else {
-          await this.consumeTargetRemotes(hostOptions, loadedRemoteInfo);
+          await consumeTypes(loadedRemoteInfo);
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Description

 download api types when types refresh

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
