### PR TITLE
fix: support rspack ssr live reload

### DIFF
--- a/apps/modernjs-ssr/dynamic-nested-remote/tsconfig.json
+++ b/apps/modernjs-ssr/dynamic-nested-remote/tsconfig.json
@@ -10,6 +10,6 @@
       "*": ["./@mf-types/*"]
     }
   },
-  "include": ["src", "shared", "config", "modern.config.ts", "./@mf-types"],
+  "include": ["src", "shared", "config", "modern.config.ts", "@mf-types"],
   "exclude": ["**/node_modules"]
 }

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -36,11 +36,13 @@ export function modifyBundlerConfig<T extends Bundler>(options: {
     isServer,
     modernjsConfig,
     remoteIpStrategy = 'ipv4',
+    bundlerType,
   } = options;
 
   patchMFConfig(mfConfig, isServer, remoteIpStrategy);
 
   patchBundlerConfig({
+    bundlerType,
     bundlerConfig: config,
     isServer,
     modernjsConfig,

--- a/packages/modernjs/src/cli/ssrPlugin.ts
+++ b/packages/modernjs/src/cli/ssrPlugin.ts
@@ -4,7 +4,7 @@ import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 import type { InternalModernPluginOptions } from '../types';
 import { ModuleFederationPlugin } from '@module-federation/enhanced';
 import { ModuleFederationPlugin as RspackModuleFederationPlugin } from '@module-federation/enhanced/rspack';
-import { EntryChunkTrackerPlugin } from '@module-federation/node';
+import { UniverseEntryChunkTrackerPlugin } from '@module-federation/node';
 import { updateStatsAndManifest } from './manifest';
 import { MODERN_JS_SERVER_DIR, PLUGIN_IDENTIFIER } from '../constant';
 import { isDev } from './constant';
@@ -82,12 +82,6 @@ export const moduleFederationSSRPlugin = (
                   // @ts-ignore
                   config.plugins?.push(userConfig.nodePlugin);
                 }
-                // config.plugins?.push(
-                //   new StreamingTargetPlugin(userConfig.nodePlugin),
-                // );
-                if (isDev) {
-                  config.plugins?.push(new EntryChunkTrackerPlugin());
-                }
               } else {
                 userConfig.distOutputDir =
                   userConfig.distOutputDir ||
@@ -137,6 +131,11 @@ export const moduleFederationSSRPlugin = (
             bundlerChain(chain, { isServer }) {
               if (isServer) {
                 chain.target('async-node');
+                if (isDev) {
+                  chain
+                    .plugin('UniverseEntryChunkTrackerPlugin')
+                    .use(UniverseEntryChunkTrackerPlugin);
+                }
               }
               if (isDev && !isServer) {
                 chain.externals({

--- a/packages/modernjs/src/cli/utils.spec.ts
+++ b/packages/modernjs/src/cli/utils.spec.ts
@@ -118,7 +118,7 @@ describe('patchBundlerConfig', async () => {
         uniqueName: 'host',
       },
       watchOptions: {
-        ignored: ['@mf-types'],
+        ignored: ['**/@mf-types/**'],
       },
     };
     // @ts-ignore temp ignore
@@ -155,7 +155,7 @@ describe('patchBundlerConfig', async () => {
         uniqueName: 'host',
       },
       watchOptions: {
-        ignored: ['@mf-types'],
+        ignored: ['**/@mf-types/**'],
       },
     };
     // @ts-ignore temp ignore

--- a/packages/modernjs/src/cli/utils.spec.ts
+++ b/packages/modernjs/src/cli/utils.spec.ts
@@ -98,6 +98,7 @@ describe('patchBundlerConfig', async () => {
       },
     };
     patchBundlerConfig<'webpack'>({
+      bundlerType: 'webpack',
       bundlerConfig,
       isServer: true,
       modernjsConfig: {
@@ -134,6 +135,7 @@ describe('patchBundlerConfig', async () => {
       },
     };
     patchBundlerConfig<'webpack'>({
+      bundlerType: 'webpack',
       bundlerConfig,
       isServer: false,
       modernjsConfig: {

--- a/packages/node/global.d.ts
+++ b/packages/node/global.d.ts
@@ -11,7 +11,7 @@ declare module 'webpack/lib/RuntimeModule';
 declare module 'webpack/lib/Template';
 declare module 'webpack/lib/util/compileBooleanMatcher';
 declare module 'webpack/lib/util/identifier';
-
+declare module 'btoa';
 declare global {
   namespace NodeJS {
     interface Global {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -57,6 +57,7 @@
   "author": "Zack Jackson <zackary.l.jackson@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "btoa": "1.2.1",
     "encoding": "^0.1.13",
     "node-fetch": "2.7.0",
     "@module-federation/enhanced": "workspace:*",

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -4,3 +4,4 @@ export { default as UniversalFederationPlugin } from './plugins/UniversalFederat
 export { default as ChunkCorrelationPlugin } from './plugins/ChunkCorrelationPlugin';
 export { default as RemotePublicPathPlugin } from './plugins/RemotePublicPathRuntimeModule';
 export { default as EntryChunkTrackerPlugin } from './plugins/EntryChunkTrackerPlugin';
+export { default as UniverseEntryChunkTrackerPlugin } from './plugins/UniverseEntryChunkTrackerPlugin';

--- a/packages/node/src/plugins/UniverseEntryChunkTrackerPlugin.ts
+++ b/packages/node/src/plugins/UniverseEntryChunkTrackerPlugin.ts
@@ -1,0 +1,28 @@
+import pBtoa from 'btoa';
+import type { WebpackPluginInstance, Compiler } from 'webpack';
+
+class UniverseEntryChunkTrackerPlugin implements WebpackPluginInstance {
+  apply(compiler: Compiler) {
+    const code = `
+    if(typeof module !== 'undefined') {
+    globalThis.entryChunkCache = globalThis.entryChunkCache || new Set();
+    module.filename && globalThis.entryChunkCache.add(module.filename);
+    if(module.children) {
+    module.children.forEach(function(c) {
+      c.filename && globalThis.entryChunkCache.add(c.filename);
+    })
+}
+  }
+    `;
+    const base64Code = pBtoa(code);
+    const dataUrl = `data:text/javascript;base64,${base64Code}`;
+
+    compiler.hooks.afterPlugins.tap('UniverseEntryChunkTrackerPlugin', () => {
+      new compiler.webpack.EntryPlugin(compiler.context, dataUrl, {}).apply(
+        compiler,
+      );
+    });
+  }
+}
+
+export default UniverseEntryChunkTrackerPlugin;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2397,6 +2397,9 @@ importers:
       '@module-federation/utilities':
         specifier: workspace:*
         version: link:../utilities
+      btoa:
+        specifier: 1.2.1
+        version: 1.2.1
       encoding:
         specifier: ^0.1.13
         version: 0.1.13


### PR DESCRIPTION
## Description

* add UniverseEntryChunkTrackerPlugin to support both webpack and rspack live reload
* only webpack need to add watchOptions.ignored to avoid i infinite refresh

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
