### PR TITLE
fix(manifest): stats should add prefetchInterface if enable dataPrefetch

### DIFF
--- a/.changeset/shaggy-ligers-teach.md
+++ b/.changeset/shaggy-ligers-teach.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/manifest': patch
+---
+
+fix(manifest): stats should add prefetchInterface if enable dataPrefetch

--- a/packages/manifest/src/ManifestManager.ts
+++ b/packages/manifest/src/ManifestManager.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import fs from 'fs';
 import chalk from 'chalk';
 import {
@@ -102,20 +101,6 @@ class ManifestManager {
       sum.push(remote);
       return sum;
     }, [] as ManifestRemote[]);
-
-    let prefetchInterface = false;
-    const prefetchFilePath = path.resolve(
-      compiler.options.context || process.cwd(),
-      `node_modules/.mf/${encodeName(stats.name)}/${MFPrefetchCommon.fileName}`,
-    );
-    const existPrefetch = fs.existsSync(prefetchFilePath);
-    if (existPrefetch) {
-      const content = fs.readFileSync(prefetchFilePath).toString();
-      if (content) {
-        prefetchInterface = true;
-      }
-    }
-    stats.metaData.prefetchInterface = prefetchInterface;
 
     this._manifest = manifest;
 

--- a/packages/manifest/src/StatsManager.ts
+++ b/packages/manifest/src/StatsManager.ts
@@ -1,7 +1,8 @@
 /* eslint-disable max-lines-per-function */
 /* eslint-disable @typescript-eslint/member-ordering */
 /* eslint-disable max-depth */
-
+import fs from 'fs';
+import path from 'path';
 import {
   StatsRemote,
   StatsBuildInfo,
@@ -11,6 +12,8 @@ import {
   StatsAssets,
   moduleFederationPlugin,
   RemoteEntryType,
+  encodeName,
+  MFPrefetchCommon,
 } from '@module-federation/sdk';
 import {
   Compilation,
@@ -135,6 +138,20 @@ class StatsManager {
       globalName: globalName,
       pluginVersion: this._pluginVersion,
     };
+
+    let prefetchInterface = false;
+    const prefetchFilePath = path.resolve(
+      compiler.options.context || process.cwd(),
+      `node_modules/.mf/${encodeName(name!)}/${MFPrefetchCommon.fileName}`,
+    );
+    const existPrefetch = fs.existsSync(prefetchFilePath);
+    if (existPrefetch) {
+      const content = fs.readFileSync(prefetchFilePath).toString();
+      if (content) {
+        prefetchInterface = true;
+      }
+    }
+    metaData.prefetchInterface = prefetchInterface;
 
     if (this._options.getPublicPath) {
       if ('publicPath' in metaData) {


### PR DESCRIPTION
## Description

the stats and manifest should both add `prefetchInterface` if enable `dataPrefetch`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
