### PR TITLE
fix: skip record remotes while the entry is legacy

### DIFF
--- a/.changeset/green-chefs-crash.md
+++ b/.changeset/green-chefs-crash.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/enhanced': patch
+---
+
+fix: intercept legacy entry

--- a/apps/runtime-demo/3005-runtime-host/webpack.config.js
+++ b/apps/runtime-demo/3005-runtime-host/webpack.config.js
@@ -18,6 +18,27 @@ module.exports = composePlugins(withNx(), withReact(), (config, context) => {
       remotes: {
         // remote2: 'runtime_remote2@http://localhost:3007/remoteEntry.js',
         remote1: 'runtime_remote1@http://127.0.0.1:3006/mf-manifest.json',
+        remote1: `promise new Promise((resolve)=>{
+          const raw = 'runtime_remote1@http://127.0.0.1:3006/remoteEntry.js'
+          const [_, remoteUrlWithVersion] = raw.split('@')
+          const script = document.createElement('script')
+          script.src = remoteUrlWithVersion
+          script.onload = () => {
+            const proxy = {
+              get: (request) => window.runtime_remote1.get(request),
+              init: (arg) => {
+                try {
+                  return window.runtime_remote1.init(arg)
+                } catch(e) {
+                  console.log('runtime_remote1 container already initialized')
+                }
+              }
+            }
+            resolve(proxy)
+          }
+          document.head.appendChild(script);
+
+        })`,
       },
       // library: { type: 'var', name: 'runtime_remote' },
       filename: 'remoteEntry.js',

--- a/apps/runtime-demo/3005-runtime-host/webpack.config.js
+++ b/apps/runtime-demo/3005-runtime-host/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = composePlugins(withNx(), withReact(), (config, context) => {
       name: 'runtime_host',
       remotes: {
         // remote2: 'runtime_remote2@http://localhost:3007/remoteEntry.js',
-        remote1: 'runtime_remote1@http://127.0.0.1:3006/mf-manifest.json',
+        // remote1: 'runtime_remote1@http://127.0.0.1:3006/mf-manifest.json',
         remote1: `promise new Promise((resolve)=>{
           const raw = 'runtime_remote1@http://127.0.0.1:3006/remoteEntry.js'
           const [_, remoteUrlWithVersion] = raw.split('@')

--- a/packages/enhanced/src/lib/container/runtime/utils.ts
+++ b/packages/enhanced/src/lib/container/runtime/utils.ts
@@ -51,6 +51,10 @@ export function normalizeRuntimeInitOptionsWithOutShared(
     const { external, shareScope } = remoteInfos;
     try {
       // only fit for remoteType: 'script'
+      const entry = external[0];
+      if (/\s/.test(entry)) {
+        return;
+      }
       const [url, globalName] = extractUrlAndGlobal(external[0]);
       remoteOptions.push({
         alias,


### PR DESCRIPTION
## Description

Skip record remotes while the entry is legacy.

ModuleFederationV2 runtime only support `script` format entry , so it will ignore others entry. 
The other format entry will be loaded as MFV1 way.

## Related Issue
#2740 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
