### PR TITLE
fix: override watchOptions.ignored if the modernjs internal value is regexp

### DIFF
--- a/.changeset/beige-terms-check.md
+++ b/.changeset/beige-terms-check.md
@@ -2,4 +2,4 @@
 '@module-federation/modern-js': patch
 ---
 
-fix: print warn if user set watchOptions.ignored value as regexp type
+fix: override watchOptions.ignored if the modernjs internal value is regexp

--- a/.changeset/fuzzy-dots-beam.md
+++ b/.changeset/fuzzy-dots-beam.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': patch
+---
+
+chore: no auto add watchOptions.ignored

--- a/apps/modernjs-ssr/host/modern.config.ts
+++ b/apps/modernjs-ssr/host/modern.config.ts
@@ -14,12 +14,5 @@ export default defineConfig({
       mode: 'stream',
     },
   },
-  tools: {
-    webpack: {
-      watchOptions: {
-        ignored: ['**/@mf-types/**'],
-      },
-    },
-  },
   plugins: [appTools(), moduleFederationPlugin()],
 });

--- a/apps/modernjs-ssr/host/modern.config.ts
+++ b/apps/modernjs-ssr/host/modern.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
       mode: 'stream',
     },
   },
-
+  tools: {
+    webpack: {
+      watchOptions: {
+        ignored: ['**/@mf-types/**'],
+      },
+    },
+  },
   plugins: [appTools(), moduleFederationPlugin()],
 });

--- a/apps/website-new/docs/en/guide/basic/type-prompt.mdx
+++ b/apps/website-new/docs/en/guide/basic/type-prompt.mdx
@@ -40,6 +40,10 @@ After modifying the producer code, the consumer will automatically pull the prod
 
 ### Federation Runtime API type prompt
 
