### PR TITLE
fix(enhanced): remove resolve replacements

### DIFF
--- a/.changeset/thick-baboons-hear.md
+++ b/.changeset/thick-baboons-hear.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/enhanced': patch
+---
+
+remove module resolve path replacements

--- a/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
+++ b/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
@@ -370,10 +370,6 @@ class FederationRuntimePlugin {
       );
     }
 
-    if (isHoisted) {
-      runtimePath = runtimePath.replace('.cjs.js', '.esm.mjs');
-    }
-
     const alias: any = compiler.options.resolve.alias || {};
     alias['@module-federation/runtime$'] =
       alias['@module-federation/runtime$'] || runtimePath;
@@ -437,11 +433,6 @@ class FederationRuntimePlugin {
     }
 
     if (this.options?.experiments?.federationRuntime === 'hoisted') {
-      this.bundlerRuntimePath = this.bundlerRuntimePath.replace(
-        '.cjs.js',
-        '.esm.mjs',
-      );
-
       new EmbedFederationRuntimePlugin().apply(compiler);
 
       new HoistContainerReferences().apply(compiler);
@@ -450,7 +441,7 @@ class FederationRuntimePlugin {
         /@module-federation\/runtime/,
         (resolveData) => {
           if (/webpack-bundler-runtime/.test(resolveData.contextInfo.issuer)) {
-            resolveData.request = RuntimePath.replace('cjs.js', 'esm.mjs');
+            resolveData.request = RuntimePath;
 
             if (resolveData.createData) {
               resolveData.createData.request = resolveData.request;


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

This pull request removes the resolution of the runtime path with the .esm.mjs extension when the federation runtime is set to "hoisted" mode. This simplifies the runtime path handling and ensures that the correct runtime path is used in the application, improving the overall reliability and maintainability of the codebase.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/module-federation/core/issues/3210

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
