### PR TITLE
fix(bridge-react): export DestroyParams and RenderParams types

### DIFF
--- a/.changeset/shy-mugs-share.md
+++ b/.changeset/shy-mugs-share.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/bridge-react': patch
+---
+
+fix(bridge-react): export DestroyParams and RenderParams types

--- a/packages/bridge/bridge-react/src/index.ts
+++ b/packages/bridge/bridge-react/src/index.ts
@@ -1,3 +1,8 @@
 export { createRemoteComponent } from './remote/create';
 export { createBridgeComponent } from './provider/create';
-export type { ProviderParams, RenderFnParams } from './types';
+export type {
+  ProviderParams,
+  RenderFnParams,
+  DestroyParams,
+  RenderParams,
+} from './types';


### PR DESCRIPTION
## Description

export DestroyParams and RenderParams types

The error as below: 

```bash
 Exported variable 'provider' has or is using name 'DestroyParams' from external module "/temp/node_modules/.pnpm/@module-federation+bridge-react@0.11.0_react-dom@18.2.0_react-router-dom@6.29.0_react@18.2.0/node_modules/@module-federation/bridge-react/dist/index" but cannot be named.

8 const provider = createBridgeComponent({
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
