### PR TITLE
fix(dts-plugin): support exposes files with multiple dots in names

### DIFF
--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
@@ -86,8 +86,9 @@ function getExposeKey(options: {
   mapExposeToEntry: Record<string, string>;
 }) {
   const { filePath, rootDir, outDir, mapExposeToEntry } = options;
-  const relativeFilePath = removeExt(
-    relative(outDir, filePath.replace(new RegExp(`\\.d.ts$`), '')),
+  const relativeFilePath = relative(
+    outDir,
+    filePath.replace(new RegExp(`\\.d.ts$`), ''),
   );
   return mapExposeToEntry[relativeFilePath];
 }


### PR DESCRIPTION
## Description

In `/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts:89`, the regex already removes the `.d.ts` extension, so the expose path can be correctly mapped to an entry. Calling removeExt was further processing paths like `foo.component` to just `foo`, resulting in `undefined` being returned in `getExposeKey`.

I didn't check the testing checkbox because I encountered issues with some tests even before making the changes. I hope that, even if this PR doesn't meet the criteria for merging, it can at least serve as documentation for someone else to fix it.

## Related Issue

https://github.com/module-federation/core/issues/2957

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
