### PR TITLE
feat(runtime): provide a root

### DIFF
--- a/apps/runtime-demo/3005-runtime-host/src/App.tsx
+++ b/apps/runtime-demo/3005-runtime-host/src/App.tsx
@@ -4,6 +4,7 @@ import { Link, Routes, Route, BrowserRouter } from 'react-router-dom';
 import Root from './Root';
 import Remote1 from './Remote1';
 import Remote2 from './Remote2';
+import Remote3 from './Remote3';
 
 const App = () => (
   <BrowserRouter>
@@ -18,11 +19,15 @@ const App = () => (
       <li>
         <Link to={'/remote2'}>remote2</Link>
       </li>
+      <li>
+        <Link to={'/remote3'}>remote3</Link>
+      </li>
     </ul>
     <Routes>
       <Route path="/" element={<Root />} />
       <Route path="/remote1" element={<Remote1 />} />
       <Route path="/remote2" element={<Remote2 />} />
+      <Route path="/remote3" element={<Remote3 />} />
     </Routes>
   </BrowserRouter>
 );

--- a/apps/runtime-demo/3005-runtime-host/src/Remote3.tsx
+++ b/apps/runtime-demo/3005-runtime-host/src/Remote3.tsx
@@ -1,0 +1,28 @@
+import React, { Suspense, lazy } from 'react';
+import { createRoot } from 'react-dom/client';
+import { loadRemote } from '@module-federation/enhanced/runtime';
+
+class CustomElement extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+  async connectedCallback() {
+    if (!this.shadowRoot) return;
+
+    const module = await loadRemote('dynamic-remote/ButtonOldAnt', {
+      //@ts-ignore
+      root: this.shadowRoot,
+    });
+    //@ts-ignore
+    createRoot(this.shadowRoot).render(React.createElement(module.default));
+  }
+}
+
+customElements.define('custom-element', CustomElement);
+
+function DynamicRemoteButton() {
+  return React.createElement('custom-element');
+}
+
+export default DynamicRemoteButton;

