### PR TITLE
docs(website-new): add docs on __FEDERATION__  (#3624)

### DIFF
--- a/apps/website-new/docs/en/guide/start/quick-start.mdx
+++ b/apps/website-new/docs/en/guide/start/quick-start.mdx
@@ -438,6 +438,49 @@ const App = () => {
 export default App;
 ```
 
+## Inspect and Debug your Configuration in the Browser
+
+### \_\_FEDERATION\_\_
+Module Federation initialization provides a global variable `window.__FEDERATION__`. This is useful to get an overview of available meta information about all detected Module Federation modules.
+Besides helping out with debugging your system, this data is also useful for the creation of custom browser extensions or runtime analysis tools for your environment.
+
+#### \_\_GLOBAL_PLUGIN\_\_
+__Type:__ Array
+
+__Description:__ List of all active RuntimePlugins.
+
+#### \_\_INSTANCES\_\_
+__Type:__ Array
+
+__Description:__ List of information about all running runtimes. Index "0" is always the Host runtime.
+
+#### \_\_MANIFEST_LOADING\_\_
+__Type:__ Object
+
+__Description:__ Object showing all loading manifest meta information about modules.
+
+#### \_\_PRELOADED_MAP\_\_
+__Type:__ Map
+
+__Description:__ Map currently only instantiated, not used by any implementation.
+
+#### \_\_SHARE_SCOPE_LOADING\_\_
+__Type:__ Object
+
+__Description:__ Object not used by any implementation.
+
+#### \_\_SHARE\_\_
+__Type:__ Object
+
+__Description:__ Object collecting all shared dependencies running in the share-scope.
+
+#### moduleInfo
+__Type:__ Object
+
+__Description:__ Object showing all manifest meta information about active modules.
+
+
+
 ## Summary
 
 Through the above process, you have completed the export of a component from a 'provider' for use by a 'consumer' based on Module Federation. Along the way, you have preliminarily used and understood the configurations of remotes, exposes, and shared in the Module Federation plugin.


### PR DESCRIPTION
## Description

Discussion about __FEDERATION__ object: #2798 
The question was answered but to prevent future questions on this topic it is a good idea to add some docs here.
Also, the __FEDERATION__ object is interesting for developing plugins or browser extensions.

Since I am not sure if the location is a good match: Please leave a comment :-)

## Related Issue

#3624 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ x ] I have updated the documentation.
