### PR TITLE
Release v0.6.10

### DIFF
--- a/.changeset/ai-calm-bear.md
+++ b/.changeset/ai-calm-bear.md
@@ -1,7 +1,0 @@
----
-"@module-federation/enhanced": patch
----
-
-Added a check to skip processing when virtualRuntimeEntry is present.
-
-- Added an early return in `FederationRuntimePlugin` to skip processing if `options.virtualRuntimeEntry` is defined.

--- a/.changeset/cuddly-pumpkins-switch.md
+++ b/.changeset/cuddly-pumpkins-switch.md
@@ -1,5 +1,0 @@
----
-'@module-federation/bridge-react': patch
----
-
-fix(bridge-react): add default basename for WraperRouterProvider

--- a/.changeset/cyan-mangos-jog.md
+++ b/.changeset/cyan-mangos-jog.md
@@ -1,5 +1,0 @@
----
-'@module-federation/runtime': patch
----
-
-fix(runtime): remove crossorigin attr from link tag which not preload success

--- a/.changeset/grumpy-avocados-cheat.md
+++ b/.changeset/grumpy-avocados-cheat.md
@@ -1,7 +1,0 @@
----
-'@module-federation/data-prefetch': patch
-'@module-federation/enhanced': patch
-'@module-federation/sdk': patch
----
-
-fix(data-prefetch): apply DataPrefetchPlugin on demand

--- a/.changeset/swift-pants-rescue.md
+++ b/.changeset/swift-pants-rescue.md
@@ -1,5 +1,0 @@
----
-'@module-federation/data-prefetch': patch
----
-
-fix(data-prefetch): set sharedStrategy in build options instead of using runtime plugin

--- a/apps/modernjs-ssr/dynamic-nested-remote/CHANGELOG.md
+++ b/apps/modernjs-ssr/dynamic-nested-remote/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-dynamic-nested-remote
 
+## 0.1.30
+
+### Patch Changes
+
+- @module-federation/modern-js@0.6.10
+
 ## 0.1.29
 
 ### Patch Changes

--- a/apps/modernjs-ssr/dynamic-nested-remote/package.json
+++ b/apps/modernjs-ssr/dynamic-nested-remote/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modernjs-ssr-dynamic-nested-remote",
   "private": true,
-  "version": "0.1.29",
+  "version": "0.1.30",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/modernjs-ssr/dynamic-remote-new-version/CHANGELOG.md
+++ b/apps/modernjs-ssr/dynamic-remote-new-version/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-dynamic-remote-new-version
 
+## 0.1.30
+
+### Patch Changes
+
+- @module-federation/modern-js@0.6.10
+
 ## 0.1.29
 
 ### Patch Changes

--- a/apps/modernjs-ssr/dynamic-remote-new-version/package.json
+++ b/apps/modernjs-ssr/dynamic-remote-new-version/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modernjs-ssr-dynamic-remote-new-version",
   "private": true,
-  "version": "0.1.29",
+  "version": "0.1.30",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/modernjs-ssr/dynamic-remote/CHANGELOG.md
+++ b/apps/modernjs-ssr/dynamic-remote/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-dynamic-remote
 
+## 0.1.30
+
+### Patch Changes
+
+- @module-federation/modern-js@0.6.10
+
 ## 0.1.29
 
 ### Patch Changes

--- a/apps/modernjs-ssr/dynamic-remote/package.json
+++ b/apps/modernjs-ssr/dynamic-remote/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modernjs-ssr-dynamic-remote",
   "private": true,
-  "version": "0.1.29",
+  "version": "0.1.30",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/modernjs-ssr/host/CHANGELOG.md
+++ b/apps/modernjs-ssr/host/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-host
 
+## 0.1.30
+
+### Patch Changes
+
+- @module-federation/modern-js@0.6.10
+
 ## 0.1.29
 
 ### Patch Changes

--- a/apps/modernjs-ssr/host/package.json
+++ b/apps/modernjs-ssr/host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modernjs-ssr-host",
   "private": true,
