### PR TITLE
fix(runtime): use document.defaultView to get real window object to solve csp issue

### DIFF
--- a/.changeset/cyan-emus-prove.md
+++ b/.changeset/cyan-emus-prove.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+fix(runtime): use document.defaultView to get real window object to solve csp issue

--- a/packages/runtime/src/global.ts
+++ b/packages/runtime/src/global.ts
@@ -28,8 +28,10 @@ export interface Federation {
 
 export const nativeGlobal: typeof global = (() => {
   try {
-    return new Function('return this')();
+    // get real window (incase of sandbox)
+    return document.defaultView;
   } catch {
+    // node env
     return globalThis;
   }
 })() as typeof global;


### PR DESCRIPTION
## Description
use [document.defaultView](https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView) to get real window object to solve csp issue


## Related Issue
https://github.com/module-federation/core/pull/3108
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
