### PR TITLE
chore(modern-js-plugin): add disableSSR option

### DIFF
--- a/.changeset/sour-carpets-walk.md
+++ b/.changeset/sour-carpets-walk.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': patch
+---
+
+chore(modern-js-plugin): add disableSSR option

--- a/.changeset/sour-carpets-walk.md
+++ b/.changeset/sour-carpets-walk.md
@@ -2,4 +2,4 @@
 '@module-federation/modern-js': patch
 ---
 
-chore(modern-js-plugin): add disableSSR option
+chore(modern-js-plugin): add ssr option

--- a/apps/website-new/docs/en/guide/framework/modernjs.mdx
+++ b/apps/website-new/docs/en/guide/framework/modernjs.mdx
@@ -169,3 +169,39 @@ Set module loading status.
 A fault-tolerant component that is rendered when the component fails to **load** or **render**.
 
 Note: This component only renders this fault-tolerant component on the client side when **rendering** fails.
+
+## Configuration
+
+### ssr
+
+- Type: `false`
+- Is it required: No
+- Default value: `undefined`
+
+`@module-federation/modern-js` will automatically add SSR related build presets based on `server.ssr` in modern.js config.
+
+If the current project only needs to load MF in the CSR, you can set `ssr: false` to help progressive migration.
+
+```title='modern.config.ts'
+import { appTools, defineConfig } from '@modern-js/app-tools';
+import { moduleFederationPlugin } from '@module-federation/modern-js';
+
+// https://modernjs.dev/en/configure/app/usage
+export default defineConfig({
+  dev: {
+    port: 3050,
+  },
+  runtime: {
+    router: true,
+  },
+  server: {
+    ssr: {
+      mode: 'stream',
+    },
+  },
+  plugins: [
+    appTools(),
+    moduleFederationPlugin({ ssr: false })
+  ],
+});
+```

--- a/apps/website-new/docs/zh/guide/framework/modernjs.mdx
+++ b/apps/website-new/docs/zh/guide/framework/modernjs.mdx
@@ -180,3 +180,39 @@ export default Product;
 当组件**加载**或**渲染**失败时，所渲染的容错组件。
 
 注意：当**渲染**失败的时候，该组件仅在客户端渲染此 容错组件。
