### PR TITLE
chore: build @changeset/assemble-release-plan before execute pnpm changeset version

### DIFF
--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -34,8 +34,14 @@ jobs:
           node-version: '18'
           cache: 'pnpm'
 
+      - name: Set Nx SHA
+        uses: nrwl/nx-set-shas@v3
+
       - name: Install Dependencies
         run: pnpm install --ignore-scripts
+        # assemble-release-plan is forked, so need to build it before execute pnpm changeset version
+      - name: Build Internal Changesets Dependencies
+        run: npx nx build assemble-release-plan
 
       - name: Create Release Pull Request
         uses: module-federation/actions@v2

--- a/packages/assemble-release-plan/project.json
+++ b/packages/assemble-release-plan/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "assemble-release-plan",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/assemble-release-plan/src",
+  "projectType": "library",
+  "tags": ["type:pkg"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["npm run build --prefix packages/assemble-release-plan"]
+      }
+    }
+  }
+}


### PR DESCRIPTION

## Description
Because we have [patched @changeset/assemble-release-plan](https://github.com/module-federation/core/pull/3184) , so we need to build internal before using it
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
