### PR TITLE
fix(runtime): use loaded or loading shared if sharedStrategy is loaded-first

### DIFF
--- a/.changeset/bright-guests-sip.md
+++ b/.changeset/bright-guests-sip.md
@@ -2,4 +2,4 @@
 '@module-federation/runtime': patch
 ---
 
-fix(runtime): if sharedStrategy is loaded-first and shared is loading , use it
+fix(runtime): use loaded or loading shared if sharedStrategy is loaded-first

--- a/.changeset/bright-guests-sip.md
+++ b/.changeset/bright-guests-sip.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+fix(runtime): if sharedStrategy is loaded-first and shared is loading , use it

--- a/packages/runtime/__tests__/get-registered-share.spec.ts
+++ b/packages/runtime/__tests__/get-registered-share.spec.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest';
+import { getRegisteredShare } from '../src/utils/share';
+import { assert } from '../src/utils/logger';
+
+describe('get expected shared', () => {
+  it('get loading shared if sharedStrategy is "loaded-first"', () => {
+    let res;
+    const promise = new Promise((resolve) => {
+      // pending
+      res = resolve;
+    });
+    const shareScopeMap = {
+      default: {
+        react: {
+          '18.2.0': {
+            deps: [],
+            useIn: [],
+            from: 'host',
+            get: () => {
+              //noop
+            },
+            loaded: undefined,
+            loading: promise,
+            lib: undefined,
+            version: '18.2.0',
+            scope: ['default'],
+            shareConfig: {
+              requiredVersion: '^18.2.0',
+              singleton: 1,
+              eager: 0,
+              strictVersion: false,
+            },
+            strategy: 'loaded-first',
+          },
+          '18.3.1': {
+            deps: [],
+            useIn: [],
+            from: 'remote',
+            loaded: undefined,
+            get: () => {
+              //noop
+            },
+            loading: null,
+            version: '18.3.1',
+            scope: ['default'],
+            shareConfig: {
+              requiredVersion: '^18.3.1',
+              singleton: 1,
+              eager: 0,
+              strictVersion: false,
+            },
+            strategy: 'loaded-first',
+          },
+        },
+      },
+    };
+
+    const shareInfoRes = {
+      deps: [],
+      useIn: [],
+      from: 'remote',
+      loaded: undefined,
+      get: () => {
+        //noop
+      },
+      loading: null,
+      version: '18.3.1',
+      scope: ['default'],
+      shareConfig: {
+        fixedDependencies: false,
+        requiredVersion: '18.3.1',
+        strictVersion: false,
+        singleton: true,
+        eager: false,
+      },
+      strategy: 'loaded-first',
+    };
+
+    // @ts-ignore
+    const registeredShared = getRegisteredShare(
+      shareScopeMap,
+      'react',
+      shareInfoRes,
+      {
+        emit: () => undefined,
+      },
+    );
+    assert(registeredShared, 'must get registeredShared');
+    expect(registeredShared.from).toEqual('host');
+    res();
+  });
+
+  it('get loaded shared if it has been loaded and sharedStrategy is "loaded-first"', () => {
+    const shareScopeMap = {
+      default: {
+        react: {
+          '18.2.0': {
+            deps: [],
+            useIn: [],
+            from: 'host',
+            get: () => {
+              //noop
+            },
+            loaded: true,
+            lib: {},
+            loading: Promise.resolve(),
+            version: '18.2.0',
+            scope: ['default'],
+            shareConfig: {
+              requiredVersion: '^18.2.0',
+              singleton: 1,
+              eager: 0,
+              strictVersion: false,
+            },
+            strategy: 'loaded-first',
+          },
+          '18.3.1': {
+            deps: [],
+            useIn: [],
+            from: 'remote',
+            loaded: undefined,
+            get: () => {
+              //noop
+            },
+            loading: null,
+            version: '18.3.1',
+            scope: ['default'],
+            shareConfig: {
+              requiredVersion: '^18.3.1',
+              singleton: 1,
+              eager: 0,
+              strictVersion: false,
+            },
+            strategy: 'loaded-first',
+          },
+        },
+      },
+    };
+
+    const shareInfoRes = {
+      deps: [],
+      useIn: [],
+      from: 'remote',
+      loaded: undefined,
+      get: () => {
+        //noop
+      },
+      loading: null,
+      version: '18.3.1',
+      scope: ['default'],
+      shareConfig: {
+        fixedDependencies: false,
+        requiredVersion: '18.3.1',
+        strictVersion: false,
+        singleton: true,
+        eager: false,
+      },
+      strategy: 'loaded-first',
+    };
+
+    // @ts-ignore
+    const registeredShared = getRegisteredShare(
+      shareScopeMap,
+      'react',
+      shareInfoRes,
+      {
+        emit: () => undefined,
+      },
+    );
+    assert(registeredShared, 'must get registeredShared');
+    expect(registeredShared.from).toEqual('host');
+  });
+
+  it('get max version shared if all registered shared no loaded or loading and sharedStrategy is "loaded-first"', () => {
+    const shareScopeMap = {
+      default: {
+        react: {
+          '18.2.0': {
+            deps: [],
+            useIn: [],
+            from: 'host',
+            get: () => {
+              //noop
+            },
+            loaded: undefined,
+            lib: undefined,
+            loading: null,
+            version: '18.2.0',
+            scope: ['default'],
+            shareConfig: {
+              requiredVersion: '^18.2.0',
+              singleton: 1,
+              eager: 0,
+              strictVersion: false,
+            },
+            strategy: 'loaded-first',
+          },
+          '18.3.1': {
+            deps: [],
+            useIn: [],
+            from: 'remote',
+            loaded: undefined,
+            get: () => {
+              //noop
+            },
+            loading: null,
+            version: '18.3.1',
+            scope: ['default'],
+            shareConfig: {
+              requiredVersion: '^18.3.1',
+              singleton: 1,
+              eager: 0,
+              strictVersion: false,
+            },
+            strategy: 'loaded-first',
+          },
+        },
+      },
+    };
+
+    const shareInfoRes = {
+      deps: [],
+      useIn: [],
+      from: 'remote',
+      loaded: undefined,
+      get: () => {
+        //noop
+      },
+      loading: null,
+      version: '18.3.1',
+      scope: ['default'],
+      shareConfig: {
+        fixedDependencies: false,
+        requiredVersion: '18.3.1',
+        strictVersion: false,
+        singleton: true,
+        eager: false,
+      },
+      strategy: 'loaded-first',
+    };
+
+    // @ts-ignore
+    const registeredShared = getRegisteredShare(
+      shareScopeMap,
+      'react',
+      shareInfoRes,
+      {
+        emit: () => undefined,
+      },
+    );
+    assert(registeredShared, 'must get registeredShared');
+    expect(registeredShared.from).toEqual('remote');
+  });
+});

