### PR TITLE
fix(rspack): avoid falsy values in `checkSingleton`

### DIFF
--- a/packages/rspack/src/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/ModuleFederationPlugin.ts
@@ -1,6 +1,8 @@
 import type {
   Compiler,
+  Falsy,
   ModuleFederationPluginOptions,
+  RspackPluginFunction,
   RspackPluginInstance,
 } from '@rspack/core';
 import {
@@ -48,16 +50,22 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
 
   private _checkSingleton(compiler: Compiler): void {
     let count = 0;
-    compiler.options.plugins.forEach((p: any) => {
-      if (p.name === this.name) {
-        count++;
-        if (count > 1) {
-          throw new Error(
-            `Detect duplicate register ${this.name},please ensure ${this.name} is singleton!`,
-          );
+    compiler.options.plugins.forEach(
+      (p: Falsy | RspackPluginInstance | RspackPluginFunction) => {
+        if (typeof p !== 'object' || !p) {
+          return;
         }
-      }
-    });
+
+        if (p['name'] === this.name) {
+          count++;
+          if (count > 1) {
+            throw new Error(
+              `Detect duplicate register ${this.name},please ensure ${this.name} is singleton!`,
+            );
+          }
+        }
+      },
+    );
   }
 
   apply(compiler: Compiler): void {


### PR DESCRIPTION
## Description

added a check for falsy values inside `checkSingleton` in `packages/rspack/src/ModuleFederationPlugin.ts`. 

This is similar to other places in the codebase when looking for `ModuleFederationPlugin` instances, this specific change was based on the logic from `packages/enhanced/src/lib/container/ContainerPlugin.ts`

## Related Issue

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
