### PR TITLE
fix(dts-plugin): add recursive:true while generate types hit cache

### DIFF
--- a/.changeset/tame-mangos-wash.md
+++ b/.changeset/tame-mangos-wash.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+fix(dts-plugin): add recursive:true while generate types hit cache

--- a/packages/dts-plugin/src/plugins/GenerateTypesPlugin.ts
+++ b/packages/dts-plugin/src/plugins/GenerateTypesPlugin.ts
@@ -207,6 +207,9 @@ export class GenerateTypesPlugin implements WebpackPluginInstance {
             await new Promise<void>((resolve, reject) => {
               compiler.outputFileSystem.mkdir(
                 path.dirname(zipOutputPath),
+                {
+                  recursive: true,
+                },
                 (err) => {
                   if (err && !isEEXIST(err)) {
                     reject(err);
@@ -239,6 +242,9 @@ export class GenerateTypesPlugin implements WebpackPluginInstance {
             await new Promise<void>((resolve, reject) => {
               compiler.outputFileSystem.mkdir(
                 path.dirname(apiOutputPath),
+                {
+                  recursive: true,
+                },
                 (err) => {
                   if (err && !isEEXIST(err)) {
                     reject(err);


### PR DESCRIPTION
## Description

Since we add incremental:true by default , the type generate may be finished first , and the compiled file not output to filesystem , so need to add recursive:true.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
