### PR TITLE
fix(rsbuild-plugin): add more MF packages to `source.include`

### DIFF
--- a/.changeset/sharp-pans-cheer.md
+++ b/.changeset/sharp-pans-cheer.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rsbuild-plugin': patch
+---
+
+fix(rsbuild-plugin): add more MF packages to `source.include`

--- a/packages/rsbuild-plugin/src/cli/index.ts
+++ b/packages/rsbuild-plugin/src/cli/index.ts
@@ -184,8 +184,7 @@ export const pluginModuleFederation = (
       // adding to include and let SWC transform it
       config.source.include = [
         ...(config.source.include || []),
-        /@module-federation[\\/]sdk/,
-        /@module-federation[\\/]runtime/,
+        /@module-federation[\\/]/,
       ];
 
       return config;


### PR DESCRIPTION
## Description

Add all `@module-federation/*` packages to `source.include` to avoid browser compatibility issues.

This change is to fix a syntax issue introduced in `@module-federation/webpack-bundler-runtime` in 0.9.1.

<img width="1294" alt="Screenshot 2025-03-03 at 10 28 30" src="https://github.com/user-attachments/assets/87aef811-f594-4605-8c3a-ae59816252fc" />

> https://github.com/web-infra-dev/rsbuild/actions/runs/13622050663/job/38073072909?pr=4690#step:7:920

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
