### PR TITLE
fix: clear globalLoading cache in node env

### DIFF
--- a/.changeset/beige-cheetahs-tap.md
+++ b/.changeset/beige-cheetahs-tap.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/runtime': patch
+'@module-federation/node': patch
+---
+
+fix: clear globalLoading cache in node env

--- a/packages/node/src/utils/hot-reload.ts
+++ b/packages/node/src/utils/hot-reload.ts
@@ -153,7 +153,9 @@ export const performReload = async (
     gs.entryChunkCache.clear();
   }
 
-  gs.__GLOBAL_LOADING_REMOTE_ENTRY__ = {};
+  Object.keys(helpers.global.globalLoading).forEach((key) => {
+    delete helpers.global.globalLoading[key];
+  });
   //@ts-ignore
   gs.__FEDERATION__.__INSTANCES__.map((i: any) => {
     //@ts-ignore

--- a/packages/node/src/utils/hot-reload.ts
+++ b/packages/node/src/utils/hot-reload.ts
@@ -153,9 +153,6 @@ export const performReload = async (
     gs.entryChunkCache.clear();
   }
 
-  Object.keys(helpers.global.globalLoading).forEach((key) => {
-    delete helpers.global.globalLoading[key];
-  });
   //@ts-ignore
   gs.__FEDERATION__.__INSTANCES__.map((i: any) => {
     //@ts-ignore

--- a/packages/runtime/src/global.ts
+++ b/packages/runtime/src/global.ts
@@ -113,6 +113,10 @@ export function resetFederationGlobalInfo(): void {
   CurrentGlobal.__FEDERATION__.moduleInfo = {};
   CurrentGlobal.__FEDERATION__.__SHARE__ = {};
   CurrentGlobal.__FEDERATION__.__MANIFEST_LOADING__ = {};
+
+  Object.keys(globalLoading).forEach((key) => {
+    delete globalLoading[key];
+  });
 }
 
 export function getGlobalFederationInstance(

--- a/packages/runtime/src/helpers.ts
+++ b/packages/runtime/src/helpers.ts
@@ -1,5 +1,4 @@
 import {
-  globalLoading,
   nativeGlobal,
   resetFederationGlobalInfo,
   getGlobalFederationInstance,
@@ -33,7 +32,6 @@ const ShareUtils: IShareUtils = {
 interface IGlobalUtils {
   Global: typeof Global;
   nativeGlobal: typeof global;
-  globalLoading: typeof globalLoading;
   resetFederationGlobalInfo: typeof resetFederationGlobalInfo;
   getGlobalFederationInstance: typeof getGlobalFederationInstance;
   setGlobalFederationInstance: typeof setGlobalFederationInstance;
@@ -55,7 +53,6 @@ interface IGlobalUtils {
 const GlobalUtils: IGlobalUtils = {
   Global,
   nativeGlobal,
-  globalLoading,
   resetFederationGlobalInfo,
   getGlobalFederationInstance,
   setGlobalFederationInstance,

--- a/packages/runtime/src/helpers.ts
+++ b/packages/runtime/src/helpers.ts
@@ -1,4 +1,5 @@
 import {
+  globalLoading,
   nativeGlobal,
   resetFederationGlobalInfo,
   getGlobalFederationInstance,
@@ -32,6 +33,7 @@ const ShareUtils: IShareUtils = {
 interface IGlobalUtils {
   Global: typeof Global;
   nativeGlobal: typeof global;
+  globalLoading: typeof globalLoading;
   resetFederationGlobalInfo: typeof resetFederationGlobalInfo;
   getGlobalFederationInstance: typeof getGlobalFederationInstance;
   setGlobalFederationInstance: typeof setGlobalFederationInstance;
@@ -53,6 +55,7 @@ interface IGlobalUtils {
 const GlobalUtils: IGlobalUtils = {
   Global,
   nativeGlobal,
+  globalLoading,
   resetFederationGlobalInfo,
   getGlobalFederationInstance,
   setGlobalFederationInstance,


### PR DESCRIPTION
## Description
The bundler bundle GLOBAL_LOADING_REMOTE_ENTRY into share object closure ,and it can not access via globalThis . 
![image](https://github.com/user-attachments/assets/10d8415d-1bf5-41fd-a21a-1e286a259654)

This PR aims to solve this issue and clear globalLoading internally in revalidate method.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/module-federation/core/issues/3119
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
