### PR TITLE
fix: no add default attrs to the element which is provided by users

### DIFF
--- a/.changeset/itchy-mayflies-destroy.md
+++ b/.changeset/itchy-mayflies-destroy.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/sdk': patch
+---
+
+fix: no add default attrs to the element which is provided by users

--- a/.changeset/thin-ducks-share.md
+++ b/.changeset/thin-ducks-share.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/runtime': patch
+'@module-federation/sdk': patch
+---
+
+fix: add attrs and useLinkPreload options to createLink hook

--- a/.changeset/thin-ducks-share.md
+++ b/.changeset/thin-ducks-share.md
@@ -3,4 +3,4 @@
 '@module-federation/sdk': patch
 ---
 
-fix: add attrs and useLinkPreload options to createLink hook
+fix: add attrs option to createLink hook

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -90,7 +90,6 @@ export class FederationHost {
         {
           url: string;
           attrs?: Record<string, any>;
-          useLinkPreload?: boolean;
         },
       ],
       CreateScriptHookReturn
@@ -100,7 +99,6 @@ export class FederationHost {
         {
           url: string;
           attrs?: Record<string, any>;
-          useLinkPreload?: boolean;
         },
       ],
       HTMLLinkElement | void

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -90,6 +90,7 @@ export class FederationHost {
         {
           url: string;
           attrs?: Record<string, any>;
+          useLinkPreload?: boolean;
         },
       ],
       CreateScriptHookReturn
