### PR TITLE
fix(rsbuild-plugin): failed to load remote modules with `server.base`

### DIFF
--- a/apps/router-demo/router-host-2000/package.json
+++ b/apps/router-demo/router-host-2000/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "workspace:*",
-    "@rsbuild/core": "^1.0.7",
+    "@rsbuild/core": "^1.0.16",
     "@rsbuild/plugin-react": "^1.0.3",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.3.0",

--- a/apps/router-demo/router-host-v5-2200/package.json
+++ b/apps/router-demo/router-host-v5-2200/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "workspace:*",
-    "@rsbuild/core": "^1.0.7",
+    "@rsbuild/core": "^1.0.16",
     "@rsbuild/plugin-react": "^1.0.3",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.3.0",

--- a/apps/router-demo/router-host-vue3-2100/package.json
+++ b/apps/router-demo/router-host-vue3-2100/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "workspace:*",
-    "@rsbuild/core": "^1.0.7",
+    "@rsbuild/core": "^1.0.16",
     "@rsbuild/plugin-vue": "^1.0.1",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.2"

--- a/apps/router-demo/router-remote1-2001/package.json
+++ b/apps/router-demo/router-remote1-2001/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@ant-design/cssinjs": "^1.20.0",
-    "@rsbuild/core": "^1.0.7",
+    "@rsbuild/core": "^1.0.16",
     "@rsbuild/plugin-react": "^1.0.3",
     "@rsbuild/shared": "^0.7.10",
     "@types/react": "^18.2.79",

--- a/apps/router-demo/router-remote2-2002/package.json
+++ b/apps/router-demo/router-remote2-2002/package.json
@@ -17,7 +17,7 @@
     "react-router-dom": "6.24.1"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.0.7",
+    "@rsbuild/core": "^1.0.16",
     "@rsbuild/plugin-react": "^1.0.3",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.3.0",

--- a/apps/router-demo/router-remote3-2003/package.json
+++ b/apps/router-demo/router-remote3-2003/package.json
@@ -14,7 +14,7 @@
     "vue-router": "^4.3.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.0.7",
+    "@rsbuild/core": "^1.0.16",
     "@rsbuild/plugin-vue": "^1.0.1",
     "@vue/tsconfig": "^0.5.1",
     "tailwindcss": "^3.4.3",

--- a/apps/router-demo/router-remote4-2004/package.json
+++ b/apps/router-demo/router-remote4-2004/package.json
@@ -17,7 +17,7 @@
     "react-router-dom": "6.24.1"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.0.7",
+    "@rsbuild/core": "^1.0.16",
     "@rsbuild/plugin-react": "^1.0.3",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.3.0",

--- a/packages/rsbuild-plugin/package.json
+++ b/packages/rsbuild-plugin/package.json
@@ -35,7 +35,7 @@
     "@module-federation/sdk": "workspace:*"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.x"
