### PR TITLE
fix(dts-plugin): overwriting a directory with types on hot updates

### DIFF
--- a/.changeset/real-ligers-design.md
+++ b/.changeset/real-ligers-design.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': minor
+---
+
+fixed overwriting a directory with types on hot updates

--- a/packages/dts-plugin/src/plugins/GenerateTypesPlugin.ts
+++ b/packages/dts-plugin/src/plugins/GenerateTypesPlugin.ts
@@ -111,6 +111,7 @@ export class GenerateTypesPlugin implements WebpackPluginInstance {
           await new Promise<void>((resolve, reject) => {
             compiler.outputFileSystem.mkdir(
               path.dirname(zipOutputPath),
+              { recursive: true },
               (err) => {
                 if (err) reject(err);
                 else {
@@ -138,6 +139,7 @@ export class GenerateTypesPlugin implements WebpackPluginInstance {
           await new Promise<void>((resolve, reject) => {
             compiler.outputFileSystem.mkdir(
               path.dirname(apiOutputPath),
+              { recursive: true },
               (err) => {
                 if (err) reject(err);
                 else {


### PR DESCRIPTION
## Description

fixed overwriting a directory with types on hot updates

## Related Issue

https://github.com/module-federation/core/issues/3374

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
