### PR TITLE
fix(vue3-bridge): correct vue-router peer dependency

### DIFF
--- a/packages/bridge/vue3-bridge/package.json
+++ b/packages/bridge/vue3-bridge/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "vue": "=3",
-    "vue-router": "=3"
+    "vue-router": "=4"
   },
   "dependencies": {
     "@module-federation/bridge-shared": "workspace:*",


### PR DESCRIPTION
Update peerDependency for vue3-bridge to point to the version of Vue Router that is compatible with Vue 3.

Closes #3567

## Description

Updated vue-router peerDependency from 3 to 4.

## Related Issue

#3567 


## Types of changes


- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
