### PR TITLE
fix(runtime): add define constant to help downgrade non-esm project

### DIFF
--- a/.changeset/dirty-bikes-report.md
+++ b/.changeset/dirty-bikes-report.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+fix(runtime): add define constant to help downgrade non-esm project

--- a/.changeset/tasty-guests-shop.md
+++ b/.changeset/tasty-guests-shop.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': patch
+---
+
+fix(modern-js-plugin): only export esm mfRuntimePlugin

--- a/packages/modernjs/package.json
+++ b/packages/modernjs/package.json
@@ -35,6 +35,21 @@
       "import": "./dist/esm/cli/ssrPlugin.js",
       "require": "./dist/cjs/cli/ssrPlugin.js",
       "types": "./dist/types/cli/ssrPlugin.d.ts"
+    },
+    "./shared-strategy": {
+      "import": "./dist/esm/cli/mfRuntimePlugins/shared-strategy.js",
+      "require": "./dist/esm/cli/mfRuntimePlugins/shared-strategy.js",
+      "types": "./dist/types/cli/mfRuntimePlugins/shared-strategy.d.ts"
+    },
+    "./resolve-entry-ipv4": {
+      "import": "./dist/esm/cli/mfRuntimePlugins/resolve-entry-ipv4.js",
+      "require": "./dist/esm/cli/mfRuntimePlugins/resolve-entry-ipv4.js",
+      "types": "./dist/types/cli/mfRuntimePlugins/resolve-entry-ipv4.d.ts"
+    },
+    "./inject-node-fetch": {
+      "import": "./dist/esm/cli/mfRuntimePlugins/inject-node-fetch.js",
+      "require": "./dist/esm/cli/mfRuntimePlugins/inject-node-fetch.js",
+      "types": "./dist/types/cli/mfRuntimePlugins/inject-node-fetch.d.ts"
     }
   },
   "typesVersions": {
@@ -50,6 +65,15 @@
       ],
       "ssr-plugin": [
         "./dist/types/cli/ssrPlugin.d.ts"
+      ],
+      "shared-strategy": [
+        "./dist/types/cli/mfRuntimePlugins/shared-strategy.d.ts"
+      ],
+      "resolve-entry-ipv4": [
+        "./dist/types/cli/mfRuntimePlugins/resolve-entry-ipv4.d.ts"
+      ],
+      "inject-node-fetch": [
+        "./dist/types/cli/mfRuntimePlugins/inject-node-fetch.d.ts"
       ]
     }
   },

--- a/packages/modernjs/src/cli/utils.spec.ts
+++ b/packages/modernjs/src/cli/utils.spec.ts
@@ -39,9 +39,9 @@ describe('patchMFConfig', async () => {
       },
       remoteType: 'script',
       runtimePlugins: [
-        path.resolve(__dirname, './mfRuntimePlugins/shared-strategy.js'),
+        require.resolve('@module-federation/modern-js/shared-strategy'),
         require.resolve('@module-federation/node/runtimePlugin'),
-        path.resolve(__dirname, './mfRuntimePlugins/inject-node-fetch.js'),
+        require.resolve('@module-federation/modern-js/inject-node-fetch'),
       ],
       shared: {
         react: {
@@ -69,7 +69,7 @@ describe('patchMFConfig', async () => {
       },
       remoteType: 'script',
       runtimePlugins: [
-        path.resolve(__dirname, './mfRuntimePlugins/shared-strategy.js'),
+        require.resolve('@module-federation/modern-js/shared-strategy'),
       ],
       shared: {
         react: {

--- a/packages/modernjs/src/cli/utils.ts
+++ b/packages/modernjs/src/cli/utils.ts
@@ -146,13 +146,13 @@ export const patchMFConfig = (
   patchDTSConfig(mfConfig, isServer);
 
   injectRuntimePlugins(
-    path.resolve(__dirname, './mfRuntimePlugins/shared-strategy.js'),
+    require.resolve('@module-federation/modern-js/shared-strategy'),
     runtimePlugins,
   );
 
   if (isDev) {
     injectRuntimePlugins(
-      path.resolve(__dirname, './mfRuntimePlugins/resolve-entry-ipv4.js'),
+      require.resolve('@module-federation/modern-js/resolve-entry-ipv4'),
       runtimePlugins,
     );
   }
@@ -172,7 +172,7 @@ export const patchMFConfig = (
     }
 
     injectRuntimePlugins(
-      path.resolve(__dirname, './mfRuntimePlugins/inject-node-fetch.js'),
+      require.resolve('@module-federation/modern-js/inject-node-fetch'),
       runtimePlugins,
     );
 

--- a/packages/runtime/global.d.ts
+++ b/packages/runtime/global.d.ts
@@ -2,3 +2,4 @@ declare const __VERSION__: string;
 declare const FEDERATION_DEBUG: string;
 declare const FEDERATION_BUILD_IDENTIFIER: string | undefined;
 declare const __RELEASE_NUMBER__: number;
+declare const FEDERATION_ALLOW_NEW_FUNCTION: string | undefined;

--- a/packages/runtime/src/utils/load.ts
+++ b/packages/runtime/src/utils/load.ts
@@ -25,9 +25,14 @@ async function loadEsmEntry({
   return new Promise<RemoteEntryExports>((resolve, reject) => {
     try {
       if (!remoteEntryExports) {
-        import(/* webpackIgnore: true */ /* @vite-ignore */ entry)
-          .then(resolve)
-          .catch(reject);
+        if (typeof FEDERATION_ALLOW_NEW_FUNCTION !== 'undefined') {
+          new Function(
+            'callbacks',
+            `import("${entry}").then(callbacks[0]).catch(callbacks[1])`,
+          )([resolve, reject]);
+        } else {
+          import(/* webpackIgnore: true */ /* @vite-ignore */ entry).then(resolve).catch(reject);
+        }
       } else {
         resolve(remoteEntryExports);
       }
@@ -223,7 +228,6 @@ export async function getRemoteEntry({
 
   if (!globalLoading[uniqueKey]) {
     const loadEntryHook = origin.remoteHandler.hooks.lifecycle.loadEntry;
-    const createScriptHook = origin.loaderHook.lifecycle.createScript;
     const loaderHook = origin.loaderHook;
 
     globalLoading[uniqueKey] = loadEntryHook


### PR DESCRIPTION
## Description

* add define constant to help downgrade non-esm project

The magic comment([webpackIgnore](https://webpack.js.org/api/module-methods/#webpackignore)) will make rspack not downgrade the code , and [@rsbuild/plugin-check-syntax](https://github.com/rspack-contrib/rsbuild-plugin-check-syntax) will throw error . If users can make sure the project not use esm type module, they can set `FEDERATION_ALLOW_NEW_FUNCTION` by define plugin in build config , and skip the checker. 

## Related Issue
reproduce repo: https://github.com/2heal1/rsbuild-demo/tree/chore/syntax-check
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
