### PR TITLE
fix(enhanced): remove useless but has side effect export

### DIFF
--- a/.changeset/friendly-pans-clean.md
+++ b/.changeset/friendly-pans-clean.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/enhanced': patch
+---
+
+fix(enhanced): remove useless but has side effect export

--- a/packages/enhanced/src/index.ts
+++ b/packages/enhanced/src/index.ts
@@ -10,12 +10,6 @@ export { default as FederationRuntimePlugin } from './wrapper/FederationRuntimeP
 export { default as AsyncBoundaryPlugin } from './wrapper/AsyncBoundaryPlugin';
 export { default as HoistContainerReferencesPlugin } from './wrapper/HoistContainerReferencesPlugin';
 
-export {
-  isRequiredVersion,
-  normalizeVersion,
-  getDescriptionFile,
-  getRequiredVersionFromDescriptionFile,
-} from './lib/sharing/utils';
 export { parseOptions } from './lib/container/options';
 
 export const container = {


### PR DESCRIPTION
## Description

remove useless but has side effect export.

`lib/sharing/utils` will require `webpack/lib/util/fs`, but `process.env['FEDERATION_WEBPACK_PATH']` only be injected after `ModuleFederationPlugin.apply` be called . 

And the utils seems not be used anymore, so it can be removed

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