--- a/packages/runtime-core/src/core.ts
+++ b/packages/runtime-core/src/core.ts
@@ -247,7 +247,7 @@ export class FederationHost {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   async loadRemote<T>(
     id: string,
-    options?: { loadFactory?: boolean; from: CallFrom },
+    options?: { loadFactory?: boolean; from: CallFrom; root?: HTMLElement },
   ): Promise<T | null> {
     return this.remoteHandler.loadRemote(id, options);
   }

--- a/packages/runtime-core/src/core.ts
+++ b/packages/runtime-core/src/core.ts
@@ -247,7 +247,7 @@ export class FederationHost {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   async loadRemote<T>(
     id: string,
-    options?: { loadFactory?: boolean; from: CallFrom; root?: HTMLElement },
+    options?: { loadFactory?: boolean; from?: CallFrom; root?: HTMLElement },
   ): Promise<T | null> {
     return this.remoteHandler.loadRemote(id, options);
   }

--- a/packages/runtime-core/src/plugins/snapshot/index.ts
+++ b/packages/runtime-core/src/plugins/snapshot/index.ts
@@ -41,7 +41,7 @@ export function snapshotPlugin(): FederationRuntimePlugin {
   return {
     name: 'snapshot-plugin',
     async afterResolve(args) {
-      const { remote, pkgNameOrAlias, expose, origin, remoteInfo } = args;
+      const { remote, pkgNameOrAlias, expose, origin, remoteInfo, root } = args;
 
       if (!isRemoteInfoWithEntry(remote) || !isPureRemoteEntry(remote)) {
         const { remoteSnapshot, globalSnapshot } =
@@ -73,7 +73,7 @@ export function snapshotPlugin(): FederationRuntimePlugin {
           );
 
         if (assets) {
-          preloadAssets(remoteInfo, origin, assets, false);
+          preloadAssets(remoteInfo, origin, assets, false, root);
         }
 
         return {

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -198,7 +198,7 @@ export class RemoteHandler {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   async loadRemote<T>(
     id: string,
-    options?: { loadFactory?: boolean; from: CallFrom; root?: HTMLElement },
+    options?: { loadFactory?: boolean; from?: CallFrom; root?: HTMLElement },
   ): Promise<T | null> {
     const { host } = this;
     try {

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -57,6 +57,7 @@ export interface LoadRemoteMatch {
   origin: FederationHost;
   remoteInfo: RemoteInfo;
   remoteSnapshot?: ModuleInfo;
+  root?: HTMLElement;
 }
 
 export class RemoteHandler {
@@ -197,7 +198,7 @@ export class RemoteHandler {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   async loadRemote<T>(
     id: string,
-    options?: { loadFactory?: boolean; from: CallFrom },
+    options?: { loadFactory?: boolean; from: CallFrom; root?: HTMLElement },
   ): Promise<T | null> {
     const { host } = this;
     try {
@@ -214,6 +215,7 @@ export class RemoteHandler {
       const { module, moduleOptions, remoteMatchInfo } =
         await this.getRemoteModuleAndOptions({
           id,
+          root: options?.root,
         });
       const {
         pkgNameOrAlias,
@@ -314,7 +316,10 @@ export class RemoteHandler {
     });
   }
 
-  async getRemoteModuleAndOptions(options: { id: string }): Promise<{
+  async getRemoteModuleAndOptions(options: {
+    id: string;
+    root?: HTMLElement;
+  }): Promise<{
     module: Module;
     moduleOptions: ModuleOptions;
     remoteMatchInfo: LoadRemoteMatch;
@@ -371,6 +376,7 @@ export class RemoteHandler {
         options: host.options,
         origin: host,
         remoteInfo,
+        root: options.root,
       });
 
     const { remote, expose } = matchInfo;

--- a/packages/runtime-core/src/utils/preload.ts
+++ b/packages/runtime-core/src/utils/preload.ts
@@ -70,6 +70,7 @@ export function preloadAssets(
   assets: PreloadAssets,
   // It is used to distinguish preload from load remote parallel loading
   useLinkPreload = true,
+  root: HTMLElement = document.head,
 ): void {
   const { cssAssets, jsAssetsWithoutEntry, entryAssets } = assets;
 
@@ -116,7 +117,7 @@ export function preloadAssets(
           },
         });
 
-        needAttach && document.head.appendChild(cssEl);
+        needAttach && root.appendChild(cssEl);
       });
     } else {
       const defaultAttrs = {
@@ -143,7 +144,7 @@ export function preloadAssets(
           needDeleteLink: false,
         });
 
-        needAttach && document.head.appendChild(cssEl);
+        needAttach && root.appendChild(cssEl);
       });
     }
 
@@ -170,7 +171,7 @@ export function preloadAssets(
             return;
           },
         });
-        needAttach && document.head.appendChild(linkEl);
+        needAttach && root.appendChild(linkEl);
       });
     } else {
       const defaultAttrs = {
@@ -196,7 +197,7 @@ export function preloadAssets(
           },
           needDeleteScript: true,
         });
-        needAttach && document.head.appendChild(scriptEl);
+        needAttach && root.appendChild(scriptEl);
       });
     }
   }

