### PR TITLE
fix(runtime): use wrapper global instead of using globalThis directly

### DIFF
--- a/.changeset/dry-bats-design.md
+++ b/.changeset/dry-bats-design.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+fix(runtime): use wrapper global instead of using globalThis directly

--- a/packages/runtime/src/remote/index.ts
+++ b/packages/runtime/src/remote/index.ts
@@ -10,7 +10,12 @@ import {
   RUNTIME_004,
   runtimeDescMap,
 } from '@module-federation/error-codes';
-import { Global, getInfoWithoutType, globalLoading } from '../global';
+import {
+  Global,
+  getInfoWithoutType,
+  globalLoading,
+  CurrentGlobal,
+} from '../global';
 import {
   Options,
   UserOptions,
@@ -462,14 +467,16 @@ export class RemoteHandler {
       const loadedModule = host.moduleCache.get(remote.name);
       if (loadedModule) {
         const remoteInfo = loadedModule.remoteInfo;
-        const key = remoteInfo.entryGlobalName as keyof typeof globalThis;
+        const key = remoteInfo.entryGlobalName as keyof typeof CurrentGlobal;
 
-        if (globalThis[key]) {
-          if (Object.getOwnPropertyDescriptor(globalThis, key)?.configurable) {
-            delete globalThis[key];
+        if (CurrentGlobal[key]) {
+          if (
+            Object.getOwnPropertyDescriptor(CurrentGlobal, key)?.configurable
+          ) {
+            delete CurrentGlobal[key];
           } else {
             // @ts-ignore
-            globalThis[key] = undefined;
+            CurrentGlobal[key] = undefined;
           }
         }
         const remoteEntryUniqueKey = getRemoteEntryUniqueKey(
@@ -487,7 +494,7 @@ export class RemoteHandler {
           ? composeKeyWithSeparator(remoteInfo.name, remoteInfo.buildVersion)
           : remoteInfo.name;
         const remoteInsIndex =
-          globalThis.__FEDERATION__.__INSTANCES__.findIndex((ins) => {
+          CurrentGlobal.__FEDERATION__.__INSTANCES__.findIndex((ins) => {
             if (remoteInfo.buildVersion) {
               return ins.options.id === remoteInsId;
             } else {
@@ -496,7 +503,7 @@ export class RemoteHandler {
           });
         if (remoteInsIndex !== -1) {
           const remoteIns =
-            globalThis.__FEDERATION__.__INSTANCES__[remoteInsIndex];
+            CurrentGlobal.__FEDERATION__.__INSTANCES__[remoteInsIndex];
           remoteInsId = remoteIns.options.id || remoteInsId;
           const globalShareScopeMap = getGlobalShareScope();
 
@@ -558,7 +565,7 @@ export class RemoteHandler {
               ];
             },
           );
-          globalThis.__FEDERATION__.__INSTANCES__.splice(remoteInsIndex, 1);
+          CurrentGlobal.__FEDERATION__.__INSTANCES__.splice(remoteInsIndex, 1);
         }
 
         const { hostGlobalSnapshot } = getGlobalRemoteInfo(remote, host);


### PR DESCRIPTION
## Description

use wrapper global instead of using globalThis directly to ensure legacy browser can use mf runtime as expected

## Related Issue
https://github.com/web-infra-dev/rsbuild/issues/3593
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
