### PR TITLE
fix: call initializeSharing before load remote while shareStrategy is version first

### DIFF
--- a/.changeset/nervous-tomatoes-marry.md
+++ b/.changeset/nervous-tomatoes-marry.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/webpack-bundler-runtime': patch
+'@module-federation/runtime': patch
+---
+
+fix: initializeSharing before load remote while shareStrategy is version first

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -215,7 +215,7 @@ export class FederationHost {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   async loadRemote<T>(
     id: string,
-    options?: { loadFactory?: boolean; from: CallFrom; shareScope?: string },
+    options?: { loadFactory?: boolean; from: CallFrom },
   ): Promise<T | null> {
     return this.remoteHandler.loadRemote(id, options);
   }

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -215,7 +215,7 @@ export class FederationHost {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   async loadRemote<T>(
     id: string,
-    options?: { loadFactory?: boolean; from: CallFrom },
+    options?: { loadFactory?: boolean; from: CallFrom; shareScope?: string },
   ): Promise<T | null> {
     return this.remoteHandler.loadRemote(id, options);
   }

--- a/packages/runtime/src/remote/index.ts
+++ b/packages/runtime/src/remote/index.ts
@@ -193,18 +193,13 @@ export class RemoteHandler {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   async loadRemote<T>(
     id: string,
-    options?: { loadFactory?: boolean; from: CallFrom; shareScope?: string },
+    options?: { loadFactory?: boolean; from: CallFrom },
   ): Promise<T | null> {
     const { host } = this;
     try {
-      const { loadFactory = true, shareScope } = options || {
+      const { loadFactory = true } = options || {
         loadFactory: true,
       };
-      if (this.host.options.shareStrategy === 'version-first') {
-        await Promise.all(
-          this.host.sharedHandler.initializeSharing(shareScope),
-        );
-      }
       // 1. Validate the parameters of the retrieved module. There are two module request methods: pkgName + expose and alias + expose.
       // 2. Request the snapshot information of the current host and globally store the obtained snapshot information. The retrieved module information is partially offline and partially online. The online module information will retrieve the modules used online.
       // 3. Retrieve the detailed information of the current module from global (remoteEntry address, expose resource address)

--- a/packages/runtime/src/remote/index.ts
+++ b/packages/runtime/src/remote/index.ts
@@ -193,11 +193,18 @@ export class RemoteHandler {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   async loadRemote<T>(
     id: string,
-    options?: { loadFactory?: boolean; from: CallFrom },
+    options?: { loadFactory?: boolean; from: CallFrom; shareScope?: string },
   ): Promise<T | null> {
     const { host } = this;
     try {
-      const { loadFactory = true } = options || { loadFactory: true };
+      const { loadFactory = true, shareScope } = options || {
+        loadFactory: true,
+      };
+      if (this.host.options.shareStrategy === 'version-first') {
+        await Promise.all(
+          this.host.sharedHandler.initializeSharing(shareScope),
+        );
+      }
       // 1. Validate the parameters of the retrieved module. There are two module request methods: pkgName + expose and alias + expose.
       // 2. Request the snapshot information of the current host and globally store the obtained snapshot information. The retrieved module information is partially offline and partially online. The online module information will retrieve the modules used online.
       // 3. Retrieve the detailed information of the current module from global (remoteEntry address, expose resource address)

--- a/packages/webpack-bundler-runtime/src/remotes.ts
+++ b/packages/webpack-bundler-runtime/src/remotes.ts
@@ -107,7 +107,7 @@ export function remotes(options: RemotesOptions) {
           const remoteModuleName = remoteName + data[1].slice(1);
           return webpackRequire.federation.instance!.loadRemote(
             remoteModuleName,
-            { loadFactory: false, from: 'build' },
+            { loadFactory: false, from: 'build', shareScope: data[0] },
           );
         } catch (error) {
           onError(error as Error);

--- a/packages/webpack-bundler-runtime/src/remotes.ts
+++ b/packages/webpack-bundler-runtime/src/remotes.ts
@@ -105,10 +105,22 @@ export function remotes(options: RemotesOptions) {
           );
 
           const remoteModuleName = remoteName + data[1].slice(1);
-          return webpackRequire.federation.instance!.loadRemote(
-            remoteModuleName,
-            { loadFactory: false, from: 'build', shareScope: data[0] },
-          );
+          const instance = webpackRequire.federation.instance!;
+          const loadRemote = () =>
+            webpackRequire.federation.instance!.loadRemote(remoteModuleName, {
+              loadFactory: false,
+              from: 'build',
+            });
+
+          if (instance.options.shareStrategy === 'version-first') {
+            return Promise.all(
+              instance.sharedHandler.initializeSharing(data[0]),
+            ).then(() => {
+              return loadRemote();
+            });
+          }
+
+          return loadRemote();
         } catch (error) {
           onError(error as Error);
         }


### PR DESCRIPTION
## Description
When shareStrategy is 'version-first' , it should make sure the remote shareScopeMap have been registered yet . So it should call initializeSharing before executing loadRemote/loadShare
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/module-federation/core/issues/3209
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
