### PR TITLE
fix(nextjs-mf): add UniverseEntryChunkTrackerPlugin 

### DIFF
--- a/.changeset/ai-noisy-owl.md
+++ b/.changeset/ai-noisy-owl.md
@@ -1,0 +1,8 @@
+---
+"@module-federation/nextjs-mf": minor
+---
+
+Added the UniverseEntryChunkTrackerPlugin to track entry chunks in the server plugin.
+
+- Applied UniverseEntryChunkTrackerPlugin in the applyServerPlugins function.
+- This change aims to enhance tracking of entry chunks in the server environment for hot reloading prod instances

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
@@ -6,6 +6,7 @@ import type {
 import type { moduleFederationPlugin } from '@module-federation/sdk';
 import path from 'path';
 import InvertedContainerPlugin from '../container/InvertedContainerPlugin';
+import UniverseEntryChunkTrackerPlugin from '@module-federation/node/universe-entry-chunk-tracker-plugin';
 
 type EntryStaticNormalized = Awaited<
   ReturnType<Extract<WebpackOptionsNormalized['entry'], () => any>>
@@ -74,7 +75,7 @@ export function applyServerPlugins(
       suffix,
     );
   }
-
+  new UniverseEntryChunkTrackerPlugin().apply(compiler);
   new InvertedContainerPlugin().apply(compiler);
 }
 

--- a/packages/node/src/utils/hot-reload.ts
+++ b/packages/node/src/utils/hot-reload.ts
@@ -1,6 +1,6 @@
 import { getAllKnownRemotes } from './flush-chunks';
 import crypto from 'crypto';
-
+import helpers from '@module-federation/runtime/helpers';
 declare global {
   var mfHashMap: Record<string, string> | undefined;
 }
@@ -25,7 +25,7 @@ export const performReload = async (shouldReload: any) => {
   }
 
   const gs = new Function('return globalThis')();
-  const entries = Array.from(gs.entryChunkCache || []);
+  const entries = gs.entryChunkCache || [];
 
   if (!gs.entryChunkCache) {
     Object.keys(req.cache).forEach((key) => {
@@ -54,7 +54,7 @@ export const performReload = async (shouldReload: any) => {
   });
   //@ts-ignore
   __webpack_require__.federation.instance.moduleCache.clear();
-  gs.__FEDERATION__.__INSTANCES__ = [];
+  helpers.global.resetFederationGlobalInfo();
 
   for (const entry of entries) {
     //@ts-ignore


### PR DESCRIPTION
Integrate UniverseEntryChunkTrackerPlugin to track server-side Universe entry chunks. Remove redundant global cache reset logic and use helper function for clean up.

## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
