### PR TITLE
fix(rsbuild-plugin): explicitly setting CORS headers

### DIFF
--- a/packages/rsbuild-plugin/src/cli/index.ts
+++ b/packages/rsbuild-plugin/src/cli/index.ts
@@ -177,6 +177,12 @@ export const pluginModuleFederation = (
       // Change some default configs for remote modules
       if (moduleFederationOptions.exposes) {
         config.dev ||= {};
+        config.server ||= {};
+
+        // Allow remote modules to be loaded by setting CORS headers
+        // This is required for MF to work properly across different origins
+        config.server.headers ||= {};
+        config.server.headers['Access-Control-Allow-Origin'] ||= '*';
 
         // For remote modules, Rsbuild should send the ws request to the provider's dev server.
         // This allows the provider to do HMR when the provider module is loaded in the consumer's page.


### PR DESCRIPTION
## Description

Due to [security concerns](https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6), starting with Rsbuild >= 1.3.0, the Rsbuild dev server will no longer set `Access-Control-Allow-Origin` to `*` by default (https://github.com/web-infra-dev/rsbuild/pull/4876).

MF requires CORS headers, so I'll set that in `@module-federation/rsbuild-plugin`, which is the same as [other plugins](https://github.com/module-federation/core/blob/4b48eb5a03e71eba5e5a792f60b0b55e5e2f31a7/packages/modernjs/src/cli/configPlugin.ts#L84).

It's worth noting that in my opinion this is still a temporary solution, and we should try to avoid using `*` as the default value. A safer default value is needed instead.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
