### PR TITLE
Release v0.2.1

### DIFF
--- a/.changeset/cold-rocks-listen.md
+++ b/.changeset/cold-rocks-listen.md
@@ -1,8 +1,0 @@
----
-'@module-federation/dts-plugin': patch
-'@module-federation/enhanced': patch
-'@module-federation/manifest': patch
-'@module-federation/sdk': patch
----
-
-Support getPublicPath in compiler plugins

--- a/.changeset/old-teachers-eat.md
+++ b/.changeset/old-teachers-eat.md
@@ -1,5 +1,0 @@
----
-'@module-federation/nextjs-mf': patch
----
-
-async function enable to stop warnings

--- a/.changeset/young-books-carry.md
+++ b/.changeset/young-books-carry.md
@@ -1,5 +1,0 @@
----
-'@module-federation/manifest': patch
----
-
-fix: fix expose collect assets do not filter entry point cause load extra file

--- a/apps/modernjs/CHANGELOG.md
+++ b/apps/modernjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/modernjs
 
+## 0.1.28
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/enhanced@0.2.1
+
 ## 0.1.27
 
 ### Patch Changes

--- a/apps/modernjs/package.json
+++ b/apps/modernjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@module-federation/modernjs",
   "private": true,
-  "version": "0.1.27",
+  "version": "0.1.28",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/router-demo/router-host-2000/CHANGELOG.md
+++ b/apps/router-demo/router-host-2000/CHANGELOG.md
@@ -1,5 +1,13 @@
 # host
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/enhanced@0.2.1
+  - @module-federation/bridge-react@0.2.1
+
 ## 1.0.1
 
 ### Patch Changes

