### PR TITLE
feat(runtime): support publicPlugins throught options

### DIFF
--- a/apps/runtime-demo/3005-runtime-host/src/index.ts
+++ b/apps/runtime-demo/3005-runtime-host/src/index.ts
@@ -4,7 +4,7 @@ import customPlugin from './runtimePlugin';
 init({
   name: 'runtime_host',
   remotes: [],
-  globalPlugins: [customPlugin(), customPlugin()],
+  globalPlugins: [customPlugin()],
 });
 
 require('./bootstrap');

--- a/apps/runtime-demo/3005-runtime-host/src/index.ts
+++ b/apps/runtime-demo/3005-runtime-host/src/index.ts
@@ -1,9 +1,10 @@
-import {
-  init,
-  registerGlobalPlugins,
-} from '@module-federation/enhanced/runtime';
+import { init } from '@module-federation/enhanced/runtime';
 import customPlugin from './runtimePlugin';
 
-registerGlobalPlugins([customPlugin()]);
+init({
+  name: 'runtime_host',
+  remotes: [],
+  globalPlugins: [customPlugin(), customPlugin()],
+});
 
 require('./bootstrap');

--- a/packages/runtime/src/embedded.ts
+++ b/packages/runtime/src/embedded.ts
@@ -179,6 +179,11 @@ export class FederationHost implements IndexModule.FederationHost {
     return this._getInstance().initShareScopeMap(...args);
   }
 
+  registerGlobalPlugins(
+    ...args: Parameters<IndexModule.FederationHost['registerGlobalPlugins']>
+  ) {
+    return this._getInstance().registerGlobalPlugins(...args);
+  }
   registerPlugins(
     ...args: Parameters<IndexModule.FederationHost['registerPlugins']>
   ) {

--- a/packages/runtime/src/global.ts
+++ b/packages/runtime/src/global.ts
@@ -300,16 +300,20 @@ export const getRemoteEntryExports = (
 // If a plugin is already registered, a warning message is logged.
 export const registerGlobalPlugins = (
   plugins: Array<FederationRuntimePlugin>,
-): void => {
+): Array<FederationRuntimePlugin> => {
+  const registeredPlugins: Array<FederationRuntimePlugin> = [];
   const { __GLOBAL_PLUGIN__ } = nativeGlobal.__FEDERATION__;
 
-  plugins.forEach((plugin) => {
+  plugins.map((plugin) => {
     if (__GLOBAL_PLUGIN__.findIndex((p) => p.name === plugin.name) === -1) {
       __GLOBAL_PLUGIN__.push(plugin);
+      registeredPlugins.push(plugin);
     } else {
       warn(`The plugin ${plugin.name} has been registered.`);
     }
   });
+
+  return registeredPlugins;
 };
 
 export const getGlobalHostPlugins = (): Array<FederationRuntimePlugin> =>

--- a/packages/runtime/src/type/config.ts
+++ b/packages/runtime/src/type/config.ts
@@ -110,12 +110,13 @@ export interface Options {
   remotes: Array<Remote>;
   shared: ShareInfos;
   plugins: Array<FederationRuntimePlugin>;
+  globalPlugins: Array<FederationRuntimePlugin>;
   inBrowser: boolean;
   shareStrategy?: ShareStrategy;
 }
 
 export type UserOptions = Omit<
-  Optional<Options, 'plugins'>,
+  Optional<Options, 'plugins' | 'globalPlugins'>,
   'shared' | 'inBrowser'
 > & {
   shared?: {


### PR DESCRIPTION
## Description

Adds support for passing `globalPlugins` to the constructor, which registers them as global plugins.

## Related Issue

Implements #3290

## Types of Changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have added tests to cover my changes.  
- [x] All new and existing tests have passed.  
- [ ] I have updated the documentation.  

## Additional Notes
I followed a similar approach to how regular plugins are handled, so I hope everything aligns correctly.  

Regarding documentation, I can update it once the implementation gets approved. Additionally, should this MR include coverage for the framework's implementation? If needed, I’m happy to add that as well.