### PR TITLE
fix(enhanced): remove normal module replacement of runtime

### DIFF
--- a/.changeset/serious-rules-shake.md
+++ b/.changeset/serious-rules-shake.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/enhanced': patch
+---
+
+remove normal module replacement on federation runtime. rely on alias instead

--- a/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
+++ b/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
@@ -413,19 +413,6 @@ class FederationRuntimePlugin {
 
     new HoistContainerReferences().apply(compiler);
 
-    const runtimePath = this.getRuntimeAlias(compiler);
-    new compiler.webpack.NormalModuleReplacementPlugin(
-      /@module-federation\/runtime/,
-      (resolveData) => {
-        if (/webpack-bundler-runtime/.test(resolveData.contextInfo.issuer)) {
-          resolveData.request = runtimePath;
-
-          if (resolveData.createData) {
-            resolveData.createData.request = resolveData.request;
-          }
-        }
-      },
-    ).apply(compiler);
     // dont run multiple times on every apply()
     if (!onceForCompiler.has(compiler)) {
       this.prependEntry(compiler);


### PR DESCRIPTION
This pull request includes a change to the `FederationRuntimePlugin` class in the `packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts` file. The most important change involves the removal of the `NormalModuleReplacementPlugin` setup.

Codebase simplification:

* [`packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts`](diffhunk://#diff-179f1bbf8541ac0e9d479ec019a6310ecfcf2a4af7a3c3624047b28eb611e54eL416-L428): Removed the setup for `NormalModuleReplacementPlugin` that was replacing the module federation runtime path based on the issuer context. This change simplifies the plugin application process and removes unnecessary complexity.


## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
