### PR TITLE
chore(retry-plugin): remove unnecessary null-check before calling beforeExecuteRetry

### DIFF
--- a/packages/retry-plugin/src/fetch-retry.ts
+++ b/packages/retry-plugin/src/fetch-retry.ts
@@ -33,7 +33,7 @@ async function fetchWithRetry({
   } catch (error) {
     if (retryTimes <= 0) {
       logger.log(
-        `[ Module Federation RetryPlugin ]: retry failed after ${retryTimes} times for url: ${url}, now will try fallbackUrl url`,
+        `${PLUGIN_IDENTIFIER}: retry failed after ${retryTimes} times for url: ${url}, now will try fallbackUrl url`,
       );
 
       if (fallback && typeof fallback === 'function') {

--- a/packages/retry-plugin/src/util.ts
+++ b/packages/retry-plugin/src/util.ts
@@ -1,4 +1,8 @@
-import { defaultRetries, defaultRetryDelay } from './constant';
+import {
+  defaultRetries,
+  defaultRetryDelay,
+  PLUGIN_IDENTIFIER,
+} from './constant';
 import type { ScriptCommonRetryOption } from './types';
 import logger from './logger';
 
@@ -22,7 +26,7 @@ export function scriptCommonRetry<T extends (...args: any[]) => void>({
       let attempts = 0;
       while (attempts - 1 < retryTimes) {
         try {
-          beforeExecuteRetry && beforeExecuteRetry();
+          beforeExecuteRetry();
           retryResponse = await retryFn(...args);
           break;
         } catch (error) {
@@ -36,7 +40,7 @@ export function scriptCommonRetry<T extends (...args: any[]) => void>({
             throw error;
           }
           logger.log(
-            `[ Module Federation RetryPlugin ]: script resource retrying ${attempts} times`,
+            `${PLUGIN_IDENTIFIER}: script resource retrying ${attempts} times`,
           );
           await new Promise((resolve) => setTimeout(resolve, retryDelay));
         }


### PR DESCRIPTION
chore(retry-plugin): remove unnecessary null-check before calling beforeExecuteRetry

## Description

removes the unnecessary null-check before calling `beforeExecuteRetry()` since a default no-op function is already assigned.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
