### PR TITLE
fix(modernjs): mfConfigPlugin should run after modernjs initial plugin

### DIFF
--- a/.changeset/fast-cherries-itch.md
+++ b/.changeset/fast-cherries-itch.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': patch
+---
+
+fix(modernjs): mfConfigPlugin should run after @modern-js/plugin-initialize

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -54,6 +54,7 @@ export const moduleFederationConfigPlugin = (
   userConfig: InternalModernPluginOptions,
 ): CliPlugin<AppTools> => ({
   name: '@modern-js/plugin-module-federation-config',
+  pre: ['@modern-js/plugin-initialize'],
   post: ['@modern-js/plugin-module-federation'],
   setup: async ({ useConfigContext, useAppContext }) => {
     const modernjsConfig = useConfigContext();


### PR DESCRIPTION
## Description

mfConfigPlugin should run after @modern-js/plugin-initialize

## Related Issue

@modern-js/plugin-initialize will inject bundlerType , so we must run our plugin after the initialize plugin has executed

https://github.com/web-infra-dev/modern.js/blob/main/packages/solutions/app-tools/src/plugins/initialize/index.ts#L44

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
