### PR TITLE
feat: cache for remote module

### DIFF
--- a/packages/runtime/src/remote/index.ts
+++ b/packages/runtime/src/remote/index.ts
@@ -164,6 +164,22 @@ export class RemoteHandler {
       const { pkgNameOrAlias, remote, expose, id: idRes } = remoteMatchInfo;
       const moduleOrFactory = (await module.get(idRes, expose, options)) as T;
 
+      // update loadRemote cache for name or alias
+      const { name, alias } = remote;
+      const nameCacheKey = `${name}${expose === '.' ? '' : `/${expose}`}_${JSON.stringify(options || {})}`;
+      const aliasCacheKey = `${alias}${expose === '.' ? '' : `/${expose}`}_${JSON.stringify(options || {})}`;
+      const idCacheKey = `${id}_${JSON.stringify(options || {})}`;
+      if (this.loadRemoteCache.has(idCacheKey)) {
+        this.loadRemoteCache.set(
+          nameCacheKey,
+          this.loadRemoteCache.get(idCacheKey)!,
+        );
+        this.loadRemoteCache.set(
+          aliasCacheKey,
+          this.loadRemoteCache.get(idCacheKey)!,
+        );
+      }
+
       const moduleWrapper = await this.hooks.lifecycle.onLoad.emit({
         id: idRes,
         pkgNameOrAlias,

--- a/packages/runtime/src/remote/index.ts
+++ b/packages/runtime/src/remote/index.ts
@@ -435,11 +435,12 @@ export class RemoteHandler {
     const { host } = this;
     const { name, alias } = remote;
     for (const [key] of this.loadRemoteCache) {
+      const id = key.split('_')[0];
       if (
-        key.startsWith(`${name}/`) ||
-        (alias && key.startsWith(`${alias}/`)) ||
-        key === name ||
-        (alias && key === alias)
+        id.startsWith(`${name}/`) ||
+        (alias && id.startsWith(`${alias}/`)) ||
+        id === name ||
+        (alias && id === alias)
       ) {
         this.loadRemoteCache.delete(key);
       }

--- a/packages/runtime/src/remote/index.ts
+++ b/packages/runtime/src/remote/index.ts
@@ -417,9 +417,14 @@ export class RemoteHandler {
 
   private removeRemote(remote: Remote): void {
     const { host } = this;
-    const { name } = remote;
+    const { name, alias } = remote;
     for (const [key] of this.loadRemoteCache) {
-      if (key.startsWith(`${name}_`)) {
+      if (
+        key.startsWith(`${name}/`) ||
+        (alias && key.startsWith(`${alias}/`)) ||
+        key === name ||
+        (alias && key === alias)
+      ) {
         this.loadRemoteCache.delete(key);
       }
     }


### PR DESCRIPTION
## Description

为 `loadRemote` 新增缓存机制，确保多次加载会复用同一个结果，同时在执行 `removeRemote` 时清除缓存

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