+    "@rsbuild/core": "^1.0.16"
   },
   "peerDependencies": {
     "@rsbuild/core": "1.x",

--- a/packages/rsbuild-plugin/src/cli/index.ts
+++ b/packages/rsbuild-plugin/src/cli/index.ts
@@ -60,7 +60,7 @@ export const pluginModuleFederation = (
         const originalConfig = api.getRsbuildConfig('original');
         if (
           originalConfig.dev?.assetPrefix === undefined &&
-          config.dev.assetPrefix === DEFAULT_ASSET_PREFIX
+          config.dev.assetPrefix === config.server?.base
         ) {
           config.dev.assetPrefix = true;
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1357,11 +1357,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/rsbuild-plugin
       '@rsbuild/core':
-        specifier: ^1.0.7
-        version: 1.0.7
+        specifier: ^1.0.16
+        version: 1.0.16
       '@rsbuild/plugin-react':
         specifier: ^1.0.3
-        version: 1.0.3(@rsbuild/core@1.0.7)
+        version: 1.0.3(@rsbuild/core@1.0.16)
       '@types/react':
         specifier: ^18.2.79
         version: 18.2.79
@@ -1406,11 +1406,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/rsbuild-plugin
       '@rsbuild/core':
-        specifier: ^1.0.7
-        version: 1.0.7
+        specifier: ^1.0.16
+        version: 1.0.16
       '@rsbuild/plugin-react':
         specifier: ^1.0.3
-        version: 1.0.3(@rsbuild/core@1.0.7)
+        version: 1.0.3(@rsbuild/core@1.0.16)
       '@types/react':
         specifier: ^18.2.79
         version: 18.2.79
@@ -1443,11 +1443,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/rsbuild-plugin
       '@rsbuild/core':
-        specifier: ^1.0.7
-        version: 1.0.7
+        specifier: ^1.0.16
+        version: 1.0.16
       '@rsbuild/plugin-vue':
         specifier: ^1.0.1
-        version: 1.0.1(@rsbuild/core@1.0.7)(@swc/core@1.7.26)(esbuild@0.24.0)(vue@3.5.10)
+        version: 1.0.1(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.24.0)(vue@3.5.10)
       tailwindcss:
         specifier: ^3.4.3
         version: 3.4.3
@@ -1483,11 +1483,11 @@ importers:
         specifier: ^1.20.0
         version: 1.21.1(react-dom@18.3.1)(react@18.3.1)
       '@rsbuild/core':
-        specifier: ^1.0.7
-        version: 1.0.7
+        specifier: ^1.0.16
+        version: 1.0.16
       '@rsbuild/plugin-react':
         specifier: ^1.0.3
-        version: 1.0.3(@rsbuild/core@1.0.7)
+        version: 1.0.3(@rsbuild/core@1.0.16)
       '@rsbuild/shared':
         specifier: ^0.7.10
         version: 0.7.10(@swc/helpers@0.5.13)
@@ -1526,11 +1526,11 @@ importers:
         version: 6.24.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^1.0.7
-        version: 1.0.7
+        specifier: ^1.0.16
+        version: 1.0.16
       '@rsbuild/plugin-react':
         specifier: ^1.0.3
-        version: 1.0.3(@rsbuild/core@1.0.7)
+        version: 1.0.3(@rsbuild/core@1.0.16)
       '@types/react':
         specifier: ^18.2.79
         version: 18.2.79
@@ -1557,11 +1557,11 @@ importers:
         version: 4.3.2(vue@3.5.10)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^1.0.7
-        version: 1.0.7
+        specifier: ^1.0.16
+        version: 1.0.16
       '@rsbuild/plugin-vue':
         specifier: ^1.0.1
-        version: 1.0.1(@rsbuild/core@1.0.7)(@swc/core@1.7.26)(esbuild@0.24.0)(vue@3.5.10)
+        version: 1.0.1(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.24.0)(vue@3.5.10)
       '@vue/tsconfig':
         specifier: ^0.5.1
         version: 0.5.1
@@ -1600,11 +1600,11 @@ importers:
         version: 6.24.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^1.0.7
-        version: 1.0.7
+        specifier: ^1.0.16
+        version: 1.0.16
       '@rsbuild/plugin-react':
         specifier: ^1.0.3
-        version: 1.0.3(@rsbuild/core@1.0.7)
+        version: 1.0.3(@rsbuild/core@1.0.16)
       '@types/react':
         specifier: ^18.2.79
         version: 18.2.79
@@ -2413,8 +2413,8 @@ importers:
         version: link:../sdk
     devDependencies:
       '@rsbuild/core':
-        specifier: 1.x
-        version: 1.0.7
+        specifier: ^1.0.16
+        version: 1.0.16
 
   packages/rspack:
     dependencies:
@@ -3039,10 +3039,10 @@ packages:
       '@babel/helpers': 7.25.7
       '@babel/parser': 7.25.8
       '@babel/template': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
       convert-source-map: 1.9.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.21
@@ -3065,10 +3065,10 @@ packages:
       '@babel/helpers': 7.25.6
       '@babel/parser': 7.25.7
       '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.7
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3087,10 +3087,10 @@ packages:
       '@babel/helpers': 7.25.7
       '@babel/parser': 7.25.7
       '@babel/template': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.7
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3109,10 +3109,10 @@ packages:
       '@babel/helpers': 7.25.7
       '@babel/parser': 7.25.8
       '@babel/template': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3206,7 +3206,7 @@ packages:
     resolution: {integrity: sha512-12xfNeKNH7jubQNm7PAkzlLwEmCs1tfuX3UjIw6vP6QXi+leKh6+LyC/+Ed4EIQermwd58wsyh070yjDHFlNGg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
@@ -3243,7 +3243,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.25.7
       '@babel/helper-replace-supers': 7.25.7(@babel/core@7.25.2)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -3261,7 +3261,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.25.7
       '@babel/helper-replace-supers': 7.25.7(@babel/core@7.25.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -3278,7 +3278,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.25.7
       '@babel/helper-replace-supers': 7.25.7(@babel/core@7.25.8)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -3315,7 +3315,7 @@ packages:
       '@babel/core': 7.25.7
       '@babel/helper-compilation-targets': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -3329,7 +3329,7 @@ packages:
       '@babel/core': 7.25.8
       '@babel/helper-compilation-targets': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -3340,7 +3340,7 @@ packages:
     resolution: {integrity: sha512-O31Ssjd5K6lPbTX9AAYpSKrZmLeagt9uwschJd+Ixo6QiRyfpvgtVQp8qrDR9UNFjZ8+DO34ZkdrN+BnPXemeA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
@@ -3349,7 +3349,16 @@ packages:
     resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
+      '@babel/types': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/helper-module-imports@7.25.7:
+    resolution: {integrity: sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.7
     transitivePeerDependencies:
       - supports-color
@@ -3373,7 +3382,7 @@ packages:
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-simple-access': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3384,10 +3393,10 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-simple-access': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3399,10 +3408,10 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.25.7
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-simple-access': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3413,10 +3422,10 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.25.8
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-simple-access': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3448,7 +3457,7 @@ packages:
       '@babel/core': 7.25.7
       '@babel/helper-annotate-as-pure': 7.25.7
       '@babel/helper-wrap-function': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3461,7 +3470,7 @@ packages:
       '@babel/core': 7.25.8
       '@babel/helper-annotate-as-pure': 7.25.7
       '@babel/helper-wrap-function': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3475,7 +3484,7 @@ packages:
       '@babel/core': 7.25.2
       '@babel/helper-member-expression-to-functions': 7.25.7
       '@babel/helper-optimise-call-expression': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3489,7 +3498,7 @@ packages:
       '@babel/core': 7.25.7
       '@babel/helper-member-expression-to-functions': 7.25.7
       '@babel/helper-optimise-call-expression': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3502,7 +3511,7 @@ packages:
       '@babel/core': 7.25.8
       '@babel/helper-member-expression-to-functions': 7.25.7
       '@babel/helper-optimise-call-expression': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3511,7 +3520,7 @@ packages:
     resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.7
     transitivePeerDependencies:
       - supports-color
@@ -3520,7 +3529,7 @@ packages:
     resolution: {integrity: sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.7
     transitivePeerDependencies:
       - supports-color
@@ -3529,7 +3538,7 @@ packages:
     resolution: {integrity: sha512-pPbNbchZBkPMD50K0p3JGcFMNLVUCuU/ABybm/PGNj4JiHrpmNyqqCphBk4i19xXtNV0JhldQJJtbSW5aUvbyA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
@@ -3559,7 +3568,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
@@ -3618,7 +3627,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3630,7 +3639,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3708,7 +3717,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3720,7 +3729,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4389,7 +4398,7 @@ packages:
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/helper-remap-async-to-generator': 7.25.7(@babel/core@7.25.7)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.7)
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -4402,7 +4411,7 @@ packages:
       '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/helper-remap-async-to-generator': 7.25.7(@babel/core@7.25.8)
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4414,7 +4423,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.25.7
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/helper-remap-async-to-generator': 7.25.7(@babel/core@7.25.7)
     transitivePeerDependencies:
@@ -4427,7 +4436,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.25.8
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/helper-remap-async-to-generator': 7.25.7(@babel/core@7.25.8)
     transitivePeerDependencies:
@@ -4534,7 +4543,7 @@ packages:
       '@babel/helper-compilation-targets': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/helper-replace-supers': 7.25.7(@babel/core@7.25.7)
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -4550,7 +4559,7 @@ packages:
       '@babel/helper-compilation-targets': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/helper-replace-supers': 7.25.7(@babel/core@7.25.8)
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -4767,7 +4776,7 @@ packages:
       '@babel/core': 7.25.7
       '@babel/helper-compilation-targets': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -4780,7 +4789,7 @@ packages:
       '@babel/core': 7.25.8
       '@babel/helper-compilation-targets': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4925,7 +4934,7 @@ packages:
       '@babel/helper-module-transforms': 7.25.7(@babel/core@7.25.7)
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -4939,7 +4948,7 @@ packages:
       '@babel/helper-module-transforms': 7.25.7(@babel/core@7.25.8)
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5360,7 +5369,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-annotate-as-pure': 7.25.7
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/plugin-syntax-jsx': 7.25.7(@babel/core@7.25.2)
       '@babel/types': 7.25.7
@@ -5376,7 +5385,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.7
       '@babel/helper-annotate-as-pure': 7.25.7
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/plugin-syntax-jsx': 7.25.7(@babel/core@7.25.7)
       '@babel/types': 7.25.7
@@ -5391,7 +5400,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.8
       '@babel/helper-annotate-as-pure': 7.25.7
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/plugin-syntax-jsx': 7.25.7(@babel/core@7.25.8)
       '@babel/types': 7.25.7
@@ -5478,7 +5487,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.25.7
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.25.7)
       babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.25.7)
@@ -5494,7 +5503,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.25.8
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.25.8)
       babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.25.8)
@@ -6076,6 +6085,20 @@ packages:
       '@babel/code-frame': 7.25.7
       '@babel/parser': 7.25.7
       '@babel/types': 7.25.7
+
+  /@babel/traverse@7.25.7:
+    resolution: {integrity: sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.25.7
+      '@babel/generator': 7.25.7
+      '@babel/parser': 7.25.7
+      '@babel/template': 7.25.7
+      '@babel/types': 7.25.7
+      debug: 4.3.7(supports-color@9.3.1)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
 
   /@babel/traverse@7.25.7(supports-color@5.5.0):
     resolution: {integrity: sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==}
@@ -6773,7 +6796,7 @@ packages:
   /@emotion/babel-plugin@11.12.0:
     resolution: {integrity: sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==}
     dependencies:
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/runtime': 7.25.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -8522,7 +8545,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -8598,7 +8621,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -9538,7 +9561,7 @@ packages:
         optional: true
     dependencies:
       '@babel/parser': 7.25.8
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
       '@modern-js/core': 2.60.3
       '@modern-js/node-bundle-require': 2.60.3
@@ -9547,14 +9570,14 @@ packages:
       '@modern-js/plugin-i18n': 2.60.3
       '@modern-js/prod-server': 2.60.3(react-dom@18.3.1)(react@18.3.1)
       '@modern-js/rsbuild-plugin-esbuild': 2.60.3(@swc/core@1.7.26)
-      '@modern-js/server': 2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.14)(react-dom@18.3.1)(react@18.3.1)
+      '@modern-js/server': 2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.16)(react-dom@18.3.1)(react@18.3.1)
       '@modern-js/server-core': 2.60.3(react-dom@18.3.1)(react@18.3.1)
-      '@modern-js/server-utils': 2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.14)
+      '@modern-js/server-utils': 2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.16)
       '@modern-js/types': 2.60.3
       '@modern-js/uni-builder': 2.60.3(@rspack/core@1.0.8)(@swc/core@1.7.26)(esbuild@0.17.19)(styled-components@6.1.13)(typescript@5.0.4)
       '@modern-js/utils': 2.60.3
-      '@rsbuild/core': 1.0.14
-      '@rsbuild/plugin-node-polyfill': 1.0.4(@rsbuild/core@1.0.14)
+      '@rsbuild/core': 1.0.16
+      '@rsbuild/plugin-node-polyfill': 1.0.4(@rsbuild/core@1.0.16)
       '@swc/helpers': 0.5.13
       '@vercel/nft': 0.26.5(encoding@0.1.13)
       es-module-lexer: 1.5.4
@@ -9606,7 +9629,7 @@ packages:
         optional: true
     dependencies:
       '@babel/parser': 7.25.8
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
       '@modern-js/core': 2.60.3
       '@modern-js/node-bundle-require': 2.60.3
@@ -9615,14 +9638,14 @@ packages:
       '@modern-js/plugin-i18n': 2.60.3
       '@modern-js/prod-server': 2.60.3(react-dom@18.3.1)(react@18.3.1)
       '@modern-js/rsbuild-plugin-esbuild': 2.60.3(@swc/core@1.7.26)
-      '@modern-js/server': 2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.14)(react-dom@18.3.1)(react@18.3.1)
+      '@modern-js/server': 2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.16)(react-dom@18.3.1)(react@18.3.1)
       '@modern-js/server-core': 2.60.3(react-dom@18.3.1)(react@18.3.1)
