### PR TITLE
chore: no auto preload when calling loadRemote

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -18,7 +18,8 @@
       "@module-federation/bridge-react",
       "@module-federation/bridge-vue3",
       "@module-federation/bridge-shared",
-      "@module-federation/bridge-react-webpack-plugin"
+      "@module-federation/bridge-react-webpack-plugin",
+      "@module-federation/auto-preload"
     ]
   ],
   "ignorePatterns": ["^alpha|^beta"],

--- a/.changeset/healthy-buses-collect.md
+++ b/.changeset/healthy-buses-collect.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+feat: expose auto-preload plugin

--- a/.changeset/tall-students-warn.md
+++ b/.changeset/tall-students-warn.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+chore: no auto preload when calling loadRemote

--- a/apps/website-new/docs/en/guide/basic/runtime.mdx
+++ b/apps/website-new/docs/en/guide/basic/runtime.mdx
@@ -271,6 +271,8 @@ type PreloadRemoteArgs = {
   // No filtering by default
   // After configuration, unnecessary resources are filtered out
   filter?: (assetUrl: string) => boolean;
+  // Whether use link to preload the resources , default value is true
+  useLinkPreload?: boolean;
 };
 ```
 

--- a/apps/website-new/docs/en/plugin/plugins/_meta.json
+++ b/apps/website-new/docs/en/plugin/plugins/_meta.json
@@ -1,1 +1,1 @@
-["index"]
+["index","auto-preload"]

--- a/apps/website-new/docs/en/plugin/plugins/auto-preload.mdx
+++ b/apps/website-new/docs/en/plugin/plugins/auto-preload.mdx
@@ -1,0 +1,66 @@
+import { PackageManagerTabs, Tabs, Tab } from '@theme';
+
+# Auto Preload Plugin
+
+Helps auto preload assets when load remote.
+
+## Usage
+
+This Runtime Plugin is Provided by the `@module-federation/node` package
+
+<PackageManagerTabs
+  command={{
+    npm: 'npm add @module-federation/enhanced @module-federation/node --save',
+    yarn: 'yarn add @module-federation/enhanced @module-federation/node --save',
+    pnpm: 'pnpm add @module-federation/enhanced @module-federation/node --save',
+    bun: 'bun add @module-federation/enhanced @module-federation/node --save',
+  }}
+/>
+
+
+### Configuration
+
+The runtime plugin can be applied at compile-time or runtime
+<Tabs>
+  <Tab label="Rspack">
+  ```typescript title="rspack.config.js"
+  const {ModuleFederationPlugin} = require('@module-federation/enhanced/rspack');
+
+  new ModuleFederationPlugin({
+    // other options
+    runtimePlugins: [
+      require.resolve('@module-federation/node/runtimePlugin')
+    ]
+  });
+  ```
+  </Tab>
+  <Tab label="Webpack">
+  ```typescript title="webpack.config.js"
+  const {ModuleFederationPlugin} = require('@module-federation/enhanced/webpack');
+
+  new ModuleFederationPlugin({
+    // other options
+    runtimePlugins: [
+      require.resolve('@module-federation/node/runtimePlugin')
+    ]
+  });
+  ```
+  </Tab>
+  <Tab label="Module Federation Runtime">
+    ```typescript title="app.js"
+    import {init} from '@module-federation/runtime';
+    import nodeRuntimePlugin from '@module-federation/node/runtimePlugin';
+    init({
+      name: '@demo/app-main',
+      remotes: [
+        {
+          name: '@demo/app2',
+          entry: 'http: //localhost:3006/mf-manifest.json',
+          alias: 'app2',
+        },
+      ],
+      plugins: [nodeRuntimePlugin()],
+    });
+    ```
+  </Tab>
+</Tabs>

--- a/apps/website-new/docs/en/plugin/plugins/auto-preload.mdx
+++ b/apps/website-new/docs/en/plugin/plugins/auto-preload.mdx
@@ -4,7 +4,7 @@ import { PackageManagerTabs, Tabs, Tab } from '@theme';
 
 Helps auto preload assets when load remote.
 
-## Usage
+## Install
 
 This Runtime Plugin is Provided by the `@module-federation/auto-preload` package
 
@@ -18,9 +18,10 @@ This Runtime Plugin is Provided by the `@module-federation/auto-preload` package
 />
 
 
-### Configuration
+### Usage
 
 The runtime plugin can be applied at compile-time or runtime
+
 <Tabs>
   <Tab label="Rspack">
   ```typescript title="rspack.config.js"
@@ -64,3 +65,33 @@ The runtime plugin can be applied at compile-time or runtime
     ```
   </Tab>
 </Tabs>
+
+
+## Params
+
+- Type: `Partial<PreloadConfig>`
+- Default value: `undefined`
+- Description: Control the preload behavior
+
+The configuration is the same as [preloadRemote](../../guide/basic/runtime#preloadremote) .
+
+Example:
+
+```typescript title="app.tsx"
+import { init } from '@module-federation/runtime';
+import autoPreloadPlugin from '@module-federation/auto-preload';
+init({
+  name: '@demo/app-main',
+  remotes: [
+    {
+      name: '@demo/app2',
+      entry: 'http: //localhost:3006/mf-manifest.json',
+      alias: 'app2',
+    },
+  ],
+  plugins: [autoPreloadPlugin({
+    // 默认值会通过 script 来预加载 js 文件，可通过 useLinkPreload: true 来修改此行为
+    useLinkPreload: false
+  })],
+});
+```

--- a/apps/website-new/docs/en/plugin/plugins/auto-preload.mdx
+++ b/apps/website-new/docs/en/plugin/plugins/auto-preload.mdx
@@ -6,14 +6,14 @@ Helps auto preload assets when load remote.
 
 ## Usage
 
-This Runtime Plugin is Provided by the `@module-federation/node` package
+This Runtime Plugin is Provided by the `@module-federation/auto-preload` package
 
 <PackageManagerTabs
   command={{
-    npm: 'npm add @module-federation/enhanced @module-federation/node --save',
-    yarn: 'yarn add @module-federation/enhanced @module-federation/node --save',
-    pnpm: 'pnpm add @module-federation/enhanced @module-federation/node --save',
-    bun: 'bun add @module-federation/enhanced @module-federation/node --save',
+    npm: 'npm add @module-federation/auto-preload --save',
+    yarn: 'yarn add @module-federation/auto-preload --save',
+    pnpm: 'pnpm add @module-federation/auto-preload --save',
+    bun: 'bun add @module-federation/auto-preload --save',
   }}
 />
 
@@ -29,7 +29,7 @@ The runtime plugin can be applied at compile-time or runtime
   new ModuleFederationPlugin({
     // other options
     runtimePlugins: [
-      require.resolve('@module-federation/node/runtimePlugin')
+      require.resolve('@module-federation/auto-preload')
     ]
   });
   ```
@@ -41,15 +41,15 @@ The runtime plugin can be applied at compile-time or runtime
   new ModuleFederationPlugin({
     // other options
     runtimePlugins: [
-      require.resolve('@module-federation/node/runtimePlugin')
+      require.resolve('@module-federation/auto-preload')
     ]
   });
   ```
   </Tab>
   <Tab label="Module Federation Runtime">
     ```typescript title="app.js"
-    import {init} from '@module-federation/runtime';
-    import nodeRuntimePlugin from '@module-federation/node/runtimePlugin';
+    import { init } from '@module-federation/runtime';
+    import autoPreloadPlugin from '@module-federation/auto-preload';
     init({
       name: '@demo/app-main',
       remotes: [
@@ -59,7 +59,7 @@ The runtime plugin can be applied at compile-time or runtime
           alias: 'app2',
         },
       ],
-      plugins: [nodeRuntimePlugin()],
+      plugins: [autoPreloadPlugin()],
     });
     ```
   </Tab>

--- a/apps/website-new/docs/zh/guide/basic/runtime.mdx
+++ b/apps/website-new/docs/zh/guide/basic/runtime.mdx
@@ -271,6 +271,8 @@ type PreloadRemoteArgs = {
   // 未配置时不过滤资源
   // 配置后会过滤掉不需要的资源
   filter?: (assetUrl: string) => boolean;
+  // 是否以 link 标签预加载资源，默认为 true
+  useLinkPreload?: boolean;
 };
 ```
 

--- a/apps/website-new/docs/zh/plugin/_meta.json
+++ b/apps/website-new/docs/zh/plugin/_meta.json
@@ -3,5 +3,10 @@
     "type": "dir",
     "name": "dev",
     "label": "插件开发"
+  },
+  {
+    "type": "dir",
+    "name": "plugins",
+    "label": "Plugins"
   }
 ]

--- a/apps/website-new/docs/zh/plugin/plugins/_meta.json
+++ b/apps/website-new/docs/zh/plugin/plugins/_meta.json
@@ -1,0 +1,1 @@
+["index","auto-preload"]

--- a/apps/website-new/docs/zh/plugin/plugins/auto-preload.mdx
+++ b/apps/website-new/docs/zh/plugin/plugins/auto-preload.mdx
@@ -1,10 +1,10 @@
 import { PackageManagerTabs, Tabs, Tab } from '@theme';
 
-# Auto Preload Plugin
+# 自动预加载资源
 
 当加载远程模块时，会自动预加载相应的远程模块资源。
 
-## Usage
+## 安装
 
 该运行时插件由 `@module-federation/auto-preload` 提供
 
@@ -18,7 +18,7 @@ import { PackageManagerTabs, Tabs, Tab } from '@theme';
 />
 
 
-### 配置
+### 使用
 
 此插件可在**运行时阶段**或**构建插件**中应用。你可以根据你的场景灵活选择。
 
@@ -65,3 +65,31 @@ import { PackageManagerTabs, Tabs, Tab } from '@theme';
     ```
   </Tab>
 </Tabs>
+
+## 参数
+
+- 类型: `Partial<PreloadConfig>`
+- 默认值: `undefined`
+- 描述: 控制预加载资源行为
+
+该配置与 [preloadRemote](../../guide/basic/runtime#preloadremote) 一致。
+
+使用示例：
+```typescript title="app.tsx"
+import { init } from '@module-federation/runtime';
+import autoPreloadPlugin from '@module-federation/auto-preload';
+init({
+  name: '@demo/app-main',
+  remotes: [
+    {
+      name: '@demo/app2',
+      entry: 'http: //localhost:3006/mf-manifest.json',
+      alias: 'app2',
+    },
+  ],
+  plugins: [autoPreloadPlugin({
+    // 默认值会通过 script 来预加载 js 文件，可通过 useLinkPreload: true 来修改此行为
+    useLinkPreload: false
+  })],
+});
+```

--- a/apps/website-new/docs/zh/plugin/plugins/auto-preload.mdx
+++ b/apps/website-new/docs/zh/plugin/plugins/auto-preload.mdx
@@ -1,27 +1,27 @@
 import { PackageManagerTabs, Tabs, Tab } from '@theme';
 
-# Node Plugin
+# Auto Preload Plugin
 
-Module Federation on the server-side enables many possibilities for backend architecture as well as enables server side rendering of apps.
-
+当加载远程模块时，会自动预加载相应的远程模块资源。
 
 ## Usage
 
-This Runtime Plugin is Provided by the `@module-federation/node` package
+该运行时插件由 `@module-federation/auto-preload` 提供
 
 <PackageManagerTabs
   command={{
-    npm: 'npm add @module-federation/enhanced @module-federation/node --save',
-    yarn: 'yarn add @module-federation/enhanced @module-federation/node --save',
-    pnpm: 'pnpm add @module-federation/enhanced @module-federation/node --save',
-    bun: 'bun add @module-federation/enhanced @module-federation/node --save',
+    npm: 'npm add @module-federation/auto-preload --save',
+    yarn: 'yarn add @module-federation/auto-preload --save',
+    pnpm: 'pnpm add @module-federation/auto-preload --save',
+    bun: 'bun add @module-federation/auto-preload --save',
   }}
 />
 
 
-### Configuration
+### 配置
 
-The runtime plugin can be applied at compile-time or runtime
+此插件可在**运行时阶段**或**构建插件**中应用。你可以根据你的场景灵活选择。
+
 <Tabs>
   <Tab label="Rspack">
   ```typescript title="rspack.config.js"
@@ -30,7 +30,7 @@ The runtime plugin can be applied at compile-time or runtime
   new ModuleFederationPlugin({
     // other options
     runtimePlugins: [
-      require.resolve('@module-federation/node/runtimePlugin')
+      require.resolve('@module-federation/auto-preload')
     ]
   });
   ```
@@ -42,15 +42,15 @@ The runtime plugin can be applied at compile-time or runtime
   new ModuleFederationPlugin({
     // other options
     runtimePlugins: [
-      require.resolve('@module-federation/node/runtimePlugin')
+      require.resolve('@module-federation/auto-preload')
     ]
   });
   ```
   </Tab>
   <Tab label="Module Federation Runtime">
     ```typescript title="app.js"
-    import {init} from '@module-federation/runtime';
-    import nodeRuntimePlugin from '@module-federation/node/runtimePlugin';
+    import { init } from '@module-federation/runtime';
+    import autoPreloadPlugin from '@module-federation/auto-preload';
     init({
       name: '@demo/app-main',
       remotes: [
@@ -60,7 +60,7 @@ The runtime plugin can be applied at compile-time or runtime
           alias: 'app2',
         },
       ],
-      plugins: [nodeRuntimePlugin()],
+      plugins: [autoPreloadPlugin()],
     });
     ```
   </Tab>

--- a/apps/website-new/docs/zh/plugin/plugins/index.mdx
+++ b/apps/website-new/docs/zh/plugin/plugins/index.mdx
@@ -5,7 +5,7 @@ import { PackageManagerTabs, Tabs, Tab } from '@theme';
 
 服务器端的模块联邦为后端架构提供了多种可能性，并支持应用程序的服务器端渲染。
 
-## 使用
+## 安装
 
 该运行时插件由 `@module-federation/node` 提供
 
@@ -19,7 +19,7 @@ import { PackageManagerTabs, Tabs, Tab } from '@theme';
 />
 
 
-### 配置
+### 使用
 
 此插件可在**运行时阶段**或**构建插件**中应用。你可以根据你的场景灵活选择。
 

--- a/apps/website-new/docs/zh/plugin/plugins/index.mdx
+++ b/apps/website-new/docs/zh/plugin/plugins/index.mdx
@@ -2,12 +2,12 @@ import { PackageManagerTabs, Tabs, Tab } from '@theme';
 
 # Node Plugin
 
-Module Federation on the server-side enables many possibilities for backend architecture as well as enables server side rendering of apps.
 
+服务器端的模块联邦为后端架构提供了多种可能性，并支持应用程序的服务器端渲染。
 
-## Usage
+## 使用
 
