### PR TITLE
fix(docs): missing PackageManagerTabs import

### DIFF
--- a/apps/website-new/docs/en/practice/bridge/vue-bridge.mdx
+++ b/apps/website-new/docs/en/practice/bridge/vue-bridge.mdx
@@ -5,6 +5,8 @@
 
 ### Installation
 
+import { PackageManagerTabs } from '@theme';
+
 <PackageManagerTabs
   command={{
     npm: 'npm install @module-federation/bridge-vue3@latest',


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
The PackageManagerTabs component is mission from the vue bridge page.

<img width="1648" alt="Screenshot 2024-06-25 at 21 54 34" src="https://github.com/module-federation/core/assets/465125/52adf118-8c3b-4375-9f95-fd42bdc835df">


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
