### PR TITLE
feat(runtime): provide users to mark share dependency as loaded #2789

### DIFF
--- a/.changeset/giant-fishes-itch.md
+++ b/.changeset/giant-fishes-itch.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': minor
+---
+
+provide users to mark shared module as loaded

--- a/packages/runtime/src/type/config.ts
+++ b/packages/runtime/src/type/config.ts
@@ -58,6 +58,7 @@ type SharedBaseArgs = {
   scope?: string | Array<string>;
   deps?: Array<string>;
   strategy?: 'version-first' | 'loaded-first';
+  loaded?: boolean;
 };
 
 export type SharedGetter = (() => () => Module) | (() => Promise<() => Module>);

--- a/packages/runtime/src/utils/share.ts
+++ b/packages/runtime/src/utils/share.ts
@@ -46,7 +46,7 @@ export function formatShare(
       ...shareArgs.shareConfig,
     },
     get,
-    loaded: 'lib' in shareArgs ? true : undefined,
+    loaded: shareArgs?.loaded || 'lib' in shareArgs ? true : undefined,
     version: shareArgs.version ?? '0',
     scope: Array.isArray(shareArgs.scope)
       ? shareArgs.scope


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
- Provide users an option to mark modules in the shared scope as loaded.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #2789 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
