### PR TITLE
feat(bridge-react): support basename passed by remote module props

### DIFF
--- a/.changeset/twelve-pumpkins-film.md
+++ b/.changeset/twelve-pumpkins-film.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/bridge-react': patch
+---
+
+feat: support basename passed by remote module props

--- a/apps/router-demo/router-host-2000/src/App.tsx
+++ b/apps/router-demo/router-host-2000/src/App.tsx
@@ -127,7 +127,9 @@ const App = () => {
         <Route path="/detail/*" Component={Detail} />
         <Route
           path="/remote1/*"
-          Component={() => <Remote1App name={'Ming'} age={12} ref={ref} />}
+          Component={() => (
+            <Remote1App name={'Ming'} age={122} basename="/remote1" />
+          )}
         />
         <Route
           path="/remote2/*"

--- a/packages/bridge/bridge-react/src/remote/index.tsx
+++ b/packages/bridge/bridge-react/src/remote/index.tsx
@@ -158,6 +158,11 @@ export function withRouterData<
   WrappedComponent: React.ComponentType<P & ExtraDataProps>,
 ): React.FC<Omit<P, keyof ExtraDataProps>> {
   const Component = forwardRef(function (props: any, ref) {
+    if (props?.basename) {
+      return (
+        <WrappedComponent {...props} basename={props.basename} ref={ref} />
+      );
+    }
     let enableDispathPopstate = false;
     let routerContextVal: any;
     try {


### PR DESCRIPTION
## Description
feat(bridge-react): support basename passed by remote module props

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
