### PR TITLE
feat(dts-plugin): allow users to specify a `cwd` to generate the types

### DIFF
--- a/.changeset/real-otters-explode.md
+++ b/.changeset/real-otters-explode.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/dts-plugin': patch
+'@module-federation/sdk': patch
+---
+
+add `cwd` property to generate types

--- a/apps/website-new/docs/en/configure/dts.mdx
+++ b/apps/website-new/docs/en/configure/dts.mdx
@@ -14,6 +14,7 @@ interface PluginDtsOptions {
   generateTypes?: boolean | DtsRemoteOptions;
   consumeTypes?: boolean | DtsHostOptions;
   tsConfigPath?: string;
+  cwd?: string;
 }
 ```
 
@@ -215,3 +216,11 @@ Before loading type files, whether to delete the previously loaded `typesFolder`
 - Default value: `path.join(process.cwd(),'./tsconfig.json')`
 
 tsconfig configuration file path
+
+### cwd
+
+- Type: `string`
+- Required: No
+- Default value: `undefined`
+
+The working directory to run the compiler

--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
@@ -181,7 +181,10 @@ export const compileTs = async (
     const cmd = `npx ${remoteOptions.compilerInstance} --project ${tempTsConfigJsonPath}`;
     try {
       await execPromise(cmd, {
-        cwd: dirname(remoteOptions.tsConfigPath),
+        cwd:
+          typeof remoteOptions.moduleFederationConfig.dts !== 'boolean'
+            ? (remoteOptions.moduleFederationConfig.dts?.cwd ?? undefined)
+            : undefined,
       });
     } catch (err) {
       throw new Error(

--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
@@ -180,7 +180,9 @@ export const compileTs = async (
     const execPromise = util.promisify(exec);
     const cmd = `npx ${remoteOptions.compilerInstance} --project ${tempTsConfigJsonPath}`;
     try {
-      await execPromise(cmd);
+      await execPromise(cmd, {
+        cwd: dirname(remoteOptions.tsConfigPath),
+      });
     } catch (err) {
       throw new Error(
         getShortErrorMsg(TYPE_001, typeDescMap, {

--- a/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
+++ b/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
@@ -166,6 +166,7 @@ export interface PluginDtsOptions {
   tsConfigPath?: string;
   extraOptions?: Record<string, any>;
   implementation?: string;
+  cwd?: string;
 }
 
 export type AsyncBoundaryOptions = {


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

This PR adds a new property to the `dts` types that allows to pass a custom Current Work Directory to be used by `exec` to generate the types. It allows to generate types in environments where the user is running the plugin in a place where the Current Work Directory does not have Typescript installed.

## Related Issue
#3338 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
