### PR TITLE
fix(dts-plugin): zipName should add prefix if remoteEntry has it

### DIFF
--- a/.changeset/kind-cups-stare.md
+++ b/.changeset/kind-cups-stare.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/dts-plugin': patch
+'@module-federation/manifest': patch
+---
+
+fix(dts-plugin): zipName should add prefix if remoteEntry has it

--- a/packages/dts-plugin/src/core/lib/utils.ts
+++ b/packages/dts-plugin/src/core/lib/utils.ts
@@ -33,13 +33,18 @@ export const validateOptions = (options: HostOptions) => {
 };
 
 export function retrieveTypesAssetsInfo(options: RemoteOptions) {
+  const { moduleFederationConfig } = options;
   let apiTypesPath = '';
   let zipTypesPath = '';
+
+  let zipPrefix = '';
+
   try {
     const { tsConfig, remoteOptions, mapComponentsToExpose } =
       retrieveRemoteConfig(options);
     if (!Object.keys(mapComponentsToExpose).length) {
       return {
+        zipPrefix,
         apiTypesPath,
         zipTypesPath,
         zipName: '',
@@ -52,7 +57,22 @@ export function retrieveTypesAssetsInfo(options: RemoteOptions) {
       apiTypesPath = retrieveMfAPITypesPath(tsConfig, remoteOptions);
     }
 
+    if (
+      typeof moduleFederationConfig.manifest === 'object' &&
+      moduleFederationConfig.manifest.filePath
+    ) {
+      zipPrefix = moduleFederationConfig.manifest.filePath;
+    } else if (
+      typeof moduleFederationConfig.manifest === 'object' &&
+      moduleFederationConfig.manifest.fileName
+    ) {
+      zipPrefix = path.dirname(moduleFederationConfig.manifest.fileName);
+    } else if (moduleFederationConfig.filename) {
+      zipPrefix = path.dirname(moduleFederationConfig.filename);
+    }
+
     return {
+      zipPrefix,
       apiTypesPath,
       zipTypesPath,
       zipName: path.basename(zipTypesPath),
@@ -61,6 +81,7 @@ export function retrieveTypesAssetsInfo(options: RemoteOptions) {
   } catch (err) {
     console.error(ansiColors.red(`Unable to compile federated types, ${err}`));
     return {
+      zipPrefix,
       apiTypesPath: '',
       zipTypesPath: '',
       zipName: '',

--- a/packages/manifest/src/utils.ts
+++ b/packages/manifest/src/utils.ts
@@ -297,7 +297,7 @@ export function getTypesMetaInfo(
       return defaultTypesMetaInfo;
     }
 
-    const { apiFileName, zipName } = retrieveTypesAssetsInfo({
+    const { apiFileName, zipName, zipPrefix } = retrieveTypesAssetsInfo({
       ...normalizedRemote,
       context,
       moduleFederationConfig: pluginOptions,
@@ -306,8 +306,8 @@ export function getTypesMetaInfo(
     return {
       path: '',
       name: '',
-      zip: zipName,
-      api: apiFileName,
+      zip: path.join(zipPrefix, zipName),
+      api: path.join(zipPrefix, apiFileName),
     };
   } catch (err) {
     console.warn(


### PR DESCRIPTION
## Description

zipName should add prefix if remoteEntry has it

## Related Issue
#2949
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
