### PR TITLE
chore(bridge-react): set react-router-dom peer version to >=4 <7

### DIFF
--- a/.changeset/great-pandas-shave.md
+++ b/.changeset/great-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/bridge-react': patch
+---
+
+chore(bridge-react): set react-router-dom peer version to >=4 <7

--- a/packages/bridge/bridge-react/package.json
+++ b/packages/bridge/bridge-react/package.json
@@ -57,7 +57,7 @@
   "peerDependencies": {
     "react": ">=16.9.0",
     "react-dom": ">=16.9.0",
-    "react-router-dom": ">=4"
+    "react-router-dom": "^4 || ^5 || ^6"
   },
   "devDependencies": {
     "@testing-library/react": "15.0.7",


### PR DESCRIPTION
## Description
Before adapting react router v7, adjust the peer scope first.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/module-federation/core/issues/3267
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
