### PR TITLE
fix(modern-js-plugin): apply ssr.distOutputDir in bundlerChain

### DIFF
--- a/.changeset/soft-islands-protect.md
+++ b/.changeset/soft-islands-protect.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': patch
+---
+
+fix(modern-js-plugin): apply ssr.distOutputDir in bundlerChain

--- a/packages/modernjs/src/cli/ssrPlugin.ts
+++ b/packages/modernjs/src/cli/ssrPlugin.ts
@@ -70,7 +70,10 @@ const mfSSRRsbuildPlugin = (
             ? pluginOptions.userConfig.ssr
             : {}
           : {};
-        config.output!.publicPath = `${config.output!.publicPath}${userSSRConfig.distOutputDir || path.relative(csrOutputPath, ssrOutputPath)}/`;
+        if (userSSRConfig.distOutputDir) {
+          return;
+        }
+        config.output!.publicPath = `${config.output!.publicPath}${path.relative(csrOutputPath, ssrOutputPath)}/`;
         return config;
       };
       api.modifyWebpackConfig((config, utils) => {
@@ -147,6 +150,17 @@ export const moduleFederationSSRPlugin = (
           chain
             .plugin('UniverseEntryChunkTrackerPlugin')
             .use(UniverseEntryChunkTrackerPlugin);
+        }
+        const userSSRConfig = pluginOptions.userConfig.ssr
+          ? typeof pluginOptions.userConfig.ssr === 'object'
+            ? pluginOptions.userConfig.ssr
+            : {}
+          : {};
+        const publicPath = chain.output.get('publicPath');
+        if (userSSRConfig.distOutputDir && publicPath) {
+          chain.output.publicPath(
+            `${publicPath}${userSSRConfig.distOutputDir}/`,
+          );
         }
       }
 


### PR DESCRIPTION
## Description

Some modernjs version may not apply rsbuild hook , if pass ssr.distOutputDir , apply it in bundlerChain hook first.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
