### PR TITLE
fix syntax highlight in modernjs.mdx

### DIFF
--- a/apps/website-new/docs/en/guide/framework/modernjs.mdx
+++ b/apps/website-new/docs/en/guide/framework/modernjs.mdx
@@ -182,7 +182,7 @@ Note: This component only renders this fault-tolerant component on the client si
 
 If the current project only needs to load MF in the CSR, you can set `ssr: false` to help progressive migration.
 
-```title='modern.config.ts'
+```ts title='modern.config.ts'
 import { appTools, defineConfig } from '@modern-js/app-tools';
 import { moduleFederationPlugin } from '@module-federation/modern-js';
 


### PR DESCRIPTION
## Description

For some reason syntax in the last code example wasn't correct highlighted. This PR fixes that problem.

## Types of changes

- [X] Docs change

## Checklist

- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] I have updated the documentation.
