### PR TITLE
fix: upgrade nx ci error

### DIFF
--- a/.github/workflows/e2e-modern.yml
+++ b/.github/workflows/e2e-modern.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: E2E Test for ModernJS
         if: steps.check-ci.outcome == 'success'
-        run: npx kill-port --port 4001 && npx nx run-many --target=test:e2e --projects=modernjs --parallel=1 --verbse
+        run: npx kill-port --port 4001 && npx nx run-many --target=test:e2e --projects=modernjs --parallel=1 && npx kill-port --port 4001
 
       - name: Kill ports
         run: npx kill-port --port 4001

--- a/apps/manifest-demo/3010-rspack-provider/tsconfig.app.json
+++ b/apps/manifest-demo/3010-rspack-provider/tsconfig.app.json
@@ -1,6 +1,17 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
     "outDir": "../../../dist/out-tsc",
     "types": [
       "node",

--- a/apps/manifest-demo/3010-rspack-provider/tsconfig.json
+++ b/apps/manifest-demo/3010-rspack-provider/tsconfig.json
@@ -11,12 +11,29 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "outDir": "../../../dist/out-tsc",
+    "types": [
+      "node",
+      "@nx/react/typings/cssmodule.d.ts",
+      "@nx/react/typings/image.d.ts"
+    ]
   },
-  "files": [],
-  "references": [
-    {
-      "path": "./tsconfig.app.json"
-    }
-  ]
+  "files": [
+    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
+    "../../../node_modules/@nx/react/typings/image.d.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    "**/*.spec.js",
+    "**/*.test.js",
+    "**/*.spec.jsx",
+    "**/*.test.jsx",
+    "dist/**"
+  ],
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
 }

--- a/packages/data-prefetch/rollup.config.js
+++ b/packages/data-prefetch/rollup.config.js
@@ -20,6 +20,6 @@ module.exports = (rollupConfig, _projectOptions) => {
     plugin: 'packages/data-prefetch/src/plugin.ts',
     shared: 'packages/data-prefetch/src/shared/index.ts',
   };
-  rollupConfig.external = [/@module-federation/];
+  // rollupConfig.external = [/@module-federation/];
   return rollupConfig;
 };


### PR DESCRIPTION
## Description

1. update 3010-rspack-provider tsConfig.json which should include .css declaration
2. remove data-prefetc rollup external option , using auto-external instead .  

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