-      '@modern-js/server-utils': 2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.14)
+      '@modern-js/server-utils': 2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.16)
       '@modern-js/types': 2.60.3
       '@modern-js/uni-builder': 2.60.3(@rspack/core@1.0.8)(@swc/core@1.7.26)(esbuild@0.17.19)(styled-components@6.1.13)(typescript@5.5.2)
       '@modern-js/utils': 2.60.3
-      '@rsbuild/core': 1.0.14
-      '@rsbuild/plugin-node-polyfill': 1.0.4(@rsbuild/core@1.0.14)
+      '@rsbuild/core': 1.0.16
+      '@rsbuild/plugin-node-polyfill': 1.0.4(@rsbuild/core@1.0.16)
       '@swc/helpers': 0.5.13
       '@vercel/nft': 0.26.5(encoding@0.1.13)
       es-module-lexer: 1.5.4
@@ -9723,7 +9746,7 @@ packages:
       - supports-color
     dev: true
 
-  /@modern-js/babel-preset@2.60.3(@rsbuild/core@1.0.14):
+  /@modern-js/babel-preset@2.60.3(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-k5FmCuyuHK70JZbsY2VBKdV+rZ0lLyosKbhYrQ6GkxNLEzDP2d9mZq/aMLUDPJungFqBar7/gcA6Gd6fC6cp1A==}
     dependencies:
       '@babel/core': 7.25.8
@@ -9736,7 +9759,7 @@ packages:
       '@babel/preset-typescript': 7.25.7(@babel/core@7.25.8)
       '@babel/runtime': 7.25.7
       '@babel/types': 7.25.8
-      '@rsbuild/plugin-babel': 1.0.2(@rsbuild/core@1.0.14)
+      '@rsbuild/plugin-babel': 1.0.2(@rsbuild/core@1.0.16)
       '@swc/helpers': 0.5.13
       '@types/babel__core': 7.20.5
       babel-plugin-dynamic-import-node: 2.3.3
@@ -10249,7 +10272,7 @@ packages:
       - supports-color
     dev: true
 
-  /@modern-js/server-utils@2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.14):
+  /@modern-js/server-utils@2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-e7i6miqx3YsshBRixbOIWi3I5jt8LnqAGHuiViQBI90RzlSbP0udoVjSAqe+7HF+nPvyMAynMsY/3ljSk0Yf9g==}
     dependencies:
       '@babel/core': 7.25.8
@@ -10259,7 +10282,7 @@ packages:
       '@babel/preset-typescript': 7.25.7(@babel/core@7.25.8)
       '@modern-js/babel-compiler': 2.60.3
       '@modern-js/babel-plugin-module-resolver': 2.60.3
-      '@modern-js/babel-preset': 2.60.3(@rsbuild/core@1.0.14)
+      '@modern-js/babel-preset': 2.60.3(@rsbuild/core@1.0.16)
       '@modern-js/utils': 2.60.3
       '@swc/helpers': 0.5.13
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.25.8)(@babel/traverse@7.25.7)
@@ -10309,7 +10332,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@modern-js/server@2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.14)(react-dom@18.3.1)(react@18.3.1):
+  /@modern-js/server@2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.16)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-fTUOdHVEgmEKf6BozU3DBHYgRfXYAX68PPRtljHhLYSCLDqQ27LHGqzjL2WUYY9pLq7mpPAy5oy7U6nnzMT+vg==}
     peerDependencies:
       devcert: ^1.2.2
@@ -10327,7 +10350,7 @@ packages:
       '@babel/register': 7.25.7(@babel/core@7.25.8)
       '@modern-js/runtime-utils': 2.60.3(react-dom@18.3.1)(react@18.3.1)
       '@modern-js/server-core': 2.60.3(react-dom@18.3.1)(react@18.3.1)
-      '@modern-js/server-utils': 2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.14)
+      '@modern-js/server-utils': 2.60.3(@babel/traverse@7.25.7)(@rsbuild/core@1.0.16)
       '@modern-js/types': 2.60.3
       '@modern-js/utils': 2.60.3
       '@swc/helpers': 0.5.13
@@ -10356,7 +10379,7 @@ packages:
       '@modern-js/runtime': 2.60.3(@types/react-dom@18.3.0)(@types/react@18.2.79)(react-dom@18.3.1)(react@18.3.1)
       '@modern-js/uni-builder': 2.60.3(@rspack/core@1.0.8)(@swc/core@1.7.26)(esbuild@0.18.20)(styled-components@6.1.13)(typescript@5.0.4)
       '@modern-js/utils': 2.60.3
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       '@storybook/components': 7.6.20(@types/react-dom@18.3.0)(@types/react@18.2.79)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/csf-plugin': 7.6.20
@@ -10554,27 +10577,27 @@ packages:
       '@babel/core': 7.25.8
       '@babel/preset-react': 7.25.7(@babel/core@7.25.8)
       '@babel/types': 7.25.8
