### PR TITLE
chore(utils): add react 19 to peer dependencies

### DIFF
--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -24,8 +24,8 @@
     "@module-federation/sdk": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16 || ^17 || ^18",
-    "react-dom": "^16 || ^17 || ^18",
+    "react": "^16 || ^17 || ^18 || ^19",
+    "react-dom": "^16 || ^17 || ^18 || ^19",
     "webpack": "^5.40.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2749,7 +2749,7 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       react-dom:
-        specifier: ^16 || ^17 || ^18
+        specifier: ^16 || ^17 || ^18 || ^19
         version: 18.3.1(react@18.3.1)
       webpack:
         specifier: ^5.40.0


### PR DESCRIPTION
## Description

Add react 19 to the optional peer dependencies for the utilities package and run `pnpm i`.
Removes some warning noise when using react 19.

## Related Issue

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
