### PR TITLE
Make the Next.js plugin work with strict CSP settings

### DIFF
--- a/.changeset/hip-pandas-care.md
+++ b/.changeset/hip-pandas-care.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/nextjs-mf": patch
+---
+
+Make the Next.js plugin work with strict CSP settings

--- a/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
+++ b/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
@@ -72,7 +72,12 @@ export default function (): FederationRuntimePlugin {
 
       var moduleCache = args.origin.moduleCache;
       var name = args.origin.name;
-      var gs = new Function('return globalThis')();
+      var gs;
+      try {
+        gs = new Function('return globalThis')();
+      } catch (e) {
+        gs = window; // fallback for browsers without 'unsafe-eval' CSP policy enabled
+      }
       var attachedRemote = gs[name];
       if (attachedRemote) {
         moduleCache.set(name, attachedRemote);

--- a/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
+++ b/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
@@ -76,7 +76,7 @@ export default function (): FederationRuntimePlugin {
       try {
         gs = new Function('return globalThis')();
       } catch (e) {
-        gs = window; // fallback for browsers without 'unsafe-eval' CSP policy enabled
+        gs = globalThis; // fallback for browsers without 'unsafe-eval' CSP policy enabled
       }
       var attachedRemote = gs[name];
       if (attachedRemote) {


### PR DESCRIPTION
## Description

Prevents a failure on parsing the Next.js script runtime when the browser has a strict CSP policy and 'unsafe-eval' is not enabled.

Note: I saw other parts of the codebase using similar code, but some of these places might execute only on the server (eg. the node plugin), I decided to just scope my changes to the Next.js plugin for now.

## Related Issue

https://github.com/module-federation/core/issues/2759


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
