### PR TITLE
Fix(packages-enhanced): enhanced runtime plugin to check imported object type

### DIFF
--- a/.changeset/forty-plants-bathe.md
+++ b/.changeset/forty-plants-bathe.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/enhanced': patch
+---
+
+runtime plugin to check for imported object type

--- a/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
+++ b/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
@@ -86,7 +86,8 @@ class FederationRuntimePlugin {
               `const pluginsToAdd = [`,
               Template.indent(
                 runtimePluginNames.map(
-                  (item) => `${item} ? ${item}() : false,`,
+                  (item) =>
+                    `typeof ${item} === 'function' ? ${item}() : typeof ${item} === 'object' && 'default' in ${item} : false,`,
                 ),
               ),
               `].filter(Boolean);`,


### PR DESCRIPTION
## Description

Runtime federation plugin to check for imported plugin object type.

## Related Issue

https://github.com/module-federation/core/issues/2853

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
