### PR TITLE
fix: check pid is undefined before kill it

### DIFF
--- a/.changeset/cuddly-cougars-deny.md
+++ b/.changeset/cuddly-cougars-deny.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+fix: check pid is undefined before kill it

--- a/packages/dts-plugin/src/core/lib/DtsWorker.ts
+++ b/packages/dts-plugin/src/core/lib/DtsWorker.ts
@@ -45,7 +45,10 @@ export class DtsWorker {
     const ensureChildProcessExit = () => {
       try {
         const pid = this.rpcWorker.process?.pid;
-        process.kill(pid, 0);
+        const rootPid = process.pid;
+        if (pid && rootPid !== pid) {
+          process.kill(pid, 0);
+        }
       } catch (error) {
         if (isDebugMode()) {
           console.error(error);


### PR DESCRIPTION
## Description

check pid is undefined before kill it

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
