### PR TITLE
fix(vue3-bridge): correct cjs build output file extension

### DIFF
--- a/packages/bridge/vue3-bridge/package.json
+++ b/packages/bridge/vue3-bridge/package.json
@@ -12,8 +12,8 @@
     "access": "public"
   },
   "type": "module",
-  "main": "./dist/index.cjs.js",
-  "module": "./dist/index.es.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/",

--- a/packages/bridge/vue3-bridge/vite.config.ts
+++ b/packages/bridge/vue3-bridge/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),
       formats: ['cjs', 'es'],
-      fileName: (format) => `index.${format}.js`,
+      fileName: 'index',
     },
     rollupOptions: {
       external: ['vue', 'vue-router'],


### PR DESCRIPTION
## Description

The file extension in `"main"` in package.json needs to be `.cjs`

Change the output of the build for vue3-bridge to have:
```
dist/index.cjs
dist/index.js
```

instead of 

```
dist/index.cjs.js
dist/index.es.js
```

Change package.json to link to the changed filenames

## Related Issue

https://github.com/module-federation/core/issues/3644


## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist


- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