@@ -98,6 +99,8 @@ export class FederationHost {
       [
         {
           url: string;
+          attrs?: Record<string, any>;
+          useLinkPreload?: boolean;
         },
       ],
       HTMLLinkElement | void

--- a/packages/runtime/src/utils/preload.ts
+++ b/packages/runtime/src/utils/preload.ts
@@ -150,7 +150,6 @@ export function preloadAssets(
             const res = host.loaderHook.lifecycle.createLink.emit({
               url,
               attrs,
-              useLinkPreload,
             });
             if (res instanceof HTMLLinkElement) {
               return res;
@@ -175,7 +174,6 @@ export function preloadAssets(
             const res = host.loaderHook.lifecycle.createLink.emit({
               url,
               attrs,
-              useLinkPreload,
             });
             if (res instanceof HTMLLinkElement) {
               return res;
@@ -204,7 +202,6 @@ export function preloadAssets(
             const res = host.loaderHook.lifecycle.createLink.emit({
               url,
               attrs,
-              useLinkPreload,
             });
             if (res instanceof HTMLLinkElement) {
               return res;

--- a/packages/runtime/src/utils/preload.ts
+++ b/packages/runtime/src/utils/preload.ts
@@ -136,18 +136,21 @@ export function preloadAssets(
     });
 
     if (useLinkPreload) {
+      const defaultAttrs = {
+        rel: 'preload',
+        as: 'style',
+        crossorigin: 'anonymous',
+      };
       cssAssets.forEach((cssUrl) => {
         const { link: cssEl, needAttach } = createLink({
           url: cssUrl,
           cb: () => {},
-          attrs: {
-            rel: 'preload',
-            as: 'style',
-            crossorigin: 'anonymous',
-          },
-          createLinkHook: (url: string) => {
+          attrs: defaultAttrs,
+          createLinkHook: (url, attrs) => {
             const res = host.loaderHook.lifecycle.createLink.emit({
               url,
+              attrs,
+              useLinkPreload,
             });
             if (res instanceof HTMLLinkElement) {
               return res;
@@ -159,17 +162,20 @@ export function preloadAssets(
         needAttach && document.head.appendChild(cssEl);
       });
     } else {
+      const defaultAttrs = {
+        rel: 'stylesheet',
+        type: 'text/css',
+      };
       cssAssets.forEach((cssUrl) => {
         const { link: cssEl, needAttach } = createLink({
           url: cssUrl,
           cb: () => {},
-          attrs: {
-            rel: 'stylesheet',
-            type: 'text/css',
-          },
-          createLinkHook: (url: string) => {
+          attrs: defaultAttrs,
+          createLinkHook: (url, attrs) => {
             const res = host.loaderHook.lifecycle.createLink.emit({
               url,
+              attrs,
+              useLinkPreload,
             });
             if (res instanceof HTMLLinkElement) {
               return res;
@@ -184,18 +190,21 @@ export function preloadAssets(
     }
 
     if (useLinkPreload) {
+      const defaultAttrs = {
+        rel: 'preload',
+        as: 'script',
+        crossorigin: 'anonymous',
+      };
       jsAssetsWithoutEntry.forEach((jsUrl) => {
         const { link: linkEl, needAttach } = createLink({
           url: jsUrl,
           cb: () => {},
-          attrs: {
-            rel: 'preload',
-            as: 'script',
-            crossorigin: 'anonymous',
-          },
-          createLinkHook: (url: string) => {
+          attrs: defaultAttrs,
+          createLinkHook: (url: string, attrs) => {
             const res = host.loaderHook.lifecycle.createLink.emit({
               url,
+              attrs,
+              useLinkPreload,
             });
             if (res instanceof HTMLLinkElement) {
               return res;
@@ -206,14 +215,15 @@ export function preloadAssets(
         needAttach && document.head.appendChild(linkEl);
       });
     } else {
+      const defaultAttrs = {
+        fetchpriority: 'high',
+        type: remoteInfo?.type === 'module' ? 'module' : 'text/javascript',
+      };
       jsAssetsWithoutEntry.forEach((jsUrl) => {
         const { script: scriptEl, needAttach } = createScript({
           url: jsUrl,
           cb: () => {},
-          attrs: {
-            fetchpriority: 'high',
-            type: remoteInfo?.type === 'module' ? 'module' : 'text/javascript',
-          },
+          attrs: defaultAttrs,
           createScriptHook: (url: string, attrs: any) => {
             const res = host.loaderHook.lifecycle.createScript.emit({
               url,

--- a/packages/sdk/__tests__/dom.spec.ts
+++ b/packages/sdk/__tests__/dom.spec.ts
@@ -145,9 +145,10 @@ describe('createScript', () => {
         },
       });
 
-      expect(script.async).toBe(true);
+      // if user return element by createScriptHook, it will not add default attrs
+      expect(script.async).toBe(false);
       expect(script.crossOrigin).toBe('use-credentials');
-      expect(script.getAttribute('data-test')).toBe('test');
+      expect(script.getAttribute('data-test')).toBe(null);
     });
   });
 });
@@ -222,10 +223,11 @@ describe('createLink', () => {
       },
     });
 
-    expect(link.rel).toBe('preload');
+    // if user return element by createScriptHook, it will not add default attrs
+    expect(link.rel).toBe('');
     expect(link.crossOrigin).toBe('use-credentials');
-    expect(link.getAttribute('as')).toBe('script');
-    expect(link.getAttribute('data-test')).toBe('test');
+    expect(link.getAttribute('as')).toBe(null);
+    expect(link.getAttribute('data-test')).toBe(null);
   });
 
   it('should call the callback when the link loads', () => {

--- a/packages/sdk/src/dom.ts
+++ b/packages/sdk/src/dom.ts
@@ -127,7 +127,10 @@ export function createLink(info: {
   cb: (value: void | PromiseLike<void>) => void;
   attrs: Record<string, string>;
   needDeleteLink?: boolean;
-  createLinkHook?: (url: string) => HTMLLinkElement | void;
+  createLinkHook?: (
+    url: string,
+    attrs?: Record<string, any>,
+  ) => HTMLLinkElement | void;
 }) {
   // <link rel="preload" href="script.js" as="script">
 
@@ -155,14 +158,15 @@ export function createLink(info: {
     link.setAttribute('href', info.url);
 
     let createLinkRes: void | HTMLLinkElement = undefined;
+    const attrs = info.attrs;
+
     if (info.createLinkHook) {
-      createLinkRes = info.createLinkHook(info.url);
+      createLinkRes = info.createLinkHook(info.url, attrs);
       if (createLinkRes instanceof HTMLLinkElement) {
         link = createLinkRes;
       }
     }
 
-    const attrs = info.attrs;
     if (attrs && !createLinkRes) {
       Object.keys(attrs).forEach((name) => {
         if (link && !link.getAttribute(name)) {
@@ -209,7 +213,7 @@ export function loadScript(
     attrs?: Record<string, any>;
     createScriptHook?: (
       url: string,
-      attrs?: Record<string, any> | undefined,
+      attrs?: Record<string, any>,
     ) => CreateScriptHookReturn;
   },
 ) {

--- a/packages/sdk/src/dom.ts
+++ b/packages/sdk/src/dom.ts
@@ -57,8 +57,9 @@ export function createScript(info: {
     script = document.createElement('script');
     script.type = 'text/javascript';
     script.src = info.url;
+    let createScriptRes: CreateScriptHookReturn = undefined;
     if (info.createScriptHook) {
-      const createScriptRes = info.createScriptHook(info.url, info.attrs);
+      createScriptRes = info.createScriptHook(info.url, info.attrs);
 
       if (createScriptRes instanceof HTMLScriptElement) {
         script = createScriptRes;
@@ -68,7 +69,7 @@ export function createScript(info: {
       }
     }
     const attrs = info.attrs;
-    if (attrs) {
+    if (attrs && !createScriptRes) {
       Object.keys(attrs).forEach((name) => {
         if (script) {
           if (name === 'async' || name === 'defer') {
@@ -153,15 +154,16 @@ export function createLink(info: {
     link = document.createElement('link');
     link.setAttribute('href', info.url);
 
+    let createLinkRes: void | HTMLLinkElement = undefined;
     if (info.createLinkHook) {
-      const createLinkRes = info.createLinkHook(info.url);
+      createLinkRes = info.createLinkHook(info.url);
       if (createLinkRes instanceof HTMLLinkElement) {
         link = createLinkRes;
       }
     }
 
     const attrs = info.attrs;
-    if (attrs) {
+    if (attrs && !createLinkRes) {
       Object.keys(attrs).forEach((name) => {
         if (link && !link.getAttribute(name)) {
           link.setAttribute(name, attrs[name]);


### PR DESCRIPTION
## Description
* no add default attrs to the element which is provided by users
If user sets `createLink` or `createScript` hook , and return the element , it will be added the default attrs ,like `crossorigin` which may cause preload failed 

![image](https://github.com/user-attachments/assets/129d59be-6eba-441a-932f-e50fa3d7f553)

So it should not add default attrs if users return the element , and just use the users element direcyly.


* add attrs option to createLink hook , which can help users remain previous behavior

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
