### PR TITLE
Fix/do not inject runtime into build time chunk(#3225)

### DIFF
--- a/packages/enhanced/src/lib/container/runtime/FederationRuntimeModule.ts
+++ b/packages/enhanced/src/lib/container/runtime/FederationRuntimeModule.ts
@@ -46,16 +46,19 @@ class FederationRuntimeModule extends RuntimeModule {
         );
       const { chunkHasJs } = jsModulePlugin;
       if (this.runtimeRequirements.has(RuntimeGlobals.ensureChunkHandlers)) {
-        const conditionMap = this.compilation.chunkGraph.getChunkConditionMap(
-          this.chunk,
-          chunkHasJs,
-        );
-        const hasJsMatcher = compileBooleanMatcher(conditionMap);
-        if (typeof hasJsMatcher === 'boolean') {
-          matcher = hasJsMatcher;
-        } else {
-          matcher = hasJsMatcher('chunkId');
+        if (this.compilation.chunkGraph) {
+          const conditionMap = this.compilation.chunkGraph.getChunkConditionMap(
+            this.chunk,
+            chunkHasJs,
+          );
+          const hasJsMatcher = compileBooleanMatcher(conditionMap);
+          if (typeof hasJsMatcher === 'boolean') {
+            matcher = hasJsMatcher;
+          } else {
+            matcher = hasJsMatcher('chunkId');
+          }
         }
+
         const outputName = this.compilation.getPath(
           jsModulePlugin.getChunkFilenameTemplate(
             this.chunk,


### PR DESCRIPTION
## Description

When working with umijs or father, during the compilation of less modules, some 'build time chunks' are generated. These temporary chunks lack chunkGraph information, leading to errors when generating runtime code.  
  
```javascript  
// enhanced/scr/lib/container/runtime/FederationRuntime.ts 49  
  
const conditionMap = this.compilation.chunkGraph.getChunkConditionMap(  
  this.chunk,  chunkHasJs,);  
  
```  
  
Then The current chunk id is build time chunk, the variable this.compilation.chunkGraph is undefined，causing an exception to be thrown

## Related Issue

https://github.com/module-federation/core/issues/3225


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
