### PR TITLE
fix(modern-js-plugin): export kit namespace to prevent import react directly

### DIFF
--- a/.changeset/many-emus-shave.md
+++ b/.changeset/many-emus-shave.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': patch
+---
+
+fix(modern-js-plugin): export kit namespace to prevent import react directly

--- a/apps/modernjs-ssr/dynamic-nested-remote/src/components/Content.tsx
+++ b/apps/modernjs-ssr/dynamic-nested-remote/src/components/Content.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import Button from 'antd/lib/button';
-import { registerRemotes, loadRemote, kit } from '@modern-js/runtime/mf';
+import {
+  registerRemotes,
+  loadRemote,
+  kit,
+} from '@module-federation/modern-js/runtime';
 import stuff from './stuff.module.css';
 
 const { createRemoteSSRComponent } = kit;

--- a/apps/modernjs-ssr/dynamic-nested-remote/src/components/Content.tsx
+++ b/apps/modernjs-ssr/dynamic-nested-remote/src/components/Content.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import Button from 'antd/lib/button';
-import {
-  registerRemotes,
-  loadRemote,
-  createRemoteSSRComponent,
-} from '@modern-js/runtime/mf';
+import { registerRemotes, loadRemote, kit } from '@modern-js/runtime/mf';
 import stuff from './stuff.module.css';
