### PR TITLE
fix(error-codes): esm file should use .mjs ext

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,7 +22,8 @@
       "@module-federation/modern-js",
       "@module-federation/retry-plugin",
       "@module-federation/data-prefetch",
-      "@module-federation/rsbuild-plugin"
+      "@module-federation/rsbuild-plugin",
+      "@module-federation/error-codes"
     ]
   ],
   "ignorePatterns": ["^alpha|^beta"],

--- a/.changeset/unlucky-cats-move.md
+++ b/.changeset/unlucky-cats-move.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/error-codes': patch
+---
+
+fix(error-codes): esm should use .mjs ext

--- a/packages/error-codes/package.json
+++ b/packages/error-codes/package.json
@@ -18,11 +18,11 @@
     "access": "public"
   },
   "main": "./dist/index.cjs.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.esm.mjs",
   "types": "./dist/index.cjs.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.esm.mjs",
       "require": "./dist/index.cjs.js"
     }
   },

--- a/packages/error-codes/project.json
+++ b/packages/error-codes/project.json
@@ -13,6 +13,7 @@
         "outputPath": "packages/error-codes/dist",
         "main": "packages/error-codes/src/index.ts",
         "tsConfig": "packages/error-codes/tsconfig.lib.json",
+        "rollupConfig": "packages/error-codes/rollup.config.js",
         "assets": [],
         "project": "packages/error-codes/package.json",
         "compiler": "swc",

--- a/packages/error-codes/rollup.config.js
+++ b/packages/error-codes/rollup.config.js
@@ -1,0 +1,32 @@
+module.exports = (rollupConfig, projectOptions) => {
+  if (Array.isArray(rollupConfig.output)) {
+    rollupConfig.output = rollupConfig.output.map((c) => ({
+      ...c,
+      hoistTransitiveImports: false,
+      entryFileNames:
+        c.format === 'esm'
+          ? c.entryFileNames.replace('.js', '.mjs')
+          : c.entryFileNames,
+      chunkFileNames:
+        c.format === 'esm'
+          ? c.chunkFileNames.replace('.js', '.mjs')
+          : c.chunkFileNames,
+    }));
+  } else {
+    rollupConfig.output = {
+      ...rollupConfig.output,
+
+      hoistTransitiveImports: false,
+      entryFileNames:
+        rollupConfig.output.format === 'esm'
+          ? rollupConfig.output.entryFileNames.replace('.js', '.mjs')
+          : rollupConfig.output.entryFileNames,
+      chunkFileNames:
+        rollupConfig.output.format === 'esm'
+          ? rollupConfig.output.chunkFileNames.replace('.js', '.mjs')
+          : rollupConfig.output.chunkFileNames,
+    };
+  }
+
+  return rollupConfig;
+};


### PR DESCRIPTION
## Description

esm file should use .mjs ext

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
