### PR TITLE
fix: do not crash if hmr fails

### DIFF
--- a/.changeset/ai-lazy-tiger.md
+++ b/.changeset/ai-lazy-tiger.md
@@ -1,0 +1,10 @@
+---
+"@module-federation/node": patch
+---
+
+Improved error handling and cache clearing process in hot-reload utility.
+
+- Added error handling with try-catch block to manage potential exceptions when clearing the path cache.
+- Replaced direct use of module with a reference to currentChunk for cache path operations.
+- Ensured compatibility with TypeScript by adding @ts-ignore annotations where necessary.
+```

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prepare": "husky install",
     "changeset": "changeset",
     "build:packages": "npx nx affected -t build --parallel=10 --exclude='*,!tag:type:pkg'",
-    "changegen": "./changeset-gen.js --path ./packages/enhanced --staged && ./changeset-gen.js --path ./packages/runtime --staged && ./changeset-gen.js --path ./packages/data-prefetch --staged && ./changeset-gen.js --path ./packages/nextjs-mf --staged",
+    "changegen": "./changeset-gen.js --path ./packages/enhanced --staged &&./changeset-gen.js --path ./packages/node --staged && ./changeset-gen.js --path ./packages/runtime --staged && ./changeset-gen.js --path ./packages/data-prefetch --staged && ./changeset-gen.js --path ./packages/nextjs-mf --staged",
     "commitgen:staged": "./commit-gen.js --path ./packages --staged",
     "commitgen:main": "./commit-gen.js --path ./packages"
   },

--- a/packages/node/src/utils/hot-reload.ts
+++ b/packages/node/src/utils/hot-reload.ts
@@ -63,21 +63,28 @@ const decache = async function (moduleName: string) {
     return;
   }
 
+  const currentChunk = getRequire().cache[__filename];
+
   // Run over the cache looking for the files
   // loaded by the specified module name
   searchCache(moduleName, function (mod: NodeModule) {
     delete getRequire().cache[mod.id];
   });
-
-  // Remove cached paths to the module.
-  // Thanks to @bentael for pointing this out.
-  Object.keys((module.constructor as any)._pathCache).forEach(
-    function (cacheKey) {
-      if (cacheKey.indexOf(moduleName) > -1) {
-        delete (module.constructor as any)._pathCache[cacheKey];
-      }
-    },
-  );
+  try {
+    // Remove cached paths to the module.
+    // Thanks to @bentael for pointing this out.
+    //@ts-ignore
+    Object.keys((currentChunk.constructor as any)._pathCache).forEach(
+      function (cacheKey) {
+        if (cacheKey.indexOf(moduleName) > -1) {
+          //@ts-ignore
+          delete (currentChunk.constructor as any)._pathCache[cacheKey];
+        }
+      },
+    );
+  } catch (error) {
+    //null
+  }
 };
 
 /**


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
fix error caused by webpack module variables not allowing access to root cjs module constructor object

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/module-federation/core/issues/3115

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
