### PR TITLE
fix(nextjs-mf): use addInclude to ensure defaults are consumed somewhere

### DIFF
--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
@@ -83,9 +83,32 @@ export class NextFederationPlugin {
         });
       },
     });
-    const runtimeESMPath = require.resolve(
-      '@module-federation/runtime/dist/index.esm.js',
-    );
+
+    const noop = this.getNoopPath();
+
+    if (!this._extraOptions.skipSharingNextInternals) {
+      compiler.hooks.make.tapAsync(
+        'NextFederationPlugin',
+        (compilation, callback) => {
+          const dep = compiler.webpack.EntryPlugin.createDependency(
+            noop,
+            'noop',
+          );
+          compilation.addEntry(
+            compiler.context,
+            dep,
+            { name: 'noop' },
+            (err, module) => {
+              if (err) {
+                return callback(err);
+              }
+              callback();
+            },
+          );
+        },
+      );
+    }
+
     if (!compiler.options.ignoreWarnings) {
       compiler.options.ignoreWarnings = [
         //@ts-ignore
@@ -171,16 +194,7 @@ export class NextFederationPlugin {
     const defaultShared = this._extraOptions.skipSharingNextInternals
       ? {}
       : retrieveDefaultShared(isServer);
-    const noop = this.getNoopPath();
 
-    const defaultExpose = this._extraOptions.skipSharingNextInternals
-      ? {}
-      : {
-          './noop': noop,
-          './react': require.resolve('react'),
-          './react-dom': require.resolve('react-dom'),
-          './next/router': require.resolve('next/router'),
-        };
     return {
       ...this._options,
       runtime: false,
@@ -194,7 +208,6 @@ export class NextFederationPlugin {
       ].map((plugin) => plugin + '?runtimePlugin'),
       //@ts-ignore
       exposes: {
-        ...defaultExpose,
         ...this._options.exposes,
         ...(this._extraOptions.exposePages
           ? exposeNextjsPages(compiler.options.context as string)


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
use add include instead of noop to expose 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
