### PR TITLE
fix(native-federation-typescript): enable remote string resolution from object

### DIFF
--- a/packages/native-federation-typescript/src/configurations/hostPlugin.test.ts
+++ b/packages/native-federation-typescript/src/configurations/hostPlugin.test.ts
@@ -21,78 +21,97 @@ describe('hostPlugin', () => {
       const invokeRetrieve = () => retrieveHostConfig({});
       expect(invokeRetrieve).toThrowError('moduleFederationConfig is required');
     });
+  });
 
-    describe('correctly intersect with default options', () => {
-      it('only moduleFederationConfig provided', () => {
-        const { hostOptions, mapRemotesToDownload } = retrieveHostConfig({
-          moduleFederationConfig,
-        });
-
-        expect(hostOptions).toStrictEqual({
-          moduleFederationConfig,
-          typesFolder: '@mf-types',
-          deleteTypesFolder: true,
-          maxRetries: 3,
-        });
-
-        expect(mapRemotesToDownload).toStrictEqual({
-          moduleFederationTypescript: 'http://localhost:3000/@mf-types.zip',
-        });
+  describe('correctly intersect with default options', () => {
+    it('only moduleFederationConfig provided', () => {
+      const { hostOptions, mapRemotesToDownload } = retrieveHostConfig({
+        moduleFederationConfig,
       });
 
-      it('all options provided', () => {
-        const options = {
-          moduleFederationConfig,
-          typesFolder: 'custom-types',
-          deleteTypesFolder: false,
-          maxRetries: 1,
-        };
-
-        const { hostOptions, mapRemotesToDownload } =
-          retrieveHostConfig(options);
-
-        expect(hostOptions).toStrictEqual(options);
-
-        expect(mapRemotesToDownload).toStrictEqual({
-          moduleFederationTypescript: 'http://localhost:3000/custom-types.zip',
-        });
-      });
-    });
-
-    it('correctly resolve subpath remotes', () => {
-      const subpathModuleFederationConfig = {
-        ...moduleFederationConfig,
-        remotes: {
-          moduleFederationTypescript:
-            'http://localhost:3000/subpatha/subpathb/remoteEntry.js',
-        },
-      };
-
-      const { mapRemotesToDownload } = retrieveHostConfig({
-        moduleFederationConfig: subpathModuleFederationConfig,
+      expect(hostOptions).toStrictEqual({
+        moduleFederationConfig,
+        typesFolder: '@mf-types',
+        deleteTypesFolder: true,
+        maxRetries: 3,
       });
 
       expect(mapRemotesToDownload).toStrictEqual({
+        moduleFederationTypescript: 'http://localhost:3000/@mf-types.zip',
+      });
+    });
+
+    it('all options provided', () => {
+      const options = {
+        moduleFederationConfig,
+        typesFolder: 'custom-types',
+        deleteTypesFolder: false,
+        maxRetries: 1,
+      };
+
+      const { hostOptions, mapRemotesToDownload } = retrieveHostConfig(options);
+
+      expect(hostOptions).toStrictEqual(options);
+
+      expect(mapRemotesToDownload).toStrictEqual({
+        moduleFederationTypescript: 'http://localhost:3000/custom-types.zip',
+      });
+    });
+  });
+
+  it('correctly resolve subpath remotes', () => {
+    const subpathModuleFederationConfig = {
+      ...moduleFederationConfig,
+      remotes: {
         moduleFederationTypescript:
-          'http://localhost:3000/subpatha/subpathb/@mf-types.zip',
-      });
+          'http://localhost:3000/subpatha/subpathb/remoteEntry.js',
+      },
+    };
+
+    const { mapRemotesToDownload } = retrieveHostConfig({
+      moduleFederationConfig: subpathModuleFederationConfig,
     });
 
-    it('correctly resolve remotes with relative reference in place of absolute url', () => {
-      const subpathModuleFederationConfig = {
-        ...moduleFederationConfig,
-        remotes: {
-          moduleFederationTypescript: '/subpatha/remoteEntry.js',
+    expect(mapRemotesToDownload).toStrictEqual({
+      moduleFederationTypescript:
+        'http://localhost:3000/subpatha/subpathb/@mf-types.zip',
+    });
+  });
+
+  it('correctly resolve remotes with relative reference in place of absolute url', () => {
+    const subpathModuleFederationConfig = {
+      ...moduleFederationConfig,
+      remotes: {
+        moduleFederationTypescript: '/subpatha/remoteEntry.js',
+      },
+    };
+
+    const { mapRemotesToDownload } = retrieveHostConfig({
+      moduleFederationConfig: subpathModuleFederationConfig,
+    });
+
+    expect(mapRemotesToDownload).toStrictEqual({
+      moduleFederationTypescript: '/subpatha/@mf-types.zip',
+    });
+  });
+
+  it('correctly resolve remotes with object entry', () => {
+    const subpathModuleFederationConfig = {
+      ...moduleFederationConfig,
+      remotes: {
+        moduleFederationTypescript: {
+          entry: 'http://localhost:3000/subpatha/subpathb/remoteEntry.js',
         },
-      };
+      },
+    };
 
-      const { mapRemotesToDownload } = retrieveHostConfig({
-        moduleFederationConfig: subpathModuleFederationConfig,
-      });
+    const { mapRemotesToDownload } = retrieveHostConfig({
+      moduleFederationConfig: subpathModuleFederationConfig,
+    });
 
-      expect(mapRemotesToDownload).toStrictEqual({
-        moduleFederationTypescript: '/subpatha/@mf-types.zip',
-      });
+    expect(mapRemotesToDownload).toStrictEqual({
+      moduleFederationTypescript:
+        'http://localhost:3000/subpatha/subpathb/@mf-types.zip',
     });
   });
 });

--- a/packages/native-federation-typescript/src/configurations/hostPlugin.ts
+++ b/packages/native-federation-typescript/src/configurations/hostPlugin.ts
@@ -6,9 +6,18 @@ const defaultOptions = {
   maxRetries: 3,
 } satisfies Partial<HostOptions>;
 
-const retrieveRemoteStringUrl = (remote: string) => {
-  const splittedRemote = remote.split('@');
-  return splittedRemote[splittedRemote.length - 1];
+const retrieveRemoteStringUrl = (remote: string | Record<string, string>) => {
+  if (typeof remote === 'string') {
+    const splittedRemote = remote.split('@');
+    return splittedRemote[splittedRemote.length - 1];
+  }
+
+  if (typeof remote === 'object' && 'entry' in remote) {
+    const splittedRemote = remote.entry.split('@');
+    return splittedRemote[splittedRemote.length - 1];
+  }
+
+  throw new Error(`Invalid type of remote: ${typeof remote}`);
 };
 
 const FILE_PROTOCOL = 'file:';


### PR DESCRIPTION
## Description

Currently cannot resolve a remote entry from an object, which is allowed in both OriginJS Federation plugin and standard WebPack Federation plugin. This is because the `retrieveRemoteStringUrl` function only accepts a string as an entry at the moment.

## Related Issue

https://github.com/module-federation/core/issues/3512

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
