### PR TITLE
feat(vue3-bridge): add support for passing parameters to defineAsyncComponent

### DIFF
--- a/.changeset/rude-berries-look.md
+++ b/.changeset/rude-berries-look.md
@@ -1,0 +1,8 @@
+---
+'@module-federation/bridge-vue3': minor
+---
+
+Added the ability to pass parameters to defineAsyncComponent, which solves the following issues: 
+- Enables control over fallback components and their display parameters; 
+- Improves compatibility with Nuxt by allowing configuration of the suspensible parameter; 
+- Eliminates the package requirement to Configure your bundler to alias "vue" to "vue/dist/vue.esm-bundler.js".

--- a/.changeset/rude-berries-look.md
+++ b/.changeset/rude-berries-look.md
@@ -2,7 +2,7 @@
 '@module-federation/bridge-vue3': minor
 ---
 
-Added the ability to pass parameters to defineAsyncComponent, which solves the following issues: 
+Added the ability to pass parameters to `defineAsyncComponent`, which solves the following issues: 
 - Enables control over fallback components and their display parameters; 
-- Improves compatibility with Nuxt by allowing configuration of the suspensible parameter; 
-- Eliminates the package requirement to Configure your bundler to alias "vue" to "vue/dist/vue.esm-bundler.js".
+- Improves compatibility with Nuxt by allowing configuration of the `suspensible` parameter; 
+- Eliminates the package requirement to `Configure your bundler to alias "vue" to "vue/dist/vue.esm-bundler.js"`.

--- a/apps/website-new/docs/en/practice/bridge/vue-bridge.mdx
+++ b/apps/website-new/docs/en/practice/bridge/vue-bridge.mdx
@@ -153,6 +153,9 @@ const Remote1App = createRemoteComponent({ loader: () => loadRemote('remote1/exp
   * `export`
     * type: `string`
     * Purpose: Used to specify module export
+  * `asyncComponentOptions`
+    * type: `Omit<AsyncComponentOptions, 'loader'>`
+    * Purpose: Parameters that will be passed to defineAsyncComponent, except for the loader parameter
 ```tsx
 // remote
 export const provider = createBridgeComponent({

--- a/apps/website-new/docs/en/practice/bridge/vue-bridge.mdx
+++ b/apps/website-new/docs/en/practice/bridge/vue-bridge.mdx
@@ -19,17 +19,19 @@ import { PackageManagerTabs } from '@theme';
 
 ```tsx
 function createRemoteComponent<T, E extends keyof T>(
-  // Function to load remote application, e.g., loadRemote('remote1/export-app') or import('remote1/export-app')
-  lazyComponent: () => Promise<T>,
-  info?:
- {
+  options: {
+    // Function to load remote application, e.g., loadRemote('remote1/export-app') or import('remote1/export-app')
+    loader: () => Promise<T>,
     // Default is 'default', used to specify module export
-    export?: E;
+    export?: E,
+    // Parameters that will be passed to defineAsyncComponent
+    asyncComponentOptions?: Omit<AsyncComponentOptions, 'loader'>;
   }
 ): (props: {
     basename?: string;
     memoryRoute?: { entryPath: string };
 }) => DefineComponent;
+
 
 function createBridgeComponent(bridgeInfo: {
   rootComponent: VueComponent;
@@ -105,9 +107,7 @@ export default defineConfig({
 // ./src/router.ts
 import * as bridge from '@module-federation/bridge-vue3';
 
-const Remote2 = bridge.createRemoteComponent(() =>
-  loadRemote('remote1/export-app'),
-);
+const Remote2 = bridge.createRemoteComponent({ loader: () => loadRemote('remote1/export-app') });
 
 const router = createRouter({
   history: createWebHistory(),
@@ -132,6 +132,8 @@ function createRemoteComponent<T, E extends keyof T>(
     loader: () => Promise<T>,
     // Default is 'default', used to specify module export
     export?: E;
+    // Parameters that will be passed to defineAsyncComponent
+    asyncComponentOptions?: Omit<AsyncComponentOptions, 'loader'>;
   }
 ): (props: {
     basename?: string;
@@ -141,7 +143,7 @@ function createRemoteComponent<T, E extends keyof T>(
 
 
 ```tsx
-const Remote1App = createRemoteComponent(() => loadRemote('remote1/export-app'));
+const Remote1App = createRemoteComponent({ loader: () => loadRemote('remote1/export-app') });
 ```
 
 * `options`
@@ -158,7 +160,8 @@ export const provider = createBridgeComponent({
 });
 
 // host
-const Remote1App = createRemoteComponent(() => loadRemote('remote1/export-app'), {
+const Remote1App = createRemoteComponent({
+  loader: () => loadRemote('remote1/export-app'),
   export: 'provider'
 });
 ```
@@ -170,9 +173,7 @@ const Remote1App = createRemoteComponent(() => loadRemote('remote1/export-app'),
 ```tsx
 import * as bridge from '@module-federation/bridge-vue3';
 
-const Remote2 = bridge.createRemoteComponent(() =>
-  loadRemote('remote1/export-app'),
-);
+const Remote2 = bridge.createRemoteComponent({ loader: () => loadRemote('remote1/export-app') });
 
 const router = createRouter({
   history: createWebHistory(),

--- a/packages/bridge/vue3-bridge/src/create.ts
+++ b/packages/bridge/vue3-bridge/src/create.ts
@@ -1,4 +1,4 @@
-import { defineAsyncComponent, h } from 'vue';
+import { type AsyncComponentOptions, defineAsyncComponent, h } from 'vue';
 import { useRoute } from 'vue-router';
 import RemoteApp from './remoteApp.jsx';
 import { LoggerInstance } from './utils.js';
@@ -8,9 +8,11 @@ declare const __APP_VERSION__: string;
 export function createRemoteComponent(info: {
   loader: () => Promise<any>;
   export?: string;
+  asyncComponentOptions?: Omit<AsyncComponentOptions, 'loader'>;
 }) {
   return defineAsyncComponent({
     __APP_VERSION__,
+    ...info.asyncComponentOptions,
     //@ts-ignore
     loader: async () => {
       const route = useRoute();
@@ -45,7 +47,6 @@ export function createRemoteComponent(info: {
           render() {
             return h(RemoteApp, {
               moduleName,
-              ...info,
               providerInfo: exportFn,
               basename,
             });
@@ -54,13 +55,5 @@ export function createRemoteComponent(info: {
       }
       throw new Error('module not found');
     },
-    loadingComponent: {
-      template: '<div>Loading...</div>',
-    },
-    errorComponent: {
-      template: '<div>Error loading component</div>',
-    },
-    delay: 200,
-    timeout: 3000,
   });
 }


### PR DESCRIPTION
## Description

Added the ability to pass parameters to defineAsyncComponent, which solves the following issues: 
- Enables control over fallback components and their display parameters; 
- Improves compatibility with Nuxt by allowing configuration of the suspensible parameter; 
- Eliminates the package requirement to Configure your bundler to alias "vue" to "vue/dist/vue.esm-bundler.js".

Also updated the documentation, which was outdated even before my changes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [X] I have updated the documentation.
