### PR TITLE
fix: prevent destroy/render the remote component every time rerendering from the host

### DIFF
--- a/packages/bridge/bridge-react/src/remote/create.tsx
+++ b/packages/bridge/bridge-react/src/remote/create.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import {
   ErrorBoundary,
   ErrorBoundaryPropsWithComponent,
@@ -102,7 +102,7 @@ export function createRemoteComponent<T, E extends keyof T>(
 
   return forwardRef<HTMLDivElement, ProviderParams & RawComponentType>(
     (props, ref) => {
-      const LazyComponent = createLazyRemoteComponent(info);
+      const LazyComponent = useMemo(() => createLazyRemoteComponent(info), []);
       return (
         <ErrorBoundary FallbackComponent={info.fallback}>
           <React.Suspense fallback={info.loading}>


### PR DESCRIPTION
## Description
Implement memoization for ```LazyComponent``` every time ```createRemoteComponent``` is called, so the remote component won't call the destroy/render method when the state changes from the host.

## Related Issue
https://github.com/module-federation/core/issues/3478
## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