+
+const { createRemoteSSRComponent } = kit;
 
 registerRemotes([
   {

--- a/apps/modernjs-ssr/host/src/routes/all/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/all/page.tsx
@@ -1,5 +1,8 @@
 import React, { Suspense } from 'react';
-import { loadRemote, registerRemotes } from '@modern-js/runtime/mf';
+import {
+  loadRemote,
+  registerRemotes,
+} from '@module-federation/modern-js/runtime';
 
 registerRemotes([
   {

--- a/apps/modernjs-ssr/host/src/routes/dynamic-nested-remote/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/dynamic-nested-remote/page.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { loadRemote, registerRemotes } from '@modern-js/runtime/mf';
+import {
+  loadRemote,
+  registerRemotes,
+} from '@module-federation/modern-js/runtime';
 
 registerRemotes([
   {

--- a/apps/modernjs-ssr/host/src/routes/dynamic-remote/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/dynamic-remote/page.tsx
@@ -2,8 +2,10 @@ import React, { useState, Suspense } from 'react';
 import {
   loadRemote,
   registerRemotes,
-  createRemoteSSRComponent,
-} from '@modern-js/runtime/mf';
+  kit,
+} from '@module-federation/modern-js/runtime';
+
+const { createRemoteSSRComponent } = kit;
 
 registerRemotes([
   {

--- a/apps/modernjs-ssr/host/src/routes/remote/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/remote/page.tsx
@@ -1,6 +1,9 @@
 import React, { useState, Suspense } from 'react';
 import Comp from 'remote/Image';
-import { registerRemotes, loadRemote } from '@modern-js/runtime/mf';
+import {
+  registerRemotes,
+  loadRemote,
+} from '@module-federation/modern-js/runtime';
 
 const NewRemoteCom = React.lazy(() =>
   loadRemote('remote/Image').then((m) => {

--- a/apps/modernjs-ssr/nested-remote/src/routes/page.tsx
+++ b/apps/modernjs-ssr/nested-remote/src/routes/page.tsx
@@ -1,7 +1,9 @@
-import { createRemoteSSRComponent } from '@modern-js/runtime/mf';
+import { kit } from '@module-federation/modern-js/runtime';
 
 import Content from '../components/Content';
 import './index.css';
+
+const { createRemoteSSRComponent } = kit;
 
 const RemoteSSRComponent = createRemoteSSRComponent({
   loader: () => import('remote/Button'),

--- a/apps/website-new/docs/en/guide/framework/modernjs.mdx
+++ b/apps/website-new/docs/en/guide/framework/modernjs.mdx
@@ -112,10 +112,11 @@ This function will also help inject the corresponding style tag/script while loa
 
 ```tsx
 import React, { FC, memo, useEffect } from 'react';
-import { registerRemotes, createRemoteSSRComponent } from '@modern-js/runtime/mf';
+import { registerRemotes, kit } from '@module-federation/modern-js/runtime';
 // The remote declared in the build plug-in can be imported directly at the top level
 import RemoteComp from 'remote/Image';
 
+const { createRemoteSSRComponent } = kit;
 
 const RemoteSSRComponent = createRemoteSSRComponent({
   // The remote declared in the build plug-in can also be loaded using this function: loader: () => import('remote/Image'),

--- a/apps/website-new/docs/en/practice/frameworks/modern/dynamic-remote.mdx
+++ b/apps/website-new/docs/en/practice/frameworks/modern/dynamic-remote.mdx
@@ -147,12 +147,14 @@ export const loader = async ({ request }: LoaderFunctionArgs): Promise<DataLoade
 Consume loader data and dynamically load the corresponding producer:
 
 ```tsx
-import { createRemoteSSRComponent, loadRemote, registerRemotes } from '@modern-js/runtime/mf';
+import { kit, loadRemote, registerRemotes } from '@module-federation/modern-js/runtime';
 // Use import type to get data loader types
 import type { DataLoaderRes } from './page.data';
 import { useLoaderData } from '@modern-js/runtime/router';
 
 import './index.css';
+
+const { createRemoteSSRComponent } = kit;
 
 const RemoteSSRComponent = createRemoteSSRComponent({
   loader: () => import('remote/Image'),

--- a/apps/website-new/docs/en/practice/frameworks/modern/index.mdx
+++ b/apps/website-new/docs/en/practice/frameworks/modern/index.mdx
@@ -217,12 +217,6 @@ export default defineConfig({
 ```
 #### 3. Type hint
 
-Add `/// <reference types='@module-federation/modern-js/types' />` to the `modern-app-env.d.ts` file to get the runtime `@modern-js/runtime/mf` type support.
-
-```diff title='modern-app-env.d.ts'
-+ /// <reference types='@module-federation/modern-js/types' />
-```
-
 Add `paths` in `tsconfig.json` to get the producer's type:
 
 ```json

--- a/apps/website-new/docs/en/practice/frameworks/modern/index.mdx
+++ b/apps/website-new/docs/en/practice/frameworks/modern/index.mdx
@@ -260,8 +260,10 @@ This is because the producer's style files cannot be injected into the correspon
 This issue can be solved by using the [createremotessrcomponent](../../../guide/framework/modernjs#createremotessrcomponent) provided by `@module-federation/modern-js`.
 
 ```tsx title='page.tsx'
-import { createRemoteSSRComponent } from '@modern-js/runtime/mf'
+import { kit } from '@module-federation/modern-js/runtime'
 import './index.css';
+
+const { createRemoteSSRComponent } = kit;
 
 const RemoteSSRComponent = createRemoteSSRComponent({
   loader: () => import('remote/Image'),

--- a/apps/website-new/docs/zh/guide/framework/modernjs.mdx
+++ b/apps/website-new/docs/zh/guide/framework/modernjs.mdx
@@ -124,9 +124,11 @@ type ComponentType = T[E] extends (...args: any) => any
 
 ```tsx
 import React, { FC, memo, useEffect } from 'react';
-import { registerRemotes, createRemoteSSRComponent } from '@modern-js/runtime/mf';
+import { registerRemotes, kit } from '@module-federation/modern-js/runtime';
 // 在构建插件声明过的 remote 可以直接在顶层 import
 import RemoteComp from 'remote/Image';
+
+const { createRemoteSSRComponent } = kit;
 
 const RemoteSSRComponent = createRemoteSSRComponent({
   // 在构建插件声明过的 remote 也可以使用此函数加载：loader: () => import('remote/Image'),

--- a/apps/website-new/docs/zh/guide/framework/modernjs.mdx
+++ b/apps/website-new/docs/zh/guide/framework/modernjs.mdx
@@ -65,12 +65,6 @@ export default createModuleFederationConfig({
 
 ### 引用类型
 
-在 `modern-app-env.d.ts` 文件增加 `/// <reference types='@module-federation/modern-js/types' />` 以获取运行时 `@@modern-js/runtime/mf` 类型支持。
-
-```diff title='modern-app-env.d.ts'
-+ /// <reference types='@module-federation/modern-js/types' />
-```
-
 在 `tsconfig.json` 添加 `paths` 以获取生产者的类型：
 
 ```json

--- a/apps/website-new/docs/zh/practice/frameworks/modern/dynamic-remote.mdx
+++ b/apps/website-new/docs/zh/practice/frameworks/modern/dynamic-remote.mdx
@@ -144,12 +144,14 @@ export const loader = async ({ request }: LoaderFunctionArgs): Promise<DataLoade
 消费 loader 数据，并动态加载对应的生产者：
 
 ```tsx
-import { createRemoteSSRComponent, loadRemote, registerRemotes } from '@modern-js/runtime/mf';
+import { kit, loadRemote, registerRemotes } from '@module-federation/modern-js/runtime';
 // 使用 import type ，仅获取类型
 import type { DataLoaderRes } from './page.data';
 import { useLoaderData } from '@modern-js/runtime/router';
 
 import './index.css';
+
+const { createRemoteSSRComponent } = kit;
 
 const RemoteSSRComponent = createRemoteSSRComponent({
   loader: () => import('remote/Image'),

--- a/apps/website-new/docs/zh/practice/frameworks/modern/index.mdx
+++ b/apps/website-new/docs/zh/practice/frameworks/modern/index.mdx
@@ -263,8 +263,10 @@ export default Index;
 修改消费者引用生产者处的代码（`src/routes/page.tsx`）：
 
 ```tsx title='page.tsx'
-import { createRemoteSSRComponent } from '@modern-js/runtime/mf'
+import { kit } from '@module-federation/modern-js/runtime'
 import './index.css';
+
+const { createRemoteSSRComponent } = kit;
 
 const RemoteSSRComponent = createRemoteSSRComponent({
   loader: () => import('remote/Image'),

--- a/apps/website-new/docs/zh/practice/frameworks/modern/index.mdx
+++ b/apps/website-new/docs/zh/practice/frameworks/modern/index.mdx
@@ -218,12 +218,6 @@ export default defineConfig({
 ```
 #### 3. 引用类型
 
-在 `modern-app-env.d.ts` 文件增加 `/// <reference types='@module-federation/modern-js/types' />` 以获取运行时 `@@modern-js/runtime/mf` 类型支持。
-
-```diff title='modern-app-env.d.ts'
-+ /// <reference types='@module-federation/modern-js/types' />
-```
-
 在 `tsconfig.json` 添加 `paths` 以获取生产者的类型：
 
 ```json

--- a/packages/modernjs/src/cli/configPlugin.spec.ts
+++ b/packages/modernjs/src/cli/configPlugin.spec.ts
@@ -77,7 +77,7 @@ describe('patchMFConfig', async () => {
       },
       dts: {
         consumeTypes: {
-          runtimePkgs: ['@modern-js/runtime/mf'],
+          runtimePkgs: ['@module-federation/modern-js/runtime'],
         },
       },
     });

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -110,7 +110,7 @@ const patchDTSConfig = (
   if (isServer) {
     return;
   }
-  const ModernJSRuntime = '@modern-js/runtime/mf';
+  const ModernJSRuntime = '@module-federation/modern-js/runtime';
   if (mfConfig.dts !== false) {
     if (typeof mfConfig.dts === 'boolean' || mfConfig.dts === undefined) {
       mfConfig.dts = {
@@ -459,6 +459,7 @@ export const moduleFederationConfigPlugin = (
         },
         source: {
           alias: {
+            // TODO: deprecated
             '@modern-js/runtime/mf': require.resolve(
               '@module-federation/modern-js/runtime',
             ),

--- a/packages/modernjs/src/runtime/index.ts
+++ b/packages/modernjs/src/runtime/index.ts
@@ -1,5 +1,11 @@
 export * from '@module-federation/enhanced/runtime';
-export {
-  createRemoteSSRComponent,
-  collectSSRAssets,
-} from './createRemoteSSRComponent';
+
+// avoid import react directly https://github.com/web-infra-dev/modern.js/issues/7096
+export const kit = {
+  get createRemoteSSRComponent() {
+    return require('./createRemoteSSRComponent').createRemoteSSRComponent;
+  },
+  get collectSSRAssets() {
+    return require('./createRemoteSSRComponent').collectSSRAssets;
+  },
+};

--- a/packages/modernjs/types.d.ts
+++ b/packages/modernjs/types.d.ts
@@ -1,5 +1,6 @@
 import './dist/types/runtime';
 
+// TODO: deprecated
 declare module '@modern-js/runtime/mf' {
   export * from './dist/types/runtime';
 }


### PR DESCRIPTION
## Description

* export kit namespace to prevent import react directly

* change the modernjs runtime import path from `@modern-js/runtime/mf ` to `@module-federation/modern-js/runtime`

before
```
import {
  registerRemotes,
  loadRemote,
  createRemoteSSRComponent,
} from '@modern-js/runtime/mf';
```

after

```
import {
  registerRemotes,
  loadRemote,
  kit,
} from '@module-federation/modern-js/runtime';

const { createRemoteSSRComponent } = kit;

```
 

## Related Issue
https://github.com/web-infra-dev/modern.js/issues/7096
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
