### PR TITLE
perf(dts-plugin): enable tsbuildinfo

### DIFF
--- a/.changeset/cuddly-turkeys-cry.md
+++ b/.changeset/cuddly-turkeys-cry.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': minor
+---
+
+feat: enable tsc incremental build

--- a/apps/website-new/docs/en/guide/troubleshooting/type/TYPE-001.mdx
+++ b/apps/website-new/docs/en/guide/troubleshooting/type/TYPE-001.mdx
@@ -10,6 +10,8 @@ When compiling the exported (`exposes`) file TS type, the current project's `tsc
 
 Execute the `cmd` command in the error message parameter in the terminal, and repair the file or `tsconfig` according to the error message.
 
+If you want to ignore the type check error in ts, you can set [`compilerOptions.noCheck`](https://www.typescriptlang.org/tsconfig/#noCheck) to `true` in `tsconfig.json` (This option is only supported for ts 5.5 and above)
+
 If the `cmd` command is executed without an error, but the error TS compilation fails is still reported, you need to check the `exposes` field in `ModuleFederationPlugin`:
 
 ```ts title="[modern|rspack|rsbuild|webpack].config.[js,ts]"

--- a/apps/website-new/docs/zh/guide/troubleshooting/type/TYPE-001.mdx
+++ b/apps/website-new/docs/zh/guide/troubleshooting/type/TYPE-001.mdx
@@ -10,6 +10,8 @@ import ErrorCodeTitle from '@components/ErrorCodeTitle';
 
 在 terminal 中执行报错信息参数中的 `cmd` 命令，根据错误信息对文件或者 `tsconfig` 进行修复。
 
+若你希望忽略 ts 中的类型检查错误，可在 `tsconfig.json` 中设置 [`compilerOptions.noCheck`](https://www.typescriptlang.org/tsconfig/#noCheck) 为 `true`（该选项仅支持 ts 5.5 及以上版本）
+
 若 `cmd` 命令执行无报错，但仍然报错 TS 编译失败，需要检查 `ModuleFederationPlugin` 中的 `exposes`字段：
 
 ```ts title="[modern|rspack|rsbuild|webpack].config.[js,ts]"

--- a/packages/dts-plugin/src/core/configurations/remotePlugin.test.ts
+++ b/packages/dts-plugin/src/core/configurations/remotePlugin.test.ts
@@ -54,6 +54,11 @@ describe('hostPlugin', () => {
               'dist/@mf-types/compiled-types',
             ),
             rootDir: resolve(__dirname),
+            incremental: true,
+            tsBuildInfoFile: resolve(
+              remoteOptions.context,
+              'node_modules/.cache/.tsbuildinfo',
+            ),
           },
           files: ['./src/components/button', './src/components/anotherButton'],
           include: [],
@@ -118,6 +123,11 @@ describe('hostPlugin', () => {
               'dist/typesFolder/compiledTypesFolder',
             ),
             rootDir: resolve(__dirname),
+            incremental: true,
+            tsBuildInfoFile: resolve(
+              remoteOptions.context,
+              'node_modules/.cache/.tsbuildinfo',
+            ),
           },
           exclude: [],
           include: [],

--- a/packages/dts-plugin/src/core/configurations/remotePlugin.ts
+++ b/packages/dts-plugin/src/core/configurations/remotePlugin.ts
@@ -97,6 +97,8 @@ const readTsConfig = (
     noEmit: false,
     declaration: true,
     outDir,
+    incremental: true,
+    tsBuildInfoFile: resolve(context, 'node_modules/.cache/.tsbuildinfo'),
   };
 
   rawTsConfigJson.compilerOptions = rawTsConfigJson.compilerOptions || {};


### PR DESCRIPTION
## Description

- Enable tsc incremental build to reduce compile time.
- Add tip to disable type check

The following is a benchmark after enabling incremental build and noCheck in a real project with a large number of type errors

Since noCheck is only available in ts 5.5 and above, this pr only enables incremental by default.

```
hyperfine -i 'npx tsc --project tsconfig.nocheck.json' 'npx tsc --project tsconfig.incremental.json' 'npx tsc --project tsconfig.full.json' 'npx tsc --project tsconfig.base.json'

Benchmark 1: npx tsc --project tsconfig.nocheck.json
  Time (mean ± σ):     16.692 s ±  4.414 s    [User: 18.791 s, System: 1.696 s]
  Range (min … max):   14.638 s … 29.099 s    10 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: npx tsc --project tsconfig.incremental.json
  Time (mean ± σ):      5.960 s ±  0.630 s    [User: 7.025 s, System: 1.125 s]
  Range (min … max):    5.329 s …  6.956 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 3: npx tsc --project tsconfig.full.json
  Time (mean ± σ):      5.440 s ±  0.357 s    [User: 6.767 s, System: 1.026 s]
  Range (min … max):    4.935 s …  6.004 s    10 runs
 
Benchmark 4: npx tsc --project tsconfig.base.json
  Time (mean ± σ):     124.257 s ± 14.528 s    [User: 139.147 s, System: 12.647 s]
  Range (min … max):   106.390 s … 157.966 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  npx tsc --project tsconfig.full.json ran
    1.10 ± 0.14 times faster than npx tsc --project tsconfig.incremental.json
    3.07 ± 0.84 times faster than npx tsc --project tsconfig.nocheck.json
   22.84 ± 3.06 times faster than npx tsc --project tsconfig.base.json
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