--- a/packages/runtime/src/utils/share.ts
+++ b/packages/runtime/src/utils/share.ts
@@ -152,6 +152,10 @@ export const isLoaded = (shared: Shared) => {
   return Boolean(shared.loaded) || typeof shared.lib === 'function';
 };
 
+const isLoading = (shared: Shared) => {
+  return Boolean(shared.loading);
+};
+
 function findSingletonVersionOrderByVersion(
   shareScopeMap: ShareScopeMap,
   scope: string,
@@ -173,14 +177,17 @@ function findSingletonVersionOrderByLoaded(
   const versions = shareScopeMap[scope][pkgName];
 
   const callback = function (prev: string, cur: string): boolean {
-    if (isLoaded(versions[cur])) {
-      if (isLoaded(versions[prev])) {
+    const isLoadingOrLoaded = (shared: Shared) => {
+      return isLoaded(shared) || isLoading(shared);
+    };
+    if (isLoadingOrLoaded(versions[cur])) {
+      if (isLoadingOrLoaded(versions[prev])) {
         return Boolean(versionLt(prev, cur));
       } else {
         return true;
       }
     }
-    if (isLoaded(versions[prev])) {
+    if (isLoadingOrLoaded(versions[prev])) {
       return false;
     }
     return versionLt(prev, cur);


### PR DESCRIPTION


## Description

use loaded or loading shared if sharedStrategy is loaded-first

## Related Issue
https://github.com/module-federation/core/issues/3170
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
