### PR TITLE
chore(node): add react 19 to peer dependencies

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -73,8 +73,8 @@
     "@module-federation/runtime": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16||^17||^18",
-    "react-dom": "^16||^17||^18",
+    "react": "^16||^17||^18|^19",
+    "react-dom": "^16||^17||^18||^19",
     "webpack": "^5.40.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2532,11 +2532,11 @@ importers:
         specifier: 2.7.0
         version: 2.7.0(encoding@0.1.13)
       react:
-        specifier: ^16||^17||^18
-        version: 18.3.1
+        specifier: ^16||^17||^18|^19
+        version: 17.0.2
       react-dom:
-        specifier: ^16||^17||^18
-        version: 18.3.1(react@18.3.1)
+        specifier: ^16||^17||^18||^19
+        version: 18.3.1(react@17.0.2)
       webpack:
         specifier: ^5.40.0
         version: 5.93.0(@swc/core@1.7.26)(esbuild@0.25.0)
@@ -42839,6 +42839,16 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
+
+  /react-dom@18.3.1(react@17.0.2):
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+    dependencies:
+      loose-envify: 1.4.0
+      react: 17.0.2
+      scheduler: 0.23.2
+    dev: false
 
   /react-dom@18.3.1(react@18.3.1):
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}


### PR DESCRIPTION
## Description

Add react 19 to the optional peer dependencies for the node package.
Also ran pnpm i to update the lock file.

## Related Issue

Relates to some of the comments in https://github.com/module-federation/core/issues/3537

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
