### PR TITLE
fix(dts-plugin): hold the broker server if the remote not start locally

### DIFF
--- a/.changeset/fair-plums-live.md
+++ b/.changeset/fair-plums-live.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+fix(dts-plugin): hold the broker server if the remote not start locally

--- a/packages/dts-plugin/src/server/DevServer.ts
+++ b/packages/dts-plugin/src/server/DevServer.ts
@@ -314,8 +314,19 @@ export class ModuleFederationDevServer {
         'warn',
       );
 
-      this._subscriberWebsocketMap[identifier] &&
-        this._subscriberWebsocketMap[identifier].close();
+      this._subscriberWebsocketMap[identifier]?.close();
+      delete this._subscriberWebsocketMap[identifier];
+    });
+
+    this._subscriberWebsocketMap[identifier].on('error', (event) => {
+      if ('code' in event && event.code === 'ETIMEDOUT') {
+        fileLog(
+          `Can not connect ${JSON.stringify(remote)}, please make sure this remote is started locally.`,
+          MF_SERVER_IDENTIFIER,
+          'warn',
+        );
+      }
+      this._subscriberWebsocketMap[identifier]?.close();
       delete this._subscriberWebsocketMap[identifier];
     });
   }


### PR DESCRIPTION
## Description

capture connection failure event, hold the broker server if the remote not start locally

## Related Issue
https://github.com/module-federation/core/issues/3201
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
