### PR TITLE
docs(website-new): add Nx and Zephyr Cloud link at zh-lang

### DIFF
--- a/apps/website-new/docs/zh/_meta.json
+++ b/apps/website-new/docs/zh/_meta.json
@@ -40,6 +40,14 @@
       {
         "text": "Practical Module Federation",
         "link": "https://module-federation.myshopify.com/products/practical-module-federation"
+      },
+      {
+        "text": "Zephyr Cloud",
+        "link": "https://zephyr-cloud.io/"
+      },
+      {
+        "text": "Nx",
+        "link": "https://nx.dev/"
       }
     ]
   }


### PR DESCRIPTION
## Description

Add Nx and Zephyr Cloud link

## Screenshots of the Changes

Add Nx and Zephyr Cloud to 生态(Ecosystem) dropdown

![before](https://github.com/user-attachments/assets/85f57b20-bea3-4989-8351-b2364ce4813a)
> before

![after](https://github.com/user-attachments/assets/4bc58ca7-e421-4e0b-884e-759f8811671d)
> after

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.(win can not run "rm -rf ")
- [X] I have updated the documentation.