--- a/apps/router-demo/router-host-2000/package.json
+++ b/apps/router-demo/router-host-2000/package.json
@@ -1,7 +1,7 @@
 {
   "name": "host",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "dev": "FEDERATION_DEBUG=true rsbuild dev --open",
     "build": "rsbuild build",

--- a/apps/router-demo/router-host-v5-2200/CHANGELOG.md
+++ b/apps/router-demo/router-host-v5-2200/CHANGELOG.md
@@ -1,5 +1,13 @@
 # host-v5
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/enhanced@0.2.1
+  - @module-federation/bridge-react@0.2.1
+
 ## 1.0.1
 
 ### Patch Changes

--- a/apps/router-demo/router-host-v5-2200/package.json
+++ b/apps/router-demo/router-host-v5-2200/package.json
@@ -1,7 +1,7 @@
 {
   "name": "host-v5",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "dev": "FEDERATION_DEBUG=true rsbuild dev",
     "build": "rsbuild build",

--- a/apps/router-demo/router-host-vue3-2100/CHANGELOG.md
+++ b/apps/router-demo/router-host-vue3-2100/CHANGELOG.md
@@ -1,5 +1,13 @@
 # host-vue3
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/enhanced@0.2.1
+  - @module-federation/bridge-vue3@0.2.1
+
 ## 1.0.1
 
 ### Patch Changes

--- a/apps/router-demo/router-host-vue3-2100/package.json
+++ b/apps/router-demo/router-host-vue3-2100/package.json
@@ -1,7 +1,7 @@
 {
   "name": "host-vue3",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/router-demo/router-remote1-2001/CHANGELOG.md
+++ b/apps/router-demo/router-remote1-2001/CHANGELOG.md
@@ -1,5 +1,13 @@
 # remote1
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/enhanced@0.2.1
+  - @module-federation/bridge-react@0.2.1
+
 ## 1.0.1
 
 ### Patch Changes

--- a/apps/router-demo/router-remote1-2001/package.json
+++ b/apps/router-demo/router-remote1-2001/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote1",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "DEBUG=true rsbuild build",

--- a/apps/router-demo/router-remote2-2002/CHANGELOG.md
+++ b/apps/router-demo/router-remote2-2002/CHANGELOG.md
@@ -1,5 +1,13 @@
 # remote2
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/enhanced@0.2.1
+  - @module-federation/bridge-react@0.2.1
+
 ## 1.0.1
 
 ### Patch Changes

--- a/apps/router-demo/router-remote2-2002/package.json
+++ b/apps/router-demo/router-remote2-2002/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote2",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/router-demo/router-remote3-2003/CHANGELOG.md
+++ b/apps/router-demo/router-remote3-2003/CHANGELOG.md
@@ -1,5 +1,13 @@
 # remote3
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/enhanced@0.2.1
+  - @module-federation/bridge-vue3@0.2.1
+
 ## 1.0.1
 
 ### Patch Changes

--- a/apps/router-demo/router-remote3-2003/package.json
+++ b/apps/router-demo/router-remote3-2003/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote3",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/runtime-demo/3008-runtime-remote/CHANGELOG.md
+++ b/apps/runtime-demo/3008-runtime-remote/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 3008-runtime-remote
 
+## 1.0.12
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/enhanced@0.2.1
+
 ## 1.0.11
 
 ### Patch Changes

--- a/apps/runtime-demo/3008-runtime-remote/package.json
+++ b/apps/runtime-demo/3008-runtime-remote/package.json
@@ -1,7 +1,7 @@
 {
   "name": "3008-runtime-remote",
   "private": true,
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
+++ b/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/bridge-react-webpack-plugin
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/sdk@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/bridge/bridge-react-webpack-plugin/package.json
+++ b/packages/bridge/bridge-react-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react-webpack-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/bridge-react/CHANGELOG.md
+++ b/packages/bridge/bridge-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/bridge-react
 
+## 0.2.1
+
+### Patch Changes
+
+- @module-federation/bridge-shared@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/bridge/bridge-react/package.json
+++ b/packages/bridge/bridge-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/bridge-shared/CHANGELOG.md
+++ b/packages/bridge/bridge-shared/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/bridge-shared
 
+## 0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/bridge/bridge-shared/package.json
+++ b/packages/bridge/bridge-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-shared",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/vue3-bridge/CHANGELOG.md
+++ b/packages/bridge/vue3-bridge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/bridge-vue3
 
+## 0.2.1
+
+### Patch Changes
+
+- @module-federation/bridge-shared@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/bridge/vue3-bridge/package.json
+++ b/packages/bridge/vue3-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@module-federation/bridge-vue3",
   "author": "zhouxiao <codingzx@gmail.com>",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/chrome-devtools/CHANGELOG.md
+++ b/packages/chrome-devtools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/devtools
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/sdk@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/packages/chrome-devtools/package.json
+++ b/packages/chrome-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/devtools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "scripts": {
     "build:storybook": "storybook build",
     "storybook": "storybook dev -p 6006",

--- a/packages/dts-plugin/CHANGELOG.md
+++ b/packages/dts-plugin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/dts-plugin
 
+## 0.2.1
+
+### Patch Changes
+
+- 88445e7: Support getPublicPath in compiler plugins
+- Updated dependencies [88445e7]
+  - @module-federation/sdk@0.2.1
+  - @module-federation/managers@0.2.1
+  - @module-federation/third-party-dts-extractor@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/packages/dts-plugin/package.json
+++ b/packages/dts-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/dts-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "hanric <hanric.zhang@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,5 +1,20 @@
 # [0.2.0-canary.5](https://github.com/module-federation/core/compare/enhanced-0.2.0-canary.4...enhanced-0.2.0-canary.5) (2023-11-20)
 
+## 0.2.1
+
+### Patch Changes
+
+- 88445e7: Support getPublicPath in compiler plugins
+- Updated dependencies [88445e7]
+- Updated dependencies [e494f1a]
+  - @module-federation/dts-plugin@0.2.1
+  - @module-federation/manifest@0.2.1
+  - @module-federation/sdk@0.2.1
+  - @module-federation/rspack@0.2.1
+  - @module-federation/bridge-react-webpack-plugin@0.2.1
+  - @module-federation/managers@0.2.1
+  - @module-federation/runtime-tools@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/enhanced",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "repository": "https://github.com/module-federation/core/tree/main/packages/enhanced",

--- a/packages/managers/CHANGELOG.md
+++ b/packages/managers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/managers
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/sdk@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/packages/managers/package.json
+++ b/packages/managers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/managers",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "description": "Provide managers for helping handle mf data .",
   "keywords": [

--- a/packages/manifest/CHANGELOG.md
+++ b/packages/manifest/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @module-federation/manifest
 
+## 0.2.1
+
+### Patch Changes
+
+- 88445e7: Support getPublicPath in compiler plugins
+- e494f1a: fix: fix expose collect assets do not filter entry point cause load extra file
+- Updated dependencies [88445e7]
+  - @module-federation/dts-plugin@0.2.1
+  - @module-federation/sdk@0.2.1
+  - @module-federation/managers@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/manifest",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "description": "Provide manifest/stats for webpack/rspack MF project .",
   "keywords": [

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -1,5 +1,17 @@
 # [8.1.0-canary.7](https://github.com/module-federation/core/compare/nextjs-mf-8.1.0-canary.6...nextjs-mf-8.1.0-canary.7) (2023-11-21)
 
+## 8.3.24
+
+### Patch Changes
+
+- a047837: async function enable to stop warnings
+- Updated dependencies [88445e7]
+  - @module-federation/enhanced@0.2.1
+  - @module-federation/sdk@0.2.1
+  - @module-federation/node@2.2.14
+  - @module-federation/runtime@0.2.1
+  - @module-federation/utilities@3.0.28
+
 ## 8.3.23
 
 ### Patch Changes

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "8.3.23",
+  "version": "8.3.24",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,15 @@
 # [2.1.0-canary.6](https://github.com/module-federation/core/compare/node-2.1.0-canary.5...node-2.1.0-canary.6) (2023-11-21)
 
+## 2.2.14
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/enhanced@0.2.1
+  - @module-federation/sdk@0.2.1
+  - @module-federation/runtime@0.2.1
+  - @module-federation/utilities@3.0.28
+
 ## 2.2.13
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "exports": {

--- a/packages/rspack/CHANGELOG.md
+++ b/packages/rspack/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @module-federation/rspack
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+- Updated dependencies [e494f1a]
+  - @module-federation/dts-plugin@0.2.1
+  - @module-federation/manifest@0.2.1
+  - @module-federation/sdk@0.2.1
+  - @module-federation/bridge-react-webpack-plugin@0.2.1
+  - @module-federation/managers@0.2.1
+  - @module-federation/runtime-tools@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rspack",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "keywords": [
     "Module Federation",

--- a/packages/runtime-tools/CHANGELOG.md
+++ b/packages/runtime-tools/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [1.0.1-canary.1](https://github.com/module-federation/core/compare/runtime-1.0.0...runtime-1.0.1-canary.1) (2023-12-06)
 
+## 0.2.1
+
+### Patch Changes
+
+- @module-federation/runtime@0.2.1
+- @module-federation/webpack-bundler-runtime@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/packages/runtime-tools/package.json
+++ b/packages/runtime-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-tools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/runtime
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/sdk@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [1.1.0-canary.1](https://github.com/module-federation/core/compare/sdk-1.0.0...sdk-1.1.0-canary.1) (2023-12-05)
 
+## 0.2.1
+
+### Patch Changes
+
+- 88445e7: Support getPublicPath in compiler plugins
+
 ## 0.2.0
 
 ## 0.1.21

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "description": "A sdk for support module federation",
   "keywords": [

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -47,7 +47,7 @@
     "@storybook/node-logger": "^6.5.16 || ^7.0.0",
     "webpack": "^5.75.0",
     "webpack-virtual-modules": "^0.5.0 || ^0.6.0",
-    "@module-federation/utilities": "^3.0.27",
+    "@module-federation/utilities": "^3.0.28",
     "@nx/react": "~16.0.0 || ~17.0.0 || ~17.2.0",
     "@nx/webpack": "~16.0.0 || ~17.0.0 || ~17.2.0"
   }

--- a/packages/third-party-dts-extractor/CHANGELOG.md
+++ b/packages/third-party-dts-extractor/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/third-party-dts-extractor
 
+## 0.2.1
+
 ## 0.2.0
 
 ## 0.1.21

--- a/packages/third-party-dts-extractor/package.json
+++ b/packages/third-party-dts-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/third-party-dts-extractor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "files": [
     "dist/",
     "README.md"

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [3.1.0](https://github.com/module-federation/core/compare/utils-3.0.2...utils-3.1.0) (2023-10-26)
 
+## 3.0.28
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/sdk@0.2.1
+
 ## 3.0.27
 
 ### Patch Changes

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/utilities",
-  "version": "3.0.27",
+  "version": "3.0.28",
   "type": "commonjs",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.cjs.d.ts",

--- a/packages/webpack-bundler-runtime/CHANGELOG.md
+++ b/packages/webpack-bundler-runtime/CHANGELOG.md
@@ -1,5 +1,13 @@
 # [1.0.0-canary.3](https://github.com/module-federation/core/compare/webpack-bundler-runtime-1.0.0-canary.2...webpack-bundler-runtime-1.0.0-canary.3) (2023-11-23)
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [88445e7]
+  - @module-federation/sdk@0.2.1
+  - @module-federation/runtime@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/packages/webpack-bundler-runtime/package.json
+++ b/packages/webpack-bundler-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/webpack-bundler-runtime",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "description": "Module Federation Runtime for webpack",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v0.2.1 -->

## What's Changed
### Bug Fixes 🐞
* fix: fix expose collect assets do not filter entry point cause load extra file by @nyqykk in https://github.com/module-federation/core/pull/2647
* fix: kill ports before next e2e by @ScriptedAlchemy in https://github.com/module-federation/core/pull/2661
* fix(runtime): modify import typescript type syntax by @chs97 in https://github.com/module-federation/core/pull/2650
* fix(docs): zh/practice/bridge/index link error by @Thulof in https://github.com/module-federation/core/pull/2660
* fix(docs): zh/practice/bridge/index char lack by @Thulof in https://github.com/module-federation/core/pull/2659
* fix(enhanced): support get public path by @ScriptedAlchemy in https://github.com/module-federation/core/pull/2638
* fix(nextjs-mf): enable async function support by @ScriptedAlchemy in https://github.com/module-federation/core/pull/2642
### Document 📖
* docs: update framework version by @zhoushaw in https://github.com/module-federation/core/pull/2651
### Other Changes
* Release v0.2.0 by @zhoushaw in https://github.com/module-federation/core/pull/2649
* chore(deps-dev): bump @babel/plugin-transform-react-jsx from 7.23.4 to 7.24.7 by @dependabot in https://github.com/module-federation/core/pull/2657
* chore(deps-dev): bump @modern-js/eslint-config from 2.50.0 to 2.54.2 by @dependabot in https://github.com/module-federation/core/pull/2655
* chore(deps-dev): bump @types/chrome from 0.0.260 to 0.0.268 by @dependabot in https://github.com/module-federation/core/pull/2653

## New Contributors
* @chs97 made their first contribution in https://github.com/module-federation/core/pull/2650
* @Thulof made their first contribution in https://github.com/module-federation/core/pull/2660

**Full Changelog**: https://github.com/module-federation/core/compare/v0.2.0...v0.2.1