### PR TITLE
feat(bridge-react): add support for custom createRoot on createBridgeComponent

### DIFF
--- a/.changeset/kind-eagles-dream.md
+++ b/.changeset/kind-eagles-dream.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/bridge-react': minor
+---
+
+feat(bridge-react): Added support for custom `createRoot` on `createBridgeComponent`

--- a/apps/website-new/docs/zh/configure/index.mdx
+++ b/apps/website-new/docs/zh/configure/index.mdx
@@ -11,7 +11,7 @@ type ModuleFederationOptions {
     // module federation remotes 远程模块别名和 entry 信息
     remotes?: Array<RemoteInfo>;
     // module federation expose 的模块信息
-    expose?: PluginExposesOptions;
+    exposes?: PluginExposesOptions;
     // 共享依赖配置
     shared?: ShareInfos;
     // 动态 publicPath

--- a/packages/bridge/bridge-react/__tests__/bridge.spec.tsx
+++ b/packages/bridge/bridge-react/__tests__/bridge.spec.tsx
@@ -102,4 +102,36 @@ describe('bridge', () => {
     expect(getHtml(container)).toMatch('hello world');
     expect(ref.current).not.toBeNull();
   });
+
+  it.only('createRemoteComponent with custom createRoot prop', async () => {
+    const renderMock = vi.fn();
+
+    function Component({ props }: { props?: Record<string, any> }) {
+      return <div>life cycle render {props?.msg}</div>;
+    }
+    const BridgeComponent = createBridgeComponent({
+      rootComponent: Component,
+      createRoot: () => {
+        return {
+          render: renderMock,
+          unmount: vi.fn(),
+        };
+      },
+    });
+    const RemoteComponent = createRemoteComponent({
+      loader: async () => {
+        return {
+          default: BridgeComponent,
+        };
+      },
+      fallback: () => <div></div>,
+      loading: <div>loading</div>,
+    });
+
+    const { container } = render(<RemoteComponent />);
+    expect(getHtml(container)).toMatch('loading');
+
+    await sleep(200);
+    expect(renderMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/bridge/bridge-react/src/provider/create.tsx
+++ b/packages/bridge/bridge-react/src/provider/create.tsx
@@ -8,7 +8,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { RouterContext } from './context';
 import { LoggerInstance } from '../utils';
 import { federationRuntime } from './plugin';
-import { createRoot } from './compat';
+import { createRoot as defaultCreateRoot } from './compat';
 
 type RenderParams = RenderFnParams & {
   [key: string]: unknown;
@@ -17,7 +17,7 @@ type DestroyParams = {
   moduleName: string;
   dom: HTMLElement;
 };
-type RootType = HTMLElement | ReturnType<typeof createRoot>;
+type RootType = HTMLElement | ReturnType<typeof defaultCreateRoot>;
 
 export type ProviderFnParams<T> = {
   rootComponent: React.ComponentType<T>;
@@ -25,9 +25,16 @@ export type ProviderFnParams<T> = {
     App: React.ReactElement,
     id?: HTMLElement | string,
   ) => RootType | Promise<RootType>;
+  createRoot?: (
+    container: Parameters<typeof defaultCreateRoot>[0],
+    options?: Parameters<typeof defaultCreateRoot>[1],
+  ) => ReturnType<typeof defaultCreateRoot>;
 };
 
-export function createBridgeComponent<T>(bridgeInfo: ProviderFnParams<T>) {
+export function createBridgeComponent<T>({
+  createRoot = defaultCreateRoot,
+  ...bridgeInfo
+}: ProviderFnParams<T>) {
   return () => {
     const rootMap = new Map<any, RootType>();
     const instance = federationRuntime.instance;


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
Extended the definition of `createBridgeComponent` method to support an optional custom `createRoot` property that can overwrite the default `createRoot` method. This can be used in the client app to load a custom React DOM for example:

```typescript
import React from 'react';
import ReactDOMClient from 'react-dom/client';
import { createBridgeComponent } from '@module-federation/bridge-react';

const App: React.FunctionComponent = () => {
    return (
        <div />
    );
};

export default createBridgeComponent({
    rootComponent: App,
    createRoot: (container, options) => {
        return ReactDOMClient.createRoot(container, options);
    }
});
``` 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://github.com/module-federation/core/issues/3537


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
