### PR TITLE
fix: parameter url for fetch retry options should not be necessary

### DIFF
--- a/.changeset/little-insects-lick.md
+++ b/.changeset/little-insects-lick.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/retry-plugin': patch
+'website-new': patch
+---
+
+fix: parameter url for fetch options should not be necessary

--- a/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
+++ b/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
@@ -184,7 +184,7 @@ init({
         // the retry resource url
         url: 'http://localhost:2001/-mf-manifest.json',
         // after all retried failed, set a fallback function to guarantee a fallback resource
-        fallback: () => 'http://localhost:2002/mf-manifest.json',
+        fallback: (url: string) => 'http://localhost:2002/mf-manifest.json',
       },
       script: {
         // the retry times

--- a/apps/website-new/docs/zh/plugin/plugins/retry-plugin.mdx
+++ b/apps/website-new/docs/zh/plugin/plugins/retry-plugin.mdx
@@ -95,7 +95,7 @@ type FetchWithRetryOptions = {
   options?: RequestInit;
   retryTimes?: number;
   retryDelay?: number;
-  fallback?: () => string;
+  fallback?: (url: string) => string;
 }
 
 type ScriptWithRetryOptions = {

--- a/packages/retry-plugin/src/fetch-retry.ts
+++ b/packages/retry-plugin/src/fetch-retry.ts
@@ -1,4 +1,4 @@
-import type { FetchWithRetryOptions } from './types';
+import type { RequiredFetchWithRetryOptions } from './types';
 import {
   defaultRetries,
   defaultRetryDelay,
@@ -12,7 +12,7 @@ async function fetchWithRetry({
   retryTimes = defaultRetries, // retry times
   retryDelay = defaultRetryDelay, // retry delay
   fallback, // fallback url
-}: FetchWithRetryOptions) {
+}: RequiredFetchWithRetryOptions) {
   try {
     const response = await fetch(url, options);
 

--- a/packages/retry-plugin/src/types.d.ts
+++ b/packages/retry-plugin/src/types.d.ts
@@ -1,5 +1,5 @@
 export interface FetchWithRetryOptions {
-  url: string;
+  url?: string;
   options?: RequestInit;
   retryTimes?: number;
   retryDelay?: number;
@@ -19,3 +19,8 @@ export type RetryPluginParams = {
   fetch?: FetchWithRetryOptions;
   script?: ScriptWithRetryOptions;
 };
+
+export type RequiredFetchWithRetryOptions = Required<
+  Pick<FetchWithRetryOptions, 'url'>
+> &
+  Omit<FetchWithRetryOptions, 'url'>;


### PR DESCRIPTION
## Description
fix: parameter url for fetch retry options should not be necessary

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
