### PR TITLE
fix(runtime): ensured attributes are forwarded to createScript hook

### DIFF
--- a/.changeset/good-shirts-cover.md
+++ b/.changeset/good-shirts-cover.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+Ensured createScript runtime hook always receives `attrs`

--- a/packages/runtime/src/utils/preload.ts
+++ b/packages/runtime/src/utils/preload.ts
@@ -82,9 +82,10 @@ export function preloadAssets(
         getRemoteEntry({
           remoteInfo: moduleInfo,
           remoteEntryExports: module.remoteEntryExports,
-          createScriptHook: (url: string) => {
+          createScriptHook: (url: string, attrs: any) => {
             const res = host.loaderHook.lifecycle.createScript.emit({
               url,
+              attrs,
             });
             if (!res) return;
 
@@ -108,9 +109,10 @@ export function preloadAssets(
         getRemoteEntry({
           remoteInfo: moduleInfo,
           remoteEntryExports: undefined,
-          createScriptHook: (url: string) => {
+          createScriptHook: (url: string, attrs: any) => {
             const res = host.loaderHook.lifecycle.createScript.emit({
               url,
+              attrs,
             });
             if (!res) return;
 
@@ -211,9 +213,10 @@ export function preloadAssets(
           attrs: {
             fetchpriority: 'high',
           },
-          createScriptHook: (url: string) => {
+          createScriptHook: (url: string, attrs: any) => {
             const res = host.loaderHook.lifecycle.createScript.emit({
               url,
+              attrs,
             });
             if (res instanceof HTMLScriptElement) {
               return res;


### PR DESCRIPTION
## Description

In NextJS, with a recent update to the nextjs-mf plugin, the app will immediately crash in the browser with "TypeError: Cannot convert undefined or null to object" because the `attrs` object is undefined in the next-internal-plugin createScript hook. It looks like there were a couple of places where only `url` was passed to the hook, and in those cases the runtime plugin bundled with nextjs-mf would fail when createScript was emitted.

The error appears only to surface when using the manifest in NextJS, but I think the underlying issue is that `attrs` is expected by the hook but it isn't present when preloading.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Steps to reproduce:

1. Checkout the `nextjs-ssr-manifest` example from this PR: https://github.com/module-federation/module-federation-examples/pull/4231
2. Update the `@module-federation/*` dependencies to their latest versions (as of now: `nextjs-mf@8.4.4`, `enhanced@0.3.1`)
3. Run `npm start`
4. Open in a browser and see the error


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
