### PR TITLE
WIP: fix(enhanced): force runtime only be bundled once

### DIFF
--- a/.changeset/ten-yaks-behave.md
+++ b/.changeset/ten-yaks-behave.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/enhanced': patch
+'@module-federation/rspack': patch
+---
+
+fix(enhanced): force runtime only be bundled once

--- a/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
+++ b/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
@@ -57,6 +57,20 @@ class ModuleFederationPlugin implements WebpackPluginInstance {
         ),
       }).apply(compiler);
     }
+
+    const { splitChunks } = compiler.options.optimization;
+    if (!splitChunks) {
+      return;
+    }
+    const cacheGroups = splitChunks.cacheGroups;
+    if (!cacheGroups) {
+      return;
+    }
+    cacheGroups['mf'] = cacheGroups['mf'] || {
+      name: 'module-federation',
+      test: /@module-federation/,
+      priority: 0,
+    };
   }
 
   /**

--- a/packages/rspack/src/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/ModuleFederationPlugin.ts
@@ -45,6 +45,20 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
         ),
       }).apply(compiler);
     }
+
+    const { splitChunks } = compiler.options.optimization;
+    if (!splitChunks) {
+      return;
+    }
+    const cacheGroups = splitChunks.cacheGroups;
+    if (!cacheGroups) {
+      return;
+    }
+    cacheGroups['mf'] = cacheGroups['mf'] || {
+      name: 'module-federation',
+      test: /@module-federation/,
+      priority: 0,
+    };
   }
 
   private _checkSingleton(compiler: Compiler): void {


### PR DESCRIPTION
## Description

If user has quite complex splitChunks, the mf runtime may be bundled into different chunk which will have multiple instances issue, so we need to add default splitChunk . 

```js
cacheGroups['mf'] = cacheGroups['mf'] || {
      name: 'module-federation',
      test: /@module-federation/,
      priority: 0,
    };
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
