### PR TITLE
fix(rspack): do not instantiate DtsPlugin when options.dts = false

### DIFF
--- a/packages/rspack/src/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/ModuleFederationPlugin.ts
@@ -71,9 +71,12 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
 
     options.implementation = options.implementation || RuntimeToolsPath;
     let disableManifest = options.manifest === false;
+    let disableDts = options.dts === false;
 
-    // @ts-ignore
-    new DtsPlugin(options).apply(compiler);
+    if (!disableDts) {
+      // @ts-ignore
+      new DtsPlugin(options).apply(compiler);
+    }
 
     if (!disableManifest && options.exposes) {
       try {


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
Currently, when using `@module-federation/rspack/ModuleFederationPlugin` (e.g. via `@module-federation/enhanced/rspack`, the DtsPlugin is still being instantiated regardless of whether `options.dts = false`.

This aligns the behaviour with `@module-federation/enhanced/webpack`


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
