### PR TITLE
fix: print warn if user set watchOptions.ignored value as regexp type

### DIFF
--- a/.changeset/beige-terms-check.md
+++ b/.changeset/beige-terms-check.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': patch
+---
+
+fix: print warn if user set watchOptions.ignored value as regexp type

--- a/packages/modernjs/src/cli/utils.ts
+++ b/packages/modernjs/src/cli/utils.ts
@@ -247,7 +247,7 @@ export function patchBundlerConfig<T extends Bundler>(options: {
           );
         } else {
           bundlerConfig.watchOptions.ignored = [
-            bundlerConfig.watchOptions.ignored as string,
+            bundlerConfig.watchOptions.ignored,
           ];
         }
       } else {

--- a/packages/modernjs/src/cli/utils.ts
+++ b/packages/modernjs/src/cli/utils.ts
@@ -254,22 +254,26 @@ export function patchBundlerConfig<T extends Bundler>(options: {
         bundlerConfig.watchOptions.ignored = [];
       }
     }
-    if (mfConfig.dts !== false) {
-      if (
-        typeof mfConfig.dts === 'object' &&
-        typeof mfConfig.dts.consumeTypes === 'object' &&
-        mfConfig.dts.consumeTypes.remoteTypesFolder
-      ) {
-        bundlerConfig.watchOptions.ignored.push(
-          `**/${mfConfig.dts.consumeTypes.remoteTypesFolder}/**`,
-        );
+
+    if (Array.isArray(bundlerConfig.watchOptions.ignored)) {
+      if (mfConfig.dts !== false) {
+        if (
+          typeof mfConfig.dts === 'object' &&
+          typeof mfConfig.dts.consumeTypes === 'object' &&
+          mfConfig.dts.consumeTypes.remoteTypesFolder
+        ) {
+          bundlerConfig.watchOptions.ignored.push(
+            `**/${mfConfig.dts.consumeTypes.remoteTypesFolder}/**`,
+          );
+        } else {
+          bundlerConfig.watchOptions.ignored.push('**/@mf-types/**');
+        }
       } else {
         bundlerConfig.watchOptions.ignored.push('**/@mf-types/**');
       }
-    } else {
-      bundlerConfig.watchOptions.ignored.push('**/@mf-types/**');
     }
   }
+
   if (bundlerConfig.output) {
     if (!bundlerConfig.output?.chunkLoadingGlobal) {
       bundlerConfig.output.chunkLoadingGlobal = `chunk_${mfConfig.name}`;

--- a/packages/modernjs/src/cli/utils.ts
+++ b/packages/modernjs/src/cli/utils.ts
@@ -241,9 +241,15 @@ export function patchBundlerConfig<T extends Bundler>(options: {
     bundlerConfig.watchOptions = bundlerConfig.watchOptions || {};
     if (!Array.isArray(bundlerConfig.watchOptions.ignored)) {
       if (bundlerConfig.watchOptions.ignored) {
-        bundlerConfig.watchOptions.ignored = [
-          bundlerConfig.watchOptions.ignored as string,
-        ];
+        if (typeof bundlerConfig.watchOptions.ignored !== 'string') {
+          logger.warn(
+            `Detect you have set watchOptions.ignore as regexp, please transform it to glob string array and add "**/@mf-types/**" to the array.`,
+          );
+        } else {
+          bundlerConfig.watchOptions.ignored = [
+            bundlerConfig.watchOptions.ignored as string,
+          ];
+        }
       } else {
         bundlerConfig.watchOptions.ignored = [];
       }


### PR DESCRIPTION
## Description

If user set watchOptions.ignored as regexp type , we should not handle it .


## Related Issue
https://github.com/web-infra-dev/rsbuild/pull/4075
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
