### PR TITLE
fix(rspack): only patchChunkSplit when config set exposes

### DIFF
--- a/.changeset/tricky-sheep-travel.md
+++ b/.changeset/tricky-sheep-travel.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rspack': patch
+---
+
+fix(rspack): only patchChunkSplit when config set exposes

--- a/packages/rspack/src/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/ModuleFederationPlugin.ts
@@ -67,7 +67,12 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
     }
     this._checkSingleton(compiler);
     this._patchBundlerConfig(compiler);
-    this._patchChunkSplit(compiler, options.name);
+    const containerManager = new ContainerManager();
+    containerManager.init(options);
+
+    if (containerManager.enable) {
+      this._patchChunkSplit(compiler, options.name);
+    }
 
     options.implementation = options.implementation || RuntimeToolsPath;
     let disableManifest = options.manifest === false;
@@ -79,8 +84,6 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
     }
     if (!disableManifest && options.exposes) {
       try {
-        const containerManager = new ContainerManager();
-        containerManager.init(options);
         options.exposes = containerManager.containerPluginExposesOptions;
       } catch (err) {
         if (err instanceof Error) {


### PR DESCRIPTION
## Description

only patchChunkSplit when config set exposes

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