-      '@modern-js/babel-preset': 2.60.3(@rsbuild/core@1.0.14)
+      '@modern-js/babel-preset': 2.60.3(@rsbuild/core@1.0.16)
       '@modern-js/utils': 2.60.3
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(webpack@5.95.0)
-      '@rsbuild/core': 1.0.14
-      '@rsbuild/plugin-assets-retry': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-babel': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-check-syntax': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-css-minimizer': 1.0.2(@rsbuild/core@1.0.14)(esbuild@0.17.19)(webpack@5.95.0)
-      '@rsbuild/plugin-less': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-pug': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-react': 1.0.4(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-rem': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-sass': 1.0.3(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-source-build': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-styled-components': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-svgr': 1.0.4(@rsbuild/core@1.0.14)(typescript@5.0.4)
-      '@rsbuild/plugin-toml': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.0.14)(@swc/core@1.7.26)(esbuild@0.17.19)(typescript@5.0.4)
-      '@rsbuild/plugin-typed-css-modules': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-yaml': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/webpack': 1.0.11(@rsbuild/core@1.0.14)(@swc/core@1.7.26)(esbuild@0.17.19)
+      '@rsbuild/core': 1.0.16
+      '@rsbuild/plugin-assets-retry': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-babel': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-check-syntax': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-css-minimizer': 1.0.2(@rsbuild/core@1.0.16)(esbuild@0.17.19)(webpack@5.95.0)
+      '@rsbuild/plugin-less': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-pug': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-react': 1.0.4(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-rem': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-sass': 1.0.3(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-source-build': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-styled-components': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-svgr': 1.0.4(@rsbuild/core@1.0.16)(typescript@5.0.4)
+      '@rsbuild/plugin-toml': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.17.19)(typescript@5.0.4)
+      '@rsbuild/plugin-typed-css-modules': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-yaml': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/webpack': 1.0.11(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.17.19)
       '@swc/helpers': 0.5.13
       autoprefixer: 10.4.20(postcss@8.4.47)
       babel-loader: 9.1.3(@babel/core@7.25.8)(webpack@5.95.0)
@@ -10631,27 +10654,27 @@ packages:
       '@babel/core': 7.25.8
       '@babel/preset-react': 7.25.7(@babel/core@7.25.8)
       '@babel/types': 7.25.8
-      '@modern-js/babel-preset': 2.60.3(@rsbuild/core@1.0.14)
+      '@modern-js/babel-preset': 2.60.3(@rsbuild/core@1.0.16)
       '@modern-js/utils': 2.60.3
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(webpack@5.95.0)
-      '@rsbuild/core': 1.0.14
-      '@rsbuild/plugin-assets-retry': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-babel': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-check-syntax': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-css-minimizer': 1.0.2(@rsbuild/core@1.0.14)(esbuild@0.17.19)(webpack@5.95.0)
-      '@rsbuild/plugin-less': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-pug': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-react': 1.0.4(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-rem': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-sass': 1.0.3(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-source-build': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-styled-components': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-svgr': 1.0.4(@rsbuild/core@1.0.14)(typescript@5.5.2)
-      '@rsbuild/plugin-toml': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.0.14)(@swc/core@1.7.26)(esbuild@0.17.19)(typescript@5.5.2)
-      '@rsbuild/plugin-typed-css-modules': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-yaml': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/webpack': 1.0.11(@rsbuild/core@1.0.14)(@swc/core@1.7.26)(esbuild@0.17.19)
+      '@rsbuild/core': 1.0.16
+      '@rsbuild/plugin-assets-retry': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-babel': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-check-syntax': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-css-minimizer': 1.0.2(@rsbuild/core@1.0.16)(esbuild@0.17.19)(webpack@5.95.0)
+      '@rsbuild/plugin-less': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-pug': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-react': 1.0.4(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-rem': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-sass': 1.0.3(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-source-build': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-styled-components': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-svgr': 1.0.4(@rsbuild/core@1.0.16)(typescript@5.5.2)
+      '@rsbuild/plugin-toml': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.17.19)(typescript@5.5.2)
+      '@rsbuild/plugin-typed-css-modules': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-yaml': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/webpack': 1.0.11(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.17.19)
       '@swc/helpers': 0.5.13
       autoprefixer: 10.4.20(postcss@8.4.47)
       babel-loader: 9.1.3(@babel/core@7.25.8)(webpack@5.95.0)
@@ -10708,27 +10731,27 @@ packages:
       '@babel/core': 7.25.8
       '@babel/preset-react': 7.25.7(@babel/core@7.25.8)
       '@babel/types': 7.25.8
-      '@modern-js/babel-preset': 2.60.3(@rsbuild/core@1.0.14)
+      '@modern-js/babel-preset': 2.60.3(@rsbuild/core@1.0.16)
       '@modern-js/utils': 2.60.3
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(webpack@5.95.0)
-      '@rsbuild/core': 1.0.14
-      '@rsbuild/plugin-assets-retry': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-babel': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-check-syntax': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-css-minimizer': 1.0.2(@rsbuild/core@1.0.14)(esbuild@0.18.20)(webpack@5.95.0)
-      '@rsbuild/plugin-less': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-pug': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-react': 1.0.4(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-rem': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-sass': 1.0.3(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-source-build': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-styled-components': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-svgr': 1.0.4(@rsbuild/core@1.0.14)(typescript@5.0.4)
-      '@rsbuild/plugin-toml': 1.0.1(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.0.14)(@swc/core@1.7.26)(esbuild@0.18.20)(typescript@5.0.4)
-      '@rsbuild/plugin-typed-css-modules': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-yaml': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/webpack': 1.0.11(@rsbuild/core@1.0.14)(@swc/core@1.7.26)(esbuild@0.18.20)
+      '@rsbuild/core': 1.0.16
+      '@rsbuild/plugin-assets-retry': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-babel': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-check-syntax': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-css-minimizer': 1.0.2(@rsbuild/core@1.0.16)(esbuild@0.18.20)(webpack@5.95.0)
+      '@rsbuild/plugin-less': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-pug': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-react': 1.0.4(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-rem': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-sass': 1.0.3(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-source-build': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-styled-components': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-svgr': 1.0.4(@rsbuild/core@1.0.16)(typescript@5.0.4)
+      '@rsbuild/plugin-toml': 1.0.1(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.18.20)(typescript@5.0.4)
+      '@rsbuild/plugin-typed-css-modules': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/plugin-yaml': 1.0.2(@rsbuild/core@1.0.16)
+      '@rsbuild/webpack': 1.0.11(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.18.20)
       '@swc/helpers': 0.5.13
       autoprefixer: 10.4.20(postcss@8.4.47)
       babel-loader: 9.1.3(@babel/core@7.25.8)(webpack@5.95.0)
@@ -11244,7 +11267,7 @@ packages:
       '@open-draft/until': 1.0.3
       '@types/debug': 4.1.12
       '@xmldom/xmldom': 0.8.10
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       headers-polyfill: 3.2.5
       outvariant: 1.4.3
       strict-event-emitter: 0.2.8
@@ -14436,7 +14459,7 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@rollup/pluginutils': 5.1.2(rollup@4.24.0)
       rollup: 4.24.0
     transitivePeerDependencies:
@@ -14912,48 +14935,34 @@ packages:
     engines: {node: '>=16.7.0'}
     hasBin: true
     dependencies:
-      '@rspack/core': 1.0.8(@swc/helpers@0.5.13)
-      '@rspack/lite-tapable': 1.0.1
-      '@swc/helpers': 0.5.13
-      caniuse-lite: 1.0.30001667
-      core-js: 3.38.1
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
-  /@rsbuild/core@1.0.14:
-    resolution: {integrity: sha512-00d0DzRUK2CncKK+dHGG8AZuiXzltVzt58BbTba2AKyLHIb2nwYW4ah33sNrDAbYzdz1kPNfsWrmQvY7z71LfA==}
-    engines: {node: '>=16.7.0'}
-    hasBin: true
-    dependencies:
       '@rspack/core': 1.0.10(@swc/helpers@0.5.13)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.13
-      core-js: 3.38.1
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
-  /@rsbuild/core@1.0.7:
-    resolution: {integrity: sha512-NqPAtKnPGdvKituKehTzUd8bnzVsdAs6vLY82OwymkmMlW9zcFYfeVYAfSUS3uTv7vDIFQwff0PHgYYV3ufpwQ==}
-    engines: {node: '>=16.7.0'}
-    hasBin: true
-    dependencies:
-      '@rspack/core': 1.0.8(@swc/helpers@0.5.13)
-      '@rspack/lite-tapable': 1.0.1
-      '@swc/helpers': 0.5.13
       caniuse-lite: 1.0.30001667
       core-js: 3.38.1
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
 
-  /@rsbuild/plugin-assets-retry@1.0.2(@rsbuild/core@1.0.14):
+  /@rsbuild/core@1.0.16:
+    resolution: {integrity: sha512-ioQg9HfDh5eXPZi+An7yCRaSE9TH4W3IBqrxBrv4IjOg/ajpVpKidiKwyYpX3QPbxY1ybfvQTH7HwATND4crCA==}
+    engines: {node: '>=16.7.0'}
+    hasBin: true
+    dependencies:
+      '@rspack/core': 1.0.13(@swc/helpers@0.5.13)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.13
+      core-js: 3.38.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /@rsbuild/plugin-assets-retry@1.0.2(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-vlQwCFibONxquQmQwDDv/crivmXAct8nsUtSovlgoMHE4UUQKFZbJ7jr54FVXvDlyL/Wp9yvOj4WhAEabBEVlA==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-rc.0
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       serialize-javascript: 6.0.2
     dev: true
 
@@ -15009,7 +15018,7 @@ packages:
       - supports-color
     dev: true
 
-  /@rsbuild/plugin-babel@1.0.2(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-babel@1.0.2(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-csTx5l6k3t8Qyd5MU3RVvq6aRg282Z+cc/0dpkDfs1NCF56ortTLyjV1LcHRmN6inXLwEp3tNt7P4EMDF0fV/w==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-rc.0
@@ -15018,7 +15027,7 @@ packages:
       '@babel/plugin-proposal-decorators': 7.25.7(@babel/core@7.25.8)
       '@babel/plugin-transform-class-properties': 7.25.7(@babel/core@7.25.8)
       '@babel/preset-typescript': 7.25.7(@babel/core@7.25.8)
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.0.0
@@ -15027,7 +15036,7 @@ packages:
       - supports-color
     dev: true
 
-  /@rsbuild/plugin-check-syntax@1.0.1(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-check-syntax@1.0.1(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-LN6OVmLJahFwv3dp9Q6k1E4GIpF78cUf7aXxKBvtvYXD0/rRP/1PPs4OWeyOqIcqSikcIdmERj50OECzPdWmpA==}
     peerDependencies:
       '@rsbuild/core': 0.x || 1.x
@@ -15035,7 +15044,7 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       acorn: 8.12.1
       browserslist-to-es-version: 1.0.0
       htmlparser2: 9.1.0
@@ -15043,7 +15052,7 @@ packages:
       source-map: 0.7.4
     dev: true
 
-  /@rsbuild/plugin-css-minimizer@1.0.2(@rsbuild/core@1.0.14)(esbuild@0.17.19)(webpack@5.95.0):
+  /@rsbuild/plugin-css-minimizer@1.0.2(@rsbuild/core@1.0.16)(esbuild@0.17.19)(webpack@5.95.0):
     resolution: {integrity: sha512-x695i5PHWI9uV9VA1Dun66G0DeJMgxbt3wEk4eHZMz9pi6n8Dah6BHG2WcloYAEi7yVoUcPIGXDdag27s2B+4A==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
@@ -15051,7 +15060,7 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       css-minimizer-webpack-plugin: 5.0.1(esbuild@0.17.19)(webpack@5.95.0)
       reduce-configs: 1.0.0
     transitivePeerDependencies:
@@ -15064,7 +15073,7 @@ packages:
       - webpack
     dev: true
 
-  /@rsbuild/plugin-css-minimizer@1.0.2(@rsbuild/core@1.0.14)(esbuild@0.18.20)(webpack@5.95.0):
+  /@rsbuild/plugin-css-minimizer@1.0.2(@rsbuild/core@1.0.16)(esbuild@0.18.20)(webpack@5.95.0):
     resolution: {integrity: sha512-x695i5PHWI9uV9VA1Dun66G0DeJMgxbt3wEk4eHZMz9pi6n8Dah6BHG2WcloYAEi7yVoUcPIGXDdag27s2B+4A==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
@@ -15072,7 +15081,7 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       css-minimizer-webpack-plugin: 5.0.1(esbuild@0.18.20)(webpack@5.95.0)
       reduce-configs: 1.0.0
     transitivePeerDependencies:
@@ -15096,17 +15105,17 @@ packages:
       - '@swc/helpers'
     dev: false
 
-  /@rsbuild/plugin-less@1.0.2(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-less@1.0.2(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-FtnJbonHfBrPP5tCiAHaOYyfqUYpvCUZVHfDv6wsky5copjDG0xnW7NL4JCNdT2QxTbssudL46UhYq67pLW5eA==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-rc.0
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       deepmerge: 4.3.1
       reduce-configs: 1.0.0
     dev: true
 
-  /@rsbuild/plugin-node-polyfill@1.0.4(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-node-polyfill@1.0.4(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-WuYnMmbRpRPGsHn1maLLa4aHY4qSlEI5wbVhf4vcYlz4Zi+F+RgM/cerFZ0zSgNW/7zEHRORoSWFEyOUff8RvQ==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
@@ -15114,7 +15123,7 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       assert: 2.1.0
       browserify-zlib: 0.2.0
       buffer: 5.7.1
@@ -15140,7 +15149,7 @@ packages:
       vm-browserify: 1.1.2
     dev: true
 
-  /@rsbuild/plugin-pug@1.0.2(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-pug@1.0.2(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-6WplxGg36PRMfNV4wFwbNRakqMM7Ms96E5PNFDTrjAhr/sX1BeyM9TDhFOcYXCeSwlO2PLjfw0L2JDf9RTwWBA==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
@@ -15148,7 +15157,7 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       '@types/pug': 2.0.10
       pug: 3.0.3
       reduce-configs: 1.0.0
@@ -15180,27 +15189,27 @@ packages:
       - '@swc/helpers'
     dev: false
 
-  /@rsbuild/plugin-react@1.0.3(@rsbuild/core@1.0.7):
+  /@rsbuild/plugin-react@1.0.3(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-HVfPiKINmDsIcLLs7YWAYQgzytVZOydBuPOFg5EoJiMHkFVjH0Rg3QViS3Hn6k3INqdc6ylpcYyOHHYItEIkWA==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-rc.0
     dependencies:
-      '@rsbuild/core': 1.0.7
+      '@rsbuild/core': 1.0.16
       '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
       react-refresh: 0.14.2
     dev: true
 
-  /@rsbuild/plugin-react@1.0.4(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-react@1.0.4(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-lZQPl2Ocw3mxdR8dGZNTx70iLILt/p1B4oAStDNnDCVK9mzeCzpG67IYP82KaAJ5KowXTPLRqEkF9fKr5lWPPA==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-rc.0
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
       react-refresh: 0.14.2
     dev: true
 
-  /@rsbuild/plugin-rem@1.0.1(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-rem@1.0.1(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-wsaEvFLVpWsvGi5Bh1j3Yxq1C5RgD+AyveNTbEHaoHHj7ChDx1lrTSRZhre3Jmgjse02gUZjbnAhcO+v5aJPVw==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
@@ -15208,7 +15217,7 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       deepmerge: 4.3.1
       terser: 5.34.1
     dev: true
@@ -15226,12 +15235,12 @@ packages:
       - '@swc/helpers'
     dev: false
 
-  /@rsbuild/plugin-sass@1.0.3(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-sass@1.0.3(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-Hy9MZtjXpoLfRvYeLP4F/1L5/mINRZ+IEFRQoaS7yAwzvydNMxI3QXoXDQvEaaUxnuNhCh2TCDrvsxd+cds22A==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-rc.0
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.4.47
@@ -15239,7 +15248,7 @@ packages:
       sass-embedded: 1.79.5
     dev: true
 
-  /@rsbuild/plugin-source-build@1.0.1(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-source-build@1.0.1(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-GA9Uapy4cTOOa0jkwf4/L4m6rPieWWOmeeEygVnJAHRdB5nW45conwlV9g1ZQC14ITHsZlai8FiZotWGPNJlwA==}
     peerDependencies:
       '@rsbuild/core': 0.x || 1.x || ^1.0.1-beta.0
@@ -15247,13 +15256,13 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       fast-glob: 3.3.2
       json5: 2.2.3
       yaml: 2.6.0
     dev: true
 
-  /@rsbuild/plugin-styled-components@1.0.1(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-styled-components@1.0.1(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-1NL0yu5yr7S9wv4xTBYE++CaCved96yoAyd+r/xu4dGfi0w+BrshHNDrPwYBKPX+DC3NZrHGMIsfvpy3QmtloA==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
@@ -15261,18 +15270,18 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       '@swc/plugin-styled-components': 2.0.11
       reduce-configs: 1.0.0
     dev: true
 
-  /@rsbuild/plugin-svgr@1.0.4(@rsbuild/core@1.0.14)(typescript@5.0.4):
+  /@rsbuild/plugin-svgr@1.0.4(@rsbuild/core@1.0.16)(typescript@5.0.4):
     resolution: {integrity: sha512-j2BXjNxsIEwRghsw3hagljbCYhe5uuw9qOMuN9Lgrb9PzNt44IMgIgrIdsS+3TR05CioMU/LHhA+Xjl+bhTMxA==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-rc.0
     dependencies:
-      '@rsbuild/core': 1.0.14
-      '@rsbuild/plugin-react': 1.0.4(@rsbuild/core@1.0.14)
+      '@rsbuild/core': 1.0.16
+      '@rsbuild/plugin-react': 1.0.4(@rsbuild/core@1.0.16)
       '@svgr/core': 8.1.0(typescript@5.0.4)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@5.0.4)
@@ -15283,13 +15292,13 @@ packages:
       - typescript
     dev: true
 
-  /@rsbuild/plugin-svgr@1.0.4(@rsbuild/core@1.0.14)(typescript@5.5.2):
+  /@rsbuild/plugin-svgr@1.0.4(@rsbuild/core@1.0.16)(typescript@5.5.2):
     resolution: {integrity: sha512-j2BXjNxsIEwRghsw3hagljbCYhe5uuw9qOMuN9Lgrb9PzNt44IMgIgrIdsS+3TR05CioMU/LHhA+Xjl+bhTMxA==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-rc.0
     dependencies:
-      '@rsbuild/core': 1.0.14
-      '@rsbuild/plugin-react': 1.0.4(@rsbuild/core@1.0.14)
+      '@rsbuild/core': 1.0.16
+      '@rsbuild/plugin-react': 1.0.4(@rsbuild/core@1.0.16)
       '@svgr/core': 8.1.0(typescript@5.5.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@5.5.2)
@@ -15300,7 +15309,7 @@ packages:
       - typescript
     dev: true
 
-  /@rsbuild/plugin-toml@1.0.1(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-toml@1.0.1(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-CsYlSKGYY2nm4nrubYGbbPsYE33p+5D1Y6i8FJKQtfAvsw6WdDO2l1Xmg9XuLL0s5mIGmAZFhj5tCMMW7yTX4A==}
     peerDependencies:
       '@rsbuild/core': 0.x || 1.x || ^1.0.1-beta.0
@@ -15308,11 +15317,11 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       toml: 3.0.0
     dev: true
 
-  /@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.0.14)(@swc/core@1.7.26)(esbuild@0.17.19)(typescript@5.0.4):
+  /@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.17.19)(typescript@5.0.4):
     resolution: {integrity: sha512-BahXAJNq4kWtL2dINUlrOL9UCN1t8c/qf5RW8JXx2HSSasfKPJGJ1BVfieMcIaFa/t8/QdafcwoxY1WKPTlSMg==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
@@ -15320,7 +15329,7 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       deepmerge: 4.3.1
       fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.0.4)(webpack@5.95.0)
       json5: 2.2.3
@@ -15334,7 +15343,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.0.14)(@swc/core@1.7.26)(esbuild@0.17.19)(typescript@5.5.2):
+  /@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.17.19)(typescript@5.5.2):
     resolution: {integrity: sha512-BahXAJNq4kWtL2dINUlrOL9UCN1t8c/qf5RW8JXx2HSSasfKPJGJ1BVfieMcIaFa/t8/QdafcwoxY1WKPTlSMg==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
@@ -15342,7 +15351,7 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       deepmerge: 4.3.1
       fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.5.2)(webpack@5.95.0)
       json5: 2.2.3
@@ -15356,7 +15365,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.0.14)(@swc/core@1.7.26)(esbuild@0.18.20)(typescript@5.0.4):
+  /@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.18.20)(typescript@5.0.4):
     resolution: {integrity: sha512-BahXAJNq4kWtL2dINUlrOL9UCN1t8c/qf5RW8JXx2HSSasfKPJGJ1BVfieMcIaFa/t8/QdafcwoxY1WKPTlSMg==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
@@ -15364,7 +15373,7 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       deepmerge: 4.3.1
       fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.0.4)(webpack@5.95.0)
       json5: 2.2.3
@@ -15378,7 +15387,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-QX376pBXWeBrZBvYLP2HGGrHiWA5O0SDHwRoBNto5BqYDXhi6y+Eol2Hb/cY+h2ARKZVanMfUiJRABULOJ/FCQ==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
@@ -15386,15 +15395,15 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
     dev: true
 
-  /@rsbuild/plugin-vue@1.0.1(@rsbuild/core@1.0.7)(@swc/core@1.7.26)(esbuild@0.24.0)(vue@3.5.10):
+  /@rsbuild/plugin-vue@1.0.1(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.24.0)(vue@3.5.10):
     resolution: {integrity: sha512-HmxGkquVbivxaLovYeZhHk2tm8fm/f6h5rKcGtHTce4BlrDDN63gjRpfCa8eLnbIsmBPYen4rPXmOwMLReEBJQ==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-rc.0
     dependencies:
-      '@rsbuild/core': 1.0.7
+      '@rsbuild/core': 1.0.16
       vue-loader: 17.4.2(vue@3.5.10)(webpack@5.95.0)
       webpack: 5.95.0(@swc/core@1.7.26)(esbuild@0.24.0)
     transitivePeerDependencies:
@@ -15406,7 +15415,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@rsbuild/plugin-yaml@1.0.2(@rsbuild/core@1.0.14):
+  /@rsbuild/plugin-yaml@1.0.2(@rsbuild/core@1.0.16):
     resolution: {integrity: sha512-M7POrqJAYS8IoY4trdLe9DUhDC01MvA0ge4ZKHoVQzlNLWVj2QHHXdz55/bfpkNYhoNGdCntoDmE/dn1zIpcAw==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
@@ -15414,7 +15423,7 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
     dev: true
 
   /@rsbuild/shared@0.3.11(@swc/helpers@0.5.3):
@@ -15515,12 +15524,12 @@ packages:
       - '@swc/helpers'
     dev: true
 
-  /@rsbuild/webpack@1.0.11(@rsbuild/core@1.0.14)(@swc/core@1.7.26)(esbuild@0.17.19):
+  /@rsbuild/webpack@1.0.11(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.17.19):
     resolution: {integrity: sha512-2x/QqNUEKEt7eao8FnYwlrwQUYSbuM9ihiI1RpSuKbi/ZZuHxrFA3fwnO7k1v/Xbs5mCQR+ni+da5dakypFktg==}
     peerDependencies:
       '@rsbuild/core': 1.x
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       copy-webpack-plugin: 11.0.0(webpack@5.95.0)
       mini-css-extract-plugin: 2.9.1(webpack@5.95.0)
       picocolors: 1.1.0
@@ -15534,12 +15543,12 @@ packages:
       - webpack-cli
     dev: true
 
-  /@rsbuild/webpack@1.0.11(@rsbuild/core@1.0.14)(@swc/core@1.7.26)(esbuild@0.18.20):
+  /@rsbuild/webpack@1.0.11(@rsbuild/core@1.0.16)(@swc/core@1.7.26)(esbuild@0.18.20):
     resolution: {integrity: sha512-2x/QqNUEKEt7eao8FnYwlrwQUYSbuM9ihiI1RpSuKbi/ZZuHxrFA3fwnO7k1v/Xbs5mCQR+ni+da5dakypFktg==}
     peerDependencies:
       '@rsbuild/core': 1.x
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.0.16
       copy-webpack-plugin: 11.0.0(webpack@5.95.0)
       mini-css-extract-plugin: 2.9.1(webpack@5.95.0)
       picocolors: 1.1.0
@@ -15601,6 +15610,14 @@ packages:
     dev: true
     optional: true
 
+  /@rspack/binding-darwin-arm64@1.0.13:
+    resolution: {integrity: sha512-HepE4V5Rj53o+o8AMzlkdeBxZnsyXKrOJ2oumVtqRLXihVlMguYwNTSkjfmjAqq/4PJAhEeaeIFyomZg+zKC0A==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rspack/binding-darwin-arm64@1.0.8:
     resolution: {integrity: sha512-1l8/eg3HNz53DHQO3fy5O5QKdYh8hSMZaWGtm3NR5IfdrTm2TaLL9tuR8oL2iHHtd87LEvVKHXdjlcuLV5IPNQ==}
     cpu: [arm64]
@@ -15650,6 +15667,14 @@ packages:
 
   /@rspack/binding-darwin-x64@1.0.10:
     resolution: {integrity: sha512-L5dGmELiDDXAW3+yN11fwDbl8S9i7dwOvzygN/Iw+Md2WAODrFnTI/g++hOfdZzjUPtefyQUqoAcFOgpdxWSCQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rspack/binding-darwin-x64@1.0.13:
+    resolution: {integrity: sha512-ucHf0q2V+K19z75BvjU6EbQggNFiz1/xJ5tSgOXUfRu5omZF1jpN/epeMGqh0MkExRwOMYKJR/pVHDw5ITcU8g==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -15711,6 +15736,14 @@ packages:
     dev: true
     optional: true
 
+  /@rspack/binding-linux-arm64-gnu@1.0.13:
+    resolution: {integrity: sha512-0fqLWDG9Z2VKxy3u6+jLVJgT2E24Xb2umP4Jtx2uNf2+aHLXifgqUdwgCElO+dj+PpOp/q8zmV5U2DXykvPU3w==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rspack/binding-linux-arm64-gnu@1.0.8:
     resolution: {integrity: sha512-QnqCL0wmwYqT/IFx5q0aw7DsIOr8oYUa4+7JI8iiqRf3RuuRJExesVW9VuWr0jS2UvChKgmb8PvRtDy/0tshFw==}
     cpu: [arm64]
@@ -15760,6 +15793,14 @@ packages:
 
   /@rspack/binding-linux-arm64-musl@1.0.10:
     resolution: {integrity: sha512-KSPLOHcUC+8zA134RTCqo5bDqmX4ZwFz4LL+n/5i9yugHoiQVplEzh2TkFCVoAH85Xc40qPhxqGLJlhHh5qGEA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rspack/binding-linux-arm64-musl@1.0.13:
+    resolution: {integrity: sha512-eK72/jAofJRcZ23FTteUh1MfTbErWYNwVLuxnliyf1f1PwH0a7exGE6ik0/y/LdAt5PWP1r8r981EEjrpsTfRQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -15821,6 +15862,14 @@ packages:
     dev: true
     optional: true
 
+  /@rspack/binding-linux-x64-gnu@1.0.13:
+    resolution: {integrity: sha512-C9wGDim1Euc10qRk5ztPvgK4NAi6bi6Ck3+ugaRzYXPFIVegnFyXu2fv42j3Y0LRhBjnKMXZJzME5nQUPuT6Ug==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rspack/binding-linux-x64-gnu@1.0.8:
     resolution: {integrity: sha512-lfqUuKCoyRN/gGeokhX/oNYqB6OpbtgQb57b0QuD8IaiH2a1ee0TtEVvRbyQNEDwht6lW4RTNg0RfMYu52LgXg==}
     cpu: [x64]
@@ -15870,6 +15919,14 @@ packages:
 
   /@rspack/binding-linux-x64-musl@1.0.10:
     resolution: {integrity: sha512-OKb1PLOIulkg83zFyeFPowIzF7WdYVO6yRK7l+Kkick/cvALOj5XzRHyxrsb8VfJMpzHrPwsLV0RcGRT18BPMw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rspack/binding-linux-x64-musl@1.0.13:
+    resolution: {integrity: sha512-7bQyGEoMCxXUS+RDo6qej8JjqS8kYd8CvlnfYZVUqWgCxgn19j29lKvWVibey0lnFpoJrqReOdSypbk91tSrzA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -15931,6 +15988,14 @@ packages:
     dev: true
     optional: true
 
+  /@rspack/binding-win32-arm64-msvc@1.0.13:
+    resolution: {integrity: sha512-6QOHiCwaQeCZApWRe1y8ZNZGOj00EFdX1ypOc3R1GrfSjn+UjoKhbBtgVl2w+sPTaCZ4SvknOk9usSgcWO4gOQ==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rspack/binding-win32-arm64-msvc@1.0.8:
     resolution: {integrity: sha512-3NN5VisnSOzhgqX77O/7NvcjPUueg1oIdMKoc5vElJCEu5FEXPqDhwZmr1PpBovaXshAcgExF3j54+20pwdg5g==}
     cpu: [arm64]
@@ -15986,6 +16051,14 @@ packages:
     dev: true
     optional: true
 
+  /@rspack/binding-win32-ia32-msvc@1.0.13:
+    resolution: {integrity: sha512-ucm7emxYDjTsOGNwgYGz30oKcnzXLjg/Fcs0mNMmQgMEFpwBXhczfKJimCyMIlAhQCFPP4WzrXFdf03EPuw6CA==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rspack/binding-win32-ia32-msvc@1.0.8:
     resolution: {integrity: sha512-17VQNC7PSygzsipSVoukDM/SOcVueVNsk9bZiB0Swl20BaqrlBts2Dvlmo+L+ZGsxOYI97WvA/zomMDv860usg==}
     cpu: [ia32]
@@ -16035,6 +16108,14 @@ packages:
 
   /@rspack/binding-win32-x64-msvc@1.0.10:
     resolution: {integrity: sha512-1ad9SONsqp6XXxrCHsClnThW7BOrK5PWWslY+J3G0sHsXztSz/s9/CDRXUyJ8vuolpIy10E1Kyk1aV9y+IMs+g==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rspack/binding-win32-x64-msvc@1.0.13:
+    resolution: {integrity: sha512-9G/hvr47ECjDEmBCyyQTZFilmEOIQJCQvpx6hUgDWsfUApwF9LZBW/PqBCSwhY+tIErr/AurJnBVAYub0MYpHA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -16130,6 +16211,20 @@ packages:
       '@rspack/binding-win32-arm64-msvc': 1.0.10
       '@rspack/binding-win32-ia32-msvc': 1.0.10
       '@rspack/binding-win32-x64-msvc': 1.0.10
+    dev: true
+
+  /@rspack/binding@1.0.13:
+    resolution: {integrity: sha512-mnSCZ3Qb/I3LzsYoo24AG4LgmaSOIc1CS38A9L9nv4MJj8x+1D2BaLErpaaMmhqI3lQBIcBSQkN7+WbpsCP3Uw==}
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.0.13
+      '@rspack/binding-darwin-x64': 1.0.13
+      '@rspack/binding-linux-arm64-gnu': 1.0.13
+      '@rspack/binding-linux-arm64-musl': 1.0.13
+      '@rspack/binding-linux-x64-gnu': 1.0.13
+      '@rspack/binding-linux-x64-musl': 1.0.13
+      '@rspack/binding-win32-arm64-msvc': 1.0.13
+      '@rspack/binding-win32-ia32-msvc': 1.0.13
+      '@rspack/binding-win32-x64-msvc': 1.0.13
     dev: true
 
   /@rspack/binding@1.0.8:
@@ -16311,6 +16406,22 @@ packages:
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
       '@rspack/binding': 1.0.10
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.13
+      caniuse-lite: 1.0.30001667
+    dev: true
+
+  /@rspack/core@1.0.13(@swc/helpers@0.5.13):
+    resolution: {integrity: sha512-lh8toWSWcYjlOuriQ8/h0U8riaaRQfzwU0oUNykFj1xokJMSKIQFH5WQWj2DQ386uHNv52nMbc+Jiuml1vYboA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@module-federation/runtime-tools': 0.5.1
+      '@rspack/binding': 1.0.13
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.13
       caniuse-lite: 1.0.30001668
@@ -16771,7 +16882,7 @@ packages:
       conventional-changelog-writer: 8.0.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       import-from-esm: 1.3.4
       lodash-es: 4.17.21
       micromatch: 4.0.8
@@ -16798,7 +16909,7 @@ packages:
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       execa: 5.1.1
       lodash: 4.17.21
       parse-json: 5.2.0
@@ -16815,7 +16926,7 @@ packages:
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       dir-glob: 3.0.1
       execa: 5.1.1
       lodash: 4.17.21
@@ -16838,7 +16949,7 @@ packages:
       '@octokit/plugin-throttling': 9.3.1(@octokit/core@6.1.2)
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       dir-glob: 3.0.1
       globby: 14.0.2
       http-proxy-agent: 7.0.2
@@ -16907,7 +17018,7 @@ packages:
       conventional-changelog-writer: 8.0.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       get-stream: 7.0.1
       import-from-esm: 1.3.4
       into-stream: 7.0.0
@@ -17712,7 +17823,7 @@ packages:
     dependencies:
       '@babel/generator': 7.25.7
       '@babel/parser': 7.25.8
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
       '@storybook/csf': 0.1.11
       '@storybook/types': 7.6.20
@@ -17728,7 +17839,7 @@ packages:
     dependencies:
       '@babel/generator': 7.25.6
       '@babel/parser': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.7
       '@storybook/csf': 0.1.11
       '@storybook/types': 8.1.11
@@ -17991,7 +18102,7 @@ packages:
       typescript: '>= 4.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -18010,13 +18121,13 @@ packages:
       typescript: '>= 4.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
       micromatch: 4.0.8
       react-docgen-typescript: 2.2.2(typescript@5.5.2)
-      tslib: 2.6.3
+      tslib: 2.7.0
       typescript: 5.5.2
       webpack: 5.93.0(@swc/core@1.7.26)(esbuild@0.24.0)
     transitivePeerDependencies:
@@ -18427,7 +18538,7 @@ packages:
       '@swc-node/sourcemap-support': 0.5.1
       '@swc/core': 1.7.26(@swc/helpers@0.5.13)
       colorette: 2.0.20
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       oxc-resolver: 1.12.0
       pirates: 4.0.6
       tslib: 2.6.3
@@ -19662,7 +19773,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.0.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.0.4)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -19714,7 +19825,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       eslint: 8.57.1
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19735,7 +19846,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       eslint: 8.57.1
       typescript: 5.5.2
     transitivePeerDependencies:
@@ -19756,7 +19867,7 @@ packages:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       eslint: 8.57.1
       typescript: 5.5.2
     transitivePeerDependencies:
@@ -19807,7 +19918,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.0.4)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
@@ -19827,7 +19938,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.2)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.5.2)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       eslint: 8.57.1
       ts-api-utils: 1.3.0(typescript@5.5.2)
       typescript: 5.5.2
@@ -19846,7 +19957,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.8.0(typescript@5.5.2)
       '@typescript-eslint/utils': 8.8.0(eslint@8.57.1)(typescript@5.5.2)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       ts-api-utils: 1.3.0(typescript@5.5.2)
       typescript: 5.5.2
     transitivePeerDependencies:
@@ -19885,7 +19996,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -19906,7 +20017,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -19928,7 +20039,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -19950,7 +20061,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 8.8.0
       '@typescript-eslint/visitor-keys': 8.8.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -20276,7 +20387,7 @@ packages:
     peerDependencies:
       vitest: 1.6.0
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
@@ -20297,7 +20408,7 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -20488,11 +20599,11 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/plugin-syntax-jsx': 7.25.7(@babel/core@7.25.2)
       '@babel/template': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.7
       '@vue/babel-helper-vue-transform-on': 1.2.5
       '@vue/babel-plugin-resolve-type': 1.2.5(@babel/core@7.25.2)
@@ -20509,7 +20620,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.25.7
       '@babel/core': 7.25.2
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/parser': 7.25.7
       '@vue/compiler-sfc': 3.5.10
@@ -21062,7 +21173,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21070,7 +21181,7 @@ packages:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -21950,7 +22061,7 @@ packages:
       '@babel/core': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/plugin-syntax-typescript': 7.25.7(@babel/core@7.25.7)
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -21969,7 +22080,7 @@ packages:
   /babel-plugin-import@1.13.5:
     resolution: {integrity: sha512-IkqnoV+ov1hdJVofly9pXRJmeDm9EtROfrc5i6eII0Hix2xMs5FEm8FG3ExMvazbnZBbgHIt6qdO8And6lCloQ==}
     dependencies:
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -21977,7 +22088,7 @@ packages:
   /babel-plugin-import@1.13.8:
     resolution: {integrity: sha512-36babpjra5m3gca44V6tSTomeBlPA7cHUynrE2WiQIm3rEGD9xy28MKsx5IdO45EbnpJY7Jrgd00C6Dwt/l/2Q==}
     dependencies:
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -22096,7 +22207,7 @@ packages:
       styled-components: '>= 2'
     dependencies:
       '@babel/helper-annotate-as-pure': 7.25.7
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.7
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.21
       styled-components: 6.1.13(react-dom@18.3.1)(react@18.3.1)
@@ -22150,7 +22261,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
     dev: true
 
   /babel-preset-current-node-syntax@1.1.0(@babel/core@7.25.2):
@@ -23672,7 +23783,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.93.0(@swc/core@1.7.26)(esbuild@0.24.0)
+      webpack: 5.93.0(@swc/core@1.7.26)(esbuild@0.18.20)
 
   /copy-webpack-plugin@11.0.0(webpack@5.93.0):
     resolution: {integrity: sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==}
@@ -24019,7 +24130,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.47)
       postcss-value-parser: 4.2.0
       semver: 7.6.3
-      webpack: 5.93.0(@swc/core@1.7.26)(esbuild@0.24.0)
+      webpack: 5.93.0(@swc/core@1.7.26)(esbuild@0.18.20)
 
   /css-minimizer-webpack-plugin@5.0.1(esbuild@0.17.19)(webpack@5.95.0):
     resolution: {integrity: sha512-3caImjKFQkS+ws1TGcFn0V1HyDJFq1Euy589JlD6/3rV2kj+w7r5G9WDMgSHvpvXHNZ2calVypZWuEDQd9wfLg==}
@@ -24759,7 +24870,6 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 9.3.1
-    dev: true
 
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
@@ -25032,7 +25142,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -25745,7 +25855,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       esbuild: 0.17.19
     transitivePeerDependencies:
       - supports-color
@@ -25756,7 +25866,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
@@ -25767,7 +25877,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       esbuild: 0.23.1
     transitivePeerDependencies:
       - supports-color
@@ -26186,7 +26296,7 @@ packages:
         optional: true
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
@@ -26576,7 +26686,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -26653,7 +26763,7 @@ packages:
     resolution: {integrity: sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==}
     engines: {node: '>=8.3.0'}
     dependencies:
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
       c8: 7.14.0
     transitivePeerDependencies:
@@ -27537,7 +27647,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -29108,7 +29218,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29118,7 +29228,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29165,7 +29275,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@types/http-proxy': 1.17.15
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       http-proxy: 1.18.1(debug@4.3.7)
       is-glob: 4.0.3
       is-plain-object: 5.0.0
@@ -29246,7 +29356,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29256,7 +29366,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -29265,7 +29375,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29400,7 +29510,7 @@ packages:
     resolution: {integrity: sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==}
     engines: {node: '>=16.20'}
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       import-meta-resolve: 4.1.0
     transitivePeerDependencies:
       - supports-color
@@ -30231,7 +30341,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -30243,7 +30353,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -31265,7 +31375,7 @@ packages:
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookies: 0.9.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       delegates: 1.0.0
       depd: 2.0.0
       destroy: 1.2.0
@@ -31419,7 +31529,7 @@ packages:
       webpack-sources:
         optional: true
     dependencies:
-      webpack: 5.93.0(@swc/core@1.7.26)(esbuild@0.24.0)
+      webpack: 5.93.0(@swc/core@1.7.26)(esbuild@0.18.20)
       webpack-sources: 3.2.3
 
   /lilconfig@2.1.0:
@@ -31736,7 +31846,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       flatted: 3.3.1
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -32591,7 +32701,7 @@ packages:
     resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -36239,7 +36349,7 @@ packages:
     engines: {node: '>=8.16.0'}
     dependencies:
       '@types/mime-types': 2.1.4
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -37414,7 +37524,7 @@ packages:
     engines: {node: '>=16.14.0'}
     dependencies:
       '@babel/core': 7.25.7
-      '@babel/traverse': 7.25.7(supports-color@5.5.0)
+      '@babel/traverse': 7.25.7
       '@babel/types': 7.25.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
@@ -39339,7 +39449,7 @@ packages:
       '@semantic-release/release-notes-generator': 14.0.1(semantic-release@24.1.2)
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.5.2)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       env-ci: 11.1.0
       execa: 9.4.0
       figures: 6.1.0
@@ -39458,7 +39568,7 @@ packages:
     resolution: {integrity: sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==}
     engines: {node: '>= 18'}
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       destroy: 1.2.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -39976,7 +40086,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -39989,7 +40099,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -40153,7 +40263,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -40423,7 +40533,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.93.0(@swc/core@1.7.26)(esbuild@0.24.0)
+      webpack: 5.93.0(@swc/core@1.7.26)(esbuild@0.18.20)
 
   /style-to-object@0.3.0:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
@@ -40607,7 +40717,7 @@ packages:
     hasBin: true
     dependencies:
       '@adobe/css-tools': 4.4.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       glob: 7.2.3
       sax: 1.2.4
       source-map: 0.7.4
@@ -40619,7 +40729,7 @@ packages:
     hasBin: true
     dependencies:
       '@adobe/css-tools': 4.3.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       glob: 7.2.3
       sax: 1.3.0
       source-map: 0.7.4
@@ -40687,7 +40797,6 @@ packages:
   /supports-color@9.3.1:
     resolution: {integrity: sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==}
     engines: {node: '>=12'}
-    dev: true
 
   /supports-hyperlinks@2.3.0:
     resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
@@ -41796,7 +41905,7 @@ packages:
       bundle-require: 4.2.1(esbuild@0.18.20)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       esbuild: 0.18.20
       execa: 5.1.1
       globby: 11.1.0
@@ -41838,7 +41947,7 @@ packages:
       cac: 6.7.14
       chokidar: 3.6.0
       consola: 3.2.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       esbuild: 0.23.0
       execa: 5.1.1
       joycon: 3.1.1
@@ -42651,7 +42760,7 @@ packages:
       compression: 1.7.4
       cookies: 0.9.1
       cors: 2.8.5
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       envinfo: 7.11.0
       express: 4.18.2
       express-rate-limit: 5.5.1
@@ -42756,7 +42865,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       pathe: 1.1.2
       picocolors: 1.1.0
       vite: 5.2.14(@types/node@20.12.14)(less@4.2.0)(stylus@0.63.0)
@@ -42777,7 +42886,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       pathe: 1.1.2
       picocolors: 1.1.0
       vite: 5.2.14(@types/node@18.16.9)(less@4.2.0)(stylus@0.63.0)
@@ -42805,7 +42914,7 @@ packages:
       '@microsoft/api-extractor': 7.43.0(@types/node@16.11.68)
       '@rollup/pluginutils': 5.1.2(rollup@4.24.0)
       '@vue/language-core': 1.8.27(typescript@5.5.2)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       kolorist: 1.8.0
       magic-string: 0.30.11
       typescript: 5.5.2
@@ -42830,7 +42939,7 @@ packages:
       '@microsoft/api-extractor': 7.43.0(@types/node@18.16.9)
       '@rollup/pluginutils': 5.1.2(rollup@4.24.0)
       '@vue/language-core': 1.8.27(typescript@5.5.2)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       kolorist: 1.8.0
       magic-string: 0.30.11
       typescript: 5.5.2
@@ -42850,7 +42959,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       globrex: 0.1.2
       tsconfck: 2.1.2(typescript@5.5.2)
       vite: 5.2.14(@types/node@18.16.9)(less@4.2.0)(stylus@0.63.0)
@@ -43020,7 +43129,7 @@ packages:
       acorn-walk: 8.3.4
       cac: 6.7.14
       chai: 4.5.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       execa: 8.0.1
       local-pkg: 0.5.0
       magic-string: 0.30.11
@@ -43077,7 +43186,7 @@ packages:
       '@vitest/utils': 1.6.0
       acorn-walk: 8.3.4
       chai: 4.5.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       execa: 8.0.1
       local-pkg: 0.5.0
       magic-string: 0.30.11
@@ -43126,7 +43235,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.3.1)
       eslint: 8.57.1
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3


### PR DESCRIPTION
## Description

Fix failed to load MF remote modules when using `server.base`.

The default `dev.assetPrefix` is set to the value of `server.base`, and Rsbuild should replace it with `dev.assetPrefix: true` to ensure that the remote module's assets can be requested by consumer apps with the correct URL.

## Related Issue

- resolve https://github.com/web-infra-dev/rsbuild/issues/3780
- the same as https://github.com/web-infra-dev/rsbuild/pull/3790

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
