### PR TITLE
fix(runtime): catch init remote error in errorLoadRemote hook

### DIFF
--- a/.changeset/nervous-tomatoes-raise.md
+++ b/.changeset/nervous-tomatoes-raise.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+fix(runtime): catch init remote error in errorLoadRemote hook

--- a/packages/runtime/src/remote/index.ts
+++ b/packages/runtime/src/remote/index.ts
@@ -102,7 +102,7 @@ export class RemoteHandler {
           error: unknown;
           options?: any;
           from: CallFrom;
-          lifecycle: 'onLoad' | 'beforeRequest';
+          lifecycle: 'onLoad' | 'beforeRequest' | 'beforeLoadShare';
           origin: FederationHost;
         },
       ],

--- a/packages/runtime/src/shared/index.ts
+++ b/packages/runtime/src/shared/index.ts
@@ -305,9 +305,21 @@ export class SharedHandler {
         id: key,
       });
       if (module.getEntry) {
-        const entry = await module.getEntry();
+        let remoteEntryExports: RemoteEntryExports;
+        try {
+          remoteEntryExports = await module.getEntry();
+        } catch (error) {
+          remoteEntryExports =
+            (await host.remoteHandler.hooks.lifecycle.errorLoadRemote.emit({
+              id: key,
+              error,
+              from: 'runtime',
+              lifecycle: 'beforeLoadShare',
+              origin: host,
+            })) as RemoteEntryExports;
+        }
         if (!module.inited) {
-          await initFn(entry);
+          await initFn(remoteEntryExports);
           module.inited = true;
         }
       }


### PR DESCRIPTION
## Description

catch init remote error in errorLoadRemote hook

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
