### PR TITLE
feat(retry-plugin): allow fallback function to receive failed URL

### DIFF
--- a/.changeset/violet-fans-sleep.md
+++ b/.changeset/violet-fans-sleep.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/retry-plugin': patch
+'website-new': patch
+---
+
+feat(retry-plugin): allow fallback function to receive failed URL

--- a/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
+++ b/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
@@ -96,7 +96,7 @@ type FetchWithRetryOptions = {
   options?: RequestInit;
   retryTimes?: number;
   retryDelay?: number;
-  fallback?: () => string;
+  fallback?: (() => string) | ((url: string | URL | globalThis.Request) => string);
 }
 
 type ScriptWithRetryOptions = {
@@ -143,9 +143,9 @@ type ScriptWithRetryOptions = {
   - The delay time between each retry (in milliseconds).
 
 - **fallback**:
-  - `() => string`
+  - `() => string | ((url: string | URL | globalThis.Request) => string)`
   - optional
-  - Returns the URL of a backup resource after all retries fail.
+  - A function, which can optionally receive the failed URL, that returns a fallback string to be used if all retries fail. This function is called when all retry attempts have failed.
 
 ### ScriptWithRetryOptions 类型说明
 

--- a/packages/retry-plugin/__tests__/retry.spec.ts
+++ b/packages/retry-plugin/__tests__/retry.spec.ts
@@ -136,4 +136,22 @@ describe('fetchWithRetry', () => {
       }),
     ).rejects.toThrow('Json parse error');
   });
+
+  it('should build fallback URL from remote after retries fail', async () => {
+    mockErrorFetch();
+    const retryTimes = 3;
+    const responsePromise = fetchWithRetry({
+      url: 'https://example.com',
+      retryTimes,
+      retryDelay: 0,
+      fallback: (url) => `${url}/fallback`,
+    });
+    vi.advanceTimersByTime(2000 * retryTimes);
+
+    await expect(responsePromise).rejects.toThrow(
+      'The request failed three times and has now been abandoned',
+    );
+    expect(fetch).toHaveBeenCalledTimes(5); //first fetch + retryTimes fetch
+    expect(fetch).toHaveBeenLastCalledWith('https://example.com/fallback', {});
+  });
 });

--- a/packages/retry-plugin/src/fetch-retry.ts
+++ b/packages/retry-plugin/src/fetch-retry.ts
@@ -37,7 +37,7 @@ async function fetchWithRetry({
       );
       if (fallback && typeof fallback === 'function') {
         return fetchWithRetry({
-          url: fallback(),
+          url: fallback(url),
           options,
           retryTimes: 0,
           retryDelay: 0,

--- a/packages/retry-plugin/src/types.d.ts
+++ b/packages/retry-plugin/src/types.d.ts
@@ -3,7 +3,9 @@ export interface FetchWithRetryOptions {
   options?: RequestInit;
   retryTimes?: number;
   retryDelay?: number;
-  fallback?: () => string;
+  fallback?:
+    | (() => string)
+    | ((url: string | URL | globalThis.Request) => string);
 }
 
 export interface ScriptWithRetryOptions {


### PR DESCRIPTION
## Description
feat(retry-plugin): allow fallback function to receive failed URL

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
