### PR TITLE
fix(managers): correct manifest shared configuration

### DIFF
--- a/.changeset/tough-yaks-lay.md
+++ b/.changeset/tough-yaks-lay.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/managers': patch
+---
+
+fix(managers): correct manifest shared configuration

--- a/packages/managers/__tests__/SharedManager.spec.ts
+++ b/packages/managers/__tests__/SharedManager.spec.ts
@@ -16,6 +16,7 @@ describe('SharedManager', () => {
       name: '@module-federation/shared-managers-test',
       shared: {
         react: {},
+        'react-dom': { singleton: false, requiredVersion: '^18.0.0' },
       },
     };
     const sharedManager = new SharedManager();
@@ -33,6 +34,7 @@ describe('SharedManager', () => {
         ].includes(key),
       ),
     ).toEqual(true);
+    expect(sharedManager.normalizedOptions['react-dom']).toMatchSnapshot();
   });
 
   it('sharedPluginOptions', () => {

--- a/packages/managers/__tests__/__snapshots__/SharedManager.spec.ts.snap
+++ b/packages/managers/__tests__/__snapshots__/SharedManager.spec.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SharedManager normalizedOptions 1`] = `
+{
+  "eager": false,
+  "name": "react-dom",
+  "requiredVersion": "^18.0.0",
+  "shareScope": "default",
+  "singleton": false,
+  "version": "18.3.1",
+}
+`;

--- a/packages/managers/src/ContainerManager.ts
+++ b/packages/managers/src/ContainerManager.ts
@@ -5,7 +5,7 @@ import type {
   ManifestModuleInfos,
   moduleFederationPlugin,
 } from '@module-federation/sdk';
-import { getBuildVersion, parseOptions } from './utils';
+import { parseOptions } from './utils';
 import type { EntryObject } from 'webpack';
 import { BasicPluginOptionsManager } from './BasicPluginOptionsManager';
 
@@ -65,7 +65,7 @@ class ContainerManager extends BasicPluginOptionsManager<moduleFederationPlugin.
       const [exposeKey, exposeObj] = item;
       sum[exposeKey] = exposeObj;
       return sum;
-    }, {});
+    }, {} as moduleFederationPlugin.ExposesObject);
   }
   // { '.' : './src/Button.jsx' } => { '__federation_expose_Component' : ['src/Buttton'] }
   get exposeFileNameImportMap(): Record<string, string[]> {
@@ -81,30 +81,36 @@ class ContainerManager extends BasicPluginOptionsManager<moduleFederationPlugin.
         name: item.name || generateExposeFilename(key, false),
       }),
     );
-    return parsedOptions.reduce((sum, item) => {
-      const [_exposeKey, exposeObj] = item;
-      const { name, import: importPath } = exposeObj;
-      sum[name] = importPath;
-      return sum;
-    }, {});
+    return parsedOptions.reduce(
+      (sum, item) => {
+        const [_exposeKey, exposeObj] = item;
+        const { name, import: importPath } = exposeObj;
+        sum[name] = importPath;
+        return sum;
+      },
+      {} as Record<string, string[]>,
+    );
   }
 
   // { '.' : './src/Button.jsx' } => { '.' : ['src/Button'] }
-  get exposeObject(): Record<string, string> {
+  get exposeObject(): Record<string, string[]> {
     const parsedOptions = this._parseOptions();
 
-    return parsedOptions.reduce((sum, item) => {
-      const [exposeKey, exposeObject] = item;
-      sum[exposeKey] = [];
-      exposeObject.import.forEach((item) => {
-        const relativePath = path.relative(
-          '.',
-          item.replace(path.extname(item), ''),
-        );
-        sum[exposeKey].push(relativePath);
-      });
-      return sum;
-    }, {});
+    return parsedOptions.reduce(
+      (sum, item) => {
+        const [exposeKey, exposeObject] = item;
+        sum[exposeKey] = [];
+        exposeObject.import.forEach((item) => {
+          const relativePath = path.relative(
+            '.',
+            item.replace(path.extname(item), ''),
+          );
+          sum[exposeKey].push(relativePath);
+        });
+        return sum;
+      },
+      {} as Record<string, string[]>,
+    );
   }
 
   // { '.' : './src/Button.jsx' } => ['./src/Button.jsx']

--- a/packages/managers/src/PKGJsonManager.ts
+++ b/packages/managers/src/PKGJsonManager.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+// @ts-ignore this pkg miss types
 import finder from 'find-pkg';
 import fs from 'fs';
 import { MFModuleType, logger } from '@module-federation/sdk';

--- a/packages/managers/src/RemoteManager.ts
+++ b/packages/managers/src/RemoteManager.ts
@@ -77,14 +77,17 @@ class RemoteManager extends BasicPluginOptionsManager<moduleFederationPlugin.Mod
   //   'micro-app-sub3': @garfish/micro-app-sub3:0.0.4
   // }
   get dtsRemotes(): Record<string, string> {
-    return Object.keys(this.normalizedOptions).reduce((sum, remoteAlias) => {
-      const remoteInfo = this.normalizedOptions[remoteAlias];
-      sum[remoteAlias] = composeKeyWithSeparator(
-        remoteInfo.name,
-        'entry' in remoteInfo ? remoteInfo.entry : remoteInfo.version,
-      );
-      return sum;
-    }, {});
+    return Object.keys(this.normalizedOptions).reduce(
+      (sum, remoteAlias) => {
+        const remoteInfo = this.normalizedOptions[remoteAlias];
+        sum[remoteAlias] = composeKeyWithSeparator(
+          remoteInfo.name,
+          'entry' in remoteInfo ? remoteInfo.entry : remoteInfo.version,
+        );
+        return sum;
+      },
+      {} as Record<string, string>,
+    );
   }
 
   get remotes(): moduleFederationPlugin.ModuleFederationPluginOptions['remotes'] {

--- a/packages/managers/src/SharedManager.ts
+++ b/packages/managers/src/SharedManager.ts
@@ -1,3 +1,4 @@
+// @ts-ignore this pkg miss types
 import findPkg from 'find-pkg';
 import path from 'path';
 import fs from 'fs-extra';
@@ -40,7 +41,7 @@ class SharedManager extends BasicPluginOptionsManager<moduleFederationPlugin.Mod
         import: sharedImport,
       };
       return sum;
-    }, {});
+    }, {} as moduleFederationPlugin.SharedObject);
     return {
       shared,
       shareScope: this.options.shareScope || 'default',
@@ -127,9 +128,7 @@ class SharedManager extends BasicPluginOptionsManager<moduleFederationPlugin.Mod
     sharedOptions.forEach((item) => {
       const [sharedName, sharedOptions] = item;
       const pkgInfo = this.findPkg(sharedName, sharedOptions);
-      const sharedConfig = this.transformSharedConfig(
-        sharedOptions[sharedName],
-      );
+      const sharedConfig = this.transformSharedConfig(sharedOptions);
       normalizedShared[sharedName] = {
         ...sharedConfig,
         requiredVersion:

--- a/packages/managers/tsconfig.json
+++ b/packages/managers/tsconfig.json
@@ -14,7 +14,7 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "declaration": true,
-    "noImplicitAny": false
+    "noImplicitAny": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
## Description
* correct manifest shared configuration
* enable `noImplicitAny: true`
* add sharedManager.normalizedOptions test
## Related Issue
https://github.com/module-federation/core/issues/3101
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
