### PR TITLE
fix(modernjs): auto set enableAsyncEntry when bundler is rspack

### DIFF
--- a/.changeset/nice-crews-beg.md
+++ b/.changeset/nice-crews-beg.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': patch
+---
+
+fix(modernjs): auto set enableAsyncEntry when bundler is rspack

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -127,6 +127,10 @@ export const moduleFederationConfigPlugin = (
               FEDERATION_IPV4: JSON.stringify(ipv4),
               REMOTE_IP_STRATEGY: JSON.stringify(userConfig.remoteIpStrategy),
             },
+            enableAsyncEntry:
+              bundlerType === 'rspack'
+                ? modernjsConfig.source?.enableAsyncEntry ?? true
+                : modernjsConfig.source?.enableAsyncEntry,
           },
           dev: {
             assetPrefix: modernjsConfig?.dev?.assetPrefix

--- a/packages/modernjs/src/cli/ssrPlugin.ts
+++ b/packages/modernjs/src/cli/ssrPlugin.ts
@@ -42,16 +42,7 @@ export const moduleFederationSSRPlugin = (
         return { entrypoint, plugins };
       },
       config: async () => {
-        const bundlerType =
-          useAppContext().bundlerType === 'rspack' ? 'rspack' : 'webpack';
-
         return {
-          source: {
-            enableAsyncEntry:
-              bundlerType === 'rspack'
-                ? modernjsConfig.source?.enableAsyncEntry ?? true
-                : modernjsConfig.source?.enableAsyncEntry,
-          },
           tools: {
             rspack(config, { isServer }) {
               if (isServer) {


### PR DESCRIPTION
## Description

auto set enableAsyncEntry when bundler is rspack

## Related Issue
#2933
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
