### PR TITLE
feat(utilities): expose esm from package json

### DIFF
--- a/.changeset/large-bikes-fail.md
+++ b/.changeset/large-bikes-fail.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/utilities': minor
+---
+
+Expose esm from the package json

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@module-federation/utilities",
   "version": "3.0.39",
-  "type": "commonjs",
   "main": "./dist/index.cjs.js",
+  "module": "./dist/index.esm.js",
   "types": "./dist/index.cjs.d.ts",
   "license": "MIT",
   "publishConfig": {
@@ -36,7 +36,11 @@
     }
   },
   "exports": {
-    ".": "./dist/index.cjs.js",
+    ".": {
+      "types": "./dist/index.cjs.d.ts",
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs.js"
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {


### PR DESCRIPTION
## Description


This PR modifies the package.json to expose the ESM files from the "utilities" package, using similar patterns as the "runtime" package. This change will help Webpack perform tree-shaking more effectively.

The import:
```js
import { importRemote as importRemoteUtility } from '@module-federation/utilities';
```

See numbers in the following images:
**Before**
![mf-utilitize-before](https://github.com/user-attachments/assets/34347262-2c7f-4e53-b55f-70291418cc76)

**After**
![mf-utilitize-after](https://github.com/user-attachments/assets/009ec98b-0785-4199-aea7-27c47107a9b7)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
