### PR TITLE
docs(retry-plugin): fix typo and clarify default retryDelay

### DIFF
--- a/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
+++ b/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
@@ -114,7 +114,7 @@ type ScriptWithRetryOptions = {
 
 ### Properties
 
-- **script**: `ScriptWithRetryOptions` (optional)
+- **fetch**: `ScriptWithRetryOptions` (optional)
   - used to configure the retry options for fetch type resources.
 
 - **script**: `ScriptWithRetryOptions` (optional)

--- a/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
+++ b/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
@@ -114,8 +114,8 @@ type ScriptWithRetryOptions = {
 
 ### Properties
 
-- **fetch**: `ScriptWithRetryOptions` (optional)
-  - used to configure the retry options for fetch type resources.
+- **fetch**: `FetchWithRetryOptions` (optional)
+  - `FetchWithRetryOptions` is the type used to configure the retry options for fetch type resources.
 
 - **script**: `ScriptWithRetryOptions` (optional)
   - `ScriptWithRetryOptions` is the type used to configure the retry options for script type resources.

--- a/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
+++ b/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
@@ -147,7 +147,7 @@ type ScriptWithRetryOptions = {
   - optional
   - A function, which can optionally receive the failed URL, that returns a fallback string to be used if all retries fail. This function is called when all retry attempts have failed.
 
-### ScriptWithRetryOptions 类型说明
+### ScriptWithRetryOptions Description
 
 - **retryTimes**:
   - `number`

--- a/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
+++ b/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
@@ -140,7 +140,7 @@ type ScriptWithRetryOptions = {
 - **retryDelay**:
   - `number`
   - optional
-  - The delay time between each retry (in milliseconds).
+  - The delay time between each retry (in milliseconds), default is 1000 (1 second).
 
 - **fallback**:
   - `() => string | ((url: string | URL | globalThis.Request) => string)`
@@ -157,7 +157,7 @@ type ScriptWithRetryOptions = {
 - **retryDelay**:
   - `number`
   - optional
-  - The delay time between each retry (in milliseconds).
+  - The delay time between each retry (in milliseconds), default is 1000 (1 second).
 
 - **moduleName**:
   - `Array<string>`
@@ -191,7 +191,7 @@ init({
         retryTimes: 3,
         // the retry delay
         retryDelay: 1000,
-        // the module name list that need to be retried, defualt behavior is to retry all modules
+        // the module name list that need to be retried, default behavior is to retry all modules
         moduleName: ['remote1'],
         // the callback function that will be called after all retried failed
         cb: (resolve, error) => {


### PR DESCRIPTION
## Description

- corrects a typo in the documentation (script -> fetch).
- updates a section heading from Chinese to English (类型说明 -> Description).
- clarifies the default retryDelay of 1000ms.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
