### PR TITLE
docs: remove rsbuild plugin from rspack part

### DIFF
--- a/apps/website-new/docs/en/guide/basic/_meta.json
+++ b/apps/website-new/docs/en/guide/basic/_meta.json
@@ -1,1 +1,1 @@
-["runtime", "rspack", "webpack", "rsbuild", "vite", "chrome-devtool", "type-prompt"]
+["runtime", "rsbuild", "rspack", "webpack", "vite", "chrome-devtool", "type-prompt"]

--- a/apps/website-new/docs/en/guide/basic/rspack.mdx
+++ b/apps/website-new/docs/en/guide/basic/rspack.mdx
@@ -22,52 +22,20 @@ import { PackageManagerTabs } from '@theme';
   command={{
     npm: `
 npm add @module-federation/enhanced
-npm add @module-federation/rsbuild-plugin --save-dev
     `,
     yarn: `
 yarn add @module-federation/enhanced
-yarn add @module-federation/rsbuild-plugin --save-dev
     `,
     pnpm: `
 pnpm add @module-federation/enhanced
-pnpm add @module-federation/rsbuild-plugin --save-dev
     `,
     bun: `
 bun add @module-federation/enhanced
-bun add @module-federation/rsbuild-plugin --save-dev
     `,
   }}
 />
 
 ### Register the Plugin
-
-#### Rsbuild
-
-In [Rsbuild](https://rsbuild.dev/), you can add the plugin in the `rsbuild.config.ts` file:
-
-```ts title='rsbuild.config.js'
-import { defineConfig } from '@rsbuild/core';
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-
-export default defineConfig({
-  output: {
-    // This will affect the build output resource url prefix in production env
-    assetPrefix: 'https://cdn.domain.com/path/to/project/',
-  },
-  server: {
-    port: 2000,
-  },
-  plugins: [
-    pluginModuleFederation({
-      name: 'federation_provider',
-      exposes: {
-        './button': './src/button.tsx',
-      },
-      shared: ['react', 'react-dom'],
-    }),
-  ],
-});
-```
 
 #### Rspack
 

--- a/apps/website-new/docs/zh/guide/basic/_meta.json
+++ b/apps/website-new/docs/zh/guide/basic/_meta.json
@@ -1,1 +1,1 @@
-["runtime", "rspack", "webpack", "rsbuild", "vite", "chrome-devtool", "type-prompt"]
+["runtime", "rsbuild", "rspack", "webpack", "vite", "chrome-devtool", "type-prompt"]

--- a/apps/website-new/docs/zh/guide/basic/rspack.mdx
+++ b/apps/website-new/docs/zh/guide/basic/rspack.mdx
@@ -22,52 +22,20 @@ import { PackageManagerTabs } from '@theme';
   command={{
     npm: `
 npm add @module-federation/enhanced
-npm add @module-federation/rsbuild-plugin --save-dev
     `,
     yarn: `
 yarn add @module-federation/enhanced
-yarn add @module-federation/rsbuild-plugin --save-dev
     `,
     pnpm: `
 pnpm add @module-federation/enhanced
-pnpm add @module-federation/rsbuild-plugin --save-dev
     `,
     bun: `
 bun add @module-federation/enhanced
-bun add @module-federation/rsbuild-plugin --save-dev
     `,
   }}
 />
 
 ### 注册插件
-
-#### Rsbuild
-
-在 [Rsbuild](https://rsbuild.dev/) 中，你可以通过 `rsbuild.config.ts` 配置文件来添加插件：
-
-```ts title='rsbuild.config.js'
-import { defineConfig } from '@rsbuild/core';
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-
-export default defineConfig({
-  output: {
-    // 这将影响生产环境中使用的产物路径前缀
-    assetPrefix: 'https://cdn.domain.com/path/to/project/',
-  },
-  server: {
-    port: 2000,
-  },
-  plugins: [
-    pluginModuleFederation({
-      name: 'federation_provider',
-      exposes: {
-        './button': './src/button.tsx',
-      },
-      shared: ['react', 'react-dom'],
-    }),
-  ],
-});
-```
 
 #### Rspack
 


### PR DESCRIPTION
## Description

remove rsbuild plugin from rspack part

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
