### PR TITLE
fix(runtime) Fix snapshot for server manifest without ssr remote entry

### DIFF
--- a/.changeset/short-lizards-behave.md
+++ b/.changeset/short-lizards-behave.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': minor
+---
+
+fix snapshot for server manifest without ssrRemoteEntry (nextjs-mfe for instance)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Thank you for your interest in contributing to Module Federation! Before startin
 **Note:** 
 - Keep your PRs concise, addressing a single issue or feature.
 - Include a detailed description in your PR and link to related issues.
+- For an up-to-date sequency of tasks to be performed in order to buil/test the libraries refer to the [buil-and-test workflow](./.github/workflows/build-and-test.yml)
 
 ## Setup Development Environment
 
@@ -58,6 +59,13 @@ What this will do:
 - Install all dependencies
 - Create symlinks between packages in the monorepo
 
+### Building
+
+To properly run some tests and packages you may need to build the existing packages, to do that simply run:
+
+```sh
+px nx run-many --targets=build --projects=tag:type:pkg
+```
 
 ## Testing
 

--- a/packages/runtime/__tests__/tool.spec.ts
+++ b/packages/runtime/__tests__/tool.spec.ts
@@ -1,0 +1,29 @@
+import { type ModuleInfo } from '@module-federation/sdk';
+import { getRemoteEntryInfoFromSnapshot } from '../src/utils';
+
+const originalWindow = global.window;
+
+describe('tool', () => {
+  afterAll(() => {
+    global.window = originalWindow;
+  });
+  it('return remoteEntry when server manifest does not contain ssrRemoteEntry', () => {
+    // Server environment
+    (global as any).window = undefined;
+
+    const snapshot = {
+      remoteEntry:
+        'http://localhost:1111/resources/snapshot/remote1/federation-manifest.json',
+      remoteEntryType: 'global',
+      globalName: 'remote1',
+    } as ModuleInfo;
+
+    const result = getRemoteEntryInfoFromSnapshot(snapshot);
+
+    expect(result).toEqual({
+      url: 'http://localhost:1111/resources/snapshot/remote1/federation-manifest.json',
+      type: 'global',
+      globalName: 'remote1',
+    });
+  });
+});

--- a/packages/runtime/src/utils/tool.ts
+++ b/packages/runtime/src/utils/tool.ts
@@ -103,6 +103,13 @@ export function getRemoteEntryInfoFromSnapshot(snapshot: ModuleInfo): {
       type: snapshot.ssrRemoteEntryType || defaultRemoteEntryInfo.type,
       globalName: snapshot.globalName,
     };
+  } else if ('remoteEntry' in snapshot) {
+    // Some plugins may not have ssrRemoteEntry, but have remoteEntry on their manifest (like nextjs-mf)
+    return {
+      url: snapshot.remoteEntry || defaultRemoteEntryInfo.url,
+      type: snapshot.remoteEntryType || defaultRemoteEntryInfo.type,
+      globalName: snapshot.globalName || defaultRemoteEntryInfo.globalName,
+    };
   }
   return defaultRemoteEntryInfo;
 }


### PR DESCRIPTION
## Description

When trying to use MF2.0 manifest as entrypoint for the nextjs-mf I found an issue where the snapshot was being rejected. the cause is that the manifest for nextjs-mf does not include a ssrRemoteEntry property (introduced a few months ago for modernJS).
This PR addresses that issue falling back to the regular remoteEntry for server-side manifests.

## Related Issue

[Snapshot fails for server manifest without ssr remote entry](https://github.com/module-federation/core/issues/3248)
It also completes the work started [here](https://github.com/module-federation/core/pull/2726)

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