+
+## 配置
+
+### ssr
+
+- 类型：`false`
+- 是否必填：否
+- 默认值：`undefined`
+
+`@module-federation/modern-js` 会根据 modern.js config 中的 `server.ssr` 来自动添加 SSR 相关的构建预设。
+
+如果当前项目仅需要在 CSR 加载 MF ，那么可以设置 `ssr: false` 来帮助渐进式迁移。
+
+```title='modern.config.ts'
+import { appTools, defineConfig } from '@modern-js/app-tools';
+import { moduleFederationPlugin } from '@module-federation/modern-js';
+
+// https://modernjs.dev/en/configure/app/usage
+export default defineConfig({
+  dev: {
+    port: 3050,
+  },
+  runtime: {
+    router: true,
+  },
+  server: {
+    ssr: {
+      mode: 'stream',
+    },
+  },
+  plugins: [
+    appTools(),
+    moduleFederationPlugin({ ssr: false })
+  ],
+});
+```

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -72,7 +72,9 @@ export const moduleFederationConfigPlugin = (
         const bundlerType =
           useAppContext().bundlerType === 'rspack' ? 'rspack' : 'webpack';
         const ipv4 = getIPV4();
-        const enableSSR = Boolean(modernjsConfig?.server?.ssr);
+        const enableSSR = userConfig.userConfig?.disableSSR
+          ? false
+          : Boolean(modernjsConfig?.server?.ssr);
 
         if (userConfig.remoteIpStrategy === undefined) {
           if (!enableSSR) {

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -72,9 +72,10 @@ export const moduleFederationConfigPlugin = (
         const bundlerType =
           useAppContext().bundlerType === 'rspack' ? 'rspack' : 'webpack';
         const ipv4 = getIPV4();
-        const enableSSR = userConfig.userConfig?.disableSSR
-          ? false
-          : Boolean(modernjsConfig?.server?.ssr);
+        const enableSSR =
+          userConfig.userConfig?.ssr === false
+            ? false
+            : Boolean(modernjsConfig?.server?.ssr);
 
         if (userConfig.remoteIpStrategy === undefined) {
           if (!enableSSR) {

--- a/packages/modernjs/src/cli/index.ts
+++ b/packages/modernjs/src/cli/index.ts
@@ -21,6 +21,7 @@ export const moduleFederationPlugin = (
     distOutputDir: '',
     originPluginOptions: userConfig,
     remoteIpStrategy: userConfig?.remoteIpStrategy,
+    userConfig,
   };
   return {
     name: '@modern-js/plugin-module-federation',

--- a/packages/modernjs/src/cli/ssrPlugin.ts
+++ b/packages/modernjs/src/cli/ssrPlugin.ts
@@ -15,7 +15,7 @@ export function setEnv() {
 }
 
 export const moduleFederationSSRPlugin = (
-  userConfig: Required<InternalModernPluginOptions>,
+  pluginOptions: Required<InternalModernPluginOptions>,
 ): CliPlugin<AppTools> => ({
   name: '@modern-js/plugin-module-federation-ssr',
   pre: [
@@ -25,7 +25,7 @@ export const moduleFederationSSRPlugin = (
   setup: async ({ useConfigContext, useAppContext }) => {
     const modernjsConfig = useConfigContext();
     const enableSSR = Boolean(modernjsConfig?.server?.ssr);
-    if (!enableSSR) {
+    if (!enableSSR || pluginOptions.userConfig?.disableSSR) {
       return {};
     }
 
@@ -50,32 +50,32 @@ export const moduleFederationSSRPlugin = (
                 // throw new Error(
                 //   `${PLUGIN_IDENTIFIER} Not support rspack ssr mode yet !`,
                 // );
-                if (!userConfig.nodePlugin) {
-                  userConfig.nodePlugin = new RspackModuleFederationPlugin(
-                    userConfig.ssrConfig,
+                if (!pluginOptions.nodePlugin) {
+                  pluginOptions.nodePlugin = new RspackModuleFederationPlugin(
+                    pluginOptions.ssrConfig,
                   );
                   // @ts-ignore
-                  config.plugins?.push(userConfig.nodePlugin);
+                  config.plugins?.push(pluginOptions.nodePlugin);
                 }
               } else {
-                userConfig.distOutputDir =
-                  userConfig.distOutputDir ||
+                pluginOptions.distOutputDir =
+                  pluginOptions.distOutputDir ||
                   config.output?.path ||
                   path.resolve(process.cwd(), 'dist');
               }
             },
             webpack(config, { isServer }) {
               if (isServer) {
-                if (!userConfig.nodePlugin) {
-                  userConfig.nodePlugin = new ModuleFederationPlugin(
-                    userConfig.ssrConfig,
+                if (!pluginOptions.nodePlugin) {
+                  pluginOptions.nodePlugin = new ModuleFederationPlugin(
+                    pluginOptions.ssrConfig,
                   );
                   // @ts-ignore
-                  config.plugins?.push(userConfig.nodePlugin);
+                  config.plugins?.push(pluginOptions.nodePlugin);
                 }
               } else {
-                userConfig.distOutputDir =
-                  userConfig.distOutputDir ||
+                pluginOptions.distOutputDir =
+                  pluginOptions.distOutputDir ||
                   config.output?.path ||
                   path.resolve(process.cwd(), 'dist');
               }
@@ -133,11 +133,11 @@ export const moduleFederationSSRPlugin = (
         };
       },
       afterBuild: () => {
-        const { nodePlugin, browserPlugin, distOutputDir } = userConfig;
+        const { nodePlugin, browserPlugin, distOutputDir } = pluginOptions;
         updateStatsAndManifest(nodePlugin, browserPlugin, distOutputDir);
       },
       afterDev: () => {
-        const { nodePlugin, browserPlugin, distOutputDir } = userConfig;
+        const { nodePlugin, browserPlugin, distOutputDir } = pluginOptions;
         updateStatsAndManifest(nodePlugin, browserPlugin, distOutputDir);
       },
     };

--- a/packages/modernjs/src/cli/ssrPlugin.ts
+++ b/packages/modernjs/src/cli/ssrPlugin.ts
@@ -25,7 +25,7 @@ export const moduleFederationSSRPlugin = (
   setup: async ({ useConfigContext, useAppContext }) => {
     const modernjsConfig = useConfigContext();
     const enableSSR = Boolean(modernjsConfig?.server?.ssr);
-    if (!enableSSR || pluginOptions.userConfig?.disableSSR) {
+    if (!enableSSR || pluginOptions.userConfig?.ssr === false) {
       return {};
     }
 

--- a/packages/modernjs/src/types/index.ts
+++ b/packages/modernjs/src/types/index.ts
@@ -5,6 +5,7 @@ import type { ModuleFederationPlugin as RspackModuleFederationPlugin } from '@mo
 export interface PluginOptions {
   config?: moduleFederationPlugin.ModuleFederationPluginOptions;
   configPath?: string;
+  disableSSR?: boolean;
   remoteIpStrategy?: 'ipv4' | 'inherit';
 }
 
@@ -16,7 +17,9 @@ export interface InternalModernPluginOptions {
   browserPlugin?: BundlerPlugin;
   nodePlugin?: BundlerPlugin;
   remoteIpStrategy?: 'ipv4' | 'inherit';
+  userConfig?: PluginOptions;
 }
+
 export type BundlerPlugin =
   | WebpackModuleFederationPlugin
   | RspackModuleFederationPlugin;

--- a/packages/modernjs/src/types/index.ts
+++ b/packages/modernjs/src/types/index.ts
@@ -5,7 +5,7 @@ import type { ModuleFederationPlugin as RspackModuleFederationPlugin } from '@mo
 export interface PluginOptions {
   config?: moduleFederationPlugin.ModuleFederationPluginOptions;
   configPath?: string;
-  disableSSR?: boolean;
+  ssr?: false;
   remoteIpStrategy?: 'ipv4' | 'inherit';
 }
 


### PR DESCRIPTION
## Description

For projects with progressive migration, they may just want to use mf in csr not ssr . 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
