### PR TITLE
fix(nextjs-mf): fix broken loading of non nextjs remotes

### DIFF
--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/remove-unnecessary-shared-keys.test.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/remove-unnecessary-shared-keys.test.ts
@@ -2,7 +2,7 @@ import { removeUnnecessarySharedKeys } from './remove-unnecessary-shared-keys';
 
 describe('removeUnnecessarySharedKeys', () => {
   beforeEach(() => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
   });
 
   afterEach(() => {

--- a/packages/nextjs-mf/src/plugins/container/InvertedContainerPlugin.ts
+++ b/packages/nextjs-mf/src/plugins/container/InvertedContainerPlugin.ts
@@ -6,8 +6,6 @@ import {
 } from '@module-federation/enhanced';
 
 class InvertedContainerPlugin {
-  constructor() {}
-
   public apply(compiler: Compiler): void {
     compiler.hooks.thisCompilation.tap(
       'EmbeddedContainerPlugin',

--- a/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
+++ b/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
@@ -1,8 +1,4 @@
 import { FederationRuntimePlugin } from '@module-federation/runtime/types';
-import {
-  ModuleInfo,
-  ConsumerModuleInfoWithPublicPath,
-} from '@module-federation/sdk';
 
 export default function (): FederationRuntimePlugin {
   return {
@@ -199,22 +195,23 @@ export default function (): FederationRuntimePlugin {
         return args;
       }
 
-      // re-assign publicPath based on remoteEntry location
-      if (options.inBrowser) {
-        remoteSnapshot.publicPath = remoteSnapshot.publicPath.substring(
+      // re-assign publicPath based on remoteEntry location if in browser nextjs remote
+      const { publicPath } = remoteSnapshot;
+      if (options.inBrowser && publicPath.includes('/_next/')) {
+        remoteSnapshot.publicPath = publicPath.substring(
           0,
-          remoteSnapshot.publicPath.lastIndexOf('/_next/') + 7,
+          publicPath.lastIndexOf('/_next/') + 7,
         );
       } else {
         const serverPublicPath = manifestUrl.substring(
           0,
           manifestUrl.indexOf('mf-manifest.json'),
         );
-
         remoteSnapshot.publicPath = serverPublicPath;
-        if ('publicPath' in manifestJson.metaData) {
-          manifestJson.metaData.publicPath = serverPublicPath;
-        }
+      }
+
+      if ('publicPath' in manifestJson.metaData) {
+        manifestJson.metaData.publicPath = remoteSnapshot.publicPath;
       }
 
       return args;

--- a/packages/nextjs-mf/utils/index.ts
+++ b/packages/nextjs-mf/utils/index.ts
@@ -22,7 +22,7 @@ export type { FlushedChunksProps } from './flushedChunks';
  */
 export const revalidate = function (
   fetchModule: any = undefined,
-  force: boolean = false,
+  force = false,
 ): Promise<boolean> {
   if (typeof window !== 'undefined') {
     console.error('revalidate should only be called server-side');


### PR DESCRIPTION
## Description

The change to consume mf 2.0 manifests broke loading of non nextjs remotes because it was hard coded to assume next remotes.

This change fixes loading of remotes while preserving the ability to load nextjs mf-manifests

Other minor changes are just to fix broken lint when running

```
pnpm nx affected -t lint --parallel=7 --exclude='*,!tag:type:pkg'
```

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
