### PR TITLE
fix: unlink storybook addon from package publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,8 +22,7 @@
       "@module-federation/modern-js",
       "@module-federation/retry-plugin",
       "@module-federation/data-prefetch",
-      "@module-federation/rsbuild-plugin",
-      "@module-federation/storybook-addon"
+      "@module-federation/rsbuild-plugin"
     ]
   ],
   "ignorePatterns": ["^alpha|^beta"],
@@ -36,6 +35,15 @@
     "node-host-e2e",
     "node-host-e2e",
     "node-local-remote",
-    "node-remote"
+    "node-remote",
+    "remote1",
+    "remote2",
+    "remote3",
+    "remote4",
+    "host",
+    "host-v5",
+    "host-vue3",
+    "3008-runtime-remote",
+    "modernjs-ssr-*"
   ]
 }


### PR DESCRIPTION
## Description

unlinking storybook addon from publish version sync as it will bump all to v3

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
