### PR TITLE
fix(runtime): The shared modules being loaded are getting overwritten

### DIFF
--- a/packages/runtime/src/shared/index.ts
+++ b/packages/runtime/src/shared/index.ts
@@ -290,6 +290,7 @@ export class SharedHandler {
         !activeVersion ||
         (activeVersion.strategy !== 'loaded-first' &&
           !activeVersion.loaded &&
+          !activeVersion.loading &&
           (Boolean(!eager) !== !activeVersionEager
             ? eager
             : hostName > activeVersion.from))


### PR DESCRIPTION
## Description
This is a very elusive bug, and it occurs with a certain probability each time the page is refreshed. Several conditions must be met:

	1.	The shared module version is the same.
	2.	The remote name is greater than the host name.
	3.	It happens randomly

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