-  "version": "0.1.29",
+  "version": "0.1.30",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/modernjs-ssr/nested-remote/CHANGELOG.md
+++ b/apps/modernjs-ssr/nested-remote/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-nested-remote
 
+## 0.1.30
+
+### Patch Changes
+
+- @module-federation/modern-js@0.6.10
+
 ## 0.1.29
 
 ### Patch Changes

--- a/apps/modernjs-ssr/nested-remote/package.json
+++ b/apps/modernjs-ssr/nested-remote/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modernjs-ssr-nested-remote",
   "private": true,
-  "version": "0.1.29",
+  "version": "0.1.30",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/modernjs-ssr/remote-new-version/CHANGELOG.md
+++ b/apps/modernjs-ssr/remote-new-version/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-remote-new-version
 
+## 0.1.32
+
+### Patch Changes
+
+- @module-federation/modern-js@0.6.10
+
 ## 0.1.31
 
 ### Patch Changes

--- a/apps/modernjs-ssr/remote-new-version/package.json
+++ b/apps/modernjs-ssr/remote-new-version/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modernjs-ssr-remote-new-version",
   "private": true,
-  "version": "0.1.31",
+  "version": "0.1.32",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/modernjs-ssr/remote/CHANGELOG.md
+++ b/apps/modernjs-ssr/remote/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-remote
 
+## 0.1.32
+
+### Patch Changes
+
+- @module-federation/modern-js@0.6.10
+
 ## 0.1.31
 
 ### Patch Changes

--- a/apps/modernjs-ssr/remote/package.json
+++ b/apps/modernjs-ssr/remote/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modernjs-ssr-remote",
   "private": true,
-  "version": "0.1.31",
+  "version": "0.1.32",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/modernjs/CHANGELOG.md
+++ b/apps/modernjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/modernjs
 
+## 0.1.56
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+
 ## 0.1.55
 
 ### Patch Changes

--- a/apps/modernjs/package.json
+++ b/apps/modernjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@module-federation/modernjs",
   "private": true,
-  "version": "0.1.55",
+  "version": "0.1.56",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/router-demo/router-host-2000/CHANGELOG.md
+++ b/apps/router-demo/router-host-2000/CHANGELOG.md
@@ -1,5 +1,16 @@
 # host
 
+## 1.0.30
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [8a77291]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+  - @module-federation/bridge-react@0.6.10
+  - @module-federation/retry-plugin@0.6.10
+
 ## 1.0.29
 
 ### Patch Changes

