### PR TITLE
fix: fix expose collect assets do not filter entry point cause load extra file

### DIFF
--- a/.changeset/young-books-carry.md
+++ b/.changeset/young-books-carry.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/manifest': patch
+---
+
+fix: fix expose collect assets do not filter entry point cause load extra file

--- a/packages/manifest/src/StatsManager.ts
+++ b/packages/manifest/src/StatsManager.ts
@@ -155,6 +155,9 @@ class StatsManager {
     const { chunks } = compilation;
     const { exposeFileNameImportMap } = this._containerManager;
     const assets: Record<string, StatsAssets> = {};
+    const entryPointNames = [...compilation.entrypoints.values()].map(
+      (e) => e.name as string,
+    );
 
     chunks.forEach((chunk) => {
       if (
@@ -163,13 +166,15 @@ class StatsManager {
       ) {
         // TODO: support multiple import
         const exposeKey = exposeFileNameImportMap[chunk.name][0];
-        assets[getFileNameWithOutExt(exposeKey)] = getAssetsByChunk(chunk);
+        assets[getFileNameWithOutExt(exposeKey)] = getAssetsByChunk(
+          chunk,
+          entryPointNames,
+        );
       }
     });
 
     return assets;
   }
-
   private _getProvideSharedAssets(
     compilation: Compilation,
     stats: StatsCompilation,

--- a/packages/manifest/src/StatsManager.ts
+++ b/packages/manifest/src/StatsManager.ts
@@ -155,9 +155,9 @@ class StatsManager {
     const { chunks } = compilation;
     const { exposeFileNameImportMap } = this._containerManager;
     const assets: Record<string, StatsAssets> = {};
-    const entryPointNames = [...compilation.entrypoints.values()].map(
-      (e) => e.name as string,
-    );
+    const entryPointNames = [...compilation.entrypoints.values()]
+      .map((e) => e.name)
+      .filter((v) => !!v) as Array<string>;
 
     chunks.forEach((chunk) => {
       if (

--- a/packages/manifest/src/utils.ts
+++ b/packages/manifest/src/utils.ts
@@ -167,7 +167,7 @@ export function getAssetsByChunk(
     type: 'sync' | 'async',
   ): void => {
     [...targetChunk.groupsIterable].forEach((chunkGroup) => {
-      if (!entryPointNames.includes(chunkGroup.name as string)) {
+      if (chunkGroup.name && !entryPointNames.includes(chunkGroup.name)) {
         collectAssets(
           chunkGroup.getFiles(),
           assesSet.js[type],

--- a/packages/manifest/src/utils.ts
+++ b/packages/manifest/src/utils.ts
@@ -147,7 +147,10 @@ export function getSharedModules(
   return effectiveSharedModules;
 }
 
-export function getAssetsByChunk(chunk: Chunk): StatsAssets {
+export function getAssetsByChunk(
+  chunk: Chunk,
+  entryPointNames: Array<string>,
+): StatsAssets {
   const assesSet = {
     js: {
       sync: new Set() as Set<string>,
@@ -164,11 +167,13 @@ export function getAssetsByChunk(chunk: Chunk): StatsAssets {
     type: 'sync' | 'async',
   ): void => {
     [...targetChunk.groupsIterable].forEach((chunkGroup) => {
-      collectAssets(
-        chunkGroup.getFiles(),
-        assesSet.js[type],
-        assesSet.css[type],
-      );
+      if (!entryPointNames.includes(chunkGroup.name as string)) {
+        collectAssets(
+          chunkGroup.getFiles(),
+          assesSet.js[type],
+          assesSet.css[type],
+        );
+      }
     });
   };
   collectChunkFiles(chunk, 'sync');


### PR DESCRIPTION
…xtra file

## Description
In some cases, manifest collect extra file, when preloadRemote is called, there will cause extra consuption
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
