### PR TITLE
feat: adjust bridge router alias strategy

### DIFF
--- a/.changeset/fifty-kangaroos-compete.md
+++ b/.changeset/fifty-kangaroos-compete.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/bridge-react-webpack-plugin': patch
+---
+
+chore: adjust bridge router alias strategy to alias to router-v6 when not found react-router-dom in package.json


### PR DESCRIPTION
## Description
feat: adjust bridge router alias strategy to alias to router-v6 when not found react-router-dom in package.json.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