--- a/apps/router-demo/router-host-2000/package.json
+++ b/apps/router-demo/router-host-2000/package.json
@@ -1,7 +1,7 @@
 {
   "name": "host",
   "private": true,
-  "version": "1.0.29",
+  "version": "1.0.30",
   "scripts": {
     "dev": "FEDERATION_DEBUG=true rsbuild dev --open",
     "build": "rsbuild build",

--- a/apps/router-demo/router-host-v5-2200/CHANGELOG.md
+++ b/apps/router-demo/router-host-v5-2200/CHANGELOG.md
@@ -1,5 +1,15 @@
 # host-v5
 
+## 1.0.30
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [8a77291]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+  - @module-federation/bridge-react@0.6.10
+
 ## 1.0.29
 
 ### Patch Changes

--- a/apps/router-demo/router-host-v5-2200/package.json
+++ b/apps/router-demo/router-host-v5-2200/package.json
@@ -1,7 +1,7 @@
 {
   "name": "host-v5",
   "private": true,
-  "version": "1.0.29",
+  "version": "1.0.30",
   "scripts": {
     "dev": "FEDERATION_DEBUG=true rsbuild dev",
     "build": "rsbuild build",

--- a/apps/router-demo/router-host-vue3-2100/CHANGELOG.md
+++ b/apps/router-demo/router-host-vue3-2100/CHANGELOG.md
@@ -1,5 +1,14 @@
 # host-vue3
 
+## 1.0.30
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+  - @module-federation/bridge-vue3@0.6.10
+
 ## 1.0.29
 
 ### Patch Changes

--- a/apps/router-demo/router-host-vue3-2100/package.json
+++ b/apps/router-demo/router-host-vue3-2100/package.json
@@ -1,7 +1,7 @@
 {
   "name": "host-vue3",
   "private": true,
-  "version": "1.0.29",
+  "version": "1.0.30",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/router-demo/router-remote1-2001/CHANGELOG.md
+++ b/apps/router-demo/router-remote1-2001/CHANGELOG.md
@@ -1,5 +1,15 @@
 # remote1
 
+## 1.0.30
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [8a77291]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+  - @module-federation/bridge-react@0.6.10
+
 ## 1.0.29
 
 ### Patch Changes

--- a/apps/router-demo/router-remote1-2001/package.json
+++ b/apps/router-demo/router-remote1-2001/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote1",
   "private": true,
-  "version": "1.0.29",
+  "version": "1.0.30",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "DEBUG=true rsbuild build",

--- a/apps/router-demo/router-remote2-2002/CHANGELOG.md
+++ b/apps/router-demo/router-remote2-2002/CHANGELOG.md
@@ -1,5 +1,15 @@
 # remote2
 
+## 1.0.30
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [8a77291]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+  - @module-federation/bridge-react@0.6.10
+
 ## 1.0.29
 
 ### Patch Changes

--- a/apps/router-demo/router-remote2-2002/package.json
+++ b/apps/router-demo/router-remote2-2002/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote2",
   "private": true,
-  "version": "1.0.29",
+  "version": "1.0.30",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/router-demo/router-remote3-2003/CHANGELOG.md
+++ b/apps/router-demo/router-remote3-2003/CHANGELOG.md
@@ -1,5 +1,14 @@
 # remote3
 
+## 1.0.30
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+  - @module-federation/bridge-vue3@0.6.10
+
 ## 1.0.29
 
 ### Patch Changes

--- a/apps/router-demo/router-remote3-2003/package.json
+++ b/apps/router-demo/router-remote3-2003/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote3",
   "private": true,
-  "version": "1.0.29",
+  "version": "1.0.30",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/router-demo/router-remote4-2004/CHANGELOG.md
+++ b/apps/router-demo/router-remote4-2004/CHANGELOG.md
@@ -1,5 +1,15 @@
 # remote4
 
+## 1.0.29
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [8a77291]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+  - @module-federation/bridge-react@0.6.10
+
 ## 1.0.28
 
 ### Patch Changes

--- a/apps/router-demo/router-remote4-2004/package.json
+++ b/apps/router-demo/router-remote4-2004/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote4",
   "private": true,
-  "version": "1.0.28",
+  "version": "1.0.29",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/runtime-demo/3008-runtime-remote/CHANGELOG.md
+++ b/apps/runtime-demo/3008-runtime-remote/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 3008-runtime-remote
 
+## 1.0.40
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+
 ## 1.0.39
 
 ### Patch Changes

--- a/apps/runtime-demo/3008-runtime-remote/package.json
+++ b/apps/runtime-demo/3008-runtime-remote/package.json
@@ -1,7 +1,7 @@
 {
   "name": "3008-runtime-remote",
   "private": true,
-  "version": "1.0.39",
+  "version": "1.0.40",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
+++ b/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/bridge-react-webpack-plugin
 
+## 0.6.10
+
+### Patch Changes
+
+- Updated dependencies [22a3b83]
+  - @module-federation/sdk@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/bridge/bridge-react-webpack-plugin/package.json
+++ b/packages/bridge/bridge-react-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react-webpack-plugin",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/bridge-react/CHANGELOG.md
+++ b/packages/bridge/bridge-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/bridge-react
 
+## 0.6.10
+
+### Patch Changes
+
+- 8a77291: fix(bridge-react): add default basename for WraperRouterProvider
+  - @module-federation/bridge-shared@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/bridge/bridge-react/package.json
+++ b/packages/bridge/bridge-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/bridge-shared/CHANGELOG.md
+++ b/packages/bridge/bridge-shared/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/bridge-shared
 
+## 0.6.10
+
 ## 0.6.9
 
 ## 0.6.8

--- a/packages/bridge/bridge-shared/package.json
+++ b/packages/bridge/bridge-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-shared",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/vue3-bridge/CHANGELOG.md
+++ b/packages/bridge/vue3-bridge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/bridge-vue3
 
+## 0.6.10
+
+### Patch Changes
+
+- @module-federation/bridge-shared@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/bridge/vue3-bridge/package.json
+++ b/packages/bridge/vue3-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@module-federation/bridge-vue3",
   "author": "zhouxiao <codingzx@gmail.com>",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/chrome-devtools/CHANGELOG.md
+++ b/packages/chrome-devtools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/devtools
 
+## 0.6.10
+
+### Patch Changes
+
+- Updated dependencies [22a3b83]
+  - @module-federation/sdk@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/chrome-devtools/package.json
+++ b/packages/chrome-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/devtools",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "scripts": {
     "build:storybook": "storybook build",
     "storybook": "storybook dev -p 6006",

--- a/packages/data-prefetch/CHANGELOG.md
+++ b/packages/data-prefetch/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @module-federation/data-prefetch
 
+## 0.6.10
+
+### Patch Changes
+
+- 22a3b83: fix(data-prefetch): apply DataPrefetchPlugin on demand
+- 22a3b83: fix(data-prefetch): set sharedStrategy in build options instead of using runtime plugin
+- Updated dependencies [b704f30]
+- Updated dependencies [22a3b83]
+  - @module-federation/runtime@0.6.10
+  - @module-federation/sdk@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/data-prefetch/package.json
+++ b/packages/data-prefetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@module-federation/data-prefetch",
   "description": "Module Federation Data Prefetch",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "nieyan <nyqykk@foxmail.com>",
   "homepage": "https://github.com/module-federation/core",
   "license": "MIT",

--- a/packages/dts-plugin/CHANGELOG.md
+++ b/packages/dts-plugin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/dts-plugin
 
+## 0.6.10
+
+### Patch Changes
+
+- Updated dependencies [22a3b83]
+  - @module-federation/sdk@0.6.10
+  - @module-federation/managers@0.6.10
+  - @module-federation/third-party-dts-extractor@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/dts-plugin/package.json
+++ b/packages/dts-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/dts-plugin",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "hanric <hanric.zhang@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,5 +1,25 @@
 # [0.2.0-canary.5](https://github.com/module-federation/core/compare/enhanced-0.2.0-canary.4...enhanced-0.2.0-canary.5) (2023-11-20)
 
+## 0.6.10
+
+### Patch Changes
+
+- 6b02145: Added a check to skip processing when virtualRuntimeEntry is present.
+
+  - Added an early return in `FederationRuntimePlugin` to skip processing if `options.virtualRuntimeEntry` is defined.
+
+- 22a3b83: fix(data-prefetch): apply DataPrefetchPlugin on demand
+- Updated dependencies [22a3b83]
+- Updated dependencies [22a3b83]
+  - @module-federation/data-prefetch@0.6.10
+  - @module-federation/sdk@0.6.10
+  - @module-federation/dts-plugin@0.6.10
+  - @module-federation/runtime-tools@0.6.10
+  - @module-federation/bridge-react-webpack-plugin@0.6.10
+  - @module-federation/managers@0.6.10
+  - @module-federation/manifest@0.6.10
+  - @module-federation/rspack@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/enhanced",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "repository": "https://github.com/module-federation/core/tree/main/packages/enhanced",

--- a/packages/esbuild/CHANGELOG.md
+++ b/packages/esbuild/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/esbuild
 
+## 0.0.28
+
+### Patch Changes
+
+- Updated dependencies [22a3b83]
+  - @module-federation/sdk@0.6.10
+
 ## 0.0.27
 
 ### Patch Changes

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/esbuild",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "author": "Zack Jackson (@ScriptedAlchemy)",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/packages/managers/CHANGELOG.md
+++ b/packages/managers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/managers
 
+## 0.6.10
+
+### Patch Changes
+
+- Updated dependencies [22a3b83]
+  - @module-federation/sdk@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/managers/package.json
+++ b/packages/managers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/managers",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "license": "MIT",
   "description": "Provide managers for helping handle mf data .",
   "keywords": [

--- a/packages/manifest/CHANGELOG.md
+++ b/packages/manifest/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/manifest
 
+## 0.6.10
+
+### Patch Changes
+
+- Updated dependencies [22a3b83]
+  - @module-federation/sdk@0.6.10
+  - @module-federation/dts-plugin@0.6.10
+  - @module-federation/managers@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/manifest",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "license": "MIT",
   "description": "Provide manifest/stats for webpack/rspack MF project .",
   "keywords": [

--- a/packages/modernjs/CHANGELOG.md
+++ b/packages/modernjs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/modern-js
 
+## 0.6.10
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+  - @module-federation/sdk@0.6.10
+  - @module-federation/node@2.5.20
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/modernjs/package.json
+++ b/packages/modernjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/modern-js",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "files": [
     "dist/",
     "types.d.ts",

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -1,5 +1,18 @@
 # [8.1.0-canary.7](https://github.com/module-federation/core/compare/nextjs-mf-8.1.0-canary.6...nextjs-mf-8.1.0-canary.7) (2023-11-21)
 
+## 8.6.3
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [b704f30]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+  - @module-federation/runtime@0.6.10
+  - @module-federation/sdk@0.6.10
+  - @module-federation/node@2.5.20
+  - @module-federation/webpack-bundler-runtime@0.6.10
+
 ## 8.6.2
 
 ### Patch Changes

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "8.6.2",
+  "version": "8.6.3",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,17 @@
 # [2.1.0-canary.6](https://github.com/module-federation/core/compare/node-2.1.0-canary.5...node-2.1.0-canary.6) (2023-11-21)
 
+## 2.5.20
+
+### Patch Changes
+
+- Updated dependencies [6b02145]
+- Updated dependencies [b704f30]
+- Updated dependencies [22a3b83]
+  - @module-federation/enhanced@0.6.10
+  - @module-federation/runtime@0.6.10
+  - @module-federation/sdk@0.6.10
+  - @module-federation/utilities@3.1.16
+
 ## 2.5.19
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "2.5.19",
+  "version": "2.5.20",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "exports": {

--- a/packages/retry-plugin/CHANGELOG.md
+++ b/packages/retry-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/retry-plugin
 
+## 0.6.10
+
 ## 0.6.9
 
 ## 0.6.8

--- a/packages/retry-plugin/package.json
+++ b/packages/retry-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/retry-plugin",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "danpeen <dapeen.feng@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/rspack/CHANGELOG.md
+++ b/packages/rspack/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @module-federation/rspack
 
+## 0.6.10
+
+### Patch Changes
+
+- Updated dependencies [22a3b83]
+  - @module-federation/sdk@0.6.10
+  - @module-federation/dts-plugin@0.6.10
+  - @module-federation/runtime-tools@0.6.10
+  - @module-federation/bridge-react-webpack-plugin@0.6.10
+  - @module-federation/managers@0.6.10
+  - @module-federation/manifest@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rspack",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "license": "MIT",
   "keywords": [
     "Module Federation",

--- a/packages/runtime-tools/CHANGELOG.md
+++ b/packages/runtime-tools/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [1.0.1-canary.1](https://github.com/module-federation/core/compare/runtime-1.0.0...runtime-1.0.1-canary.1) (2023-12-06)
 
+## 0.6.10
+
+### Patch Changes
+
+- Updated dependencies [b704f30]
+  - @module-federation/runtime@0.6.10
+  - @module-federation/webpack-bundler-runtime@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/runtime-tools/package.json
+++ b/packages/runtime-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-tools",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/runtime
 
+## 0.6.10
+
+### Patch Changes
+
+- b704f30: fix(runtime): remove crossorigin attr from link tag which not preload success
+- Updated dependencies [22a3b83]
+  - @module-federation/sdk@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [1.1.0-canary.1](https://github.com/module-federation/core/compare/sdk-1.0.0...sdk-1.1.0-canary.1) (2023-12-05)
 
+## 0.6.10
+
+### Patch Changes
+
+- 22a3b83: fix(data-prefetch): apply DataPrefetchPlugin on demand
+
 ## 0.6.9
 
 ## 0.6.8

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/sdk",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "license": "MIT",
   "description": "A sdk for support module federation",
   "keywords": [

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -41,7 +41,7 @@
     "webpack-virtual-modules": "0.6.2"
   },
   "peerDependencies": {
-    "@module-federation/utilities": "^3.1.15",
+    "@module-federation/utilities": "^3.1.16",
     "@nx/react": "~16.0.0 || ~17.0.0 || ~17.2.0",
     "@nx/webpack": "~16.0.0 || ~17.0.0 || ~17.2.0",
     "@storybook/core-common": "^6.5.16 || ^7.0.0",

--- a/packages/third-party-dts-extractor/CHANGELOG.md
+++ b/packages/third-party-dts-extractor/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/third-party-dts-extractor
 
+## 0.6.10
+
 ## 0.6.9
 
 ## 0.6.8

--- a/packages/third-party-dts-extractor/package.json
+++ b/packages/third-party-dts-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/third-party-dts-extractor",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "files": [
     "dist/",
     "README.md"

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [3.1.0](https://github.com/module-federation/core/compare/utils-3.0.2...utils-3.1.0) (2023-10-26)
 
+## 3.1.16
+
+### Patch Changes
+
+- Updated dependencies [22a3b83]
+  - @module-federation/sdk@0.6.10
+
 ## 3.1.15
 
 ### Patch Changes

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/utilities",
-  "version": "3.1.15",
+  "version": "3.1.16",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",
   "types": "./dist/index.cjs.d.ts",

--- a/packages/webpack-bundler-runtime/CHANGELOG.md
+++ b/packages/webpack-bundler-runtime/CHANGELOG.md
@@ -1,5 +1,14 @@
 # [1.0.0-canary.3](https://github.com/module-federation/core/compare/webpack-bundler-runtime-1.0.0-canary.2...webpack-bundler-runtime-1.0.0-canary.3) (2023-11-23)
 
+## 0.6.10
+
+### Patch Changes
+
+- Updated dependencies [b704f30]
+- Updated dependencies [22a3b83]
+  - @module-federation/runtime@0.6.10
+  - @module-federation/sdk@0.6.10
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/webpack-bundler-runtime/package.json
+++ b/packages/webpack-bundler-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/webpack-bundler-runtime",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "license": "MIT",
   "description": "Module Federation Runtime for webpack",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v0.6.10 -->

## What's Changed
### New Features 🎉
* feat(nextjs-mf): remove module-federation/utilities by @ScriptedAlchemy in https://github.com/module-federation/core/pull/3038
### Bug Fixes 🐞
* fix(bridge-react): add default basename for WraperRouterProvider by @chenyuan-new in https://github.com/module-federation/core/pull/3020
* fix(runtime): remove crossorigin attr from link tag which not preload… by @2heal1 in https://github.com/module-federation/core/pull/3057
* fix(data-prefetch): apply DataPrefetchPlugin on demand by @2heal1 in https://github.com/module-federation/core/pull/3061
### Document 📖
* docs: add registerPlugins docs by @2heal1 in https://github.com/module-federation/core/pull/3060
### Other Changes
* Release v0.6.9 by @zhoushaw in https://github.com/module-federation/core/pull/3040
* chore: package updates by @ScriptedAlchemy in https://github.com/module-federation/core/pull/3048
* Pgk minors by @ScriptedAlchemy in https://github.com/module-federation/core/pull/3049
* chore: update rollup by @ScriptedAlchemy in https://github.com/module-federation/core/pull/3051
* chore: update modernjs packages by @ScriptedAlchemy in https://github.com/module-federation/core/pull/3055
* chore: update modernjs deps by @ScriptedAlchemy in https://github.com/module-federation/core/pull/3056
* chore(deps-dev): bump @storybook/nextjs from 8.3.4 to 8.3.5 by @dependabot in https://github.com/module-federation/core/pull/3046

## New Contributors
* @chenyuan-new made their first contribution in https://github.com/module-federation/core/pull/3020

**Full Changelog**: https://github.com/module-federation/core/compare/v0.6.9...v0.6.10