### PR TITLE
fix(manifest): add default exposes fields if enable disableAssetsAnalyze

### DIFF
--- a/.changeset/metal-bags-admire.md
+++ b/.changeset/metal-bags-admire.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/manifest': patch
+---
+
+fix(manifest): add default exposes fields if set disableAssetsAnalyze: true

--- a/packages/manifest/src/StatsManager.ts
+++ b/packages/manifest/src/StatsManager.ts
@@ -42,7 +42,7 @@ import {
   utils,
 } from '@module-federation/managers';
 import { HOT_UPDATE_SUFFIX, PLUGIN_IDENTIFIER } from './constants';
-import { ModuleHandler } from './ModuleHandler';
+import { ModuleHandler, getExposeItem } from './ModuleHandler';
 import { StatsInfo } from './types';
 
 class StatsManager {
@@ -300,7 +300,11 @@ class StatsManager {
     extraOptions?: {},
   ): Promise<Stats> {
     try {
-      const { name, manifest: manifestOptions = {} } = this._options;
+      const {
+        name,
+        manifest: manifestOptions = {},
+        exposes = {},
+      } = this._options;
 
       const metaData = this._getMetaData(compiler, compilation, extraOptions);
 
@@ -320,6 +324,15 @@ class StatsManager {
         const remotes: StatsRemote[] =
           this._remoteManager.statsRemoteWithEmptyUsedIn;
         stats.remotes = remotes;
+        stats.exposes = Object.keys(exposes).map((exposeKey) => {
+          return getExposeItem({
+            exposeKey,
+            name: name!,
+            file: {
+              import: exposes[exposeKey].import,
+            },
+          });
+        });
         return stats;
       }
 


### PR DESCRIPTION


## Description
 add default exposes fields if enable disableAssetsAnalyze
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
