### PR TITLE
fix(dts-plugin): temp tsconfig path should extends original tsconfig

### DIFF
--- a/.changeset/clean-kiwis-repair.md
+++ b/.changeset/clean-kiwis-repair.md
@@ -2,4 +2,4 @@
 '@module-federation/dts-plugin': patch
 ---
 
-fix(dts-plugin): output temp tsconfig to current project root
+fix(dts-plugin): temp tsconfig path should extends original tsconfig

--- a/.changeset/clean-kiwis-repair.md
+++ b/.changeset/clean-kiwis-repair.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+fix(dts-plugin): output temp tsconfig to current project root

--- a/packages/dts-plugin/src/core/configurations/hostPlugin.test.ts
+++ b/packages/dts-plugin/src/core/configurations/hostPlugin.test.ts
@@ -6,7 +6,7 @@ import { retrieveTypesArchiveDestinationPath } from '../lib/archiveHandler';
 
 describe('hostPlugin', () => {
   const moduleFederationConfig = {
-    name: 'moduleFederationHost',
+    name: 'hostPluginTestHost',
     filename: 'remoteEntry.js',
     remotes: {
       moduleFederationTypescript: 'http://localhost:3000/remoteEntry.js',

--- a/packages/dts-plugin/src/core/configurations/remotePlugin.test.ts
+++ b/packages/dts-plugin/src/core/configurations/remotePlugin.test.ts
@@ -35,6 +35,7 @@ describe('hostPlugin', () => {
           });
 
         expect(tsConfig).toStrictEqual({
+          extends: tsConfigPath,
           compileOnSave: false,
           compilerOptions: {
             target: 'es2017',
@@ -98,6 +99,7 @@ describe('hostPlugin', () => {
 
         expect(tsConfig).toStrictEqual({
           compileOnSave: false,
+          extends: tsConfigPath,
           compilerOptions: {
             module: 'esnext',
             resolveJsonModule: true,

--- a/packages/dts-plugin/src/core/configurations/remotePlugin.test.ts
+++ b/packages/dts-plugin/src/core/configurations/remotePlugin.test.ts
@@ -5,7 +5,7 @@ import { retrieveRemoteConfig } from './remotePlugin';
 
 describe('hostPlugin', () => {
   const moduleFederationConfig = {
-    name: 'moduleFederationHost',
+    name: 'remotePluginTestHost',
     filename: 'remoteEntry.js',
     exposes: {
       './button': './src/components/button',

--- a/packages/dts-plugin/src/core/configurations/remotePlugin.ts
+++ b/packages/dts-plugin/src/core/configurations/remotePlugin.ts
@@ -105,6 +105,8 @@ const readTsConfig = (
     ...defaultCompilerOptions,
   };
 
+  delete rawTsConfigJson.compilerOptions?.paths;
+
   const filesToCompile = [
     ...Object.values(mapComponentsToExpose),
     ...additionalFilesToCompile,
@@ -115,10 +117,7 @@ const readTsConfig = (
   rawTsConfigJson.exclude = [];
   'references' in rawTsConfigJson && delete rawTsConfigJson.references;
 
-  const extendsPath = rawTsConfigJson.extends;
-  if (extendsPath && extendsPath.startsWith('.')) {
-    rawTsConfigJson.extends = resolve(context, extendsPath);
-  }
+  rawTsConfigJson.extends = resolvedTsConfigPath;
   return rawTsConfigJson;
 };
 

--- a/packages/dts-plugin/src/core/lib/DTSManager.advance.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.advance.spec.ts
@@ -12,7 +12,7 @@ describe('DTSManager advance usage', () => {
   const typesFolder = '@mf-types-dts-test-advance';
   const remoteOptions = {
     moduleFederationConfig: {
-      name: 'moduleFederationTypescript',
+      name: 'dtsManagerAdvanceSpecRemote',
       filename: 'remoteEntry.js',
       exposes: {
         './index': join(__dirname, '..', './index.ts'),
@@ -36,7 +36,7 @@ describe('DTSManager advance usage', () => {
   const hostOptions = {
     context: projectRoot,
     moduleFederationConfig: {
-      name: 'moduleFederationTypescript',
+      name: 'dtsManagerAdvanceSpecHost',
       filename: 'remoteEntry.js',
       remotes: {
         remotes: 'remote@https://bar.it',

--- a/packages/dts-plugin/src/core/lib/DTSManager.advance.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.advance.spec.ts
@@ -110,13 +110,7 @@ describe('DTSManager advance usage', () => {
     const targetFolder = join(projectRoot, hostOptions.typesFolder);
     expect(
       dirTree(targetFolder, {
-        exclude: [
-          /node_modules/,
-          /dev-worker/,
-          /plugins/,
-          /server/,
-          /tsconfig/,
-        ],
+        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
       }),
     ).toMatchObject({
       name: '@mf-types-dts-test-consume-types-advance',

--- a/packages/dts-plugin/src/core/lib/DTSManager.advance.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.advance.spec.ts
@@ -110,7 +110,13 @@ describe('DTSManager advance usage', () => {
     const targetFolder = join(projectRoot, hostOptions.typesFolder);
     expect(
       dirTree(targetFolder, {
-        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
+        exclude: [
+          /node_modules/,
+          /dev-worker/,
+          /plugins/,
+          /server/,
+          /tsconfig/,
+        ],
       }),
     ).toMatchObject({
       name: '@mf-types-dts-test-consume-types-advance',

--- a/packages/dts-plugin/src/core/lib/DTSManager.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.spec.ts
@@ -72,13 +72,7 @@ describe('DTSManager', () => {
 
     expect(
       dirTree(distFolder, {
-        exclude: [
-          /node_modules/,
-          /dev-worker/,
-          /plugins/,
-          /server/,
-          /tsconfig/,
-        ],
+        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
       }),
     ).toMatchObject({
       name: '@mf-types-dts-test',
@@ -336,13 +330,7 @@ describe('DTSManager', () => {
 
       expect(
         dirTree(targetFolder, {
-          exclude: [
-            /node_modules/,
-            /dev-worker/,
-            /plugins/,
-            /server/,
-            /tsconfig/,
-          ],
+          exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
         }),
       ).toMatchObject(expectedStructure);
     });
@@ -352,13 +340,7 @@ describe('DTSManager', () => {
       await dtsManager.consumeTypes();
       expect(
         dirTree(targetFolder, {
-          exclude: [
-            /node_modules/,
-            /dev-worker/,
-            /plugins/,
-            /server/,
-            /tsconfig/,
-          ],
+          exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
         }),
       ).toMatchObject(expectedStructure);
     });
@@ -379,13 +361,7 @@ describe('DTSManager', () => {
     });
     expect(
       dirTree(distFolder, {
-        exclude: [
-          /node_modules/,
-          /dev-worker/,
-          /plugins/,
-          /server/,
-          /tsconfig/,
-        ],
+        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/, ,],
       }),
     ).toMatchObject({
       name: '@mf-types-dts-test',
@@ -526,13 +502,7 @@ describe('DTSManager', () => {
 
     expect(
       dirTree(targetFolder, {
-        exclude: [
-          /node_modules/,
-          /dev-worker/,
-          /plugins/,
-          /server/,
-          /tsconfig/,
-        ],
+        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
       }),
     ).toMatchObject({
       name: '@mf-types-dts-test-consume-types',

--- a/packages/dts-plugin/src/core/lib/DTSManager.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.spec.ts
@@ -2,8 +2,8 @@ import AdmZip from 'adm-zip';
 import axios from 'axios';
 import dirTree from 'directory-tree';
 import { rmSync, existsSync } from 'fs';
-import { basename, join } from 'path';
-import { describe, expect, it, vi, afterAll } from 'vitest';
+import { join } from 'path';
+import { describe, expect, it, vi } from 'vitest';
 import { DTSManager } from './DTSManager';
 import { UpdateMode } from '../../server/constant';
 
@@ -14,7 +14,7 @@ describe('DTSManager', () => {
   const typesFolder = '@mf-types-dts-test';
   const remoteOptions = {
     moduleFederationConfig: {
-      name: 'moduleFederationTypescript',
+      name: 'dtsManagerSpecRemote',
       filename: 'remoteEntry.js',
       exposes: {
         './index': join(__dirname, '..', './index.ts'),
@@ -34,7 +34,7 @@ describe('DTSManager', () => {
 
   const hostOptions = {
     moduleFederationConfig: {
-      name: 'moduleFederationTypescript',
+      name: 'dtsManagerSpecHost',
       filename: 'remoteEntry.js',
       remotes: {
         remotes: 'remote@https://foo.it',
@@ -51,15 +51,6 @@ describe('DTSManager', () => {
   const dtsManager = new DTSManager({
     remote: remoteOptions,
     host: hostOptions,
-  });
-
-  afterAll(() => {
-    [
-      join(projectRoot, TEST_DIT_DIR, remoteOptions.typesFolder),
-      join(projectRoot, hostOptions.typesFolder),
-    ].forEach((tmpDir) => {
-      rmSync(tmpDir, { recursive: true });
-    });
   });
 
   it('generate types', async () => {
@@ -355,7 +346,7 @@ describe('DTSManager', () => {
     rmSync(distFolder, { recursive: true });
     expect(existsSync(distFolder)).toEqual(false);
     await dtsManager.updateTypes({
-      remoteName: remoteOptions.moduleFederationConfig.name,
+      remoteName: hostOptions.moduleFederationConfig.name,
       remoteTarPath: '',
       updateMode: UpdateMode.POSITIVE,
     });

--- a/packages/dts-plugin/src/core/lib/DTSManager.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.spec.ts
@@ -72,7 +72,13 @@ describe('DTSManager', () => {
 
     expect(
       dirTree(distFolder, {
-        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
+        exclude: [
+          /node_modules/,
+          /dev-worker/,
+          /plugins/,
+          /server/,
+          /tsconfig/,
+        ],
       }),
     ).toMatchObject({
       name: '@mf-types-dts-test',
@@ -330,7 +336,13 @@ describe('DTSManager', () => {
 
       expect(
         dirTree(targetFolder, {
-          exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
+          exclude: [
+            /node_modules/,
+            /dev-worker/,
+            /plugins/,
+            /server/,
+            /tsconfig/,
+          ],
         }),
       ).toMatchObject(expectedStructure);
     });
@@ -340,7 +352,13 @@ describe('DTSManager', () => {
       await dtsManager.consumeTypes();
       expect(
         dirTree(targetFolder, {
-          exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
+          exclude: [
+            /node_modules/,
+            /dev-worker/,
+            /plugins/,
+            /server/,
+            /tsconfig/,
+          ],
         }),
       ).toMatchObject(expectedStructure);
     });
@@ -361,7 +379,13 @@ describe('DTSManager', () => {
     });
     expect(
       dirTree(distFolder, {
-        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
+        exclude: [
+          /node_modules/,
+          /dev-worker/,
+          /plugins/,
+          /server/,
+          /tsconfig/,
+        ],
       }),
     ).toMatchObject({
       name: '@mf-types-dts-test',
@@ -502,7 +526,13 @@ describe('DTSManager', () => {
 
     expect(
       dirTree(targetFolder, {
-        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
+        exclude: [
+          /node_modules/,
+          /dev-worker/,
+          /plugins/,
+          /server/,
+          /tsconfig/,
+        ],
       }),
     ).toMatchObject({
       name: '@mf-types-dts-test-consume-types',

--- a/packages/dts-plugin/src/core/lib/DtsWorker.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DtsWorker.spec.ts
@@ -82,7 +82,13 @@ describe('generateTypesInChildProcess', () => {
     await dtsWorker.controlledPromise;
     expect(
       dirTree(distFolder, {
-        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
+        exclude: [
+          /node_modules/,
+          /dev-worker/,
+          /plugins/,
+          /server/,
+          /tsconfig/,
+        ],
       }),
     ).toMatchObject({
       name: '@mf-types-dts-test-child-process',

--- a/packages/dts-plugin/src/core/lib/DtsWorker.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DtsWorker.spec.ts
@@ -9,7 +9,7 @@ describe('generateTypesInChildProcess', () => {
   const typesFolder = '@mf-types-dts-test-child-process';
   const remoteOptions = {
     moduleFederationConfig: {
-      name: 'moduleFederationTypescript',
+      name: 'dtsWorkerSpecRemote',
       filename: 'remoteEntry.js',
       exposes: {
         './index': join(__dirname, '..', './index.ts'),
@@ -30,7 +30,7 @@ describe('generateTypesInChildProcess', () => {
   const hostOptions = {
     context: projectRoot,
     moduleFederationConfig: {
-      name: 'moduleFederationTypescript',
+      name: 'dtsWorkerSpecHost',
       filename: 'remoteEntry.js',
       remotes: {
         remotes: 'remote@https://foo.it',

--- a/packages/dts-plugin/src/core/lib/DtsWorker.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DtsWorker.spec.ts
@@ -82,13 +82,7 @@ describe('generateTypesInChildProcess', () => {
     await dtsWorker.controlledPromise;
     expect(
       dirTree(distFolder, {
-        exclude: [
-          /node_modules/,
-          /dev-worker/,
-          /plugins/,
-          /server/,
-          /tsconfig/,
-        ],
+        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
       }),
     ).toMatchObject({
       name: '@mf-types-dts-test-child-process',

--- a/packages/dts-plugin/src/core/lib/archiveHandler.test.ts
+++ b/packages/dts-plugin/src/core/lib/archiveHandler.test.ts
@@ -73,6 +73,7 @@ describe('archiveHandler', () => {
       context: process.cwd(),
       abortOnError: true,
       consumeAPITypes: false,
+      runtimePkgs: [],
     };
 
     const destinationFolder = 'typesHostFolder';
@@ -118,6 +119,7 @@ describe('archiveHandler', () => {
         context: process.cwd(),
         abortOnError: false,
         consumeAPITypes: false,
+        runtimePkgs: [],
       };
       axios.get = vi.fn().mockRejectedValue(new Error(message));
       const res = await downloadTypesArchive(hostOptions)([

--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.test.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.test.ts
@@ -111,7 +111,13 @@ describe('typeScriptCompiler', () => {
       const directoryStructure = dirTree(
         join(tsConfig.compilerOptions.outDir, '..'),
         {
-          exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
+          exclude: [
+            /node_modules/,
+            /dev-worker/,
+            /plugins/,
+            /server/,
+            /tsconfig/,
+          ],
         },
       );
       const expectedStructure = {

--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.test.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.test.ts
@@ -111,13 +111,7 @@ describe('typeScriptCompiler', () => {
       const directoryStructure = dirTree(
         join(tsConfig.compilerOptions.outDir, '..'),
         {
-          exclude: [
-            /node_modules/,
-            /dev-worker/,
-            /plugins/,
-            /server/,
-            /tsconfig/,
-          ],
+          exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
         },
       );
       const expectedStructure = {

--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
@@ -1,9 +1,5 @@
-import {
-  ensureDirSync,
-  writeFileSync,
-  existsSync,
-  readFileSync,
-} from 'fs-extra';
+import { ensureDirSync, writeFileSync, existsSync } from 'fs-extra';
+import crypto from 'crypto';
 import { stat, readdir, writeFile, rm, readFile } from 'fs/promises';
 import { randomUUID } from 'crypto';
 import {
@@ -64,11 +60,15 @@ function writeTempTsConfig(
   context: string,
   name: string,
 ) {
+  const createHash = (contents: string) => {
+    return crypto.createHash('md5').update(contents).digest('hex');
+  };
+  const hash = createHash(`${JSON.stringify(tsConfig)}${name}`);
   const tempTsConfigJsonPath = resolve(
     context,
     'node_modules',
     TEMP_DIR,
-    `tsconfig.${name}.${randomUUID()}.json`,
+    `tsconfig.${hash}.json`,
   );
   ensureDirSync(dirname(tempTsConfigJsonPath));
   writeFileSync(tempTsConfigJsonPath, JSON.stringify(tsConfig, null, 2));
@@ -218,11 +218,6 @@ export const compileTs = async (
   } catch (err) {
     if (isDebugMode()) {
       console.log('tsconfig: ', JSON.stringify(tsConfig, null, 2));
-      console.log('tsconfig path: ', tempTsConfigJsonPath);
-      console.log(
-        'tsconfig path content: ',
-        readFileSync(tempTsConfigJsonPath),
-      );
     }
     throw err;
   }

--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
@@ -54,12 +54,16 @@ export const retrieveMfAPITypesPath = (
     `${remoteOptions.typesFolder}.d.ts`,
   );
 
-function writeTempTsConfig(tsConfig: TsConfigJson, context: string) {
+function writeTempTsConfig(
+  tsConfig: TsConfigJson,
+  context: string,
+  name: string,
+) {
   const tempTsConfigJsonPath = resolve(
     context,
     'node_modules',
     TEMP_DIR,
-    `tsconfig.${randomUUID()}.json`,
+    `tsconfig.${name}.${randomUUID()}.json`,
   );
   ensureDirSync(dirname(tempTsConfigJsonPath));
   writeFileSync(tempTsConfigJsonPath, JSON.stringify(tsConfig, null, 2));
@@ -152,6 +156,7 @@ export const compileTs = async (
   const tempTsConfigJsonPath = writeTempTsConfig(
     tsConfig,
     remoteOptions.context,
+    remoteOptions.moduleFederationConfig.name || 'mf',
   );
   try {
     const mfTypePath = retrieveMfTypesPath(tsConfig, remoteOptions);

--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
@@ -57,7 +57,9 @@ export const retrieveMfAPITypesPath = (
 function writeTempTsConfig(tsConfig: TsConfigJson, context: string) {
   const tempTsConfigJsonPath = resolve(
     context,
-    `tsconfig.mf.${randomUUID()}.json`,
+    'node_modules',
+    TEMP_DIR,
+    `tsconfig.${randomUUID()}.json`,
   );
   ensureDirSync(dirname(tempTsConfigJsonPath));
   writeFileSync(tempTsConfigJsonPath, JSON.stringify(tsConfig, null, 2));

--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
@@ -57,9 +57,7 @@ export const retrieveMfAPITypesPath = (
 function writeTempTsConfig(tsConfig: TsConfigJson, context: string) {
   const tempTsConfigJsonPath = resolve(
     context,
-    'node_modules',
-    TEMP_DIR,
-    `tsconfig.${randomUUID()}.json`,
+    `tsconfig.mf.${randomUUID()}.json`,
   );
   ensureDirSync(dirname(tempTsConfigJsonPath));
   writeFileSync(tempTsConfigJsonPath, JSON.stringify(tsConfig, null, 2));

--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
@@ -1,4 +1,9 @@
-import { ensureDirSync, writeFileSync, existsSync } from 'fs-extra';
+import {
+  ensureDirSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+} from 'fs-extra';
 import { stat, readdir, writeFile, rm, readFile } from 'fs/promises';
 import { randomUUID } from 'crypto';
 import {
@@ -213,6 +218,11 @@ export const compileTs = async (
   } catch (err) {
     if (isDebugMode()) {
       console.log('tsconfig: ', JSON.stringify(tsConfig, null, 2));
+      console.log('tsconfig path: ', tempTsConfigJsonPath);
+      console.log(
+        'tsconfig path content: ',
+        readFileSync(tempTsConfigJsonPath),
+      );
     }
     throw err;
   }

--- a/packages/dts-plugin/tests/setup.ts
+++ b/packages/dts-plugin/tests/setup.ts
@@ -1,0 +1,9 @@
+import { rmSync } from 'fs';
+import path from 'path';
+
+const TEMP_TS_CONFIG_DIR = path.resolve(__dirname, 'node_modules/.federation');
+try {
+  rmSync(TEMP_TS_CONFIG_DIR, { recursive: true });
+} catch (err) {
+  // noop
+}

--- a/packages/dts-plugin/tests/vue-tsc2/index.spec.ts
+++ b/packages/dts-plugin/tests/vue-tsc2/index.spec.ts
@@ -34,7 +34,13 @@ describe('DTSManager', () => {
 
     expect(
       dirTree(distFolder, {
-        exclude: [/node_modules/, /dev-worker/, /plugins/, /server/],
+        exclude: [
+          /node_modules/,
+          /dev-worker/,
+          /plugins/,
+          /server/,
+          /tsconfig/,
+        ],
       }),
     ).toMatchObject({
       children: [

--- a/packages/dts-plugin/vite.config.ts
+++ b/packages/dts-plugin/vite.config.ts
@@ -5,12 +5,11 @@ import path from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 
 export default defineConfig({
-  cacheDir: '../../node_modules/.vite/dts-plugin',
+  cacheDir: '../../node_modules/.vitest/dts-plugin',
 
   plugins: [nxViteTsPaths()],
 
   test: {
-    // cache: false,
     cache: {
       dir: '../../node_modules/.vitest',
     },

--- a/packages/dts-plugin/vite.config.ts
+++ b/packages/dts-plugin/vite.config.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite';
+import path from 'path';
 
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 
@@ -20,5 +21,6 @@ export default defineConfig({
     ],
     reporters: ['default'],
     testTimeout: 60000,
+    setupFiles: [path.resolve(__dirname, './tests/setup.ts')],
   },
 });


### PR DESCRIPTION
## Description

* delete temp tsConfig.compilerOptions.paths 
* add extends which value is original tsConfig.json

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