--- a/packages/runtime-core/src/utils/preload.ts
+++ b/packages/runtime-core/src/utils/preload.ts
@@ -100,6 +100,7 @@ export function preloadAssets(
       };
       cssAssets.forEach((cssUrl) => {
         const { link: cssEl, needAttach } = createLink({
+          root,
           url: cssUrl,
           cb: () => {
             // noop
@@ -126,6 +127,7 @@ export function preloadAssets(
       };
       cssAssets.forEach((cssUrl) => {
         const { link: cssEl, needAttach } = createLink({
+          root,
           url: cssUrl,
           cb: () => {
             // noop
@@ -155,6 +157,7 @@ export function preloadAssets(
       };
       jsAssetsWithoutEntry.forEach((jsUrl) => {
         const { link: linkEl, needAttach } = createLink({
+          root: document.head,
           url: jsUrl,
           cb: () => {
             // noop
@@ -171,7 +174,7 @@ export function preloadAssets(
             return;
           },
         });
-        needAttach && root.appendChild(linkEl);
+        needAttach && document.head.appendChild(linkEl);
       });
     } else {
       const defaultAttrs = {
@@ -197,7 +200,7 @@ export function preloadAssets(
           },
           needDeleteScript: true,
         });
-        needAttach && root.appendChild(scriptEl);
+        needAttach && document.head.appendChild(scriptEl);
       });
     }
   }

--- a/packages/runtime/__tests__/load-remote.spec.ts
+++ b/packages/runtime/__tests__/load-remote.spec.ts
@@ -535,6 +535,14 @@ describe('lazy loadRemote and add remote into snapshot', () => {
 });
 
 describe('loadRemote', () => {
+  beforeEach(() => {
+    document.querySelectorAll('script').forEach((script) => {
+      script.remove();
+    });
+    document.querySelectorAll('link').forEach((link) => {
+      link.remove();
+    });
+  });
   it('loads remote synchronously', async () => {
     const jsSyncAssetPath = 'resources/load-remote/app2/say.sync.js';
     const remotePublicPath = 'http://localhost:1111/';

--- a/packages/sdk/__tests__/dom.spec.ts
+++ b/packages/sdk/__tests__/dom.spec.ts
@@ -164,6 +164,7 @@ describe('createLink', () => {
     const url = 'https://example.com/script.js';
     const cb = jest.fn();
     const { link, needAttach } = createLink({
+      root: document.head,
       url,
       cb,
       attrs: { as: 'script' },
@@ -181,6 +182,7 @@ describe('createLink', () => {
     document.head.innerHTML = `<link href="${url}" rel="preload" as="script">`;
     const { link, needAttach } = createLink({
       url,
+      root: document.head,
       cb,
       attrs: {
         rel: 'preload',
@@ -197,7 +199,7 @@ describe('createLink', () => {
     const url = 'https://example.com/script.js';
     const cb = jest.fn();
     const attrs = { rel: 'preload', as: 'script', 'data-test': 'test' };
-    const { link } = createLink({ url, cb, attrs });
+    const { link } = createLink({ url, cb, attrs, root: document.head });
 
     expect(link.rel).toBe('preload');
     expect(link.getAttribute('as')).toBe('script');
@@ -215,6 +217,7 @@ describe('createLink', () => {
     };
     const { link } = createLink({
       url,
+      root: document.head,
       cb,
       attrs,
       createLinkHook: (url) => {
@@ -237,6 +240,7 @@ describe('createLink', () => {
     const cb = jest.fn();
     const { link, needAttach } = createLink({
       url,
+      root: document.head,
       cb,
       attrs: { as: 'script' },
     });
@@ -255,6 +259,7 @@ describe('createLink', () => {
     const onErrorCallback = jest.fn();
     const { link, needAttach } = createLink({
       url,
+      root: document.head,
       cb,
       onErrorCallback,
       attrs: { as: 'script' },
@@ -277,6 +282,7 @@ describe('createLink', () => {
     const { link } = createLink({
       url,
       cb,
+      root: document.head,
       attrs: {},
       createLinkHook: () => customLink,
     });

--- a/packages/sdk/src/dom.ts
+++ b/packages/sdk/src/dom.ts
@@ -136,6 +136,7 @@ export function createScript(info: {
 }
 
 export function createLink(info: {
+  root: HTMLElement;
   url: string;
   cb?: (value: void | PromiseLike<void>) => void;
   onErrorCallback?: (error: Error) => void;
@@ -151,7 +152,7 @@ export function createLink(info: {
   // Retrieve the existing script element by its src attribute
   let link: HTMLLinkElement | null = null;
   let needAttach = true;
-  const links = document.getElementsByTagName('link');
+  const links = info.root.querySelectorAll('link');
   for (let i = 0; i < links.length; i++) {
     const l = links[i];
     const linkHref = l.getAttribute('href');


### PR DESCRIPTION
## Description

Allows providing a root element to loadRemote so that it can be used with shadow dom. If one isn't provided it falls back to current `document.head` behavior.

## Related Issue

https://github.com/module-federation/core/issues/3746


## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

Would love guidance on how best to test and implement this, if this is even the right API idea.

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
