### PR TITLE
fix(modernjs): correct splitChunks.cacheGroups key which need to be removed

### DIFF
--- a/.changeset/grumpy-lobsters-boil.md
+++ b/.changeset/grumpy-lobsters-boil.md
@@ -2,4 +2,4 @@
 '@module-federation/modern-js': patch
 ---
 
-fix(modernjs): update rsbuild cacheGroupKeys
+fix(modernjs): correct splitChunks.cacheGroups key which need to be removed

--- a/.changeset/grumpy-lobsters-boil.md
+++ b/.changeset/grumpy-lobsters-boil.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': patch
+---
+
+fix(modernjs): update rsbuild cacheGroupKeys

--- a/packages/modernjs/src/cli/utils.ts
+++ b/packages/modernjs/src/cli/utils.ts
@@ -370,8 +370,8 @@ export const getIPV4 = (): string => {
 // lib-axios.js: include axios.
 
 const SPLIT_CHUNK_MAP = {
-  REACT: 'lib-react',
-  ROUTER: 'lib-router',
+  REACT: 'react',
+  ROUTER: 'router',
   LODASH: 'lib-lodash',
   ANTD: 'lib-antd',
   ARCO: 'lib-arco',


### PR DESCRIPTION
## Description
correct splitChunks.cacheGroups key which need to be removed

* `lib-react` => `react`
* `lib-router` => `router`


## Related Issue
#2933
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
