### PR TITLE
fix(rspack): export container and container reference plugins

### DIFF
--- a/.changeset/three-doors-bow.md
+++ b/.changeset/three-doors-bow.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rspack': patch
+---
+
+re-export ContainerPlugin and ContainerReferencePlugin from rspack core

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -45,7 +45,8 @@
   },
   "peerDependencies": {
     "typescript": "^4.9.0 || ^5.0.0",
-    "vue-tsc": ">=1.0.24"
+    "vue-tsc": ">=1.0.24",
+    "@rspack/core": ">=0.7"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/rspack/project.json
+++ b/packages/rspack/project.json
@@ -13,7 +13,7 @@
         "main": "packages/rspack/src/index.ts",
         "tsConfig": "packages/rspack/tsconfig.lib.json",
         "assets": [],
-        "external": ["@module-federation/*"],
+        "external": ["@module-federation/*", "@rspack/core"],
         "project": "packages/rspack/package.json",
         "rollupConfig": "packages/rspack/rollup.config.js",
         "compiler": "swc",

--- a/packages/rspack/src/index.ts
+++ b/packages/rspack/src/index.ts
@@ -1,1 +1,4 @@
 export { ModuleFederationPlugin } from './ModuleFederationPlugin';
+import { container } from '@rspack/core';
+export const ContainerPlugin = container.ContainerPlugin;
+export const ContainerReferencePlugin = container.ContainerReferencePlugin;


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
Re-export inner plugins from rspack, to allow handling of cases like single runtime chunk where 2 containerPlugins need to be applied by user

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/module-federation/module-federation-examples/pull/4317

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
