### PR TITLE
feat(runtime): pass all loader hooks to the fetch and script functions

### DIFF
--- a/.changeset/lucky-buckets-add.md
+++ b/.changeset/lucky-buckets-add.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/runtime': minor
+'@module-federation/sdk': minor
+---
+
+pass all loaderHooks to loadEntry and fetch functions instead of just createScript

--- a/packages/runtime/src/remote/index.ts
+++ b/packages/runtime/src/remote/index.ts
@@ -145,7 +145,7 @@ export class RemoteHandler {
     loadEntry: new AsyncHook<
       [
         {
-          createScriptHook: FederationHost['loaderHook']['lifecycle']['createScript'];
+          loaderHook: FederationHost['loaderHook'];
           remoteInfo: RemoteInfo;
           remoteEntryExports?: RemoteEntryExports;
         },

--- a/packages/sdk/src/types/hooks.ts
+++ b/packages/sdk/src/types/hooks.ts
@@ -23,3 +23,7 @@ export type CreateScriptHook = (
   url: string,
   attrs?: Record<string, any> | undefined,
 ) => CreateScriptHookReturn;
+
+export type FetchHook = (
+  args: [string, RequestInit],
+) => Promise<Response> | void | false;


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

The pull request introduces changes to the runtime and SDK modules to allow for the passing of all loader hooks to the fetch and script functions. This provides more flexibility and control over the remote loading process, enabling developers to customize the fetch and script creation behavior using the provided hooks.

The key changes include:

- Updating the `RemoteHandler` class in the runtime module to accept a `loaderHook` parameter, which allows for passing all loader hooks to the `fetch` and `script` functions.
- Modifying the `loadEntryScript`, `loadEntryDom`, and `loadEntryNode` functions in the runtime utilities to accept a `loaderHook` parameter, enabling the passing of all loader hooks to the `fetch` and `script` functions.
- Adding a `loaderHook` parameter to the `createScriptNode` and `loadScriptNode` functions in the SDK module, allowing for customization of the fetch and script creation behavior using the provided hooks.
- Introducing a new `FetchHook` type in the SDK types, which represents a function that can be used to intercept and customize the fetch request made by the SDK.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
