### PR TITLE
fix: skip when current project is storybook

### DIFF
--- a/.changeset/heavy-dragons-count.md
+++ b/.changeset/heavy-dragons-count.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rsbuild-plugin': patch
+---
+
+fix(rsbuild-plugin): skip when current project is storybook

--- a/.changeset/heavy-dragons-count.md
+++ b/.changeset/heavy-dragons-count.md
@@ -2,4 +2,4 @@
 '@module-federation/rsbuild-plugin': patch
 ---
 
-fix(rsbuild-plugin): skip when current project is storybook
+fix: skip when current project is storybook

--- a/apps/rslib-module/module-federation.config.ts
+++ b/apps/rslib-module/module-federation.config.ts
@@ -1,0 +1,16 @@
+import { createModuleFederationConfig } from '@module-federation/rsbuild-plugin';
+
+export default createModuleFederationConfig({
+  name: 'rslib_provider',
+  exposes: {
+    '.': './src/index.tsx',
+  },
+  shared: {
+    react: {
+      singleton: true,
+    },
+    'react-dom': {
+      singleton: true,
+    },
+  },
+});

--- a/apps/rslib-module/rslib.config.ts
+++ b/apps/rslib-module/rslib.config.ts
@@ -1,6 +1,7 @@
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
+import moduleFederationConfig from './module-federation.config';
 
 const shared = {
   dts: {
@@ -41,21 +42,5 @@ export default defineConfig({
   server: {
     port: 3001,
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'rslib_provider',
-      exposes: {
-        '.': './src/index.tsx',
-      },
-      shared: {
-        react: {
-          singleton: true,
-        },
-        'react-dom': {
-          singleton: true,
-        },
-      },
-    }),
-  ],
+  plugins: [pluginReact(), pluginModuleFederation(moduleFederationConfig)],
 });

--- a/packages/rsbuild-plugin/src/cli/index.ts
+++ b/packages/rsbuild-plugin/src/cli/index.ts
@@ -43,6 +43,17 @@ function isStoryBook(rsbuildConfig: RsbuildConfig) {
   }
 }
 
+function isStoryBook(rsbuildConfig: RsbuildConfig) {
+  if (
+    rsbuildConfig.plugins?.find(
+      (p) =>
+        p && 'name' in p && p.name === 'module-federation-storybook-plugin',
+    )
+  ) {
+    return true;
+  }
+}
+
 export function isMFFormat(bundlerConfig: Rspack.Configuration) {
   const library = bundlerConfig.output?.library;
 


### PR DESCRIPTION
## Description

Because current rsbuild plugin is global plugin , so it need to skip when current project is storybook to prevent pollute the storybook default env


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