-This Runtime Plugin is Provided by the `@module-federation/node` package
+该运行时插件由 `@module-federation/node` 提供
 
 <PackageManagerTabs
   command={{
@@ -19,9 +19,10 @@ This Runtime Plugin is Provided by the `@module-federation/node` package
 />
 
 
-### Configuration
+### 配置
 
-The runtime plugin can be applied at compile-time or runtime
+此插件可在**运行时阶段**或**构建插件**中应用。你可以根据你的场景灵活选择。
+
 <Tabs>
   <Tab label="Rspack">
   ```typescript title="rspack.config.js"

--- a/packages/runtime-plugins/auto-preload/CHANGELOG.md
+++ b/packages/runtime-plugins/auto-preload/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @module-federation/runtime-auto-preload-plugin

--- a/packages/runtime-plugins/auto-preload/LICENSE
+++ b/packages/runtime-plugins/auto-preload/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-present zhanghang(2heal1)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/runtime-plugins/auto-preload/README.md
+++ b/packages/runtime-plugins/auto-preload/README.md
@@ -1,0 +1,1 @@
+# @module-federation/runtime-auto-preload-plugin

--- a/packages/runtime-plugins/auto-preload/__tests__/basic.spec.ts
+++ b/packages/runtime-plugins/auto-preload/__tests__/basic.spec.ts
@@ -1,0 +1,265 @@
+import { describe, it, assert } from 'vitest';
+import { init } from '@module-federation/runtime';
+import helpers from '@module-federation/runtime/helpers';
+import autoPreloadPlugin from '../src';
+import { mockStaticServer } from './mock/utils';
+
+interface LinkInfo {
+  type: string;
+  href: string;
+}
+
+interface ScriptInfo {
+  src: string;
+  crossorigin: string;
+}
+
+function getLinkInfos(): Array<LinkInfo> {
+  const links = document.querySelectorAll('link');
+  const linkInfos: Array<LinkInfo> = Array.from(links).map((link) => ({
+    type: link.getAttribute('as') || '',
+    href: link.getAttribute('href') || '',
+    rel: link.getAttribute('rel') || '',
+  }));
+  return linkInfos;
+}
+function getScriptInfos(): Array<ScriptInfo> {
+  const scripts = document.querySelectorAll('script');
+  const scriptInfos: Array<ScriptInfo> = Array.from(scripts).map((script) => ({
+    src: script.getAttribute('src') || '',
+    crossorigin: script.getAttribute('crossorigin') || '',
+  }));
+
+  return scriptInfos;
+}
+
+function getPreloadElInfos(): {
+  links: LinkInfo[];
+  scripts: ScriptInfo[];
+} {
+  return {
+    links: getLinkInfos(),
+    scripts: getScriptInfos(),
+  };
+}
+
+// eslint-disable-next-line max-lines-per-function
+describe('basic usage', () => {
+  const mockSnapshot = {
+    '@federation/host': {
+      buildVersion: 'custom',
+      publicPath: 'http://localhost:1111/resources/preload/preload-resource/',
+      remoteEntry: 'federation-remote-entry.js',
+      remotesInfo: {
+        '@federation/sub1': {
+          matchedVersion: '1.0.2',
+        },
+        '@federation/sub2': {
+          matchedVersion: '1.0.3',
+        },
+        '@federation/sub3': {
+          matchedVersion: '1.0.3',
+        },
+      },
+    },
+    '@federation/sub1:1.0.2': {
+      buildVersion: 'custom',
+      modules: [
+        {
+          moduleName: 'button',
+          assets: {
+            css: {
+              sync: ['button.sync.css', 'ignore.sync.css'],
+              async: ['button.async.css'],
+            },
+            js: {
+              sync: ['button.sync.js'],
+              async: ['button.async.js'],
+            },
+          },
+        },
+      ],
+      publicPath: 'http://localhost:1111/resources/preload/preload-resource/',
+      remoteEntry: 'federation-remote-entry.js',
+      remotesInfo: {
+        '@federation/sub1-button': {
+          matchedVersion: '1.0.3',
+        },
+        '@federation/sub1-add': {
+          matchedVersion: '1.0.3',
+        },
+      },
+    },
+    '@federation/sub1-button:1.0.3': {
+      buildVersion: 'custom',
+      modules: [
+        {
+          moduleName: 'button',
+          assets: {
+            css: {
+              sync: [],
+              async: [],
+            },
+            js: {
+              sync: ['sub1-button/button.sync.js'],
+              async: ['sub1-button/button.async.js'],
+            },
+          },
+        },
+      ],
+      publicPath: 'http://localhost:1111/resources/preload/preload-resource/',
+      remoteEntry: 'sub1-button/federation-remote-entry.js',
+    },
+    '@federation/sub1-add:1.0.3': {
+      buildVersion: 'custom',
+      modules: [
+        {
+          moduleName: 'add',
+          assets: {
+            css: {
+              sync: [],
+              async: [],
+            },
+            js: {
+              sync: ['sub1-add/add.sync.js'],
+              async: ['sub1-add/add.async.js'],
+            },
+          },
+        },
+      ],
+      publicPath: 'http://localhost:1111/resources/preload/preload-resource/',
+      remoteEntry: 'sub1-add/federation-remote-entry.js',
+    },
+    '@federation/sub2:1.0.3': {
+      buildVersion: 'custom',
+      modules: [
+        {
+          moduleName: 'button',
+          assets: {
+            css: {
+              sync: ['sub2/button.sync.css'],
+              async: ['sub2/button.async.css'],
+            },
+            js: {
+              sync: ['sub2/button.sync.js'],
+              async: ['sub2/button.async.js'],
+            },
+          },
+        },
+      ],
+      publicPath: 'http://localhost:1111/resources/preload/preload-resource/',
+      remoteEntry: 'sub2/federation-remote-entry.js',
+      remotesInfo: {
+        '@federation/sub2-button': {
+          matchedVersion: '1.0.3',
+        },
+        '@federation/sub2-add': {
+          matchedVersion: '1.0.3',
+        },
+      },
+    },
+    '@federation/sub2-button:1.0.3': {
+      buildVersion: 'custom',
+      modules: [
+        {
+          moduleName: 'button',
+          assets: {
+            css: {
+              sync: [],
+              async: [],
+            },
+            js: {
+              sync: ['sub2-button/button.sync.js'],
+              async: ['sub2-button/button.async.js'],
+            },
+          },
+        },
+      ],
+      publicPath: 'http://localhost:1111/resources/preload/preload-resource/',
+      remoteEntry: 'sub2-button/federation-remote-entry.js',
+    },
+    '@federation/sub2-add:1.0.3': {
+      buildVersion: 'custom',
+      modules: [
+        {
+          moduleName: 'add',
+          assets: {
+            css: {
+              sync: [],
+              async: [],
+            },
+            js: {
+              sync: ['sub2-add/add.sync.js'],
+              async: ['sub2-add/add.async.js'],
+            },
+          },
+        },
+      ],
+      publicPath: 'http://localhost:1111/resources/preload/preload-resource/',
+      remoteEntry: 'sub2-button/federation-remote-entry.js',
+    },
+    '@federation/sub3:1.0.3': {
+      buildVersion: 'custom',
+      modules: [
+        {
+          moduleName: 'button',
+          assets: {
+            css: {
+              sync: [],
+              async: [],
+            },
+            js: {
+              sync: ['sub3/button.sync.js'],
+              async: [],
+            },
+          },
+        },
+        {
+          moduleName: 'add',
+          assets: {
+            css: {
+              sync: [],
+              async: [],
+            },
+            js: {
+              sync: ['sub3/add.sync.js'],
+              async: [],
+            },
+          },
+        },
+      ],
+      publicPath: 'http://localhost:1111/resources/preload/preload-resource/',
+      remoteEntry: 'sub3/federation-remote-entry.js',
+    },
+  };
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    helpers.global.Global.__FEDERATION__.__PRELOADED_MAP__.clear();
+  });
+  const FMInstance = init({
+    name: '@federation/host',
+    remotes: [
+      {
+        name: '@federation/sub1',
+        version: '1.0.2',
+      },
+      {
+        name: '@federation/sub2',
+        version: '1.0.3',
+      },
+      {
+        name: '@federation/sub3',
+        version: '1.0.3',
+      },
+    ],
+    plugins: [autoPreloadPlugin()],
+  });
+
+  it('auto preload assets when calling load remote', async () => {
+    const reset = helpers.global.addGlobalSnapshot(mockSnapshot);
+    await FMInstance.loadRemote('@federation/sub1/say');
+    reset();
+    expect(getPreloadElInfos()).toEqual({});
+  });
+});

--- a/packages/runtime-plugins/auto-preload/__tests__/mock/handlers.ts
+++ b/packages/runtime-plugins/auto-preload/__tests__/mock/handlers.ts
@@ -6,6 +6,7 @@ export const handlers = [
   rest.get(
     'http://localhost:1111/resources/:category/:app/:file',
     (req, res, ctx) => {
+      console.log(1111, req);
       const category = req.params.category;
       const app = req.params.app;
       const file = req.params.file;

--- a/packages/runtime-plugins/auto-preload/__tests__/mock/handlers.ts
+++ b/packages/runtime-plugins/auto-preload/__tests__/mock/handlers.ts
@@ -1,0 +1,25 @@
+import { rest } from 'msw';
+import fs from 'fs';
+import path from 'path';
+
+export const handlers = [
+  rest.get(
+    'http://localhost:1111/resources/:category/:app/:file',
+    (req, res, ctx) => {
+      const category = req.params.category;
+      const app = req.params.app;
+      const file = req.params.file;
+      const filepath = path.resolve(
+        __dirname,
+        `../resources/${category}/${app}/${file}`,
+      );
+
+      const content = fs.readFileSync(filepath, 'utf-8');
+      if (typeof file === 'string' && file.includes('json')) {
+        return res(ctx.status(200), ctx.json(JSON.parse(content)));
+      } else {
+        return res(ctx.status(200), ctx.text(content));
+      }
+    },
+  ),
+];

--- a/packages/runtime-plugins/auto-preload/__tests__/mock/mock-script.ts
+++ b/packages/runtime-plugins/auto-preload/__tests__/mock/mock-script.ts
@@ -45,11 +45,7 @@ function injector(current: Function, methodName: string) {
         (matchKey) => element?.src?.indexOf(matchKey) > -1,
       );
       const matchInfo = matchInfoKey && responseMatchInfo[matchInfoKey];
-      if (
-        matchInfo &&
-        element.tagName === 'SCRIPT' &&
-        !element.src.includes('preload-resource')
-      ) {
+      if (matchInfo && element.tagName === 'SCRIPT') {
         element.setAttribute('innerHTML', matchInfoKey);
         const nEl = document.createElement('script');
         const attrs = element.attributes;
@@ -71,7 +67,6 @@ function injector(current: Function, methodName: string) {
           }
         }
         const filePath = element.src.replace(matchInfo.baseUrl, '');
-
         const execScriptContent = fs.readFileSync(
           path.resolve(matchInfo.baseDir, filePath),
           'utf-8',
@@ -84,6 +79,9 @@ function injector(current: Function, methodName: string) {
         // vitest 无法让 jsdom 和当前环境处于同一个执行环境
         if (!preload) {
           new Function(execScriptContent)();
+        }
+        if (element && element.onload) {
+          element.onload.call(element);
         }
         // eslint-disable-next-line prefer-rest-params
         oriArguments[index] = nEl;

--- a/packages/runtime-plugins/auto-preload/__tests__/mock/mock-script.ts
+++ b/packages/runtime-plugins/auto-preload/__tests__/mock/mock-script.ts
@@ -1,0 +1,136 @@
+import fs from 'fs';
+import path from 'path';
+
+async function safeWrapper<T extends (...args: Array<any>) => any>(
+  callback: T,
+  disableWarn?: boolean,
+): Promise<ReturnType<T> | undefined> {
+  try {
+    const res = await callback();
+    return res;
+  } catch (e) {
+    !disableWarn && console.warn(e);
+  }
+}
+
+const mountElementMethods = [
+  'append',
+  'appendChild',
+  'insertBefore',
+  'insertAdjacentElement',
+];
+const rawElementMethods = Object.create(null);
+
+type MatchInfo = {
+  baseUrl: string;
+  baseDir: string;
+};
+
+let responseMatchInfo: {
+  [key: string]: MatchInfo;
+} = {};
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+function injector(current: Function, methodName: string) {
+  return function (this: Element) {
+    const index = methodName === 'insertAdjacentElement' ? 1 : 0;
+    // eslint-disable-next-line prefer-rest-params
+    const el = arguments[index];
+    let oriArguments = arguments;
+
+    // eslint-disable-next-line prefer-rest-params
+    const originProcess = () => current.apply(this, oriArguments);
+    function evalScript(element: HTMLScriptElement, preload?: boolean) {
+      const matchInfoKey = Object.keys(responseMatchInfo).find(
+        (matchKey) => element?.src?.indexOf(matchKey) > -1,
+      );
+      const matchInfo = matchInfoKey && responseMatchInfo[matchInfoKey];
+      if (
+        matchInfo &&
+        element.tagName === 'SCRIPT' &&
+        !element.src.includes('preload-resource')
+      ) {
+        element.setAttribute('innerHTML', matchInfoKey);
+        const nEl = document.createElement('script');
+        const attrs = element.attributes;
+        for (var j = 0; j < attrs.length; j++) {
+          // Setting src causes a timeout
+          if (attrs[j].name !== 'src') {
+            nEl.setAttribute(attrs[j].name, attrs[j].value);
+          }
+        }
+        // eslint-disable-next-line no-restricted-syntax
+        for (const key in element) {
+          if (key !== 'src') {
+            safeWrapper(() => {
+              (nEl as any)[key] = (element as any)[key];
+            }, true);
+          } else {
+            // Setting src causes a timeout
+            (nEl as any)['fakeSrc'] = (element as any)[key];
+          }
+        }
+        const filePath = element.src.replace(matchInfo.baseUrl, '');
+
+        const execScriptContent = fs.readFileSync(
+          path.resolve(matchInfo.baseDir, filePath),
+          'utf-8',
+        );
+        // nEl.innerHTML = fs.readFileSync(
+        //   path.resolve(matchInfo.baseDir, matchInfo.innerHTML),
+        //   'utf-8',
+        // );
+        nEl.innerHTML = execScriptContent;
+        // vitest 无法让 jsdom 和当前环境处于同一个执行环境
+        if (!preload) {
+          new Function(execScriptContent)();
+        }
+        // eslint-disable-next-line prefer-rest-params
+        oriArguments[index] = nEl;
+      }
+    }
+    if (el instanceof DocumentFragment) {
+      let listEl = el.querySelectorAll('script');
+      listEl.forEach((element) => {
+        evalScript(element, true);
+      });
+    } else if (el instanceof HTMLScriptElement) {
+      evalScript(el);
+    }
+    return originProcess();
+  };
+}
+
+const rewrite = (methods: Array<string>, builder: typeof injector) => {
+  for (const name of methods) {
+    const fn = (window.Element as any).prototype[name];
+    rawElementMethods[name] = fn;
+    const wrapper = builder(fn, name);
+    (window.Element as any).prototype[name] = wrapper;
+  }
+};
+
+rewrite(mountElementMethods, injector);
+
+/**
+ * vite 无法让 jsdom 和当前环境处于同一个执行环境
+ * 所以需要 mock script dom response
+ * 直接代理 http 返回结果无法对 script dom 进行处理
+ * 目前实现的方式是通过劫持添加 script dom 的方法，将 script dom 的 src 替换为 script dom 的 innerHTML
+ */
+export const mockScriptDomResponse = ({
+  baseUrl,
+  baseDir,
+}: {
+  baseDir: string;
+  baseUrl: string;
+}): (() => void) => {
+  responseMatchInfo[baseUrl] = {
+    baseDir,
+    baseUrl,
+  };
+
+  return () => {
+    delete responseMatchInfo[baseUrl];
+  };
+};

--- a/packages/runtime-plugins/auto-preload/__tests__/mock/server.ts
+++ b/packages/runtime-plugins/auto-preload/__tests__/mock/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+// This configures a Service Worker with the given request handlers.
+export const server = setupServer(...handlers);

--- a/packages/runtime-plugins/auto-preload/__tests__/mock/utils.ts
+++ b/packages/runtime-plugins/auto-preload/__tests__/mock/utils.ts
@@ -1,0 +1,91 @@
+import createFetchMock from 'vitest-fetch-mock';
+import { vi } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+
+function isAbsolute(url: string) {
+  // `c:\\` 这种 case 返回 false，在浏览器中使用本地图片，应该用 file 协议
+  if (!/^[a-zA-Z]:\\/.test(url)) {
+    if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const fetchMocker = createFetchMock(vi);
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function mockStaticServer({
+  baseDir,
+  filterKeywords,
+  customerHeaders = {},
+  basename = '',
+  responseMatchs = {},
+}: {
+  baseDir: string;
+  basename?: string;
+  filterKeywords?: Array<string>;
+  customerHeaders?: Record<string, Record<string, any>>;
+  responseMatchs?: Record<string, string>;
+}) {
+  const match = (input: Request) =>
+    Array.isArray(filterKeywords)
+      ? !filterKeywords.some((words) => input.url.includes(words))
+      : true;
+
+  fetchMocker.enableMocks();
+  fetchMocker.doMock();
+
+  fetchMocker.mockIf(match, (req) => {
+    let pathname = req.url;
+    if (isAbsolute(req.url)) {
+      // eslint-disable-next-line prefer-destructuring
+      pathname = new URL(req.url).pathname;
+      if (basename) {
+        pathname = pathname.replace(basename, './');
+      }
+    }
+    const fullDir = path.resolve(baseDir, `./${pathname}`);
+    const { ext } = path.parse(fullDir);
+    // prettier-ignore
+    const mimeType =
+        // eslint-disable-next-line no-nested-ternary
+        ext === '.html' ?
+          'text/html' :
+          // eslint-disable-next-line no-nested-ternary
+          ext === '.js' ?
+            'text/javascript' :
+            ext === '.css' ?
+              'text/css' :
+              'text/plain';
+    const { timeConsuming = 0, ...headers } = customerHeaders[pathname] || {
+      timeConsuming: 0,
+    };
+
+    return new Promise((resolve, reject) => {
+      try {
+        const body =
+          responseMatchs[pathname] || fs.readFileSync(fullDir, 'utf-8');
+        const res = {
+          url: req.url,
+          body,
+          headers: {
+            'Content-Type': mimeType,
+            ...(headers || {}),
+          },
+        };
+        if (timeConsuming) {
+          setTimeout(() => resolve(res), timeConsuming);
+        } else {
+          resolve(res);
+        }
+      } catch (err) {
+        console.error(
+          `mockStaticServer: request ${pathname}, fullDir: ${fullDir}`,
+        );
+        return reject(err);
+      }
+    });
+  });
+}

--- a/packages/runtime-plugins/auto-preload/__tests__/resources/preload/preload-resource/federation-remote-entry.js
+++ b/packages/runtime-plugins/auto-preload/__tests__/resources/preload/preload-resource/federation-remote-entry.js
@@ -1,0 +1,16 @@
+// eslint-disable-next-line no-var
+var pkgName = '@federation/sub1';
+// eslint-disable-next-line no-var
+var version = 'custom';
+
+globalThis[`__FEDERATION_${`${pkgName}:${version}`}__`] = {
+  get(scope) {
+    const moduleMap = {
+      './say'() {
+        return () => 'hello app2';
+      },
+    };
+    return moduleMap[scope];
+  },
+  init() {},
+};

--- a/packages/runtime-plugins/auto-preload/__tests__/resources/preload/preload-resource/federation-remote-entry.js
+++ b/packages/runtime-plugins/auto-preload/__tests__/resources/preload/preload-resource/federation-remote-entry.js
@@ -6,7 +6,7 @@ var version = 'custom';
 globalThis[`__FEDERATION_${`${pkgName}:${version}`}__`] = {
   get(scope) {
     const moduleMap = {
-      './say'() {
+      './button'() {
         return () => 'hello app2';
       },
     };

--- a/packages/runtime-plugins/auto-preload/__tests__/setup.ts
+++ b/packages/runtime-plugins/auto-preload/__tests__/setup.ts
@@ -1,0 +1,16 @@
+import 'whatwg-fetch';
+import { server } from './mock/server';
+import { mockScriptDomResponse } from './mock/mock-script';
+import helpers from '@module-federation/runtime/helpers';
+
+mockScriptDomResponse({
+  baseDir: __dirname,
+  baseUrl: 'http://localhost:1111/',
+});
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+afterAll(() => server.close());
+afterEach(() => {
+  helpers.global.resetFederationGlobalInfo();
+  server.resetHandlers();
+});

--- a/packages/runtime-plugins/auto-preload/package.json
+++ b/packages/runtime-plugins/auto-preload/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@module-federation/runtime-auto-preload-plugin",
+  "name": "@module-federation/auto-preload",
   "version": "0.2.5",
   "files": [
     "dist/",

--- a/packages/runtime-plugins/auto-preload/package.json
+++ b/packages/runtime-plugins/auto-preload/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@module-federation/runtime-auto-preload-plugin",
+  "version": "0.2.5",
+  "files": [
+    "dist/",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "author": "hanric <hanric.zhang@gmail.com>",
+  "license": "MIT",
+  "devDependencies": {
+    "@module-federation/runtime": "workspace:*"
+  }
+}

--- a/packages/runtime-plugins/auto-preload/project.json
+++ b/packages/runtime-plugins/auto-preload/project.json
@@ -1,0 +1,60 @@
+{
+  "name": "auto-preload",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/runtime-plugins/auto-preload/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/packages/runtime-plugins/auto-preload/dist"],
+      "options": {
+        "parallel": false,
+        "commands": [
+          "tsup --config packages/runtime-plugins/auto-preload/tsup.config.ts",
+          "cp packages/runtime-plugins/auto-preload/package.json packages/runtime-plugins/auto-preload/dist",
+          "cp packages/runtime-plugins/auto-preload/*.md packages/runtime-plugins/auto-preload/dist"
+        ]
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/runtime-plugins/auto-preload/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": [
+          {
+            "command": "vitest run -u -c packages/runtime-plugins/auto-preload/vitest.config.ts",
+            "forwardAllArgs": false
+          }
+        ]
+      }
+    },
+    "pre-release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": [
+          {
+            "command": "nx run auto-preload:test",
+            "forwardAllArgs": false
+          },
+          {
+            "command": "nx run auto-preload:build",
+            "forwardAllArgs": false
+          }
+        ]
+      }
+    },
+    "semantic-release": {
+      "executor": "@goestav/nx-semantic-release:semantic-release"
+    }
+  },
+  "tags": ["type:pkg"],
+  "implicitDependencies": []
+}

--- a/packages/runtime-plugins/auto-preload/src/index.ts
+++ b/packages/runtime-plugins/auto-preload/src/index.ts
@@ -1,11 +1,6 @@
 import type { FederationRuntimePlugin } from '@module-federation/runtime';
-import type {
-  PreloadOptions,
-  PreloadConfig,
-} from '@module-federation/runtime/types';
-import helpers from '@module-federation/runtime/helpers';
-
-const tool = helpers.tool;
+import type { PreloadConfig } from '@module-federation/runtime/types';
+import { autoPreload } from './plugin';
 
 function autoPreloadPlugin(
   preloadConfig?: PreloadConfig,
@@ -13,27 +8,7 @@ function autoPreloadPlugin(
   return {
     name: 'auto-preload-plugin',
     async afterResolve(args) {
-      const { remote, origin, expose, pkgNameOrAlias } = args;
-
-      if (
-        !tool.isRemoteInfoWithEntry(remote) ||
-        !tool.isPureRemoteEntry(remote)
-      ) {
-        return args;
-      }
-      // preloading assets
-      const preloadOptions: PreloadOptions[0] = {
-        remote: remote,
-        preloadConfig: {
-          nameOrAlias: pkgNameOrAlias,
-          exposes: [expose],
-          resourceCategory: 'sync',
-          share: false,
-          depsRemote: false,
-          ...preloadConfig,
-        },
-      };
-      origin.remoteHandler.preloadAssets(preloadOptions);
+      autoPreload(args, preloadConfig);
       return args;
     },
   };

--- a/packages/runtime-plugins/auto-preload/src/index.ts
+++ b/packages/runtime-plugins/auto-preload/src/index.ts
@@ -3,7 +3,7 @@ import type { PreloadConfig } from '@module-federation/runtime/types';
 import { autoPreload } from './plugin';
 
 function autoPreloadPlugin(
-  preloadConfig?: PreloadConfig,
+  preloadConfig?: Partial<PreloadConfig>,
 ): FederationRuntimePlugin {
   return {
     name: 'auto-preload-plugin',

--- a/packages/runtime-plugins/auto-preload/src/index.ts
+++ b/packages/runtime-plugins/auto-preload/src/index.ts
@@ -1,8 +1,11 @@
-import { FederationRuntimePlugin } from '../type/plugin';
-import { isPureRemoteEntry, isRemoteInfoWithEntry } from '../utils';
-import { PreloadConfig, PreloadOptions } from '../type';
-import { preloadAssets } from '../utils/preload';
-import { getGlobalSnapshot } from '../global';
+import type { FederationRuntimePlugin } from '@module-federation/runtime';
+import type {
+  PreloadOptions,
+  PreloadConfig,
+} from '@module-federation/runtime/types';
+import helpers from '@module-federation/runtime/helpers';
+
+const tool = helpers.tool;
 
 function autoPreloadPlugin(
   preloadConfig?: PreloadConfig,
@@ -10,14 +13,14 @@ function autoPreloadPlugin(
   return {
     name: 'auto-preload-plugin',
     async afterResolve(args) {
-      const { remote, origin, remoteInfo, expose, pkgNameOrAlias } = args;
+      const { remote, origin, expose, pkgNameOrAlias } = args;
 
-      if (!isRemoteInfoWithEntry(remote) || !isPureRemoteEntry(remote)) {
+      if (
+        !tool.isRemoteInfoWithEntry(remote) ||
+        !tool.isPureRemoteEntry(remote)
+      ) {
         return args;
       }
-      const { remoteSnapshot, globalSnapshot } =
-        await origin.snapshotHandler.loadRemoteSnapshotInfo(remote);
-
       // preloading assets
       const preloadOptions: PreloadOptions[0] = {
         remote: remote,

--- a/packages/runtime-plugins/auto-preload/src/plugin.ts
+++ b/packages/runtime-plugins/auto-preload/src/plugin.ts
@@ -1,0 +1,26 @@
+import type {
+  PreloadOptions,
+  PreloadConfig,
+  LoadRemoteMatch,
+} from '@module-federation/runtime/types';
+
+export function autoPreload(
+  hookArgs: LoadRemoteMatch,
+  preloadConfig?: Partial<PreloadConfig>,
+) {
+  const { remote, origin, expose, pkgNameOrAlias } = hookArgs;
+  // preloading assets
+  const preloadOptions: PreloadOptions[0] = {
+    remote: remote,
+    preloadConfig: {
+      nameOrAlias: pkgNameOrAlias,
+      exposes: [expose],
+      resourceCategory: 'sync',
+      share: false,
+      depsRemote: false,
+      useLinkPreload: false,
+      ...preloadConfig,
+    },
+  };
+  return origin.remoteHandler.preloadAssets(preloadOptions);
+}

--- a/packages/runtime-plugins/auto-preload/tsconfig.json
+++ b/packages/runtime-plugins/auto-preload/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "esnext",
+    "lib": ["esnext", "DOM"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}

--- a/packages/runtime-plugins/auto-preload/tsconfig.lib.json
+++ b/packages/runtime-plugins/auto-preload/tsconfig.lib.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": [
+    "jest.config.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "tsup.config.ts"
+  ]
+}

--- a/packages/runtime-plugins/auto-preload/tsconfig.spec.json
+++ b/packages/runtime-plugins/auto-preload/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node"]
+  },
+  "include": [
+    "vite.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/packages/runtime-plugins/auto-preload/tsup.config.ts
+++ b/packages/runtime-plugins/auto-preload/tsup.config.ts
@@ -1,0 +1,12 @@
+import { join } from 'path';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: [join(__dirname, 'src', 'index.ts')],
+  dts: true,
+  splitting: true,
+  clean: true,
+  format: ['cjs', 'esm'],
+  outDir: join('packages', 'runtime-plugins', 'auto-preload', 'dist'),
+  external: [join(__dirname, 'package.json')],
+});

--- a/packages/runtime-plugins/auto-preload/vitest.config.ts
+++ b/packages/runtime-plugins/auto-preload/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import path from 'path';
+export default defineConfig({
+  define: {
+    __DEV__: true,
+    __TEST__: true,
+    __BROWSER__: false,
+    __VERSION__: '"unknown"',
+  },
+  plugins: [nxViteTsPaths()],
+  test: {
+    environment: 'jsdom',
+    include: [path.resolve(__dirname, '__tests__/*.spec.ts')],
+    globals: true,
+    setupFiles: [path.resolve(__dirname, './__tests__/setup.ts')],
+    testTimeout: 10000,
+  },
+});

--- a/packages/runtime-plugins/auto-preload/vitest.config.ts
+++ b/packages/runtime-plugins/auto-preload/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   },
   plugins: [nxViteTsPaths()],
   test: {
+    cache: { dir: path.resolve(__dirname, 'node_modules/.vite/auto-preload') },
     environment: 'jsdom',
     include: [path.resolve(__dirname, '__tests__/*.spec.ts')],
     globals: true,

--- a/packages/runtime/rollup.config.js
+++ b/packages/runtime/rollup.config.js
@@ -8,6 +8,7 @@ module.exports = (rollupConfig, projectOptions) => {
     index: 'packages/runtime/src/index.ts',
     types: 'packages/runtime/src/types.ts',
     helpers: 'packages/runtime/src/helpers.ts',
+    'auto-preload': 'packages/runtime/src/plugins/auto-preload.ts',
   };
 
   const project = projectOptions.project;

--- a/packages/runtime/src/helpers.ts
+++ b/packages/runtime/src/helpers.ts
@@ -19,6 +19,7 @@ import {
   Global,
 } from './global';
 import { getRegisteredShare, getGlobalShareScope } from './utils/share';
+import { isRemoteInfoWithEntry, isPureRemoteEntry } from './utils/tool';
 
 interface IShareUtils {
   getRegisteredShare: typeof getRegisteredShare;
@@ -71,9 +72,19 @@ const GlobalUtils: IGlobalUtils = {
   setPreloaded,
 };
 
+interface IToolUtils {
+  isRemoteInfoWithEntry: typeof isRemoteInfoWithEntry;
+  isPureRemoteEntry: typeof isPureRemoteEntry;
+}
+const ToolUtils: IToolUtils = {
+  isRemoteInfoWithEntry,
+  isPureRemoteEntry,
+};
+
 export default {
   global: GlobalUtils,
   share: ShareUtils,
+  tool: ToolUtils,
 };
 
 export type { IGlobalUtils, IShareUtils };

--- a/packages/runtime/src/plugins/auto-preload.ts
+++ b/packages/runtime/src/plugins/auto-preload.ts
@@ -1,0 +1,57 @@
+import { FederationRuntimePlugin } from '../type/plugin';
+import { isPureRemoteEntry, isRemoteInfoWithEntry } from '../utils';
+import { PreloadConfig, PreloadOptions } from '../type';
+import { preloadAssets } from '../utils/preload';
+import { getGlobalSnapshot } from '../global';
+
+function autoPreloadPlugin(
+  preloadConfig?: PreloadConfig,
+): FederationRuntimePlugin {
+  return {
+    name: 'auto-preload-plugin',
+    async afterResolve(args) {
+      const { remote, origin, remoteInfo, expose, pkgNameOrAlias } = args;
+
+      if (!isRemoteInfoWithEntry(remote) || !isPureRemoteEntry(remote)) {
+        return args;
+      }
+      const { remoteSnapshot, globalSnapshot } =
+        await origin.snapshotHandler.loadRemoteSnapshotInfo(remote);
+
+      // preloading assets
+      const preloadOptions: PreloadOptions[0] = {
+        remote: remote,
+        preloadConfig: {
+          nameOrAlias: pkgNameOrAlias,
+          exposes: [expose],
+          resourceCategory: 'sync',
+          share: false,
+          depsRemote: false,
+          ...preloadConfig,
+        },
+      };
+      const assets =
+        await origin.remoteHandler.hooks.lifecycle.generatePreloadAssets.emit({
+          origin,
+          preloadOptions,
+          remoteInfo,
+          remote,
+          remoteSnapshot,
+          globalSnapshot: getGlobalSnapshot(),
+        });
+
+      if (assets) {
+        preloadAssets(
+          remoteInfo,
+          origin,
+          assets,
+          Boolean(preloadOptions.preloadConfig.useLinkPreload),
+        );
+      }
+
+      return args;
+    },
+  };
+}
+
+export default autoPreloadPlugin;

--- a/packages/runtime/src/plugins/snapshot/index.ts
+++ b/packages/runtime/src/plugins/snapshot/index.ts
@@ -54,22 +54,6 @@ export function snapshotPlugin(): FederationRuntimePlugin {
           },
         };
 
-        const assets =
-          await origin.remoteHandler.hooks.lifecycle.generatePreloadAssets.emit(
-            {
-              origin,
-              preloadOptions,
-              remoteInfo,
-              remote,
-              remoteSnapshot,
-              globalSnapshot,
-            },
-          );
-
-        if (assets) {
-          preloadAssets(remoteInfo, origin, assets, false);
-        }
-
         return {
           ...args,
           remoteSnapshot,

--- a/packages/runtime/src/plugins/snapshot/index.ts
+++ b/packages/runtime/src/plugins/snapshot/index.ts
@@ -6,8 +6,7 @@ import {
   isPureRemoteEntry,
   isRemoteInfoWithEntry,
 } from '../../utils';
-import { PreloadOptions, RemoteInfo } from '../../type';
-import { preloadAssets } from '../../utils/preload';
+import { RemoteInfo } from '../../type';
 
 export function assignRemoteInfo(
   remoteInfo: RemoteInfo,
@@ -35,24 +34,13 @@ export function snapshotPlugin(): FederationRuntimePlugin {
   return {
     name: 'snapshot-plugin',
     async afterResolve(args) {
-      const { remote, pkgNameOrAlias, expose, origin, remoteInfo } = args;
+      const { remote, origin, remoteInfo } = args;
 
       if (!isRemoteInfoWithEntry(remote) || !isPureRemoteEntry(remote)) {
-        const { remoteSnapshot, globalSnapshot } =
+        const { remoteSnapshot } =
           await origin.snapshotHandler.loadRemoteSnapshotInfo(remote);
 
         assignRemoteInfo(remoteInfo, remoteSnapshot);
-        // preloading assets
-        const preloadOptions: PreloadOptions[0] = {
-          remote,
-          preloadConfig: {
-            nameOrAlias: pkgNameOrAlias,
-            exposes: [expose],
-            resourceCategory: 'sync',
-            share: false,
-            depsRemote: false,
-          },
-        };
 
         return {
           ...args,

--- a/packages/runtime/src/remote/index.ts
+++ b/packages/runtime/src/remote/index.ts
@@ -231,7 +231,12 @@ export class RemoteHandler {
         if (!assets) {
           return;
         }
-        preloadAssets(remoteInfo, host, assets);
+        preloadAssets(
+          remoteInfo,
+          host,
+          assets,
+          Boolean(ops.preloadConfig.useLinkPreload),
+        );
       }),
     );
   }

--- a/packages/runtime/src/remote/index.ts
+++ b/packages/runtime/src/remote/index.ts
@@ -220,7 +220,7 @@ export class RemoteHandler {
       remoteInfo,
       host,
       assets,
-      Boolean(preloadOps.preloadConfig.useLinkPreload),
+      preloadOps.preloadConfig.useLinkPreload,
     );
   }
 

--- a/packages/runtime/src/type/index.ts
+++ b/packages/runtime/src/type/index.ts
@@ -1,3 +1,4 @@
 export * from './config';
 export * from './plugin';
 export * from './preload';
+export type { LoadRemoteMatch } from '../remote';

--- a/packages/runtime/src/type/preload.ts
+++ b/packages/runtime/src/type/preload.ts
@@ -10,6 +10,7 @@ export interface PreloadRemoteArgs {
   depsRemote?: boolean | Array<depsPreloadArg>;
   filter?: (assetUrl: string) => boolean;
   prefetchInterface?: boolean;
+  useLinkPreload?: boolean;
 }
 
 export type PreloadConfig = PreloadRemoteArgs;

--- a/packages/runtime/src/utils/preload.ts
+++ b/packages/runtime/src/utils/preload.ts
@@ -22,6 +22,7 @@ export function defaultPreloadArgs(
     share: true,
     depsRemote: true,
     prefetchInterface: false,
+    useLinkPreload: true,
     ...preloadConfig,
   } as PreloadConfig;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -804,7 +804,7 @@ importers:
     dependencies:
       antd:
         specifier: 4.24.14
-        version: 4.24.14(react-dom@18.3.1)(react@18.3.1)
+        version: 4.24.14(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@module-federation/core':
         specifier: workspace:*
@@ -826,7 +826,7 @@ importers:
     dependencies:
       antd:
         specifier: 4.24.15
-        version: 4.24.15(react-dom@18.3.1)(react@18.3.1)
+        version: 4.24.15(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@module-federation/enhanced':
         specifier: workspace:*
@@ -845,7 +845,7 @@ importers:
     dependencies:
       antd:
         specifier: 4.24.15
-        version: 4.24.15(react-dom@18.3.1)(react@18.3.1)
+        version: 4.24.15(react-dom@18.2.0)(react@18.2.0)
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -867,7 +867,7 @@ importers:
     dependencies:
       antd:
         specifier: 4.24.15
-        version: 4.24.15(react-dom@18.3.1)(react@18.3.1)
+        version: 4.24.15(react-dom@18.2.0)(react@18.2.0)
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -889,7 +889,7 @@ importers:
     dependencies:
       antd:
         specifier: 4.24.15
-        version: 4.24.15(react-dom@18.3.1)(react@18.3.1)
+        version: 4.24.15(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@module-federation/core':
         specifier: workspace:*
@@ -1083,7 +1083,7 @@ importers:
     dependencies:
       '@ant-design/icons':
         specifier: ^5.3.6
-        version: 5.3.7(react-dom@18.3.1)(react@18.3.1)
+        version: 5.3.7(react-dom@18.2.0)(react@18.2.0)
       '@module-federation/bridge-react':
         specifier: workspace:*
         version: link:../../../packages/bridge/bridge-react
@@ -1092,7 +1092,7 @@ importers:
         version: link:../../../packages/enhanced
       react-error-boundary:
         specifier: ^4.0.13
-        version: 4.0.13(react@18.3.1)
+        version: 4.0.13(react@18.2.0)
     devDependencies:
       '@rsbuild/core':
         specifier: ^0.6.15
@@ -1240,10 +1240,10 @@ importers:
     dependencies:
       '@emotion/react':
         specifier: ^11.11.4
-        version: 11.11.4(@types/react@18.2.79)(react@18.3.1)
+        version: 11.11.4(@types/react@18.2.79)(react@18.2.0)
       '@emotion/styled':
         specifier: ^11.11.5
-        version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.2.79)(react@18.3.1)
+        version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.2.79)(react@18.2.0)
       '@module-federation/bridge-react':
         specifier: workspace:*
         version: link:../../../packages/bridge/bridge-react
@@ -1299,7 +1299,7 @@ importers:
     dependencies:
       antd:
         specifier: 4.24.15
-        version: 4.24.15(react-dom@18.3.1)(react@18.3.1)
+        version: 4.24.15(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@module-federation/core':
         specifier: workspace:*
@@ -1327,7 +1327,7 @@ importers:
     dependencies:
       antd:
         specifier: 4.24.15
-        version: 4.24.15(react-dom@18.3.1)(react@18.3.1)
+        version: 4.24.15(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@module-federation/core':
         specifier: workspace:*
@@ -1349,7 +1349,7 @@ importers:
     dependencies:
       antd:
         specifier: 4.24.15
-        version: 4.24.15(react-dom@18.3.1)(react@18.3.1)
+        version: 4.24.15(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@module-federation/core':
         specifier: workspace:*
@@ -1392,7 +1392,7 @@ importers:
     dependencies:
       framer-motion:
         specifier: ^10.0.0
-        version: 10.18.0(react-dom@18.3.1)(react@18.3.1)
+        version: 10.18.0(react-dom@18.2.0)(react@18.2.0)
       rspress:
         specifier: ^1.22.0
         version: 1.25.2(@swc/helpers@0.5.11)(webpack@5.92.1)
@@ -1401,10 +1401,10 @@ importers:
         version: 3.4.4(ts-node@10.9.2)
       video-react:
         specifier: ^0.16.0
-        version: 0.16.0(react-dom@18.3.1)(react@18.3.1)
+        version: 0.16.0(react-dom@18.2.0)(react@18.2.0)
       xgplayer:
         specifier: ^3.0.16
-        version: 3.0.18(core-js@3.37.1)
+        version: 3.0.18(core-js@3.34.0)
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -1968,6 +1968,12 @@ importers:
         specifier: workspace:*
         version: link:../sdk
 
+  packages/runtime-plugins/auto-preload:
+    devDependencies:
+      '@module-federation/runtime':
+        specifier: workspace:*
+        version: link:../../runtime
+
   packages/runtime-tools:
     dependencies:
       '@module-federation/runtime':
@@ -1986,10 +1992,10 @@ importers:
         version: link:../utilities
       '@nx/react':
         specifier: ^17.1.3
-        version: 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(eslint@8.56.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)(webpack@5.89.0)
+        version: 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.89.0)
       '@nx/webpack':
         specifier: ^17.1.3
-        version: 17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(esbuild@0.18.20)(html-webpack-plugin@5.6.0)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)
+        version: 17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(esbuild@0.18.20)(html-webpack-plugin@5.6.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)
       '@storybook/core-common':
         specifier: 7.6.20
         version: 7.6.20(encoding@0.1.13)
@@ -2139,7 +2145,7 @@ packages:
     resolution: {integrity: sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==}
     dev: false
 
-  /@ant-design/icons@4.8.3(react-dom@18.3.1)(react@18.3.1):
+  /@ant-design/icons@4.8.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-HGlIQZzrEbAhpJR6+IGdzfbPym94Owr6JZkJ2QCCnOkPVIWMO2xgIVcOKnl8YcpijIo39V7l2qQL5fmtw56cMw==}
     engines: {node: '>=8'}
     peerDependencies:
@@ -2151,9 +2157,9 @@ packages:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
       lodash: 4.17.21
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@ant-design/icons@5.3.7(react-dom@17.0.2)(react@17.0.2):
@@ -2188,23 +2194,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@ant-design/icons@5.3.7(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-bCPXTAg66f5bdccM4TT21SQBDO1Ek2gho9h3nO9DAKXJP4sq+5VBjrQMSxMVXSB3HyEz+cUbHQ5+6ogxCOpaew==}
-    engines: {node: '>=8'}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-    dependencies:
-      '@ant-design/colors': 7.1.0
-      '@ant-design/icons-svg': 4.4.2
-      '@babel/runtime': 7.24.5
-      classnames: 2.5.0
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    dev: false
-
-  /@ant-design/react-slick@1.0.2(react@18.3.1):
+  /@ant-design/react-slick@1.0.2(react@18.2.0):
     resolution: {integrity: sha512-Wj8onxL/T8KQLFFiCA4t8eIRGpRR+UPgOdac2sYzonv+i0n3kXHmvHLLiOYL655DQx2Umii9Y9nNgL7ssu5haQ==}
     peerDependencies:
       react: '>=16.9.0'
@@ -2212,7 +2202,7 @@ packages:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
       json2mq: 0.2.0
-      react: 18.3.1
+      react: 18.2.0
       resize-observer-polyfill: 1.5.1
       throttle-debounce: 5.0.2
     dev: false
@@ -2593,10 +2583,10 @@ packages:
       '@babel/helpers': 7.24.7
       '@babel/parser': 7.24.7
       '@babel/template': 7.24.7
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
       convert-source-map: 1.9.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.21
@@ -2619,10 +2609,10 @@ packages:
       '@babel/helpers': 7.24.7
       '@babel/parser': 7.24.7
       '@babel/template': 7.24.7
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
       convert-source-map: 2.0.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2643,20 +2633,6 @@ packages:
       semver: 6.3.1
     dev: true
 
-  /@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@9.6.0):
-    resolution: {integrity: sha512-SO5E3bVxDuxyNxM5agFv480YA2HO6ohZbGxbazZdIk3KQOPOGVNw6q78I9/lbviIf95eq6tPozeYnJLbjnC8IA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
-    peerDependencies:
-      '@babel/core': ^7.11.0
-      eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.6.0
-      eslint-visitor-keys: 2.1.0
-      semver: 6.3.1
-    dev: true
-
   /@babel/eslint-plugin@7.24.7(@babel/eslint-parser@7.24.7)(eslint@8.56.0):
     resolution: {integrity: sha512-lODNPJnM+OfcxxBvdmI2YmUeC0fBK3k9yET5O+1Eukr8d5VpO19c6ARtNheE2t2i/8XNYTzp3HeGEAAGZH3nnQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
@@ -2664,7 +2640,7 @@ packages:
       '@babel/eslint-parser': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
     dependencies:
-      '@babel/eslint-parser': 7.24.7(@babel/core@7.24.7)(eslint@9.6.0)
+      '@babel/eslint-parser': 7.24.7(@babel/core@7.24.7)(eslint@8.56.0)
       eslint: 8.56.0
       eslint-rule-composer: 0.3.0
     dev: true
@@ -2688,7 +2664,7 @@ packages:
     resolution: {integrity: sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
@@ -2743,10 +2719,10 @@ packages:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-compilation-targets': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.24.7
-      '@babel/traverse': 7.24.7
-      debug: 4.3.5(supports-color@8.1.1)
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
+      debug: 4.3.5(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
       semver: 6.3.1
@@ -2762,7 +2738,7 @@ packages:
       '@babel/core': 7.24.7
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -2792,7 +2768,7 @@ packages:
     resolution: {integrity: sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
@@ -2804,15 +2780,6 @@ packages:
     dependencies:
       '@babel/types': 7.24.7
     dev: true
-
-  /@babel/helper-module-imports@7.24.7:
-    resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/helper-module-imports@7.24.7(supports-color@5.5.0):
     resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
@@ -2831,7 +2798,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/helper-simple-access': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
@@ -2847,7 +2814,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/helper-simple-access': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
@@ -2901,7 +2868,7 @@ packages:
     resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
@@ -2910,7 +2877,7 @@ packages:
     resolution: {integrity: sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
@@ -2940,7 +2907,7 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.24.7
       '@babel/template': 7.24.7
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
@@ -3465,7 +3432,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.24.7)
     transitivePeerDependencies:
@@ -3960,7 +3927,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.7)
       '@babel/types': 7.24.7
@@ -4007,7 +3974,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.24.7
       babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.7)
       babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.7)
@@ -4313,23 +4280,6 @@ packages:
       '@babel/code-frame': 7.24.7
       '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
-
-  /@babel/traverse@7.24.7:
-    resolution: {integrity: sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-function-name': 7.24.7
-      '@babel/helper-hoist-variables': 7.24.7
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
-      debug: 4.3.5(supports-color@8.1.1)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/traverse@7.24.7(supports-color@5.5.0):
     resolution: {integrity: sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==}
@@ -5062,7 +5012,7 @@ packages:
   /@emotion/babel-plugin@11.11.0:
     resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
     dependencies:
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/runtime': 7.24.5
       '@emotion/hash': 0.9.1
       '@emotion/memoize': 0.8.1
@@ -5116,7 +5066,7 @@ packages:
   /@emotion/memoize@0.8.1:
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
 
-  /@emotion/react@11.11.4(@types/react@18.2.79)(react@18.3.1):
+  /@emotion/react@11.11.4(@types/react@18.2.79)(react@18.2.0):
     resolution: {integrity: sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==}
     peerDependencies:
       '@types/react': '*'
@@ -5129,12 +5079,12 @@ packages:
       '@emotion/babel-plugin': 11.11.0
       '@emotion/cache': 11.11.0
       '@emotion/serialize': 1.1.4
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.3.1)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
       '@emotion/utils': 1.2.1
       '@emotion/weak-memoize': 0.3.1
       '@types/react': 18.2.79
       hoist-non-react-statics: 3.3.2
-      react: 18.3.1
+      react: 18.2.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5153,7 +5103,7 @@ packages:
     resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
     dev: false
 
-  /@emotion/styled@11.11.5(@emotion/react@11.11.4)(@types/react@18.2.79)(react@18.3.1):
+  /@emotion/styled@11.11.5(@emotion/react@11.11.4)(@types/react@18.2.79)(react@18.2.0):
     resolution: {integrity: sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==}
     peerDependencies:
       '@emotion/react': ^11.0.0-rc.0
@@ -5166,12 +5116,12 @@ packages:
       '@babel/runtime': 7.24.5
       '@emotion/babel-plugin': 11.11.0
       '@emotion/is-prop-valid': 1.2.2
-      '@emotion/react': 11.11.4(@types/react@18.2.79)(react@18.3.1)
+      '@emotion/react': 11.11.4(@types/react@18.2.79)(react@18.2.0)
       '@emotion/serialize': 1.1.4
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.3.1)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
       '@emotion/utils': 1.2.1
       '@types/react': 18.2.79
-      react: 18.3.1
+      react: 18.2.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5191,15 +5141,6 @@ packages:
       react: '>=16.8.0'
     dependencies:
       react: 18.2.0
-    dev: true
-
-  /@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.3.1):
-    resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
-    peerDependencies:
-      react: '>=16.8.0'
-    dependencies:
-      react: 18.3.1
-    dev: false
 
   /@emotion/utils@1.2.1:
     resolution: {integrity: sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==}
@@ -6393,30 +6334,9 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@9.6.0):
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 9.6.0
-      eslint-visitor-keys: 3.4.3
-    dev: true
-
   /@eslint-community/regexpp@4.11.0:
     resolution: {integrity: sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
-
-  /@eslint/config-array@0.17.0:
-    resolution: {integrity: sha512-A68TBu6/1mHHuc5YJL0U0VVeGNiklLAL6rRmhTCP2B5XjWLMnrX+HkO+IAXyHvks5cyyY1jjK5ITPQ1HGS2EVA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dependencies:
-      '@eslint/object-schema': 2.1.4
-      debug: 4.3.5(supports-color@8.1.1)
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@eslint/eslintrc@2.1.4:
@@ -6424,26 +6344,9 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
-      ignore: 5.3.1
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@eslint/eslintrc@3.1.0:
-    resolution: {integrity: sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.5(supports-color@8.1.1)
-      espree: 10.1.0
-      globals: 14.0.0
       ignore: 5.3.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -6456,16 +6359,6 @@ packages:
   /@eslint/js@8.56.0:
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /@eslint/js@9.6.0:
-    resolution: {integrity: sha512-D9B0/3vNg44ZeWbYMpBoXqNP4j6eQD5vNwIlGAuFRRzK/WtT/jvDQW3Bi9kkf3PMDMlM7Yi+73VLUsn5bJcl8A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: true
-
-  /@eslint/object-schema@2.1.4:
-    resolution: {integrity: sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
   /@fal-works/esbuild-plugin-global-externals@2.1.2:
@@ -6579,7 +6472,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -6593,11 +6486,6 @@ packages:
   /@humanwhocodes/object-schema@2.0.3:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
-    dev: true
-
-  /@humanwhocodes/retry@0.3.0:
-    resolution: {integrity: sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==}
-    engines: {node: '>=18.18'}
     dev: true
 
   /@hyrious/esbuild-plugin-commonjs@0.2.4(cjs-module-lexer@1.3.1)(esbuild@0.18.20):
@@ -7419,12 +7307,12 @@ packages:
       typescript: ^4 || ^5
     dependencies:
       '@babel/core': 7.24.7
-      '@babel/eslint-parser': 7.24.7(@babel/core@7.24.7)(eslint@9.6.0)
+      '@babel/eslint-parser': 7.24.7(@babel/core@7.24.7)(eslint@8.56.0)
       '@babel/eslint-plugin': 7.24.7(@babel/eslint-parser@7.24.7)(eslint@8.56.0)
       '@rsbuild/babel-preset': 0.7.10(@rsbuild/core@0.7.10)(@swc/helpers@0.5.3)
       '@rsbuild/core': 0.7.10
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.0.4)
-      '@typescript-eslint/parser': 5.62.0(eslint@9.6.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.0.4)
       eslint: 8.56.0
       eslint-config-prettier: 8.10.0(eslint@8.56.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.56.0)
@@ -7519,7 +7407,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/parser': 7.24.7
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
       '@modern-js/core': 2.46.1
       '@modern-js/new-action': 2.46.1(typescript@5.0.4)
@@ -7579,7 +7467,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/parser': 7.24.7
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
       '@modern-js/core': 2.54.6
       '@modern-js/node-bundle-require': 2.54.6
@@ -7685,7 +7573,7 @@ packages:
       '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
       '@modern-js/prod-server': 2.46.1(@types/express@4.17.21)(react-dom@18.2.0)(react@18.2.0)
-      '@modern-js/server': 2.46.1(@rsbuild/core@0.3.11)(@types/express@4.17.21)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.2)
+      '@modern-js/server': 2.46.1(@babel/traverse@7.24.7)(@rsbuild/core@0.3.11)(@types/express@4.17.21)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.2)
       '@modern-js/types': 2.46.1
       '@modern-js/utils': 2.46.1
       '@swc/helpers': 0.5.3
@@ -7735,7 +7623,7 @@ packages:
       '@babel/preset-react': 7.24.7(@babel/core@7.24.7)
       '@modern-js/builder-shared': 2.46.1(@rsbuild/core@0.3.11)(@swc/core@1.6.13)(@types/express@4.17.21)(esbuild@0.18.20)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.2)(typescript@5.0.4)
       '@modern-js/inspector-webpack-plugin': 1.0.6
-      '@modern-js/server': 2.46.1(@rsbuild/core@0.3.11)(@types/express@4.17.21)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.2)
+      '@modern-js/server': 2.46.1(@babel/traverse@7.24.7)(@rsbuild/core@0.3.11)(@types/express@4.17.21)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.2)
       '@modern-js/types': 2.46.1
       '@modern-js/utils': 2.46.1
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.14.2)(webpack@5.92.1)
@@ -8346,26 +8234,6 @@ packages:
       - supports-color
     dev: true
 
-  /@modern-js/server-utils@2.46.1(@rsbuild/core@0.3.11):
-    resolution: {integrity: sha512-Wo+g6q55A2UUTMwbbYUWkGey/H/1yE8mI4awdZ7GKMxemYKXlrvbGax0adiRrbB0R8NPjCSiB3Pq3t9aY2Ejuw==}
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.24.7)
-      '@babel/preset-env': 7.24.7(@babel/core@7.24.7)
-      '@babel/preset-react': 7.24.7(@babel/core@7.24.7)
-      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.7)
-      '@modern-js/babel-compiler': 2.46.1
-      '@modern-js/babel-plugin-module-resolver': 2.46.1
-      '@modern-js/utils': 2.46.1
-      '@rsbuild/babel-preset': 0.3.4(@rsbuild/core@0.3.11)(@swc/helpers@0.5.3)
-      '@swc/helpers': 0.5.3
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.24.7)(@babel/traverse@7.24.7)
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@rsbuild/core'
-      - supports-color
-    dev: true
-
   /@modern-js/server-utils@2.54.6(@babel/traverse@7.24.7)(@rsbuild/core@0.7.10):
     resolution: {integrity: sha512-OnVZkUPDJINDyfVAZfP2zZ+T/LTqw564xyc6aLGUOqQLRqHlLCLr+v4ogS0GcB+K+3VnR/au+LEKk9PG+e6ToA==}
     dependencies:
@@ -8446,47 +8314,6 @@ packages:
       '@modern-js/prod-server': 2.46.1(@types/express@4.17.21)(react-dom@18.2.0)(react@18.2.0)
       '@modern-js/runtime-utils': 2.46.1(react-dom@18.2.0)(react@18.2.0)
       '@modern-js/server-utils': 2.46.1(@babel/traverse@7.24.7)(@rsbuild/core@0.3.4)
-      '@modern-js/types': 2.46.1
-      '@modern-js/utils': 2.46.1
-      '@swc/helpers': 0.5.3
-      axios: 1.7.2
-      connect-history-api-fallback: 2.0.0
-      http-compression: 1.0.6
-      minimatch: 3.1.2
-      path-to-regexp: 6.2.2
-      ts-node: 10.9.2(@swc/core@1.6.13)(@types/node@20.12.12)(typescript@5.5.2)
-      ws: 8.17.1
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@rsbuild/core'
-      - '@types/express'
-      - bufferutil
-      - debug
-      - react
-      - react-dom
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@modern-js/server@2.46.1(@rsbuild/core@0.3.11)(@types/express@4.17.21)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.2):
-    resolution: {integrity: sha512-7n9LuQ7gJ9PdS1/YC7IjApZBNiqvQ+bsHKgeB7yvUYk0/FSL5GU/oqyOqMddMx05tQXuTdQRAabB26yGbV+jBg==}
-    peerDependencies:
-      devcert: ^1.2.2
-      ts-node: ^10.1.0
-      tsconfig-paths: '>= 3.0.0 || >= 4.0.0'
-    peerDependenciesMeta:
-      devcert:
-        optional: true
-      ts-node:
-        optional: true
-      tsconfig-paths:
-        optional: true
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/register': 7.24.6(@babel/core@7.24.7)
-      '@modern-js/prod-server': 2.46.1(@types/express@4.17.21)(react-dom@18.2.0)(react@18.2.0)
-      '@modern-js/runtime-utils': 2.46.1(react-dom@18.2.0)(react@18.2.0)
-      '@modern-js/server-utils': 2.46.1(@rsbuild/core@0.3.11)
       '@modern-js/types': 2.46.1
       '@modern-js/utils': 2.46.1
       '@swc/helpers': 0.5.3
@@ -9035,7 +8862,7 @@ packages:
       '@open-draft/until': 1.0.3
       '@types/debug': 4.1.12
       '@xmldom/xmldom': 0.8.10
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       headers-polyfill: 3.2.5
       outvariant: 1.4.3
       strict-event-emitter: 0.2.8
@@ -9185,14 +9012,6 @@ packages:
       - nx
     dev: true
 
-  /@nrwl/devkit@17.2.8(nx@18.3.5):
-    resolution: {integrity: sha512-l2dFy5LkWqSA45s6pee6CoqJeluH+sjRdVnAAQfjLHRNSx6mFAKblyzq5h1f4P0EUCVVVqLs+kVqmNx5zxYqvw==}
-    dependencies:
-      '@nx/devkit': 17.2.8(nx@18.3.5)
-    transitivePeerDependencies:
-      - nx
-    dev: true
-
   /@nrwl/devkit@17.3.2(nx@17.2.8):
     resolution: {integrity: sha512-31wh7dDZPM1YUCfhhk/ioHnUeoPIlKYLFLW0fGdw76Ow2nmTqrmxha2m0CSIR1/9En9GpYut2IdUdNh9CctNlA==}
     dependencies:
@@ -9332,40 +9151,6 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/js@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.2.2)(verdaccio@5.29.2):
-    resolution: {integrity: sha512-ZfTGNSmSBqvEfP8NOfOHcnqKwhXsfqBrN4IhthQR02sqTA9GkrjSfSUtcGXY01fUitsNUDOn6RZjgX6UysDCXg==}
-    dependencies:
-      '@nx/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.2.2)(verdaccio@5.29.2)
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - debug
-      - nx
-      - supports-color
-      - typescript
-      - verdaccio
-    dev: true
-
-  /@nrwl/js@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2):
-    resolution: {integrity: sha512-ZfTGNSmSBqvEfP8NOfOHcnqKwhXsfqBrN4IhthQR02sqTA9GkrjSfSUtcGXY01fUitsNUDOn6RZjgX6UysDCXg==}
-    dependencies:
-      '@nx/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - debug
-      - nx
-      - supports-color
-      - typescript
-      - verdaccio
-    dev: true
-
   /@nrwl/js@17.3.2(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(nx@17.2.8)(typescript@5.3.3)(verdaccio@5.29.2):
     resolution: {integrity: sha512-WuIeSErulJuMeSpeK41RfiWI3jLjDD0S+tLnYdOLaWdjaIPqjknClM2BAJKlq472NnkkNWvtwtOS8jm518OjOQ==}
     dependencies:
@@ -9487,10 +9272,10 @@ packages:
       - debug
     dev: true
 
-  /@nrwl/react@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.92.1):
+  /@nrwl/react@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.89.0):
     resolution: {integrity: sha512-fj5Qf3B3Nok8T8lF9DpYEeP7DWqP7KF/jBO6h4eniTifh5BRjEq5PaRIhMiVMdepqQiWMPd2tsZyf9nx1qzY6w==}
     dependencies:
-      '@nx/react': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.92.1)
+      '@nx/react': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.89.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -9507,10 +9292,10 @@ packages:
       - webpack
     dev: true
 
-  /@nrwl/react@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(eslint@8.56.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)(webpack@5.89.0):
+  /@nrwl/react@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.92.1):
     resolution: {integrity: sha512-fj5Qf3B3Nok8T8lF9DpYEeP7DWqP7KF/jBO6h4eniTifh5BRjEq5PaRIhMiVMdepqQiWMPd2tsZyf9nx1qzY6w==}
     dependencies:
-      '@nx/react': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(eslint@8.56.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)(webpack@5.89.0)
+      '@nx/react': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.92.1)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -9617,18 +9402,6 @@ packages:
       - debug
     dev: true
 
-  /@nrwl/tao@18.3.5(@swc-node/register@1.6.8)(@swc/core@1.6.13):
-    resolution: {integrity: sha512-gB7Vxa6FReZZEGva03Eh+84W8BSZOjsNyXboglOINu6d8iZZ0eotSXGziKgjpkj3feZ1ofKZMs0PRObVAOROVw==}
-    hasBin: true
-    dependencies:
-      nx: 18.3.5(@swc-node/register@1.6.8)(@swc/core@1.6.13)
-      tslib: 2.6.3
-    transitivePeerDependencies:
-      - '@swc-node/register'
-      - '@swc/core'
-      - debug
-    dev: true
-
   /@nrwl/tao@19.2.3(@swc-node/register@1.6.8)(@swc/core@1.6.13):
     resolution: {integrity: sha512-vwo6ogcy6A9vJggDOsHGi1F0cTRqSqRypbgq/EdNuZqL7rGyZB/ctId69/i8dV6cLkl8BJG/4WpEe5BIrMTsjA==}
     hasBin: true
@@ -9689,27 +9462,10 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/web@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2):
-    resolution: {integrity: sha512-oBiuSQ7Q6hOXHuZW5Gf8m0gcrLTV78jxhSjmhC5F6yzgvBvnfMpCdrJn7W1G+O+kEg3byko8v+Rz39tfc8YPjg==}
-    dependencies:
-      '@nx/web': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - debug
-      - nx
-      - supports-color
-      - typescript
-      - verdaccio
-    dev: true
-
-  /@nrwl/webpack@17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(esbuild@0.23.0)(html-webpack-plugin@5.6.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2):
+  /@nrwl/webpack@17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(esbuild@0.18.20)(html-webpack-plugin@5.6.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2):
     resolution: {integrity: sha512-HcwdfjXVz1NrZZnx1Fv48vleOTlsDAgTRHnQL02xYWT6ElhuKRQsqJGvDduQIFAp4KrnEEhEKEx6oDAEZKUkDg==}
     dependencies:
-      '@nx/webpack': 17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(esbuild@0.23.0)(html-webpack-plugin@5.6.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)
+      '@nx/webpack': 17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(esbuild@0.18.20)(html-webpack-plugin@5.6.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@parcel/css'
@@ -9739,10 +9495,10 @@ packages:
       - webpack-cli
     dev: true
 
-  /@nrwl/webpack@17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(esbuild@0.18.20)(html-webpack-plugin@5.6.0)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2):
+  /@nrwl/webpack@17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(esbuild@0.23.0)(html-webpack-plugin@5.6.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2):
     resolution: {integrity: sha512-HcwdfjXVz1NrZZnx1Fv48vleOTlsDAgTRHnQL02xYWT6ElhuKRQsqJGvDduQIFAp4KrnEEhEKEx6oDAEZKUkDg==}
     dependencies:
-      '@nx/webpack': 17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(esbuild@0.18.20)(html-webpack-plugin@5.6.0)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)
+      '@nx/webpack': 17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(esbuild@0.23.0)(html-webpack-plugin@5.6.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@parcel/css'
@@ -9854,21 +9610,6 @@ packages:
       enquirer: 2.3.6
       ignore: 5.3.1
       nx: 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)
-      semver: 7.5.3
-      tmp: 0.2.3
-      tslib: 2.6.3
-    dev: true
-
-  /@nx/devkit@17.2.8(nx@18.3.5):
-    resolution: {integrity: sha512-6LtiQihtZwqz4hSrtT5cCG5XMCWppG6/B8c1kNksg97JuomELlWyUyVF+sxmeERkcLYFaKPTZytP0L3dmCFXaw==}
-    peerDependencies:
-      nx: '>= 16 <= 18'
-    dependencies:
-      '@nrwl/devkit': 17.2.8(nx@18.3.5)
-      ejs: 3.1.10
-      enquirer: 2.3.6
-      ignore: 5.3.1
-      nx: 18.3.5(@swc-node/register@1.6.8)(@swc/core@1.6.13)
       semver: 7.5.3
       tmp: 0.2.3
       tslib: 2.6.3
@@ -10053,36 +9794,6 @@ packages:
       '@nx/devkit': 17.2.8(nx@17.2.8)
       '@nx/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(nx@17.2.8)(typescript@5.2.2)(verdaccio@5.29.2)
       '@nx/linter': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(verdaccio@5.29.2)
-      eslint: 8.56.0
-      js-yaml: 4.1.0
-      tslib: 2.6.3
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - debug
-      - nx
-      - supports-color
-      - verdaccio
-    dev: true
-
-  /@nx/eslint@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(eslint@8.56.0)(js-yaml@4.1.0)(nx@18.3.5)(verdaccio@5.29.2):
-    resolution: {integrity: sha512-P6s85cIK7LYHixCJFZ+tLCPDxeOt9m2bQQOLxBCLEy5mqaGmjMHzWkLaoQBueCSntE6PSao0MMA+1TeeZjOoDw==}
-    peerDependencies:
-      eslint: ^8.0.0
-      js-yaml: 4.1.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      js-yaml:
-        optional: true
-    dependencies:
-      '@nx/devkit': 17.2.8(nx@18.3.5)
-      '@nx/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.2.2)(verdaccio@5.29.2)
-      '@nx/linter': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(eslint@8.56.0)(js-yaml@4.1.0)(nx@18.3.5)(verdaccio@5.29.2)
       eslint: 8.56.0
       js-yaml: 4.1.0
       tslib: 2.6.3
@@ -10347,108 +10058,6 @@ packages:
       - typescript
     dev: true
 
-  /@nx/js@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.2.2)(verdaccio@5.29.2):
-    resolution: {integrity: sha512-M91tw9tfSnkoC8pZaC9wNxrgaFU4MeQcgdT08ievaroo77kH4RheySsU1uNc0J58Jk4X4315wu/X7Bf/35m0Mw==}
-    peerDependencies:
-      verdaccio: ^5.0.4
-    peerDependenciesMeta:
-      verdaccio:
-        optional: true
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-runtime': 7.24.7(@babel/core@7.24.7)
-      '@babel/preset-env': 7.24.7(@babel/core@7.24.7)
-      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.7)
-      '@babel/runtime': 7.24.5
-      '@nrwl/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.2.2)(verdaccio@5.29.2)
-      '@nx/devkit': 17.2.8(nx@18.3.5)
-      '@nx/workspace': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)
-      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.2.2)
-      babel-plugin-const-enum: 1.2.0(@babel/core@7.24.7)
-      babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.24.7)(@babel/traverse@7.24.7)
-      chalk: 4.1.2
-      columnify: 1.6.0
-      detect-port: 1.6.1
-      fast-glob: 3.2.7
-      fs-extra: 11.2.0
-      ignore: 5.3.1
-      js-tokens: 4.0.0
-      minimatch: 3.0.5
-      npm-package-arg: 11.0.1
-      npm-run-path: 4.0.1
-      ora: 5.3.0
-      semver: 7.5.3
-      source-map-support: 0.5.19
-      ts-node: 10.9.1(@swc/core@1.6.13)(@types/node@20.14.10)(typescript@5.2.2)
-      tsconfig-paths: 4.2.0
-      tslib: 2.6.3
-      verdaccio: 5.29.2(encoding@0.1.13)(typanion@3.14.0)
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - debug
-      - nx
-      - supports-color
-      - typescript
-    dev: true
-
-  /@nx/js@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2):
-    resolution: {integrity: sha512-M91tw9tfSnkoC8pZaC9wNxrgaFU4MeQcgdT08ievaroo77kH4RheySsU1uNc0J58Jk4X4315wu/X7Bf/35m0Mw==}
-    peerDependencies:
-      verdaccio: ^5.0.4
-    peerDependenciesMeta:
-      verdaccio:
-        optional: true
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-runtime': 7.24.7(@babel/core@7.24.7)
-      '@babel/preset-env': 7.24.7(@babel/core@7.24.7)
-      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.7)
-      '@babel/runtime': 7.24.5
-      '@nrwl/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)
-      '@nx/devkit': 17.2.8(nx@18.3.5)
-      '@nx/workspace': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)
-      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.5.3)
-      babel-plugin-const-enum: 1.2.0(@babel/core@7.24.7)
-      babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.24.7)(@babel/traverse@7.24.7)
-      chalk: 4.1.2
-      columnify: 1.6.0
-      detect-port: 1.6.1
-      fast-glob: 3.2.7
-      fs-extra: 11.2.0
-      ignore: 5.3.1
-      js-tokens: 4.0.0
-      minimatch: 3.0.5
-      npm-package-arg: 11.0.1
-      npm-run-path: 4.0.1
-      ora: 5.3.0
-      semver: 7.5.3
-      source-map-support: 0.5.19
-      ts-node: 10.9.1(@swc/core@1.6.13)(@types/node@20.14.10)(typescript@5.5.3)
-      tsconfig-paths: 4.2.0
-      tslib: 2.6.3
-      verdaccio: 5.29.2(encoding@0.1.13)(typanion@3.14.0)
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - debug
-      - nx
-      - supports-color
-      - typescript
-    dev: true
-
   /@nx/js@17.3.2(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(nx@17.2.8)(typescript@5.3.3)(verdaccio@5.29.2):
     resolution: {integrity: sha512-37E3OILyu/7rCj6Z7tvC6PktHYa51UQBU+wWPdVWSZ64xu1SUsg9B9dfiyD1LXR9/rhjg4+0+g4cou0aqDK1Wg==}
     peerDependencies:
@@ -10668,24 +10277,6 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/linter@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(eslint@8.56.0)(js-yaml@4.1.0)(nx@18.3.5)(verdaccio@5.29.2):
-    resolution: {integrity: sha512-dwqE742TIw1+/djzlikKakIfComq8nFnhupWjvl7KrU9r8ytcKyQbxHw7KGMUT9HAEG4xSNuwiaELr/8w4MM2Q==}
-    dependencies:
-      '@nx/eslint': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(eslint@8.56.0)(js-yaml@4.1.0)(nx@18.3.5)(verdaccio@5.29.2)
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - debug
-      - eslint
-      - js-yaml
-      - nx
-      - supports-color
-      - verdaccio
-    dev: true
-
   /@nx/linter@17.3.2(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(js-yaml@4.1.0)(nx@17.2.8)(verdaccio@5.29.2):
     resolution: {integrity: sha512-ruB72ODekAlqGI65IeO37vqgJIY+ROcx2Gyf12H3tZGUYeC1IwpPltbU63vD5Qkgj2znrD6aNkpYPV7C0b0scQ==}
     dependencies:
@@ -10825,15 +10416,6 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-darwin-arm64@18.3.5:
-    resolution: {integrity: sha512-4I5UpZ/x2WO9OQyETXKjaYhXiZKUTYcLPewruRMODWu6lgTM9hHci0SqMQB+TWe3f80K8VT8J8x3+uJjvllGlg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@nx/nx-darwin-arm64@19.2.3:
     resolution: {integrity: sha512-1beJscdMraGgLHpvjyC5FXUzpdQYW8JwnPK0Yj9iti9Vnahtx3PLQHCFOFwoE0KZF9VEL1KsZSSVPljMgW/j+g==}
     engines: {node: '>= 10'}
@@ -10863,15 +10445,6 @@ packages:
 
   /@nx/nx-darwin-x64@17.3.2:
     resolution: {integrity: sha512-5F28wrfE7yU60MzEXGjndy1sPJmNMIaV2W/g82kTXzxAbGHgSjwrGFmrJsrexzLp9oDlWkbc6YmInKV8gmmIaQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nx/nx-darwin-x64@18.3.5:
-    resolution: {integrity: sha512-Drn6jOG237AD/s6OWPt06bsMj0coGKA5Ce1y5gfLhptOGk4S4UPE/Ay5YCjq+/yhTo1gDHzCHxH0uW2X9MN9Fg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -10915,15 +10488,6 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-freebsd-x64@18.3.5:
-    resolution: {integrity: sha512-8tA8Yw0Iir4liFjffIFS5THTS3TtWY/No2tkVj91gwy/QQ/otvKbOyc5RCIPpbZU6GS3ZWfG92VyCSm06dtMFg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@nx/nx-freebsd-x64@19.2.3:
     resolution: {integrity: sha512-ytY18USCyf83wqyUgFaeRO/3zvysJXPJf1Di8czBhiUSroSMB6088OaeqW7SnzdcYNdACZUv0Q6PupXpx3w2Ng==}
     engines: {node: '>= 10'}
@@ -10953,15 +10517,6 @@ packages:
 
   /@nx/nx-linux-arm-gnueabihf@17.3.2:
     resolution: {integrity: sha512-gQxMF6U/h18Rz+FZu50DZCtfOdk27hHghNh3d3YTeVsrJTd1SmUQbYublmwU/ia1HhFS8RVI8GvkaKt5ph0HoA==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nx/nx-linux-arm-gnueabihf@18.3.5:
-    resolution: {integrity: sha512-BrPGAHM9FCGkB9/hbvlJhe+qtjmvpjIjYixGIlUxL3gGc8E/ucTyCnz5pRFFPFQlBM7Z/9XmbHvGPoUi/LYn5A==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -11005,15 +10560,6 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-linux-arm64-gnu@18.3.5:
-    resolution: {integrity: sha512-/Xd0Q3LBgJeigJqXC/Jck/9l5b+fK+FCM0nRFMXgPXrhZPhoxWouFkoYl2F1Ofr+AQf4jup4DkVTB5r98uxSCA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@nx/nx-linux-arm64-gnu@19.2.3:
     resolution: {integrity: sha512-VOuzPD5FBPZmctvXqdB9K1MYVzkV8TgOZFS7Md6ClH7UwJTEOjnMoomYCMM1VlOZV4P0S5E0u/Zere5YWh+ZWw==}
     engines: {node: '>= 10'}
@@ -11043,15 +10589,6 @@ packages:
 
   /@nx/nx-linux-arm64-musl@17.3.2:
     resolution: {integrity: sha512-yko3Xsezkn4tjeudZYLjxFl07X/YB84K+DLK7EFyh9elRWV/8VjFcQmBAKUS2r9LfaEMNXq8/vhWMOWYyWBrIA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nx/nx-linux-arm64-musl@18.3.5:
-    resolution: {integrity: sha512-r18qd7pUrl1haAZ/e9Q+xaFTsLJnxGARQcf/Y76q+K2psKmiUXoRlqd3HAOw43KTllaUJ5HkzLq2pIwg3p+xBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -11095,15 +10632,6 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-linux-x64-gnu@18.3.5:
-    resolution: {integrity: sha512-vYrikG6ff4I9cvr3Ysk3y3gjQ9cDcvr3iAr+4qqcQ4qVE+OLL2++JDS6xfPvG/TbS3GTQpyy2STRBwiHgxTeJw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@nx/nx-linux-x64-gnu@19.2.3:
     resolution: {integrity: sha512-wE08BstTD65dt6c+9L9bEp98PxFwc7CuaUVX2cZTDFAERBXCMhu7y6Gb1JbiAvfVci4+yLrm+h0E1ieY1wMTXw==}
     engines: {node: '>= 10'}
@@ -11133,15 +10661,6 @@ packages:
 
   /@nx/nx-linux-x64-musl@17.3.2:
     resolution: {integrity: sha512-PWfVGmFsFJi+N1Nljg/jTKLHdufpGuHlxyfHqhDso/o4Qc0exZKSeZ1C63WkD7eTcT5kInifTQ/PffLiIDE3MA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nx/nx-linux-x64-musl@18.3.5:
-    resolution: {integrity: sha512-6np86lcYy3+x6kkW/HrBHIdNWbUu/MIsvMuNH5UXgyFs60l5Z7Cocay2f7WOaAbTLVAr0W7p4RxRPamHLRwWFA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -11185,15 +10704,6 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-win32-arm64-msvc@18.3.5:
-    resolution: {integrity: sha512-H3p2ZVhHV1WQWTICrQUTplOkNId0y3c23X3A2fXXFDbWSBs0UgW7m55LhMcA9p0XZ7wDHgh+yFtVgu55TXLjug==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@nx/nx-win32-arm64-msvc@19.2.3:
     resolution: {integrity: sha512-fkbcTp+XuxGaL5e4Ve8AjxNEim5Ifdn61ofaxEDMoGjauKvKZBejbLhBFOonCKDqntXsY8D2nDXjhcsdNYxzMg==}
     engines: {node: '>= 10'}
@@ -11230,15 +10740,6 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-win32-x64-msvc@18.3.5:
-    resolution: {integrity: sha512-xFwKVTIXSgjdfxkpriqHv5NpmmFILTrWLEkUGSoimuRaAm1u15YWx/VmaUQ+UWuJnmgqvB/so4SMHSfNkq3ijA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@nx/nx-win32-x64-msvc@19.2.3:
     resolution: {integrity: sha512-E2q3c504xjFXTY+/iq57DOZmS6CPA8RbFwLf6bCG5wo2BDajxmvU3VCeCSkxqXEwCY7NJSI3PT1V/3vRDzJ3lQ==}
     engines: {node: '>= 10'}
@@ -11257,10 +10758,10 @@ packages:
     dev: true
     optional: true
 
-  /@nx/react@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.92.1):
+  /@nx/react@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.89.0):
     resolution: {integrity: sha512-iJcpKi+Bzi9JZtgZmhQ2QWkt3PxOppYVah/EV9B6m9wOFhNI7IQYOp4NY8BruGZYRhkSsz59ZWZVu9iJSSrayg==}
     dependencies:
-      '@nrwl/react': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.92.1)
+      '@nrwl/react': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.89.0)
       '@nx/devkit': 17.2.8(nx@17.2.8)
       '@nx/eslint': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(verdaccio@5.29.2)
       '@nx/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)
@@ -11268,7 +10769,7 @@ packages:
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.5.2)
       '@svgr/webpack': 8.1.0(typescript@5.5.2)
       chalk: 4.1.2
-      file-loader: 6.2.0(webpack@5.92.1)
+      file-loader: 6.2.0(webpack@5.89.0)
       minimatch: 3.0.5
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -11287,18 +10788,18 @@ packages:
       - webpack
     dev: true
 
-  /@nx/react@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(eslint@8.56.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)(webpack@5.89.0):
+  /@nx/react@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.92.1):
     resolution: {integrity: sha512-iJcpKi+Bzi9JZtgZmhQ2QWkt3PxOppYVah/EV9B6m9wOFhNI7IQYOp4NY8BruGZYRhkSsz59ZWZVu9iJSSrayg==}
     dependencies:
-      '@nrwl/react': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(eslint@8.56.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)(webpack@5.89.0)
-      '@nx/devkit': 17.2.8(nx@18.3.5)
-      '@nx/eslint': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(eslint@8.56.0)(js-yaml@4.1.0)(nx@18.3.5)(verdaccio@5.29.2)
-      '@nx/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)
-      '@nx/web': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)
-      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.5.3)
-      '@svgr/webpack': 8.1.0(typescript@5.5.3)
+      '@nrwl/react': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)(webpack@5.92.1)
+      '@nx/devkit': 17.2.8(nx@17.2.8)
+      '@nx/eslint': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(eslint@8.56.0)(js-yaml@4.1.0)(nx@17.2.8)(verdaccio@5.29.2)
+      '@nx/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)
+      '@nx/web': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)
+      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.5.2)
+      '@svgr/webpack': 8.1.0(typescript@5.5.2)
       chalk: 4.1.2
-      file-loader: 6.2.0(webpack@5.89.0)
+      file-loader: 6.2.0(webpack@5.92.1)
       minimatch: 3.0.5
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -11475,27 +10976,72 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/web@17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2):
-    resolution: {integrity: sha512-ovPvFVJOiB/ZmOxnCOOyT+ibbdgazXjpa4506hLJxRohDZQw/6jwbCWkTBy/ch6Y8NSN6uNUpB5XUdscfrp52A==}
+  /@nx/webpack@17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(esbuild@0.18.20)(html-webpack-plugin@5.6.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2):
+    resolution: {integrity: sha512-Gud9Z+VO0dlLpVEJLfPxkEV5wG+ebZ1mv0S0cfTBdD24Fj4MAs0W8QWhRQBtLd2SayU9KMfJr+8gJjkNT6D3Kw==}
     dependencies:
-      '@nrwl/web': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)
-      '@nx/devkit': 17.2.8(nx@18.3.5)
-      '@nx/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)
+      '@babel/core': 7.24.7
+      '@nrwl/webpack': 17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(esbuild@0.18.20)(html-webpack-plugin@5.6.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)
+      '@nx/devkit': 17.2.8(nx@17.2.8)
+      '@nx/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2)
+      autoprefixer: 10.4.17(postcss@8.4.39)
+      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1)
+      browserslist: 4.23.1
       chalk: 4.1.2
-      detect-port: 1.6.1
-      http-server: 14.1.1
-      tslib: 2.6.3
+      copy-webpack-plugin: 10.2.4(webpack@5.92.1)
+      css-loader: 6.11.0(@rspack/core@0.5.9)(webpack@5.92.1)
+      css-minimizer-webpack-plugin: 5.0.1(esbuild@0.18.20)(webpack@5.92.1)
+      fork-ts-checker-webpack-plugin: 7.2.13(typescript@5.5.2)(webpack@5.92.1)
+      less: 4.1.3
+      less-loader: 11.1.0(less@4.1.3)(webpack@5.92.1)
+      license-webpack-plugin: 4.0.2(webpack@5.92.1)
+      loader-utils: 2.0.4
+      mini-css-extract-plugin: 2.4.7(webpack@5.92.1)
+      parse5: 4.0.0
+      postcss: 8.4.39
+      postcss-import: 14.1.0(postcss@8.4.39)
+      postcss-loader: 6.2.1(postcss@8.4.39)(webpack@5.92.1)
+      rxjs: 7.8.1
+      sass: 1.77.6
+      sass-loader: 12.6.0(sass@1.77.6)(webpack@5.92.1)
+      source-map-loader: 3.0.2(webpack@5.92.1)
+      style-loader: 3.3.4(webpack@5.92.1)
+      stylus: 0.59.0
+      stylus-loader: 7.1.3(stylus@0.59.0)(webpack@5.92.1)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.6.13)(esbuild@0.18.20)(webpack@5.92.1)
+      ts-loader: 9.5.1(typescript@5.5.2)(webpack@5.92.1)
+      tsconfig-paths-webpack-plugin: 4.0.0
+      tslib: 2.6.2
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.18.20)
+      webpack-dev-server: 4.15.2(webpack@5.92.1)
+      webpack-node-externals: 3.0.0
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.0)(webpack@5.92.1)
     transitivePeerDependencies:
       - '@babel/traverse'
+      - '@parcel/css'
+      - '@rspack/core'
       - '@swc-node/register'
       - '@swc/core'
+      - '@swc/css'
       - '@swc/wasm'
       - '@types/node'
+      - bufferutil
+      - clean-css
+      - csso
       - debug
+      - esbuild
+      - fibers
+      - html-webpack-plugin
+      - lightningcss
+      - node-sass
       - nx
+      - sass-embedded
       - supports-color
       - typescript
+      - uglify-js
+      - utf-8-validate
       - verdaccio
+      - vue-template-compiler
+      - webpack-cli
     dev: true
 
   /@nx/webpack@17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.12.12)(esbuild@0.23.0)(html-webpack-plugin@5.6.0)(nx@17.2.8)(typescript@5.5.2)(verdaccio@5.29.2):
@@ -11534,74 +11080,6 @@ packages:
       tsconfig-paths-webpack-plugin: 4.0.0
       tslib: 2.6.2
       webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.23.0)
-      webpack-dev-server: 4.15.2(webpack@5.92.1)
-      webpack-node-externals: 3.0.0
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.0)(webpack@5.92.1)
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/wasm'
-      - '@types/node'
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - fibers
-      - html-webpack-plugin
-      - lightningcss
-      - node-sass
-      - nx
-      - sass-embedded
-      - supports-color
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - verdaccio
-      - vue-template-compiler
-      - webpack-cli
-    dev: true
-
-  /@nx/webpack@17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(esbuild@0.18.20)(html-webpack-plugin@5.6.0)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2):
-    resolution: {integrity: sha512-Gud9Z+VO0dlLpVEJLfPxkEV5wG+ebZ1mv0S0cfTBdD24Fj4MAs0W8QWhRQBtLd2SayU9KMfJr+8gJjkNT6D3Kw==}
-    dependencies:
-      '@babel/core': 7.24.7
-      '@nrwl/webpack': 17.2.8(@rspack/core@0.5.9)(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(esbuild@0.18.20)(html-webpack-plugin@5.6.0)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)
-      '@nx/devkit': 17.2.8(nx@18.3.5)
-      '@nx/js': 17.2.8(@swc-node/register@1.6.8)(@swc/core@1.6.13)(@types/node@20.14.10)(nx@18.3.5)(typescript@5.5.3)(verdaccio@5.29.2)
-      autoprefixer: 10.4.17(postcss@8.4.39)
-      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1)
-      browserslist: 4.23.1
-      chalk: 4.1.2
-      copy-webpack-plugin: 10.2.4(webpack@5.92.1)
-      css-loader: 6.11.0(@rspack/core@0.5.9)(webpack@5.92.1)
-      css-minimizer-webpack-plugin: 5.0.1(esbuild@0.18.20)(webpack@5.92.1)
-      fork-ts-checker-webpack-plugin: 7.2.13(typescript@5.5.3)(webpack@5.92.1)
-      less: 4.1.3
-      less-loader: 11.1.0(less@4.1.3)(webpack@5.92.1)
-      license-webpack-plugin: 4.0.2(webpack@5.92.1)
-      loader-utils: 2.0.4
-      mini-css-extract-plugin: 2.4.7(webpack@5.92.1)
-      parse5: 4.0.0
-      postcss: 8.4.39
-      postcss-import: 14.1.0(postcss@8.4.39)
-      postcss-loader: 6.2.1(postcss@8.4.39)(webpack@5.92.1)
-      rxjs: 7.8.1
-      sass: 1.77.6
-      sass-loader: 12.6.0(sass@1.77.6)(webpack@5.92.1)
-      source-map-loader: 3.0.2(webpack@5.92.1)
-      style-loader: 3.3.4(webpack@5.92.1)
-      stylus: 0.59.0
-      stylus-loader: 7.1.3(stylus@0.59.0)(webpack@5.92.1)
-      terser-webpack-plugin: 5.3.10(@swc/core@1.6.13)(esbuild@0.18.20)(webpack@5.92.1)
-      ts-loader: 9.5.1(typescript@5.5.3)(webpack@5.92.1)
-      tsconfig-paths-webpack-plugin: 4.0.0
-      tslib: 2.6.2
-      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.18.20)
       webpack-dev-server: 4.15.2(webpack@5.92.1)
       webpack-node-externals: 3.0.0
       webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.0)(webpack@5.92.1)
@@ -11828,15 +11306,6 @@ packages:
     dependencies:
       esquery: 1.5.0
       typescript: 5.5.2
-    dev: true
-
-  /@phenomnomnominal/tsquery@5.0.1(typescript@5.5.3):
-    resolution: {integrity: sha512-3nVv+e2FQwsW8Aw6qTU6f+1rfcJ3hrcnvH/mu9i8YhxO+9sqbOfpL8m6PbET5+xKOlz/VSbp0RoYWYCtIsnmuA==}
-    peerDependencies:
-      typescript: ^3 || ^4 || ^5
-    dependencies:
-      esquery: 1.5.0
-      typescript: 5.5.3
     dev: true
 
   /@pkgjs/parseargs@0.11.0:
@@ -13241,20 +12710,6 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@rc-component/portal@1.1.2(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    dependencies:
-      '@babel/runtime': 7.24.5
-      classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    dev: false
-
   /@rc-component/qrcode@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-L+rZ4HXP2sJ1gHMGHjsg9jlYBX/SLN2D6OxP9Zn3qgtpMWtO2vUfxVFwiogHpAIqs54FnALxraUy/BCO1yRIgg==}
     engines: {node: '>=8.x'}
@@ -13566,7 +13021,7 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
       rollup: 2.79.1
     transitivePeerDependencies:
@@ -15827,7 +15282,7 @@ packages:
       conventional-changelog-writer: 8.0.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.0.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       import-from-esm: 1.3.4
       lodash-es: 4.17.21
       micromatch: 4.0.7
@@ -15854,7 +15309,7 @@ packages:
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       execa: 5.1.1
       lodash: 4.17.21
       parse-json: 5.2.0
@@ -15871,7 +15326,7 @@ packages:
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       dir-glob: 3.0.1
       execa: 5.1.1
       lodash: 4.17.21
@@ -15894,7 +15349,7 @@ packages:
       '@octokit/plugin-throttling': 9.3.0(@octokit/core@6.1.2)
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       dir-glob: 3.0.1
       globby: 14.0.2
       http-proxy-agent: 7.0.2
@@ -15921,7 +15376,7 @@ packages:
       '@octokit/plugin-throttling': 9.3.0(@octokit/core@6.1.2)
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       dir-glob: 3.0.1
       globby: 14.0.2
       http-proxy-agent: 7.0.2
@@ -15990,7 +15445,7 @@ packages:
       conventional-changelog-writer: 8.0.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.0.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       get-stream: 7.0.1
       import-from-esm: 1.3.4
       into-stream: 7.0.0
@@ -17340,7 +16795,7 @@ packages:
     dependencies:
       '@babel/generator': 7.24.7
       '@babel/parser': 7.24.7
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
       '@storybook/csf': 0.1.11
       '@storybook/types': 7.6.20
@@ -17356,7 +16811,7 @@ packages:
     dependencies:
       '@babel/generator': 7.24.7
       '@babel/parser': 7.24.7
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
       '@storybook/csf': 0.1.11
       '@storybook/types': 8.1.10
@@ -17372,7 +16827,7 @@ packages:
     dependencies:
       '@babel/generator': 7.24.7
       '@babel/parser': 7.24.7
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
       '@storybook/csf': 0.1.11
       '@storybook/types': 8.1.11
@@ -17735,7 +17190,7 @@ packages:
       typescript: '>= 4.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -18206,20 +17661,6 @@ packages:
       - typescript
     dev: true
 
-  /@svgr/core@8.1.0(typescript@5.5.3):
-    resolution: {integrity: sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@babel/core': 7.24.7
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.24.7)
-      camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.5.3)
-      snake-case: 3.0.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@svgr/hast-util-to-babel-ast@8.0.0:
     resolution: {integrity: sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==}
     engines: {node: '>=14'}
@@ -18236,7 +17677,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.7
       '@svgr/babel-preset': 8.1.0(@babel/core@7.24.7)
-      '@svgr/core': 8.1.0(typescript@5.5.3)
+      '@svgr/core': 8.1.0(typescript@5.5.2)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -18265,20 +17706,6 @@ packages:
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.5.2)
       cosmiconfig: 8.3.6(typescript@5.5.2)
-      deepmerge: 4.3.1
-      svgo: 3.3.2
-    transitivePeerDependencies:
-      - typescript
-    dev: true
-
-  /@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@5.5.3):
-    resolution: {integrity: sha512-Ywtl837OGO9pTLIN/onoWLmDQ4zFUycI1g76vuKGEz6evR/ZTJlJuz3G/fIkb6OVBJ2g0o6CGJzaEjfmEo3AHA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@svgr/core': '*'
-    dependencies:
-      '@svgr/core': 8.1.0(typescript@5.5.3)
-      cosmiconfig: 8.3.6(typescript@5.5.3)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
@@ -18319,23 +17746,6 @@ packages:
       - typescript
     dev: true
 
-  /@svgr/webpack@8.1.0(typescript@5.5.3):
-    resolution: {integrity: sha512-LnhVjMWyMQV9ZmeEy26maJk+8HTIbd59cH4F2MJ439k9DqejRisfFNGAPvRYlKETuh9LrImlS8aKsBgKjMA8WA==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-transform-react-constant-elements': 7.24.7(@babel/core@7.24.7)
-      '@babel/preset-env': 7.24.7(@babel/core@7.24.7)
-      '@babel/preset-react': 7.24.7(@babel/core@7.24.7)
-      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.7)
-      '@svgr/core': 8.1.0(typescript@5.5.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@5.5.3)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@swc-node/core@1.13.2(@swc/core@1.6.13)(@swc/types@0.1.9):
     resolution: {integrity: sha512-skceAbeKUmEK8z1nxStJTTsbIInKqW4n4+ZCYFexy6UsHjsc7MAfR2v5QqNJr/Fl/j+yLY6UkXY2VUU63nEC/Q==}
     engines: {node: '>= 10'}
@@ -18357,7 +17767,7 @@ packages:
       '@swc-node/sourcemap-support': 0.3.0
       '@swc/core': 1.6.13(@swc/helpers@0.5.11)
       colorette: 2.0.20
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       pirates: 4.0.6
       tslib: 2.6.3
       typescript: 5.5.2
@@ -19297,12 +18707,6 @@ packages:
     dependencies:
       undici-types: 5.26.5
 
-  /@types/node@20.14.10:
-    resolution: {integrity: sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==}
-    dependencies:
-      undici-types: 5.26.5
-    dev: true
-
   /@types/node@20.5.1:
     resolution: {integrity: sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==}
     dev: true
@@ -19535,11 +18939,11 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 5.62.0(eslint@9.6.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.0.4)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.56.0)(typescript@5.0.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.0.4)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -19568,7 +18972,7 @@ packages:
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.56.0)(typescript@5.5.2)
       '@typescript-eslint/utils': 6.21.0(eslint@8.56.0)(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -19593,28 +18997,8 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.56.0
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/parser@5.62.0(eslint@9.6.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
-      debug: 4.3.5(supports-color@8.1.1)
-      eslint: 9.6.0
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
@@ -19634,7 +19018,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.56.0
       typescript: 5.5.2
     transitivePeerDependencies:
@@ -19677,7 +19061,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.0.4)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.56.0
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
@@ -19697,7 +19081,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.2)
       '@typescript-eslint/utils': 6.21.0(eslint@8.56.0)(typescript@5.5.2)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.56.0
       ts-api-utils: 1.3.0(typescript@5.5.2)
       typescript: 5.5.2
@@ -19717,7 +19101,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.15.0(typescript@5.5.2)
       '@typescript-eslint/utils': 7.15.0(eslint@8.56.0)(typescript@5.5.2)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.56.0
       ts-api-utils: 1.3.0(typescript@5.5.2)
       typescript: 5.5.2
@@ -19751,7 +19135,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
@@ -19772,7 +19156,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -19794,7 +19178,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.15.0
       '@typescript-eslint/visitor-keys': 7.15.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -20133,7 +19517,7 @@ packages:
     peerDependencies:
       vitest: ^1.0.0
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
@@ -20154,7 +19538,7 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 4.0.1
@@ -20275,7 +19659,7 @@ packages:
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.7)
       '@babel/template': 7.24.7
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
       '@vue/babel-helper-vue-transform-on': 1.2.2
       '@vue/babel-plugin-resolve-type': 1.2.2(@babel/core@7.24.7)
@@ -20959,7 +20343,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -20968,7 +20352,7 @@ packages:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -21176,109 +20560,109 @@ packages:
       entities: 2.2.0
     dev: true
 
-  /antd@4.24.14(react-dom@18.3.1)(react@18.3.1):
+  /antd@4.24.14(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-hY/MPm7XI0G+9MvjhTlbDkA2sf8oHVbhtrT0XRstlm9+fXYGNXz8oEh3d5qiA3/tY5NL2Kh2tF7Guh01hwWJdg==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
       '@ant-design/colors': 6.0.0
-      '@ant-design/icons': 4.8.3(react-dom@18.3.1)(react@18.3.1)
-      '@ant-design/react-slick': 1.0.2(react@18.3.1)
+      '@ant-design/icons': 4.8.3(react-dom@18.2.0)(react@18.2.0)
+      '@ant-design/react-slick': 1.0.2(react@18.2.0)
       '@babel/runtime': 7.24.5
       '@ctrl/tinycolor': 3.6.1
       classnames: 2.5.0
       copy-to-clipboard: 3.3.3
       lodash: 4.17.21
       moment: 2.30.1
-      rc-cascader: 3.7.3(react-dom@18.3.1)(react@18.3.1)
-      rc-checkbox: 3.0.1(react-dom@18.3.1)(react@18.3.1)
-      rc-collapse: 3.4.2(react-dom@18.3.1)(react@18.3.1)
-      rc-dialog: 9.0.2(react-dom@18.3.1)(react@18.3.1)
-      rc-drawer: 6.3.0(react-dom@18.3.1)(react@18.3.1)
-      rc-dropdown: 4.0.1(react-dom@18.3.1)(react@18.3.1)
-      rc-field-form: 1.34.2(react-dom@18.3.1)(react@18.3.1)
-      rc-image: 5.13.0(react-dom@18.3.1)(react@18.3.1)
-      rc-input: 0.1.4(react-dom@18.3.1)(react@18.3.1)
-      rc-input-number: 7.3.11(react-dom@18.3.1)(react@18.3.1)
-      rc-mentions: 1.13.1(react-dom@18.3.1)(react@18.3.1)
-      rc-menu: 9.8.4(react-dom@18.3.1)(react@18.3.1)
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-notification: 4.6.1(react-dom@18.3.1)(react@18.3.1)
-      rc-pagination: 3.2.0(react-dom@18.3.1)(react@18.3.1)
-      rc-picker: 2.7.6(react-dom@18.3.1)(react@18.3.1)
-      rc-progress: 3.4.2(react-dom@18.3.1)(react@18.3.1)
-      rc-rate: 2.9.3(react-dom@18.3.1)(react@18.3.1)
-      rc-resize-observer: 1.4.0(react-dom@18.3.1)(react@18.3.1)
-      rc-segmented: 2.1.2(react-dom@18.3.1)(react@18.3.1)
-      rc-select: 14.1.18(react-dom@18.3.1)(react@18.3.1)
-      rc-slider: 10.0.1(react-dom@18.3.1)(react@18.3.1)
-      rc-steps: 5.0.0(react-dom@18.3.1)(react@18.3.1)
-      rc-switch: 3.2.2(react-dom@18.3.1)(react@18.3.1)
-      rc-table: 7.26.0(react-dom@18.3.1)(react@18.3.1)
-      rc-tabs: 12.5.10(react-dom@18.3.1)(react@18.3.1)
-      rc-textarea: 0.4.7(react-dom@18.3.1)(react@18.3.1)
-      rc-tooltip: 5.2.2(react-dom@18.3.1)(react@18.3.1)
-      rc-tree: 5.7.12(react-dom@18.3.1)(react@18.3.1)
-      rc-tree-select: 5.5.5(react-dom@18.3.1)(react@18.3.1)
-      rc-trigger: 5.3.4(react-dom@18.3.1)(react@18.3.1)
-      rc-upload: 4.3.6(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-cascader: 3.7.3(react-dom@18.2.0)(react@18.2.0)
+      rc-checkbox: 3.0.1(react-dom@18.2.0)(react@18.2.0)
+      rc-collapse: 3.4.2(react-dom@18.2.0)(react@18.2.0)
+      rc-dialog: 9.0.2(react-dom@18.2.0)(react@18.2.0)
+      rc-drawer: 6.3.0(react-dom@18.2.0)(react@18.2.0)
+      rc-dropdown: 4.0.1(react-dom@18.2.0)(react@18.2.0)
+      rc-field-form: 1.34.2(react-dom@18.2.0)(react@18.2.0)
+      rc-image: 5.13.0(react-dom@18.2.0)(react@18.2.0)
+      rc-input: 0.1.4(react-dom@18.2.0)(react@18.2.0)
+      rc-input-number: 7.3.11(react-dom@18.2.0)(react@18.2.0)
+      rc-mentions: 1.13.1(react-dom@18.2.0)(react@18.2.0)
+      rc-menu: 9.8.4(react-dom@18.2.0)(react@18.2.0)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-notification: 4.6.1(react-dom@18.2.0)(react@18.2.0)
+      rc-pagination: 3.2.0(react-dom@18.2.0)(react@18.2.0)
+      rc-picker: 2.7.6(react-dom@18.2.0)(react@18.2.0)
+      rc-progress: 3.4.2(react-dom@18.2.0)(react@18.2.0)
+      rc-rate: 2.9.3(react-dom@18.2.0)(react@18.2.0)
+      rc-resize-observer: 1.4.0(react-dom@18.2.0)(react@18.2.0)
+      rc-segmented: 2.1.2(react-dom@18.2.0)(react@18.2.0)
+      rc-select: 14.1.18(react-dom@18.2.0)(react@18.2.0)
+      rc-slider: 10.0.1(react-dom@18.2.0)(react@18.2.0)
+      rc-steps: 5.0.0(react-dom@18.2.0)(react@18.2.0)
+      rc-switch: 3.2.2(react-dom@18.2.0)(react@18.2.0)
+      rc-table: 7.26.0(react-dom@18.2.0)(react@18.2.0)
+      rc-tabs: 12.5.10(react-dom@18.2.0)(react@18.2.0)
+      rc-textarea: 0.4.7(react-dom@18.2.0)(react@18.2.0)
+      rc-tooltip: 5.2.2(react-dom@18.2.0)(react@18.2.0)
+      rc-tree: 5.7.12(react-dom@18.2.0)(react@18.2.0)
+      rc-tree-select: 5.5.5(react-dom@18.2.0)(react@18.2.0)
+      rc-trigger: 5.3.4(react-dom@18.2.0)(react@18.2.0)
+      rc-upload: 4.3.6(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 2.2.31
     dev: false
 
-  /antd@4.24.15(react-dom@18.3.1)(react@18.3.1):
+  /antd@4.24.15(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-pXCNJB8cTSjQdqeW5RNadraiYiJkMec/Qt0Zh+fEKUK9UqwmD4TxIYs/xnEbyQIVtHHwtl0fW684xql73KhCyQ==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
       '@ant-design/colors': 6.0.0
-      '@ant-design/icons': 4.8.3(react-dom@18.3.1)(react@18.3.1)
-      '@ant-design/react-slick': 1.0.2(react@18.3.1)
+      '@ant-design/icons': 4.8.3(react-dom@18.2.0)(react@18.2.0)
+      '@ant-design/react-slick': 1.0.2(react@18.2.0)
       '@babel/runtime': 7.24.5
       '@ctrl/tinycolor': 3.6.1
       classnames: 2.5.1
       copy-to-clipboard: 3.3.3
       lodash: 4.17.21
       moment: 2.30.1
-      rc-cascader: 3.7.3(react-dom@18.3.1)(react@18.3.1)
-      rc-checkbox: 3.0.1(react-dom@18.3.1)(react@18.3.1)
-      rc-collapse: 3.4.2(react-dom@18.3.1)(react@18.3.1)
-      rc-dialog: 9.0.2(react-dom@18.3.1)(react@18.3.1)
-      rc-drawer: 6.3.0(react-dom@18.3.1)(react@18.3.1)
-      rc-dropdown: 4.0.1(react-dom@18.3.1)(react@18.3.1)
-      rc-field-form: 1.38.2(react-dom@18.3.1)(react@18.3.1)
-      rc-image: 5.13.0(react-dom@18.3.1)(react@18.3.1)
-      rc-input: 0.1.4(react-dom@18.3.1)(react@18.3.1)
-      rc-input-number: 7.3.11(react-dom@18.3.1)(react@18.3.1)
-      rc-mentions: 1.13.1(react-dom@18.3.1)(react@18.3.1)
-      rc-menu: 9.8.4(react-dom@18.3.1)(react@18.3.1)
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-notification: 4.6.1(react-dom@18.3.1)(react@18.3.1)
-      rc-pagination: 3.2.0(react-dom@18.3.1)(react@18.3.1)
-      rc-picker: 2.7.6(react-dom@18.3.1)(react@18.3.1)
-      rc-progress: 3.4.2(react-dom@18.3.1)(react@18.3.1)
-      rc-rate: 2.9.3(react-dom@18.3.1)(react@18.3.1)
-      rc-resize-observer: 1.4.0(react-dom@18.3.1)(react@18.3.1)
-      rc-segmented: 2.1.2(react-dom@18.3.1)(react@18.3.1)
-      rc-select: 14.1.18(react-dom@18.3.1)(react@18.3.1)
-      rc-slider: 10.0.1(react-dom@18.3.1)(react@18.3.1)
-      rc-steps: 5.0.0(react-dom@18.3.1)(react@18.3.1)
-      rc-switch: 3.2.2(react-dom@18.3.1)(react@18.3.1)
-      rc-table: 7.26.0(react-dom@18.3.1)(react@18.3.1)
-      rc-tabs: 12.5.10(react-dom@18.3.1)(react@18.3.1)
-      rc-textarea: 0.4.7(react-dom@18.3.1)(react@18.3.1)
-      rc-tooltip: 5.2.2(react-dom@18.3.1)(react@18.3.1)
-      rc-tree: 5.7.12(react-dom@18.3.1)(react@18.3.1)
-      rc-tree-select: 5.5.5(react-dom@18.3.1)(react@18.3.1)
-      rc-trigger: 5.3.4(react-dom@18.3.1)(react@18.3.1)
-      rc-upload: 4.3.6(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-cascader: 3.7.3(react-dom@18.2.0)(react@18.2.0)
+      rc-checkbox: 3.0.1(react-dom@18.2.0)(react@18.2.0)
+      rc-collapse: 3.4.2(react-dom@18.2.0)(react@18.2.0)
+      rc-dialog: 9.0.2(react-dom@18.2.0)(react@18.2.0)
+      rc-drawer: 6.3.0(react-dom@18.2.0)(react@18.2.0)
+      rc-dropdown: 4.0.1(react-dom@18.2.0)(react@18.2.0)
+      rc-field-form: 1.38.2(react-dom@18.2.0)(react@18.2.0)
+      rc-image: 5.13.0(react-dom@18.2.0)(react@18.2.0)
+      rc-input: 0.1.4(react-dom@18.2.0)(react@18.2.0)
+      rc-input-number: 7.3.11(react-dom@18.2.0)(react@18.2.0)
+      rc-mentions: 1.13.1(react-dom@18.2.0)(react@18.2.0)
+      rc-menu: 9.8.4(react-dom@18.2.0)(react@18.2.0)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-notification: 4.6.1(react-dom@18.2.0)(react@18.2.0)
+      rc-pagination: 3.2.0(react-dom@18.2.0)(react@18.2.0)
+      rc-picker: 2.7.6(react-dom@18.2.0)(react@18.2.0)
+      rc-progress: 3.4.2(react-dom@18.2.0)(react@18.2.0)
+      rc-rate: 2.9.3(react-dom@18.2.0)(react@18.2.0)
+      rc-resize-observer: 1.4.0(react-dom@18.2.0)(react@18.2.0)
+      rc-segmented: 2.1.2(react-dom@18.2.0)(react@18.2.0)
+      rc-select: 14.1.18(react-dom@18.2.0)(react@18.2.0)
+      rc-slider: 10.0.1(react-dom@18.2.0)(react@18.2.0)
+      rc-steps: 5.0.0(react-dom@18.2.0)(react@18.2.0)
+      rc-switch: 3.2.2(react-dom@18.2.0)(react@18.2.0)
+      rc-table: 7.26.0(react-dom@18.2.0)(react@18.2.0)
+      rc-tabs: 12.5.10(react-dom@18.2.0)(react@18.2.0)
+      rc-textarea: 0.4.7(react-dom@18.2.0)(react@18.2.0)
+      rc-tooltip: 5.2.2(react-dom@18.2.0)(react@18.2.0)
+      rc-tree: 5.7.12(react-dom@18.2.0)(react@18.2.0)
+      rc-tree-select: 5.5.5(react-dom@18.2.0)(react@18.2.0)
+      rc-trigger: 5.3.4(react-dom@18.2.0)(react@18.2.0)
+      rc-upload: 4.3.6(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 2.2.31
     dev: false
 
@@ -22006,7 +21390,7 @@ packages:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.7)
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -22026,7 +21410,7 @@ packages:
   /babel-plugin-import@1.13.5:
     resolution: {integrity: sha512-IkqnoV+ov1hdJVofly9pXRJmeDm9EtROfrc5i6eII0Hix2xMs5FEm8FG3ExMvazbnZBbgHIt6qdO8And6lCloQ==}
     dependencies:
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -22124,7 +21508,7 @@ packages:
       styled-components: '>= 2'
     dependencies:
       '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.21
       styled-components: 6.1.11(react-dom@18.2.0)(react@18.2.0)
@@ -22170,7 +21554,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
     dev: true
 
   /babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.7):
@@ -23805,11 +23189,6 @@ packages:
     resolution: {integrity: sha512-BTvUrwxVBezj5SZ3f10ImnX2oRByMxql3EimVqMysepbC9EeMUOpLwdy6Eoili2x6E4kf+ZUB5k/+Jv55alPfA==}
     requiresBuild: true
 
-  /core-js@3.37.1:
-    resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
-    requiresBuild: true
-    dev: false
-
   /core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
     dev: true
@@ -23911,22 +23290,6 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       typescript: 5.5.2
-    dev: true
-
-  /cosmiconfig@8.3.6(typescript@5.5.3):
-    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=4.9.5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      typescript: 5.5.3
     dev: true
 
   /cosmiconfig@9.0.0(typescript@5.5.2):
@@ -24849,6 +24212,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+    dev: true
 
   /debug@4.3.5(supports-color@9.3.1):
     resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
@@ -25140,7 +24504,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -25911,7 +25275,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       esbuild: 0.17.19
     transitivePeerDependencies:
       - supports-color
@@ -25922,7 +25286,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
@@ -26271,7 +25635,7 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       enhanced-resolve: 5.17.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
@@ -26308,7 +25672,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@9.6.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.0.4)
       debug: 3.2.7(supports-color@8.1.1)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
@@ -26399,7 +25763,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@9.6.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.0.4)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -26628,14 +25992,6 @@ packages:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  /eslint-scope@8.0.1:
-    resolution: {integrity: sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-    dev: true
-
   /eslint-utils@2.1.0:
     resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==}
     engines: {node: '>=6'}
@@ -26658,11 +26014,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint-visitor-keys@4.0.0:
-    resolution: {integrity: sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: true
-
   /eslint@8.56.0:
     resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -26679,7 +26030,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -26710,49 +26061,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint@9.6.0:
-    resolution: {integrity: sha512-ElQkdLMEEqQNM9Njff+2Y4q2afHk7JpkPvrd7Xh7xefwgQynqPxwf55J7di9+MEibWUGdNjFF9ITG9Pck5M84w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    hasBin: true
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.6.0)
-      '@eslint-community/regexpp': 4.11.0
-      '@eslint/config-array': 0.17.0
-      '@eslint/eslintrc': 3.1.0
-      '@eslint/js': 9.6.0
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.3.0
-      '@nodelib/fs.walk': 1.2.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.5(supports-color@8.1.1)
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.0.1
-      eslint-visitor-keys: 4.0.0
-      espree: 10.1.0
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.1
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /esniff@2.0.1:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
@@ -26762,15 +26070,6 @@ packages:
       event-emitter: 0.3.5
       type: 2.7.3
     dev: false
-
-  /espree@10.1.0:
-    resolution: {integrity: sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dependencies:
-      acorn: 8.12.1
-      acorn-jsx: 5.3.2(acorn@8.12.1)
-      eslint-visitor-keys: 4.0.0
-    dev: true
 
   /espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -26788,13 +26087,6 @@ packages:
 
   /esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
-    engines: {node: '>=0.10'}
-    dependencies:
-      estraverse: 5.3.0
-    dev: true
-
-  /esquery@1.6.0:
-    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
@@ -26818,7 +26110,7 @@ packages:
     resolution: {integrity: sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==}
     engines: {node: '>=8.3.0'}
     dependencies:
-      '@babel/traverse': 7.24.7
+      '@babel/traverse': 7.24.7(supports-color@5.5.0)
       '@babel/types': 7.24.7
       c8: 7.14.0
     transitivePeerDependencies:
@@ -27447,13 +26739,6 @@ packages:
       flat-cache: 3.2.0
     dev: true
 
-  /file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      flat-cache: 4.0.1
-    dev: true
-
   /file-loader@6.2.0(webpack@5.89.0):
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
     engines: {node: '>= 10.13.0'}
@@ -27718,14 +27003,6 @@ packages:
       rimraf: 3.0.2
     dev: true
 
-  /flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
-    dependencies:
-      flatted: 3.3.1
-      keyv: 4.5.4
-    dev: true
-
   /flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
@@ -27863,33 +27140,6 @@ packages:
       semver: 7.6.2
       tapable: 2.2.1
       typescript: 5.5.2
-      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.23.0)
-    dev: true
-
-  /fork-ts-checker-webpack-plugin@7.2.13(typescript@5.5.3)(webpack@5.92.1):
-    resolution: {integrity: sha512-fR3WRkOb4bQdWB/y7ssDUlVdrclvwtyCUIHCfivAoYxq9dF7XfrDKbMdZIfwJ7hxIAqkYSGeU7lLJE6xrxIBdg==}
-    engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
-    peerDependencies:
-      typescript: '>3.6.0'
-      vue-template-compiler: '*'
-      webpack: ^5.11.0
-    peerDependenciesMeta:
-      vue-template-compiler:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.24.7
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      cosmiconfig: 7.1.0
-      deepmerge: 4.3.1
-      fs-extra: 10.1.0
-      memfs: 3.5.3
-      minimatch: 3.1.2
-      node-abort-controller: 3.1.1
-      schema-utils: 3.3.0
-      semver: 7.6.2
-      tapable: 2.2.1
-      typescript: 5.5.3
       webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.18.20)
     dev: true
 
@@ -28014,7 +27264,7 @@ packages:
       map-cache: 0.2.2
     dev: true
 
-  /framer-motion@10.18.0(react-dom@18.3.1)(react@18.3.1):
+  /framer-motion@10.18.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==}
     peerDependencies:
       react: ^18.0.0
@@ -28025,8 +27275,8 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
@@ -28555,11 +27805,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
-    dev: true
-
-  /globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
     dev: true
 
   /globalthis@1.0.4:
@@ -29418,7 +28663,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29428,7 +28673,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29520,7 +28765,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29530,7 +28775,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29540,7 +28785,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29678,7 +28923,7 @@ packages:
     resolution: {integrity: sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==}
     engines: {node: '>=16.20'}
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       import-meta-resolve: 4.1.0
     transitivePeerDependencies:
       - supports-color
@@ -30511,7 +29756,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -31949,7 +31194,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       flatted: 3.3.1
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -33185,7 +32430,7 @@ packages:
     resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -33209,7 +32454,7 @@ packages:
     resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -34285,70 +33530,6 @@ packages:
       '@nx/nx-linux-x64-musl': 17.3.2
       '@nx/nx-win32-arm64-msvc': 17.3.2
       '@nx/nx-win32-x64-msvc': 17.3.2
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
-  /nx@18.3.5(@swc-node/register@1.6.8)(@swc/core@1.6.13):
-    resolution: {integrity: sha512-wWcvwoTgiT5okdrG0RIWm1tepC17bDmSpw+MrOxnjfBjARQNTURkiq4U6cxjCVsCxNHxCrlAaBSQLZeBgJZTzQ==}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      '@swc-node/register': ^1.8.0
-      '@swc/core': ^1.3.85
-    peerDependenciesMeta:
-      '@swc-node/register':
-        optional: true
-      '@swc/core':
-        optional: true
-    dependencies:
-      '@nrwl/tao': 18.3.5(@swc-node/register@1.6.8)(@swc/core@1.6.13)
-      '@swc-node/register': 1.6.8(@swc/core@1.6.13)(@swc/types@0.1.9)(typescript@5.5.2)
-      '@swc/core': 1.6.13(@swc/helpers@0.5.11)
-      '@yarnpkg/lockfile': 1.1.0
-      '@yarnpkg/parsers': 3.0.0-rc.46
-      '@zkochan/js-yaml': 0.0.6
-      axios: 1.7.2
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-spinners: 2.6.1
-      cliui: 8.0.1
-      dotenv: 16.3.2
-      dotenv-expand: 10.0.0
-      enquirer: 2.3.6
-      figures: 3.2.0
-      flat: 5.0.2
-      fs-extra: 11.2.0
-      ignore: 5.3.1
-      jest-diff: 29.7.0
-      js-yaml: 4.1.0
-      jsonc-parser: 3.2.0
-      lines-and-columns: 2.0.4
-      minimatch: 9.0.3
-      node-machine-id: 1.1.12
-      npm-run-path: 4.0.1
-      open: 8.4.2
-      ora: 5.3.0
-      semver: 7.6.2
-      string-width: 4.2.3
-      strong-log-transformer: 2.1.0
-      tar-stream: 2.2.0
-      tmp: 0.2.3
-      tsconfig-paths: 4.2.0
-      tslib: 2.6.3
-      yargs: 17.7.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@nx/nx-darwin-arm64': 18.3.5
-      '@nx/nx-darwin-x64': 18.3.5
-      '@nx/nx-freebsd-x64': 18.3.5
-      '@nx/nx-linux-arm-gnueabihf': 18.3.5
-      '@nx/nx-linux-arm64-gnu': 18.3.5
-      '@nx/nx-linux-arm64-musl': 18.3.5
-      '@nx/nx-linux-x64-gnu': 18.3.5
-      '@nx/nx-linux-x64-musl': 18.3.5
-      '@nx/nx-win32-arm64-msvc': 18.3.5
-      '@nx/nx-win32-x64-msvc': 18.3.5
     transitivePeerDependencies:
       - debug
     dev: true
@@ -37016,7 +36197,7 @@ packages:
     engines: {node: '>=8.16.0'}
     dependencies:
       '@types/mime-types': 2.1.4
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -37161,7 +36342,7 @@ packages:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  /rc-align@4.0.15(react-dom@18.3.1)(react@18.3.1):
+  /rc-align@4.0.15(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-wqJtVH60pka/nOX7/IspElA8gjPNQKIx/ZqJ6heATCkXpe1Zg4cPVrMD2vC96wjsFFL8WsmhPbx9tdMo1qqlIA==}
     peerDependencies:
       react: '>=16.9.0'
@@ -37170,9 +36351,9 @@ packages:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
       dom-align: 1.12.4
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       resize-observer-polyfill: 1.5.1
     dev: false
 
@@ -37208,7 +36389,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-cascader@3.7.3(react-dom@18.3.1)(react@18.3.1):
+  /rc-cascader@3.7.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-KBpT+kzhxDW+hxPiNk4zaKa99+Lie2/8nnI11XF+FIOPl4Bj9VlFZi61GrnWzhLGA7VEN+dTxAkNOjkySDa0dA==}
     peerDependencies:
       react: '>=16.9.0'
@@ -37217,14 +36398,14 @@ packages:
       '@babel/runtime': 7.24.5
       array-tree-filter: 2.1.0
       classnames: 2.5.1
-      rc-select: 14.1.18(react-dom@18.3.1)(react@18.3.1)
-      rc-tree: 5.7.12(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-select: 14.1.18(react-dom@18.2.0)(react@18.2.0)
+      rc-tree: 5.7.12(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-checkbox@3.0.1(react-dom@18.3.1)(react@18.3.1):
+  /rc-checkbox@3.0.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-k7nxDWxYF+jDI0ZcCvuvj71xONmWRVe5+1MKcERRR9MRyP3tZ69b+yUCSXXh+sik4/Hc9P5wHr2nnUoGS2zBjA==}
     peerDependencies:
       react: '>=16.9.0'
@@ -37232,9 +36413,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-checkbox@3.3.0(react-dom@17.0.2)(react@17.0.2):
@@ -37263,7 +36444,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-collapse@3.4.2(react-dom@18.3.1)(react@18.3.1):
+  /rc-collapse@3.4.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-jpTwLgJzkhAgp2Wpi3xmbTbbYExg6fkptL67Uu5LCRVEj6wqmy0DHTjjeynsjOLsppHGHu41t1ELntZ0lEvS/Q==}
     peerDependencies:
       react: '>=16.9.0'
@@ -37271,10 +36452,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       shallowequal: 1.1.0
     dev: false
 
@@ -37306,19 +36487,19 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-dialog@9.0.2(react-dom@18.3.1)(react@18.3.1):
+  /rc-dialog@9.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-s3U+24xWUuB6Bn2Lk/Qt6rufy+uT+QvWkiFhNBcO9APLxcFFczWamaq7x9h8SCuhfc1nHcW4y8NbMsnAjNnWyg==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
       '@babel/runtime': 7.24.5
-      '@rc-component/portal': 1.1.2(react-dom@18.3.1)(react@18.3.1)
+      '@rc-component/portal': 1.1.2(react-dom@18.2.0)(react@18.2.0)
       classnames: 2.5.1
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-dialog@9.5.2(react-dom@17.0.2)(react@17.0.2):
@@ -37351,19 +36532,19 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-drawer@6.3.0(react-dom@18.3.1)(react@18.3.1):
+  /rc-drawer@6.3.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-uBZVb3xTAR+dBV53d/bUhTctCw3pwcwJoM7g5aX+7vgwt2zzVzoJ6aqFjYJpBlZ9zp0dVYN8fV+hykFE7c4lig==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
       '@babel/runtime': 7.24.5
-      '@rc-component/portal': 1.1.2(react-dom@18.3.1)(react@18.3.1)
+      '@rc-component/portal': 1.1.2(react-dom@18.2.0)(react@18.2.0)
       classnames: 2.5.1
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-drawer@7.2.0(react-dom@17.0.2)(react@17.0.2):
@@ -37396,7 +36577,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-dropdown@4.0.1(react-dom@18.3.1)(react@18.3.1):
+  /rc-dropdown@4.0.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-OdpXuOcme1rm45cR0Jzgfl1otzmU4vuBVb+etXM8vcaULGokAKVpKlw8p6xzspG7jGd/XxShvq+N3VNEfk/l5g==}
     peerDependencies:
       react: '>=16.11.0'
@@ -37404,10 +36585,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-trigger: 5.3.4(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-trigger: 5.3.4(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-dropdown@4.2.0(react-dom@17.0.2)(react@17.0.2):
@@ -37438,7 +36619,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-field-form@1.34.2(react-dom@18.3.1)(react@18.3.1):
+  /rc-field-form@1.34.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-BdciU5C7dBO51/9ZKcMvK2f8zaaO12Lt1eBhlAo8nNv+6htlNcgY9DAkUlZ7gfyWjnCc1Oo4hHIXau1m6tLw1A==}
     engines: {node: '>=8.x'}
     peerDependencies:
@@ -37447,12 +36628,12 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       async-validator: 4.2.5
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-field-form@1.38.2(react-dom@18.3.1)(react@18.3.1):
+  /rc-field-form@1.38.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-O83Oi1qPyEv31Sg+Jwvsj6pXc8uQI2BtIAkURr5lvEYHVggXJhdU/nynK8wY1gbw0qR48k731sN5ON4egRCROA==}
     engines: {node: '>=8.x'}
     peerDependencies:
@@ -37461,9 +36642,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       async-validator: 4.2.5
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-field-form@2.2.1(react-dom@17.0.2)(react@17.0.2):
@@ -37494,20 +36675,20 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-image@5.13.0(react-dom@18.3.1)(react@18.3.1):
+  /rc-image@5.13.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-iZTOmw5eWo2+gcrJMMcnd7SsxVHl3w5xlyCgsULUdJhJbnuI8i/AL0tVOsE7aLn9VfOh1qgDT3mC2G75/c7mqg==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
       '@babel/runtime': 7.24.5
-      '@rc-component/portal': 1.1.2(react-dom@18.3.1)(react@18.3.1)
+      '@rc-component/portal': 1.1.2(react-dom@18.2.0)(react@18.2.0)
       classnames: 2.5.1
-      rc-dialog: 9.0.2(react-dom@18.3.1)(react@18.3.1)
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-dialog: 9.0.2(react-dom@18.2.0)(react@18.2.0)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-image@7.9.0(react-dom@17.0.2)(react@17.0.2):
@@ -37542,7 +36723,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-input-number@7.3.11(react-dom@18.3.1)(react@18.3.1):
+  /rc-input-number@7.3.11(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-aMWPEjFeles6PQnMqP5eWpxzsvHm9rh1jQOWXExUEIxhX62Fyl/ptifLHOn17+waDG1T/YUb6flfJbvwRhHrbA==}
     peerDependencies:
       react: '>=16.9.0'
@@ -37550,9 +36731,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-input-number@9.1.0(react-dom@17.0.2)(react@17.0.2):
@@ -37585,7 +36766,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-input@0.1.4(react-dom@18.3.1)(react@18.3.1):
+  /rc-input@0.1.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-FqDdNz+fV2dKNgfXzcSLKvC+jEs1709t7nD+WdfjrdSaOcefpgc7BUJYadc3usaING+b7ediMTfKxuJBsEFbXA==}
     peerDependencies:
       react: '>=16.0.0'
@@ -37593,9 +36774,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-input@1.5.1(react-dom@17.0.2)(react@17.0.2):
@@ -37624,7 +36805,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-mentions@1.13.1(react-dom@18.3.1)(react@18.3.1):
+  /rc-mentions@1.13.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-FCkaWw6JQygtOz0+Vxz/M/NWqrWHB9LwqlY2RtcuFqWJNFK9njijOOzTSsBGANliGufVUzx/xuPHmZPBV0+Hgw==}
     peerDependencies:
       react: '>=16.9.0'
@@ -37632,12 +36813,12 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-menu: 9.8.4(react-dom@18.3.1)(react@18.3.1)
-      rc-textarea: 0.4.7(react-dom@18.3.1)(react@18.3.1)
-      rc-trigger: 5.3.4(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-menu: 9.8.4(react-dom@18.2.0)(react@18.2.0)
+      rc-textarea: 0.4.7(react-dom@18.2.0)(react@18.2.0)
+      rc-trigger: 5.3.4(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-mentions@2.14.0(react-dom@17.0.2)(react@17.0.2):
@@ -37706,7 +36887,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-menu@9.8.4(react-dom@18.3.1)(react@18.3.1):
+  /rc-menu@9.8.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-lmw2j8I2fhdIzHmC9ajfImfckt0WDb2KVJJBBRIsxPEw2kGkEfjLMUoB1NgiNT/Q5cC8PdjGOGQjHJIJMwyNMw==}
     peerDependencies:
       react: '>=16.9.0'
@@ -37714,12 +36895,12 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-overflow: 1.3.2(react-dom@18.3.1)(react@18.3.1)
-      rc-trigger: 5.3.4(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-overflow: 1.3.2(react-dom@18.2.0)(react@18.2.0)
+      rc-trigger: 5.3.4(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-motion@2.9.2(react-dom@17.0.2)(react@17.0.2):
@@ -37748,20 +36929,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-motion@2.9.2(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-fUAhHKLDdkAXIDLH0GYwof3raS58dtNUmzLF2MeiR8o6n4thNpSDQhOqQzWE4WfFZDCi9VEN8n7tiB7czREcyw==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    dependencies:
-      '@babel/runtime': 7.24.5
-      classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    dev: false
-
-  /rc-notification@4.6.1(react-dom@18.3.1)(react@18.3.1):
+  /rc-notification@4.6.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-NSmFYwrrdY3+un1GvDAJQw62Xi9LNMSsoQyo95tuaYrcad5Bn9gJUL8AREufRxSQAQnr64u3LtP3EUyLYT6bhw==}
     engines: {node: '>=8.x'}
     peerDependencies:
@@ -37770,10 +36938,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-notification@5.6.0(react-dom@17.0.2)(react@17.0.2):
@@ -37834,21 +37002,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-overflow@1.3.2(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-nsUm78jkYAoPygDAcGZeC2VwIg/IBGSodtOY3pMof4W3M9qRJgqaDYm03ZayHlde3I6ipliAxbN0RUcGf5KOzw==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    dependencies:
-      '@babel/runtime': 7.24.5
-      classnames: 2.5.1
-      rc-resize-observer: 1.4.0(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    dev: false
-
-  /rc-pagination@3.2.0(react-dom@18.3.1)(react@18.3.1):
+  /rc-pagination@3.2.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-5tIXjB670WwwcAJzAqp2J+cOBS9W3cH/WU1EiYwXljuZ4vtZXKlY2Idq8FZrnYBz8KhN3vwPo9CoV/SJS6SL1w==}
     peerDependencies:
       react: '>=16.9.0'
@@ -37856,8 +37010,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-pagination@4.2.0(react-dom@17.0.2)(react@17.0.2):
@@ -37886,7 +37040,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-picker@2.7.6(react-dom@18.3.1)(react@18.3.1):
+  /rc-picker@2.7.6(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-H9if/BUJUZBOhPfWcPeT15JUI3/ntrG9muzERrXDkSoWmDj4yzmBvumozpxYrHwjcKnjyDGAke68d+whWwvhHA==}
     engines: {node: '>=8.x'}
     peerDependencies:
@@ -37898,10 +37052,10 @@ packages:
       date-fns: 2.30.0
       dayjs: 1.11.11
       moment: 2.30.1
-      rc-trigger: 5.3.4(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-trigger: 5.3.4(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       shallowequal: 1.1.0
     dev: false
 
@@ -37967,7 +37121,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-progress@3.4.2(react-dom@18.3.1)(react@18.3.1):
+  /rc-progress@3.4.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-iAGhwWU+tsayP+Jkl9T4+6rHeQTG9kDz8JAHZk4XtQOcYN5fj9H34NXNEdRdZx94VUDHMqCb1yOIvi8eJRh67w==}
     peerDependencies:
       react: '>=16.9.0'
@@ -37975,9 +37129,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-progress@4.0.0(react-dom@17.0.2)(react@17.0.2):
@@ -38034,7 +37188,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-rate@2.9.3(react-dom@18.3.1)(react@18.3.1):
+  /rc-rate@2.9.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-2THssUSnRhtqIouQIIXqsZGzRczvp4WsH4WvGuhiwm+LG2fVpDUJliP9O1zeDOZvYfBE/Bup4SgHun/eCkbjgQ==}
     engines: {node: '>=8.x'}
     peerDependencies:
@@ -38043,9 +37197,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-resize-observer@1.4.0(react-dom@17.0.2)(react@17.0.2):
@@ -38076,21 +37230,7 @@ packages:
       resize-observer-polyfill: 1.5.1
     dev: false
 
-  /rc-resize-observer@1.4.0(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-PnMVyRid9JLxFavTjeDXEXo65HCRqbmLBw9xX9gfC4BZiSzbLXKzW3jPz+J0P71pLbD5tBMTT+mkstV5gD0c9Q==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    dependencies:
-      '@babel/runtime': 7.24.5
-      classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      resize-observer-polyfill: 1.5.1
-    dev: false
-
-  /rc-segmented@2.1.2(react-dom@18.3.1)(react@18.3.1):
+  /rc-segmented@2.1.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-qGo1bCr83ESXpXVOCXjFe1QJlCAQXyi9KCiy8eX3rIMYlTeJr/ftySIaTnYsitL18SvWf5ZEHsfqIWoX0EMfFQ==}
     peerDependencies:
       react: '>=16.0.0'
@@ -38098,10 +37238,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-segmented@2.3.0(react-dom@17.0.2)(react@17.0.2):
@@ -38132,7 +37272,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-select@14.1.18(react-dom@18.3.1)(react@18.3.1):
+  /rc-select@14.1.18(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-4JgY3oG2Yz68ECMUSCON7mtxuJvCSj+LJpHEg/AONaaVBxIIrmI/ZTuMJkyojall/X50YdBe5oMKqHHPNiPzEg==}
     engines: {node: '>=8.x'}
     peerDependencies:
@@ -38141,13 +37281,13 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-overflow: 1.3.2(react-dom@18.3.1)(react@18.3.1)
-      rc-trigger: 5.3.4(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      rc-virtual-list: 3.14.5(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-overflow: 1.3.2(react-dom@18.2.0)(react@18.2.0)
+      rc-trigger: 5.3.4(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      rc-virtual-list: 3.14.5(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-select@14.15.0(react-dom@17.0.2)(react@17.0.2):
@@ -38186,7 +37326,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-slider@10.0.1(react-dom@18.3.1)(react@18.3.1):
+  /rc-slider@10.0.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-igTKF3zBet7oS/3yNiIlmU8KnZ45npmrmHlUUio8PNbIhzMcsh+oE/r2UD42Y6YD2D/s+kzCQkzQrPD6RY435Q==}
     engines: {node: '>=8.x'}
     peerDependencies:
@@ -38195,9 +37335,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       shallowequal: 1.1.0
     dev: false
 
@@ -38229,7 +37369,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-steps@5.0.0(react-dom@18.3.1)(react@18.3.1):
+  /rc-steps@5.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-9TgRvnVYirdhbV0C3syJFj9EhCRqoJAsxt4i1rED5o8/ZcSv5TLIYyo4H8MCjLPvbe2R+oBAm/IYBEtC+OS1Rw==}
     engines: {node: '>=8.x'}
     peerDependencies:
@@ -38238,9 +37378,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-steps@6.0.1(react-dom@17.0.2)(react@17.0.2):
@@ -38271,7 +37411,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-switch@3.2.2(react-dom@18.3.1)(react@18.3.1):
+  /rc-switch@3.2.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-+gUJClsZZzvAHGy1vZfnwySxj+MjLlGRyXKXScrtCTcmiYNPzxDFOxdQ/3pK1Kt/0POvwJ/6ALOR8gwdXGhs+A==}
     peerDependencies:
       react: '>=16.9.0'
@@ -38279,9 +37419,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-switch@4.1.0(react-dom@17.0.2)(react@17.0.2):
@@ -38310,7 +37450,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-table@7.26.0(react-dom@18.3.1)(react@18.3.1):
+  /rc-table@7.26.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-0cD8e6S+DTGAt5nBZQIPFYEaIukn17sfa5uFL98faHlH/whZzD8ii3dbFL4wmUDEL4BLybhYop+QUfZJ4CPvNQ==}
     engines: {node: '>=8.x'}
     peerDependencies:
@@ -38319,10 +37459,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-resize-observer: 1.4.0(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-resize-observer: 1.4.0(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       shallowequal: 1.1.0
     dev: false
 
@@ -38360,7 +37500,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-tabs@12.5.10(react-dom@18.3.1)(react@18.3.1):
+  /rc-tabs@12.5.10(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Ay0l0jtd4eXepFH9vWBvinBjqOpqzcsJTerBGwJy435P2S90Uu38q8U/mvc1sxUEVOXX5ZCFbxcWPnfG3dH+tQ==}
     engines: {node: '>=8.x'}
     peerDependencies:
@@ -38369,13 +37509,13 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-dropdown: 4.0.1(react-dom@18.3.1)(react@18.3.1)
-      rc-menu: 9.8.4(react-dom@18.3.1)(react@18.3.1)
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-resize-observer: 1.4.0(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-dropdown: 4.0.1(react-dom@18.2.0)(react@18.2.0)
+      rc-menu: 9.8.4(react-dom@18.2.0)(react@18.2.0)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-resize-observer: 1.4.0(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-tabs@15.1.1(react-dom@17.0.2)(react@17.0.2):
@@ -38414,7 +37554,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-textarea@0.4.7(react-dom@18.3.1)(react@18.3.1):
+  /rc-textarea@0.4.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-IQPd1CDI3mnMlkFyzt2O4gQ2lxUsnBAeJEoZGJnkkXgORNqyM9qovdrCj9NzcRfpHgLdzaEbU3AmobNFGUznwQ==}
     peerDependencies:
       react: '>=16.9.0'
@@ -38422,10 +37562,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-resize-observer: 1.4.0(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-resize-observer: 1.4.0(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       shallowequal: 1.1.0
     dev: false
 
@@ -38459,7 +37599,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-tooltip@5.2.2(react-dom@18.3.1)(react@18.3.1):
+  /rc-tooltip@5.2.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-jtQzU/18S6EI3lhSGoDYhPqNpWajMtS5VV/ld1LwyfrDByQpYmw/LW6U7oFXXLukjfDHQ7Ju705A82PRNFWYhg==}
     peerDependencies:
       react: '>=16.9.0'
@@ -38467,9 +37607,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-trigger: 5.3.4(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-trigger: 5.3.4(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-tooltip@6.2.0(react-dom@17.0.2)(react@17.0.2):
@@ -38528,7 +37668,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-tree-select@5.5.5(react-dom@18.3.1)(react@18.3.1):
+  /rc-tree-select@5.5.5(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-k2av7jF6tW9bIO4mQhaVdV4kJ1c54oxV3/hHVU+oD251Gb5JN+m1RbJFTMf1o0rAFqkvto33rxMdpafaGKQRJw==}
     peerDependencies:
       react: '*'
@@ -38536,14 +37676,14 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-select: 14.1.18(react-dom@18.3.1)(react@18.3.1)
-      rc-tree: 5.7.12(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-select: 14.1.18(react-dom@18.2.0)(react@18.2.0)
+      rc-tree: 5.7.12(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-tree@5.7.12(react-dom@18.3.1)(react@18.3.1):
+  /rc-tree@5.7.12(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-LXA5nY2hG5koIAlHW5sgXgLpOMz+bFRbnZZ+cCg0tQs4Wv1AmY7EDi1SK7iFXhslYockbqUerQan82jljoaItg==}
     engines: {node: '>=10.x'}
     peerDependencies:
@@ -38552,11 +37692,11 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      rc-virtual-list: 3.14.5(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      rc-virtual-list: 3.14.5(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-tree@5.8.8(react-dom@17.0.2)(react@17.0.2):
@@ -38591,7 +37731,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-trigger@5.3.4(react-dom@18.3.1)(react@18.3.1):
+  /rc-trigger@5.3.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-mQv+vas0TwKcjAO2izNPkqR4j86OemLRmvL2nOzdP9OWNWA1ivoTt5hzFqYNW9zACwmTezRiN8bttrC7cZzYSw==}
     engines: {node: '>=8.x'}
     peerDependencies:
@@ -38600,14 +37740,14 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-align: 4.0.15(react-dom@18.3.1)(react@18.3.1)
-      rc-motion: 2.9.2(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-align: 4.0.15(react-dom@18.2.0)(react@18.2.0)
+      rc-motion: 2.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /rc-upload@4.3.6(react-dom@18.3.1)(react@18.3.1):
+  /rc-upload@4.3.6(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Bt7ESeG5tT3IY82fZcP+s0tQU2xmo1W6P3S8NboUUliquJLQYLkUcsaExi3IlBVr43GQMCjo30RA2o0i70+NjA==}
     peerDependencies:
       react: '>=16.9.0'
@@ -38615,9 +37755,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       classnames: 2.5.1
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /rc-upload@4.5.2(react-dom@17.0.2)(react@17.0.2):
@@ -38669,18 +37809,6 @@ packages:
       react-is: 18.3.1
     dev: false
 
-  /rc-util@5.43.0(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-AzC7KKOXFqAdIBqdGWepL9Xn7cm3vnAmjlHqUnoQaTMZYhM4VlXGLkkHHxj/BZ7Td0+SOPKB4RGPboBVKT9htw==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    dependencies:
-      '@babel/runtime': 7.24.5
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-is: 18.3.1
-    dev: false
-
   /rc-virtual-list@3.14.5(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-ZMOnkCLv2wUN8Jz7yI4XiSLa9THlYvf00LuMhb1JlsQCewuU7ydPuHw1rGVPhe9VZYl/5UqODtNd7QKJ2DMGfg==}
     engines: {node: '>=8.x'}
@@ -38709,21 +37837,6 @@ packages:
       rc-util: 5.43.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
-  /rc-virtual-list@3.14.5(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-ZMOnkCLv2wUN8Jz7yI4XiSLa9THlYvf00LuMhb1JlsQCewuU7ydPuHw1rGVPhe9VZYl/5UqODtNd7QKJ2DMGfg==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    dependencies:
-      '@babel/runtime': 7.24.5
-      classnames: 2.5.1
-      rc-resize-observer: 1.4.0(react-dom@18.3.1)(react@18.3.1)
-      rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
     dev: false
 
   /rc@1.2.8:
@@ -38852,13 +37965,13 @@ packages:
       react: 18.1.0
     dev: false
 
-  /react-error-boundary@4.0.13(react@18.3.1):
+  /react-error-boundary@4.0.13(react@18.2.0):
     resolution: {integrity: sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==}
     peerDependencies:
       react: '>=16.13.1'
     dependencies:
       '@babel/runtime': 7.24.5
-      react: 18.3.1
+      react: 18.2.0
     dev: false
 
   /react-fast-compare@3.2.2:
@@ -40596,7 +39709,7 @@ packages:
       '@semantic-release/release-notes-generator': 14.0.1(semantic-release@24.0.0)
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.5.2)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       env-ci: 11.0.0
       execa: 9.3.0
       figures: 6.1.0
@@ -41195,7 +40308,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -41209,7 +40322,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -41405,7 +40518,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -41876,7 +40989,7 @@ packages:
     hasBin: true
     dependencies:
       '@adobe/css-tools': 4.4.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       glob: 7.2.3
       sax: 1.2.4
       source-map: 0.7.4
@@ -41889,7 +41002,7 @@ packages:
     hasBin: true
     dependencies:
       '@adobe/css-tools': 4.3.3
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       glob: 7.2.3
       sax: 1.3.0
       source-map: 0.7.4
@@ -42814,22 +41927,6 @@ packages:
       semver: 7.6.2
       source-map: 0.7.4
       typescript: 5.5.2
-      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.23.0)
-    dev: true
-
-  /ts-loader@9.5.1(typescript@5.5.3)(webpack@5.92.1):
-    resolution: {integrity: sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      typescript: '*'
-      webpack: ^5.0.0
-    dependencies:
-      chalk: 4.1.2
-      enhanced-resolve: 5.17.0
-      micromatch: 4.0.7
-      semver: 7.6.2
-      source-map: 0.7.4
-      typescript: 5.5.3
       webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.18.20)
     dev: true
 
@@ -42961,70 +42058,6 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-node@10.9.1(@swc/core@1.6.13)(@types/node@20.14.10)(typescript@5.2.2):
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.6.13(@swc/helpers@0.5.11)
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.14.10
-      acorn: 8.12.1
-      acorn-walk: 8.3.3
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.2.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
-  /ts-node@10.9.1(@swc/core@1.6.13)(@types/node@20.14.10)(typescript@5.5.3):
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.6.13(@swc/helpers@0.5.11)
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.14.10
-      acorn: 8.12.1
-      acorn-walk: 8.3.3
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.5.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
   /ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.12.12)(typescript@5.5.2):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -43139,7 +42172,7 @@ packages:
       bundle-require: 4.2.1(esbuild@0.18.20)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       esbuild: 0.18.20
       execa: 5.1.1
       globby: 11.1.0
@@ -43180,7 +42213,7 @@ packages:
       bundle-require: 4.2.1(esbuild@0.21.4)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       esbuild: 0.21.4
       execa: 5.1.1
       globby: 11.1.0
@@ -43398,12 +42431,6 @@ packages:
     resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  /typescript@5.5.3:
-    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
 
   /typical@4.0.0:
     resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
@@ -44096,7 +43123,7 @@ packages:
       compression: 1.7.4
       cookies: 0.9.1
       cors: 2.8.5
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       envinfo: 7.11.0
       express: 4.18.2
       express-rate-limit: 5.5.1
@@ -44186,7 +43213,7 @@ packages:
       vfile-message: 4.0.2
     dev: true
 
-  /video-react@0.16.0(react-dom@18.3.1)(react@18.3.1):
+  /video-react@0.16.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-138NHPS8bmgqCYVCdbv2GVFhXntemNHWGw9AN8iJSzr3jizXMmWJd2LTBppr4hZJUbyW1A1tPZ3CQXZUaexMVA==}
     peerDependencies:
       react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
@@ -44196,8 +43223,8 @@ packages:
       classnames: 2.5.0
       lodash.throttle: 4.1.1
       prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       redux: 4.2.1
     dev: false
 
@@ -44228,7 +43255,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       pathe: 1.1.2
       picocolors: 1.0.1
       vite: 5.2.11(@types/node@20.12.12)(less@4.2.0)(stylus@0.63.0)
@@ -44256,7 +43283,7 @@ packages:
       '@microsoft/api-extractor': 7.43.0(@types/node@16.11.68)
       '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       '@vue/language-core': 1.8.27(typescript@5.5.2)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       kolorist: 1.8.0
       magic-string: 0.30.10
       typescript: 5.5.2
@@ -44281,7 +43308,7 @@ packages:
       '@microsoft/api-extractor': 7.43.0(@types/node@20.12.12)
       '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       '@vue/language-core': 1.8.27(typescript@5.5.2)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       kolorist: 1.8.0
       magic-string: 0.30.10
       typescript: 5.5.2
@@ -44301,7 +43328,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 2.1.2(typescript@5.5.2)
       vite: 5.2.11(@types/node@20.12.12)(less@4.2.0)(stylus@0.63.0)
@@ -44433,7 +43460,7 @@ packages:
       acorn-walk: 8.3.3
       cac: 6.7.14
       chai: 4.4.1
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       execa: 8.0.1
       local-pkg: 0.5.0
       magic-string: 0.30.10
@@ -44483,7 +43510,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.56.0
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -45464,26 +44491,26 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /xgplayer-subtitles@3.0.18(core-js@3.37.1):
+  /xgplayer-subtitles@3.0.18(core-js@3.34.0):
     resolution: {integrity: sha512-8xGt3RB1FIu7393Qmfejd9f2JMogEzHjjxv+mzskWHmfT7N9X1xm6JmwCVnfMQXhKZSTtZsinEGCl1VqRjkE1g==}
     peerDependencies:
       core-js: '>=3.12.1'
     dependencies:
-      core-js: 3.37.1
+      core-js: 3.34.0
       eventemitter3: 4.0.7
     dev: false
 
-  /xgplayer@3.0.18(core-js@3.37.1):
+  /xgplayer@3.0.18(core-js@3.34.0):
     resolution: {integrity: sha512-6GXcA8r9c1ANfOch0bsGO9y74YFGO0b2aLRPhhSA7BY8BCWBF1YzF6wQjssCUzVHfBtlS8p73RldL2Mpnggfiw==}
     peerDependencies:
       core-js: '>=3.12.1'
     dependencies:
-      core-js: 3.37.1
+      core-js: 3.34.0
       danmu.js: 1.1.13
       delegate: 3.2.0
       downloadjs: 1.4.7
       eventemitter3: 4.0.7
-      xgplayer-subtitles: 3.0.18(core-js@3.37.1)
+      xgplayer-subtitles: 3.0.18(core-js@3.34.0)
     dev: false
 
   /xml-name-validator@4.0.0:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - '!**/dist/**'
   - 'packages/*'
   - 'packages/bridge/*'
+  - 'packages/runtime-plugins/*'
   - 'packages/enhance'
   - 'apps/runtime-demo/*'
   - 'apps/router-demo/*'


### PR DESCRIPTION
## Description
Stop auto preload when calling loadRemote, users should call preloadRemote Api by manually or use `autoPreloadPlugin` 

### When use autoPreloadPlugin ？

Before `@module-federation/enhanced@0.2.5`, ModuleFederation would automatically preload the resources of remote modules by default.
However, in some scenarios, users do not need this behavior, so we no longer automatically preload, but instead provide this plug-in and let users control whether to enable this behavior.

Therefore, if you use `@module-federation/enhanced@0.2.5` and later versions, want to maintain the same behavior as before, or want to enable automatic preloading, then you need to enable this plugin.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
