### PR TITLE
fix(rspack): import plugin from sub path

### DIFF
--- a/.changeset/six-yaks-teach.md
+++ b/.changeset/six-yaks-teach.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rspack': patch
+---
+
+fix(rspack): import plugin from sub path

--- a/packages/enhanced/src/rspack.ts
+++ b/packages/enhanced/src/rspack.ts
@@ -1,1 +1,1 @@
-export { ModuleFederationPlugin } from '@module-federation/rspack';
+export { ModuleFederationPlugin } from '@module-federation/rspack/plugin';

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -34,12 +34,20 @@
       "import": "./dist/index.esm.js",
       "require": "./dist/index.cjs.js",
       "types": "./dist/index.cjs.d.ts"
+    },
+    "./plugin": {
+      "types": "./dist/plugin.cjs.d.ts",
+      "import": "./dist/plugin.esm.mjs",
+      "require": "./dist/plugin.cjs.js"
     }
   },
   "typesVersions": {
     "*": {
       ".": [
         "./dist/index.cjs.d.ts"
+      ],
+      "plugin": [
+        "./dist/plugin.cjs.d.ts"
       ]
     }
   },

--- a/packages/rspack/rollup.config.js
+++ b/packages/rspack/rollup.config.js
@@ -1,9 +1,14 @@
 const copy = require('rollup-plugin-copy');
 const replace = require('@rollup/plugin-replace');
+const path = require('path');
 
 module.exports = (rollupConfig, projectOptions) => {
   const pkg = require('./package.json');
 
+  rollupConfig.input['plugin'] = path.resolve(
+    process.cwd(),
+    './packages/rspack/src/ModuleFederationPlugin.ts',
+  );
   rollupConfig.plugins.push(
     replace({
       __VERSION__: JSON.stringify(pkg.version),

--- a/packages/rspack/src/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/ModuleFederationPlugin.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Compiler,
   ModuleFederationPluginOptions,
   RspackPluginInstance,


### PR DESCRIPTION
## Description

enhanced import rspack plugin from `@module-federation/rspack/plugin` instead of `@module-federation/rspack` directly . 

Because the default `@module-federation/rspack` entry will export `rspack.container.ContainerPlugin` , but the `enhanced` or `modern-js-plugin` not install directly. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
