### PR TITLE
Removed duplicate plugins property from the rsbuild config

### DIFF
--- a/apps/website-new/docs/en/guide/start/quick-start.mdx
+++ b/apps/website-new/docs/en/guide/start/quick-start.mdx
@@ -98,11 +98,11 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 
 export default defineConfig({
-  plugins: [pluginReact()],
   server: {
     port: 3000,
   },
   plugins: [
+    pluginReact(),
     pluginModuleFederation({
       name: 'federation_provider',
       exposes: {


### PR DESCRIPTION
Removed duplicate plugins property from the RSBuild config file to avoid redundancy.

## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
