### PR TITLE
fix: enable SSR by utilizing pluginOptions and configuration

### DIFF
--- a/.changeset/flat-olives-check.md
+++ b/.changeset/flat-olives-check.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': patch
+---
+
+fix: enable SSR by utilizing pluginOptions and configuration adjustments for improved accuracy

--- a/packages/modernjs/src/cli/ssrPlugin.ts
+++ b/packages/modernjs/src/cli/ssrPlugin.ts
@@ -24,9 +24,12 @@ export const moduleFederationSSRPlugin = (
   ],
   setup: async (api) => {
     const modernjsConfig = api.getConfig();
-    const enableSSR = Boolean(modernjsConfig?.server?.ssr);
-    if (!enableSSR || pluginOptions.userConfig?.ssr === false) {
-      return {} as any;
+    const enableSSR =
+      pluginOptions.userConfig?.ssr === false
+        ? false
+        : Boolean(modernjsConfig?.server?.ssr);
+    if (!enableSSR) {
+      return;
     }
 
     setEnv();


### PR DESCRIPTION
## Description

Modern.js ssr plugin check enableSSR:
```
const enableSSR = pluginOptions.userConfig?.ssr === false ? false : Boolean(modernjsConfig?.server?.ssr);
```
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