+:::info
+If the builder is `webpack`, you also need to add `**/@mf-types/**` to [watchOptions.ignored](https://webpack.js.org/configuration/watch/#watchoptionsignored) to avoid Circular compilation issues caused by type updates
+:::
+
 It needs to add `./@mf-types/*` in the `include` field to enjoy `Federation Runtime` `loadRemote` type hints and type hot reloading
 
 ```json title="tsconfig.json"

--- a/apps/website-new/docs/zh/guide/basic/type-prompt.mdx
+++ b/apps/website-new/docs/zh/guide/basic/type-prompt.mdx
@@ -40,6 +40,10 @@
 
 ### Federation Runtime API 类型提示
 
+:::info
+如果构建器为 `webpack` ，还需要再 [watchOptions.ignored](https://webpack.js.org/configuration/watch/#watchoptionsignored) 增加 `**/@mf-types/**`，以避免类型更新导致的循环编译问题
+:::
+
 需要在 `include` 字段增加 `./@mf-types/*` 以享有 `Federation Runtime` `loadRemote` 类型提示以及类型热重载
 
 ```json title="tsconfig.json"

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -12,6 +12,7 @@ import {
   getIPV4,
   getMFConfig,
   patchMFConfig,
+  addMyTypes2Ignored,
 } from './utils';
 import { moduleFederationPlugin } from '@module-federation/sdk';
 
@@ -83,6 +84,9 @@ export const moduleFederationConfigPlugin = (
 
         return {
           tools: {
+            bundlerChain(chain, { isServer }) {
+              addMyTypes2Ignored(chain, isServer ? ssrConfig : csrConfig);
+            },
             rspack(config, { isServer }) {
               modifyBundlerConfig({
                 bundlerType,

--- a/packages/modernjs/src/cli/utils.spec.ts
+++ b/packages/modernjs/src/cli/utils.spec.ts
@@ -1,12 +1,5 @@
 import { it, expect, describe } from 'vitest';
-import path from 'path';
-import { BundlerConfig } from '../interfaces/bundler';
-import {
-  patchMFConfig,
-  patchBundlerConfig,
-  getIPV4,
-  patchIgnoreWarning,
-} from './utils';
+import { patchMFConfig, patchBundlerConfig, getIPV4 } from './utils';
 
 const mfConfig = {
   name: 'host',
@@ -158,4 +151,38 @@ describe('patchBundlerConfig', async () => {
     // patchIgnoreWarning(expectedConfig as BundlerConfig<'webpack'>);
     expect(bundlerConfig).toStrictEqual(expectedConfig);
   });
+});
+
+it('no add watchOptions.ignored if the ', async () => {
+  const bundlerConfig = {
+    output: {
+      publicPath: 'auto',
+    },
+  };
+  patchBundlerConfig<'webpack'>({
+    bundlerType: 'webpack',
+    bundlerConfig,
+    isServer: false,
+    modernjsConfig: {
+      server: {
+        ssr: {
+          mode: 'stream',
+        },
+      },
+    },
+    mfConfig,
+  });
+
+  const expectedConfig = {
+    output: {
+      chunkLoadingGlobal: 'chunk_host',
+      publicPath: 'auto',
+      uniqueName: 'host',
+    },
+  };
+  // @ts-ignore temp ignore
+  delete bundlerConfig?.ignoreWarnings;
+
+  // patchIgnoreWarning(expectedConfig as BundlerConfig<'webpack'>);
+  expect(bundlerConfig).toStrictEqual(expectedConfig);
 });

--- a/packages/modernjs/src/cli/utils.spec.ts
+++ b/packages/modernjs/src/cli/utils.spec.ts
@@ -152,37 +152,3 @@ describe('patchBundlerConfig', async () => {
     expect(bundlerConfig).toStrictEqual(expectedConfig);
   });
 });
-
-it('no add watchOptions.ignored if the ', async () => {
-  const bundlerConfig = {
-    output: {
-      publicPath: 'auto',
-    },
-  };
-  patchBundlerConfig<'webpack'>({
-    bundlerType: 'webpack',
-    bundlerConfig,
-    isServer: false,
-    modernjsConfig: {
-      server: {
-        ssr: {
-          mode: 'stream',
-        },
-      },
-    },
-    mfConfig,
-  });
-
-  const expectedConfig = {
-    output: {
-      chunkLoadingGlobal: 'chunk_host',
-      publicPath: 'auto',
-      uniqueName: 'host',
-    },
-  };
-  // @ts-ignore temp ignore
-  delete bundlerConfig?.ignoreWarnings;
-
-  // patchIgnoreWarning(expectedConfig as BundlerConfig<'webpack'>);
-  expect(bundlerConfig).toStrictEqual(expectedConfig);
-});

--- a/packages/modernjs/src/cli/utils.spec.ts
+++ b/packages/modernjs/src/cli/utils.spec.ts
@@ -117,9 +117,6 @@ describe('patchBundlerConfig', async () => {
         publicPath: 'auto',
         uniqueName: 'host',
       },
-      watchOptions: {
-        ignored: ['**/@mf-types/**'],
-      },
     };
     // @ts-ignore temp ignore
 
@@ -153,9 +150,6 @@ describe('patchBundlerConfig', async () => {
         chunkLoadingGlobal: 'chunk_host',
         publicPath: 'auto',
         uniqueName: 'host',
-      },
-      watchOptions: {
-        ignored: ['**/@mf-types/**'],
       },
     };
     // @ts-ignore temp ignore

--- a/packages/modernjs/src/cli/utils.ts
+++ b/packages/modernjs/src/cli/utils.ts
@@ -1,3 +1,12 @@
+import os from 'os';
+import path from 'path';
+import { moduleFederationPlugin, encodeName } from '@module-federation/sdk';
+import { bundle } from '@modern-js/node-bundle-require';
+import { PluginOptions } from '../types';
+import { LOCALHOST, PLUGIN_IDENTIFIER } from '../constant';
+import logger from './logger';
+
+import type { BundlerConfig, BundlerChainConfig } from '../interfaces/bundler';
 import type {
   webpack,
   UserConfig,
@@ -5,14 +14,6 @@ import type {
   Rspack,
   Bundler,
 } from '@modern-js/app-tools';
-import { moduleFederationPlugin, encodeName } from '@module-federation/sdk';
-import path from 'path';
-import os from 'os';
-import { bundle } from '@modern-js/node-bundle-require';
-import { PluginOptions } from '../types';
-import { LOCALHOST, PLUGIN_IDENTIFIER } from '../constant';
-import { BundlerConfig } from '../interfaces/bundler';
-import logger from './logger';
 
 const defaultPath = path.resolve(process.cwd(), 'module-federation.config.ts');
 const isDev = process.env.NODE_ENV === 'development';
@@ -220,6 +221,59 @@ export function patchIgnoreWarning<T extends Bundler>(
       return true;
     }
     return false;
+  });
+}
+
+export function addMyTypes2Ignored(
+  chain: BundlerChainConfig,
+  mfConfig: moduleFederationPlugin.ModuleFederationPluginOptions,
+) {
+  const watchOptions = chain.get(
+    'watchOptions',
+  ) as webpack.Configuration['watchOptions'];
+  if (!watchOptions || !watchOptions.ignored) {
+    chain.watchOptions({
+      ignored: /[\\/](?:\.git|node_modules|@mf-types)[\\/]/,
+    });
+    return;
+  }
+  const ignored = watchOptions.ignored;
+  const DEFAULT_IGNORED_GLOB = '**/@mf-types/**';
+
+  if (Array.isArray(ignored)) {
+    if (
+      mfConfig.dts !== false &&
+      typeof mfConfig.dts === 'object' &&
+      typeof mfConfig.dts.consumeTypes === 'object' &&
+      mfConfig.dts.consumeTypes.remoteTypesFolder
+    ) {
+      chain.watchOptions({
+        ...watchOptions,
+        ignored: ignored.concat(
+          `**/${mfConfig.dts.consumeTypes.remoteTypesFolder}/**`,
+        ),
+      });
+    } else {
+      chain.watchOptions({
+        ...watchOptions,
+        ignored: ignored.concat(DEFAULT_IGNORED_GLOB),
+      });
+    }
+
+    return;
+  }
+
+  if (typeof ignored !== 'string') {
+    chain.watchOptions({
+      ...watchOptions,
+      ignored: /[\\/](?:\.git|node_modules|@mf-types)[\\/]/,
+    });
+    return;
+  }
+
+  chain.watchOptions({
+    ...watchOptions,
+    ignored: ignored.concat(DEFAULT_IGNORED_GLOB),
   });
 }
 export function patchBundlerConfig<T extends Bundler>(options: {

--- a/packages/modernjs/src/cli/utils.ts
+++ b/packages/modernjs/src/cli/utils.ts
@@ -237,43 +237,6 @@ export function patchBundlerConfig<T extends Bundler>(options: {
 
   patchIgnoreWarning(bundlerConfig);
 
-  if (bundlerType === 'webpack') {
-    bundlerConfig.watchOptions = bundlerConfig.watchOptions || {};
-    if (!Array.isArray(bundlerConfig.watchOptions.ignored)) {
-      if (bundlerConfig.watchOptions.ignored) {
-        if (typeof bundlerConfig.watchOptions.ignored !== 'string') {
-          logger.warn(
-            `Detect you have set watchOptions.ignore as regexp, please transform it to glob string array and add "**/@mf-types/**" to the array.`,
-          );
-        } else {
-          bundlerConfig.watchOptions.ignored = [
-            bundlerConfig.watchOptions.ignored,
-          ];
-        }
-      } else {
-        bundlerConfig.watchOptions.ignored = [];
-      }
-    }
-
-    if (Array.isArray(bundlerConfig.watchOptions.ignored)) {
-      if (mfConfig.dts !== false) {
-        if (
-          typeof mfConfig.dts === 'object' &&
-          typeof mfConfig.dts.consumeTypes === 'object' &&
-          mfConfig.dts.consumeTypes.remoteTypesFolder
-        ) {
-          bundlerConfig.watchOptions.ignored.push(
-            `**/${mfConfig.dts.consumeTypes.remoteTypesFolder}/**`,
-          );
-        } else {
-          bundlerConfig.watchOptions.ignored.push('**/@mf-types/**');
-        }
-      } else {
-        bundlerConfig.watchOptions.ignored.push('**/@mf-types/**');
-      }
-    }
-  }
-
   if (bundlerConfig.output) {
     if (!bundlerConfig.output?.chunkLoadingGlobal) {
       bundlerConfig.output.chunkLoadingGlobal = `chunk_${mfConfig.name}`;

--- a/packages/modernjs/src/interfaces/bundler.ts
+++ b/packages/modernjs/src/interfaces/bundler.ts
@@ -1,4 +1,4 @@
-import type { AppTools, Bundler } from '@modern-js/app-tools';
+import type { AppTools, Bundler, UserConfig } from '@modern-js/app-tools';
 
 type AppToolsUserConfig<T extends Bundler> = AppTools<T>['userConfig']['tools'];
 
@@ -20,6 +20,14 @@ type RspackConfigs =
     ? U
     : never;
 type ObjectRspack = ExtractObjectType<OmitArrayConfiguration<RspackConfigs>>;
+
+type BundlerChain = ExcludeUndefined<
+  ExcludeUndefined<UserConfig<AppTools>['tools']>['bundlerChain']
+>;
+
+type BundlerChainFunc = Extract<BundlerChain, (chain: any, utils: any) => any>;
+
+export type BundlerChainConfig = Parameters<BundlerChainFunc>[0];
 
 export type BundlerConfig<T extends Bundler> = T extends 'rspack'
   ? ObjectRspack


### PR DESCRIPTION
## Description

* override watchOptions.ignored if the modernjs internal value is regexp
* add `**/@my-types/**` to watchOptions.ignored if the value is string or string[]

## Related Issue
https://github.com/web-infra-dev/rsbuild/pull/4075
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
