### PR TITLE
feat(chrome-devtools): add inspector

### DIFF
--- a/.changeset/few-dolls-mix.md
+++ b/.changeset/few-dolls-mix.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/devtools': patch
+---
+
+feat(chrome-devtools): add inspector

--- a/packages/chrome-devtools/demos/inspector.css
+++ b/packages/chrome-devtools/demos/inspector.css
@@ -1,0 +1,123 @@
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family:
+    PingFang SC,
+    Hiragino Sans GB,
+    Microsoft YaHei,
+    Arial,
+    sans-serif;
+  background: linear-gradient(to bottom, transparent, #fff) #eceeef;
+}
+
+p {
+  margin: 0;
+}
+
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  box-sizing: border-box;
+}
+
+.container-box {
+  min-height: 100vh;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 50px;
+}
+
+.landing-page {
+  padding: 20px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.header {
+  display: flex;
+  margin: 4rem 0 4rem;
+  align-items: center;
+  font-size: 4rem;
+  font-weight: 600;
+}
+
+.name {
+  color: #4ecaff;
+}
+
+.description {
+  text-align: center;
+  line-height: 1.5;
+  font-size: 1.3rem;
+  color: #1b3a42;
+  margin-bottom: 5rem;
+}
+
+.code {
+  background: #fafafa;
+  border-radius: 12px;
+  padding: 0.6rem 0.9rem;
+  font-size: 1.05rem;
+  font-family:
+    Menlo,
+    Monaco,
+    Lucida Console,
+    Liberation Mono,
+    DejaVu Sans Mono,
+    Bitstream Vera Sans Mono,
+    Courier New,
+    monospace;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1100px;
+  margin-top: 3rem;
+}
+
+.card {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100px;
+  color: inherit;
+  text-decoration: none;
+  transition: 0.15s ease;
+  width: 45%;
+}
+
+.card:hover,
+.card:focus {
+  transform: scale(1.05);
+}
+
+.card h2 {
+  display: flex;
+  align-items: center;
+  font-size: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.card p {
+  opacity: 0.6;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin-top: 1rem;
+}
+
+.arrow-right {
+  width: 1.3rem;
+  margin-left: 0.5rem;
+  margin-top: 3px;
+}

--- a/packages/chrome-devtools/demos/inspector.tsx
+++ b/packages/chrome-devtools/demos/inspector.tsx
@@ -1,0 +1,159 @@
+import { Helmet } from '@modern-js/runtime/head';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './inspector.css';
+import { wrapComponent } from '../src/utils/chrome/ComponentInspector';
+
+const Header = () => {
+  return (
+    <div className="header">
+      Welcome to
+      <img
+        className="logo"
+        src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/modern-js-logo.svg"
+        alt="Modern.js Logo"
+      />
+      <p className="name">Modern.js</p>
+    </div>
+  );
+};
+
+const Footer = () => {
+  return (
+    <div className="footer">
+      <a
+        href="https://modernjs.dev/guides/get-started/introduction.html"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="card"
+      >
+        <h2>
+          Guide
+          <img
+            className="arrow-right"
+            src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/arrow-right.svg"
+            alt="Guide"
+          />
+        </h2>
+        <p>Follow the guides to use all features of Modern.js.</p>
+      </a>
+      <a
+        href="https://modernjs.dev/tutorials/foundations/introduction.html"
+        target="_blank"
+        className="card"
+        rel="noreferrer"
+      >
+        <h2>
+          Tutorials
+          <img
+            className="arrow-right"
+            src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/arrow-right.svg"
+            alt="Tutorials"
+          />
+        </h2>
+        <p>Learn to use Modern.js to create your first application.</p>
+      </a>
+      <a
+        href="https://modernjs.dev/configure/app/usage.html"
+        target="_blank"
+        className="card"
+        rel="noreferrer"
+      >
+        <h2>
+          Config
+          <img
+            className="arrow-right"
+            src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/arrow-right.svg"
+            alt="Config"
+          />
+        </h2>
+        <p>Find all configuration options provided by Modern.js.</p>
+      </a>
+      <a
+        href="https://github.com/web-infra-dev/modern.js"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="card"
+      >
+        <h2>
+          Github
+          <img
+            className="arrow-right"
+            src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/arrow-right.svg"
+            alt="Github"
+          />
+        </h2>
+        <p>View the source code of Github, feel free to contribute.</p>
+      </a>
+    </div>
+  );
+};
+
+const Description = () => {
+  return (
+    <p className="description">
+      Get started by editing <code className="code">src/routes/page.tsx</code>
+    </p>
+  );
+};
+
+function MyComponent() {
+  return <div>Hello</div>;
+}
+console.log(222, MyComponent.name);
+
+class MyClassComponent extends React.Component {
+  render() {
+    return <div>Hello</div>;
+  }
+}
+
+console.log(222, MyClassComponent.name);
+
+const Index = () => (
+  <div className="container-box">
+    <Helmet>
+      <link
+        rel="icon"
+        type="image/x-icon"
+        href="https://lf3-static.bytednsdoc.com/obj/eden-cn/uhbfnupenuhf/favicon.ico"
+      />
+    </Helmet>
+
+    <div className="landing-page">
+      {wrapComponent({
+        react: React,
+        CustomComponent: Header,
+        componentName: Header.name,
+        mfName: 'provider1',
+      })}
+
+      {wrapComponent({
+        react: React,
+        CustomComponent: Description,
+        componentName: Description.name,
+        mfName: 'provider2',
+        versionOrEntry: '1.2.3',
+      })}
+
+      {wrapComponent({
+        react: React,
+        CustomComponent: Footer,
+        componentName: Footer.name,
+        mfName: 'provider3',
+      })}
+    </div>
+  </div>
+);
+
+export default Index;
+
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  const root = ReactDOM.createRoot(rootEl);
+  root.render(
+    <React.StrictMode>
+      <Index />
+    </React.StrictMode>,
+  );
+}

--- a/packages/chrome-devtools/manifest.json
+++ b/packages/chrome-devtools/manifest.json
@@ -17,6 +17,7 @@
         "static/js/post-message.js",
         "static/js/post-message-start.js",
         "static/js/fast-refresh.js",
+        "static/js/inspector-plugin.js",
         "static/js/snapshot-plugin.js"
       ],
       "matches": ["<all_urls>"]
@@ -35,7 +36,11 @@
     },
     {
       "matches": ["<all_urls>"],
-      "js": ["static/js/fast-refresh.js", "static/js/snapshot-plugin.js"],
+      "js": [
+        "static/js/fast-refresh.js",
+        "static/js/snapshot-plugin.js",
+        "static/js/inspector-plugin.js"
+      ],
       "world": "MAIN",
       "run_at": "document_start"
     }

--- a/packages/chrome-devtools/modern.config.ts
+++ b/packages/chrome-devtools/modern.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
     },
   },
   output: {
+    injectStyles: process.env.INSPECTOR ? true : false,
+    cleanDistPath: process.env.INSPECTOR ? true : false,
     disableInlineRuntimeChunk: true,
     disableFilenameHash: true,
     disableMinimize: true,
@@ -20,6 +22,16 @@ export default defineConfig({
   },
   tools: {
     webpack: (config: Record<string, any>) => {
+      if (process.env.INSPECTOR) {
+        config.entry = {
+          'inspector-plugin': './src/utils/chrome/inspector-plugin.ts',
+        };
+        config.externals = {
+          react: '_mfReact',
+        };
+        return config;
+      }
+
       if (process.env.E2ETEST) {
         config.entry.worker = './src/worker/index.ts';
       }

--- a/packages/chrome-devtools/modern.config.ts
+++ b/packages/chrome-devtools/modern.config.ts
@@ -44,6 +44,10 @@ export default defineConfig({
         './src/utils/chrome/post-message-listener.ts';
       config.entry['post-message-start'] =
         './src/utils/chrome/post-message-start.ts';
+
+      if (process.env.TEST_INSPECTOR) {
+        config.entry = './demos/inspector.tsx';
+      }
       return config;
     },
   },

--- a/packages/chrome-devtools/modern.lib.config.ts
+++ b/packages/chrome-devtools/modern.lib.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   buildConfig: {
     input: ['src', '!src/index.tsx'],
     tsconfig: 'tsconfig.lib.json',
+    minify: false,
   },
 });

--- a/packages/chrome-devtools/package.json
+++ b/packages/chrome-devtools/package.json
@@ -12,7 +12,7 @@
     "storybook": "storybook dev -p 6006",
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern-app dev",
-    "build": "modern-app build && node postpack.js",
+    "build": " INSPECTOR=true modern-app build && modern-app build && node postpack.js",
     "build:debug": "DEBUG=true modern-app build && node postpack.js",
     "build:lib": "rm -rf dist && modern-module build -c modern.lib.config.ts",
     "release": "npm publish --tag canary",

--- a/packages/chrome-devtools/package.json
+++ b/packages/chrome-devtools/package.json
@@ -12,6 +12,7 @@
     "storybook": "storybook dev -p 6006",
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern-app dev",
+    "dev:inspector": "TEST_INSPECTOR=true modern-app dev",
     "build": " INSPECTOR=true modern-app build && modern-app build && node postpack.js",
     "build:debug": "DEBUG=true modern-app build && node postpack.js",
     "build:lib": "rm -rf dist && modern-module build -c modern.lib.config.ts",
@@ -61,7 +62,8 @@
     "dagre": "^0.8.5",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",
-    "reactflow": "11.11.4"
+    "reactflow": "11.11.4",
+    "react-toastify": "11.0.5"
   },
   "devDependencies": {
     "@modern-js-app/eslint-config": "2.54.6",

--- a/packages/chrome-devtools/project.json
+++ b/packages/chrome-devtools/project.json
@@ -29,6 +29,18 @@
         }
       ]
     },
+    "dev:inspector": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["npm run dev:inspector --prefix packages/chrome-devtools"]
+      },
+      "dependsOn": [
+        {
+          "target": "build",
+          "dependencies": true
+        }
+      ]
+    },
     "test": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/chrome-devtools/src/component/Form/index.tsx
+++ b/packages/chrome-devtools/src/component/Form/index.tsx
@@ -44,7 +44,9 @@ interface FormProps {
   setFormStatus: React.Dispatch<SetStateAction<FormItemStatus[]>>;
   validateForm: any;
   enableHMR: string;
+  enableInspector: string;
   onHMRChange: (on: boolean) => void;
+  onInspectorChange: (on: boolean) => void;
 }
 const FormComponent = (props: FormProps & RootComponentProps) => {
   const {
@@ -54,7 +56,9 @@ const FormComponent = (props: FormProps & RootComponentProps) => {
     setFormStatus,
     validateForm,
     enableHMR,
+    enableInspector,
     onHMRChange,
+    onInspectorChange,
     versionList,
     setVersionList,
     getVersion,
@@ -185,6 +189,10 @@ const FormComponent = (props: FormProps & RootComponentProps) => {
     onHMRChange(on);
   };
 
+  const inspectorChange = (on: boolean) => {
+    onInspectorChange(on);
+  };
+
   const onKeyChange = async (key: string, index: number) => {
     const version = await getVersion?.(key);
     if (version) {
@@ -227,6 +235,13 @@ const FormComponent = (props: FormProps & RootComponentProps) => {
                 checkedText={'Enable HMR'}
                 uncheckedText={'Disable HMR'}
                 onChange={hmrChange}
+                className={styles.switch}
+              />
+              <Switch
+                checked={enableInspector === 'enable'}
+                checkedText={'Enable Inspector'}
+                uncheckedText={'Disable Inspector'}
+                onChange={inspectorChange}
                 className={styles.switch}
               />
             </div>

--- a/packages/chrome-devtools/src/component/Layout/index.tsx
+++ b/packages/chrome-devtools/src/component/Layout/index.tsx
@@ -33,6 +33,8 @@ import {
   __ENABLE_FAST_REFRESH__,
   BROWSER_ENV_KEY,
   __FEDERATION_DEVTOOLS__,
+  ENABLEINSPECTOR,
+  __ENABLE_INSPECTOR__,
 } from '../../template/constant';
 interface FormItemType {
   key: string;
@@ -66,6 +68,7 @@ const Layout = (
   const [snapshot, setSnapshot] = useState(moduleInfo);
   const [form] = Form.useForm();
   const [enableHMR, setEnalbeHMR] = useState('disable');
+  const [enableInspector, setEnalbeInspector] = useState('disable');
 
   const { run } = useDebounceFn(
     async (formData) => {
@@ -159,6 +162,12 @@ const Layout = (
         onHMRChange(enable);
       }
     });
+    chrome.storage.sync.get([ENABLEINSPECTOR]).then((data) => {
+      const enable = data[ENABLEINSPECTOR];
+      if (typeof enable === 'boolean') {
+        onHMRChange(enable);
+      }
+    });
   }, []);
 
   useEffect(() => {
@@ -200,6 +209,19 @@ const Layout = (
     injectScript(reloadPage, false);
   };
 
+  const onInspectorChange = (on: boolean) => {
+    setEnalbeInspector(on ? 'enable' : 'disable');
+    chrome.storage.sync.set({
+      [ENABLEINSPECTOR]: on,
+    });
+    if (on) {
+      mergeStorage(__FEDERATION_DEVTOOLS__, __ENABLE_INSPECTOR__, on);
+    } else {
+      removeStorageKey(__FEDERATION_DEVTOOLS__, __ENABLE_INSPECTOR__);
+    }
+    injectScript(reloadPage, false);
+  };
+
   return (
     <>
       <Form
@@ -215,6 +237,8 @@ const Layout = (
           validateForm={() => validateForm(form)}
           enableHMR={enableHMR}
           onHMRChange={onHMRChange}
+          enableInspector={enableInspector}
+          onInspectorChange={onInspectorChange}
           versionList={versionList}
           setVersionList={setVersionList}
           getVersion={getVersion}

--- a/packages/chrome-devtools/src/template/constant.ts
+++ b/packages/chrome-devtools/src/template/constant.ts
@@ -1,6 +1,7 @@
 export const FormID = 'FormID';
 
 export const ENABLEHMR = 'enableHMR';
+export const ENABLEINSPECTOR = 'enableInspector';
 
 export const proxyFormField = 'proxyFormField';
 
@@ -51,6 +52,7 @@ export const statusInfo: Record<
 };
 
 export const __ENABLE_FAST_REFRESH__ = 'enableFastRefresh';
+export const __ENABLE_INSPECTOR__ = 'enableInspector';
 
 export const BROWSER_ENV_KEY = 'MF_ENV';
 

--- a/packages/chrome-devtools/src/utils/chrome/ComponentInspector.css
+++ b/packages/chrome-devtools/src/utils/chrome/ComponentInspector.css
@@ -1,0 +1,86 @@
+.component-inspector {
+  position: relative;
+  display: inline-block;
+}
+
+.inspector-info {
+  position: fixed;
+  z-index: 1000;
+  background: #1a1a1a;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  color: #fff;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.inspector-overlay {
+  position: fixed;
+  border-radius: 4px;
+  pointer-events: none;
+  z-index: 999;
+  background:
+    linear-gradient(90deg, #3b82f6 0%, #ec4899 50%, #3b82f6 100%) 0 0,
+    linear-gradient(90deg, #3b82f6 0%, #ec4899 50%, #3b82f6 100%) 0 100%,
+    linear-gradient(0deg, #3b82f6 0%, #ec4899 50%, #3b82f6 100%) 0 0,
+    linear-gradient(0deg, #3b82f6 0%, #ec4899 50%, #3b82f6 100%) 100% 0;
+  background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
+  background-size:
+    200% 3px,
+    200% 3px,
+    3px 200%,
+    3px 200%; /* 将边框从 2px 加粗到 3px */
+  animation: borderRotate 4s linear infinite;
+}
+
+@keyframes borderRotate {
+  0% {
+    background-position:
+      0% 0,
+      0% 100%,
+      0 0%,
+      100% 0%;
+  }
+  100% {
+    background-position:
+      200% 0,
+      -200% 100%,
+      0 -200%,
+      100% 200%;
+  }
+}
+.mf-tag {
+  color: #646cff;
+  font-weight: 500;
+  position: relative;
+  padding-left: 16px;
+}
+
+.mf-tag::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 12px;
+  height: 12px;
+  background-image: url('https://module-federation.io/svg.svg');
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+
+.divider {
+  color: #4a4a4a;
+}
+
+.gradient-text {
+  background: linear-gradient(90deg, #60a5fa, #ec4899);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  font-weight: 500;
+}

--- a/packages/chrome-devtools/src/utils/chrome/ComponentInspector.css
+++ b/packages/chrome-devtools/src/utils/chrome/ComponentInspector.css
@@ -6,15 +6,15 @@
 .inspector-info {
   position: fixed;
   z-index: 1000;
-  background: #1a1a1a;
+  background: #323232;
   padding: 4px 8px;
-  border-radius: 4px;
+  border-radius: 6px;
   font-size: 12px;
   color: #fff;
-  pointer-events: none;
   display: flex;
   align-items: center;
   gap: 8px;
+  justify-content: space-between;
 }
 
 .inspector-overlay {
@@ -22,17 +22,18 @@
   border-radius: 4px;
   pointer-events: none;
   z-index: 999;
+  /* 3b82f6 */
   background:
-    linear-gradient(90deg, #3b82f6 0%, #ec4899 50%, #3b82f6 100%) 0 0,
-    linear-gradient(90deg, #3b82f6 0%, #ec4899 50%, #3b82f6 100%) 0 100%,
-    linear-gradient(0deg, #3b82f6 0%, #ec4899 50%, #3b82f6 100%) 0 0,
-    linear-gradient(0deg, #3b82f6 0%, #ec4899 50%, #3b82f6 100%) 100% 0;
+    linear-gradient(90deg, #656565 0%, #cbcbcb 50%, #656565 100%) 0 0,
+    linear-gradient(90deg, #656565 0%, #cbcbcb 50%, #656565 100%) 0 100%,
+    linear-gradient(0deg, #656565 0%, #cbcbcb 50%, #656565 100%) 0 0,
+    linear-gradient(180deg, #656565 0%, #cbcbcb 50%, #656565 100%) 100% 0;
   background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
   background-size:
-    200% 3px,
-    200% 3px,
-    3px 200%,
-    3px 200%; /* 将边框从 2px 加粗到 3px */
+    200% 2px,
+    200% 2px,
+    2px 200%,
+    2px 200%;
   animation: borderRotate 4s linear infinite;
 }
 
@@ -53,34 +54,31 @@
   }
 }
 .mf-tag {
-  color: #646cff;
-  font-weight: 500;
-  position: relative;
-  padding-left: 16px;
+  color: #cbcbcb;
+  margin-left: 6px;
 }
 
-.mf-tag::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 12px;
-  height: 12px;
-  background-image: url('https://module-federation.io/svg.svg');
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: contain;
+.mf-info {
+  display: flex;
+  align-items: center;
+}
+
+.mf-img {
+  width: 16px;
 }
 
 .divider {
-  color: #4a4a4a;
+  color: #cbcbcb;
 }
 
-.gradient-text {
-  background: linear-gradient(90deg, #60a5fa, #ec4899);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  font-weight: 500;
+.copy-btn {
+  width: 16px;
+  height: 16px;
+  background: #cbcbcb;
+  border: 1px solid #cbcbcb;
+  border-radius: 4px;
+}
+
+.copy-btn:hover {
+  background: #e5e5e5;
 }

--- a/packages/chrome-devtools/src/utils/chrome/ComponentInspector.tsx
+++ b/packages/chrome-devtools/src/utils/chrome/ComponentInspector.tsx
@@ -1,0 +1,85 @@
+import type React from 'react';
+import './ComponentInspector.css';
+
+interface InspectorInfo {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+export const wrapComponent = ({
+  react,
+  CustomComponent,
+  componentName,
+  mfName,
+}: {
+  react: typeof React;
+  CustomComponent: React.ComponentType;
+  componentName: string;
+  mfName: string;
+}) => {
+  const ComponentInspector: React.FC<{
+    children: React.ReactNode;
+    componentName: string;
+    mfName: string;
+  }> = ({ children, componentName, mfName }) => {
+    const [inspectorInfo, setInspectorInfo] =
+      react.useState<InspectorInfo | null>(null);
+
+    const handleMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
+      const rect = e.currentTarget.getBoundingClientRect();
+      setInspectorInfo({
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+      });
+    };
+
+    const handleMouseLeave = () => {
+      setInspectorInfo(null);
+    };
+
+    return (
+      <div
+        className="component-inspector"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        {children}
+        {inspectorInfo && (
+          <>
+            <div
+              className="inspector-info"
+              style={{
+                top: `${inspectorInfo.top - 30}px`,
+                left: `${inspectorInfo.left}px`,
+                width: `${inspectorInfo.width}px`,
+              }}
+            >
+              <span className="mf-tag">{mfName}</span>
+              <span className="divider">|</span>
+              <span className="gradient-text">{componentName}</span>
+            </div>
+            <div
+              className="inspector-overlay"
+              style={{
+                top: `${inspectorInfo.top}px`,
+                left: `${inspectorInfo.left}px`,
+                width: `${inspectorInfo.width}px`,
+                height: `${inspectorInfo.height}px`,
+              }}
+            />
+          </>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <ComponentInspector componentName={componentName} mfName={mfName}>
+      <CustomComponent />
+    </ComponentInspector>
+  );
+};

--- a/packages/chrome-devtools/src/utils/chrome/ComponentInspector.tsx
+++ b/packages/chrome-devtools/src/utils/chrome/ComponentInspector.tsx
@@ -58,10 +58,7 @@ export const wrapComponent = ({
         clearTimeout(leaveTimeout);
       }
       leaveTimeout = setTimeout(() => {
-        if (
-          localStorage.getItem('mf-inspector-show') !== 'all' &&
-          !isMouseOverInspectorInfo
-        ) {
+        if (!isMouseOverInspectorInfo) {
           setInspectorInfo(null);
         }
       }, 50); // Add a small delay to allow mouse to enter the info box

--- a/packages/chrome-devtools/src/utils/chrome/copy.svg
+++ b/packages/chrome-devtools/src/utils/chrome/copy.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 6H38C39.1046 6 40 6.89543 40 8V30" stroke="#656565" stroke-width="4"/>
+<path d="M8 40V16C8 14.8954 8.89543 14 10 14H30C31.1046 14 32 14.8922 32 15.9968V40.0085C32 41.1131 31.1072 42 30.0026 42H9.99552C8.89095 42 8 41.1046 8 40Z" stroke="#656565" stroke-width="4"/>
+</svg>

--- a/packages/chrome-devtools/src/utils/chrome/inspector-plugin.ts
+++ b/packages/chrome-devtools/src/utils/chrome/inspector-plugin.ts
@@ -23,7 +23,13 @@ const inspectorPluginPlugin = (): FederationRuntimePlugin => {
         return;
       }
 
-      const { exposeModuleFactory, exposeModule, remote } = args;
+      const {
+        exposeModuleFactory,
+        exposeModule,
+        remote,
+        expose,
+        moduleInstance,
+      } = args;
       let react: typeof React;
       try {
         // eslint-disable-next-line prettier/prettier
@@ -81,8 +87,11 @@ const inspectorPluginPlugin = (): FederationRuntimePlugin => {
                 //@ts-ignore
                 CustomComponent: mod,
                 //@ts-ignore
-                componentName: mod.name,
+                componentName: expose.replace('./', ''),
                 mfName: remote.name,
+                versionOrEntry:
+                  moduleInstance.remoteInfo.version ||
+                  moduleInstance.remoteInfo.entry,
               });
           }
           // no handle element
@@ -97,8 +106,11 @@ const inspectorPluginPlugin = (): FederationRuntimePlugin => {
             //@ts-ignore
             CustomComponent: exposeModule,
             //@ts-ignore
-            componentName: exposeModule.name,
+            componentName: expose.replace('./', ''),
             mfName: remote.name,
+            versionOrEntry:
+              moduleInstance.remoteInfo.version ||
+              moduleInstance.remoteInfo.entry,
           });
         }
       }

--- a/packages/chrome-devtools/src/utils/chrome/inspector-plugin.ts
+++ b/packages/chrome-devtools/src/utils/chrome/inspector-plugin.ts
@@ -1,0 +1,119 @@
+import type { FederationRuntimePlugin } from '@module-federation/runtime/types';
+import type React from 'react';
+
+import { definePropertyGlobalVal } from '../sdk';
+import { __FEDERATION_DEVTOOLS__ } from '../../template';
+
+const inspectorPluginPlugin = (): FederationRuntimePlugin => {
+  return {
+    name: 'mf-inspector-plugin',
+    async onLoad(args) {
+      let enableInspector = false;
+
+      const devtoolsMessageStr = localStorage.getItem(__FEDERATION_DEVTOOLS__);
+      if (devtoolsMessageStr) {
+        try {
+          const devtoolsMessage = JSON.parse(devtoolsMessageStr);
+          enableInspector = devtoolsMessage?.enableInspector;
+        } catch (e) {
+          console.debug('Fast Refresh Plugin Error: ', e);
+        }
+      }
+      if (!enableInspector) {
+        return;
+      }
+
+      const { exposeModuleFactory, exposeModule, remote } = args;
+      let react: typeof React;
+      try {
+        // eslint-disable-next-line prettier/prettier
+        react = args.options.host.loadShareSync('react')() as typeof React;
+      } catch (e) {
+        console.error('Inspector failed! React lib not found!');
+      }
+      // @ts-expect-error if react not found, return
+      if (!react) {
+        return;
+      }
+      // @ts-expect-error set react lib
+      window._mfReact = react;
+
+      const isReactComponent = (
+        component: any,
+      ): component is React.Component => {
+        const isFunctionComponent = (component: any) => {
+          return (
+            typeof component === 'function' &&
+            !component.prototype?.isReactComponent && // 类组件会有 isReactComponent
+            !component.prototype?.render // 类组件原型有 render 方法
+          );
+        };
+        const isClassComponent = (component: any) => {
+          return (
+            typeof component === 'function' &&
+            component.prototype?.isReactComponent === true &&
+            component.prototype?.render !== undefined
+          );
+        };
+        return isFunctionComponent(component) || isClassComponent(component);
+      };
+      const { wrapComponent } = await import(
+        /* webpackMode: "eager" */ './ComponentInspector'
+      );
+
+      const getMod = (
+        factory: () => React.Component | { default?: React.Component },
+      ) => {
+        const mod = factory();
+        if ('default' in mod) {
+          return mod.default;
+        }
+        return mod;
+      };
+
+      if (exposeModuleFactory) {
+        let factory = () => {
+          const mod = getMod(exposeModuleFactory);
+          if (isReactComponent(mod) && 'name' in mod) {
+            return () =>
+              wrapComponent({
+                react,
+                //@ts-ignore
+                CustomComponent: mod,
+                //@ts-ignore
+                componentName: mod.name,
+                mfName: remote.name,
+              });
+          }
+          // no handle element
+          return mod;
+        };
+        return factory;
+      }
+      if (exposeModule) {
+        if (isReactComponent(exposeModule) && 'name' in exposeModule) {
+          return wrapComponent({
+            react,
+            //@ts-ignore
+            CustomComponent: exposeModule,
+            //@ts-ignore
+            componentName: exposeModule.name,
+            mfName: remote.name,
+          });
+        }
+      }
+      return;
+    },
+  };
+};
+
+if (!window?.__FEDERATION__) {
+  definePropertyGlobalVal(window, '__FEDERATION__', {});
+  definePropertyGlobalVal(window, '__VMOK__', window.__FEDERATION__);
+}
+
+if (!window?.__FEDERATION__.__GLOBAL_PLUGIN__) {
+  window.__FEDERATION__.__GLOBAL_PLUGIN__ = [];
+}
+
+window.__FEDERATION__.__GLOBAL_PLUGIN__?.push(inspectorPluginPlugin());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2340,6 +2340,9 @@ importers:
       react-dom:
         specifier: ~18.3.1
         version: 18.3.1(react@18.3.1)
+      react-toastify:
+        specifier: 11.0.5
+        version: 11.0.5(react-dom@18.3.1)(react@18.3.1)
       reactflow:
         specifier: 11.11.4
         version: 11.11.4(@types/react@18.2.79)(react-dom@18.3.1)(react@18.3.1)
@@ -3207,7 +3210,7 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.25.7
       '@emotion/hash': 0.8.0
       '@emotion/unitless': 0.7.5
       classnames: 2.5.1
@@ -3612,7 +3615,7 @@ packages:
       '@babel/traverse': 7.27.1
       '@babel/types': 7.27.1
       convert-source-map: 1.9.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.21
@@ -3660,7 +3663,7 @@ packages:
       '@babel/traverse': 7.27.1
       '@babel/types': 7.27.1
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3683,7 +3686,7 @@ packages:
       '@babel/traverse': 7.26.9
       '@babel/types': 7.27.0
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3705,7 +3708,7 @@ packages:
       '@babel/traverse': 7.27.1
       '@babel/types': 7.27.1
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3984,7 +3987,7 @@ packages:
       '@babel/core': 7.26.10
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -6164,7 +6167,7 @@ packages:
       '@babel/parser': 7.27.2
       '@babel/template': 7.25.9
       '@babel/types': 7.27.1
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -6178,7 +6181,7 @@ packages:
       '@babel/parser': 7.27.2
       '@babel/template': 7.26.9
       '@babel/types': 7.27.1
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -6192,7 +6195,7 @@ packages:
       '@babel/parser': 7.27.2
       '@babel/template': 7.27.0
       '@babel/types': 7.27.1
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -6207,7 +6210,7 @@ packages:
       '@babel/parser': 7.27.2
       '@babel/template': 7.27.2
       '@babel/types': 7.27.1
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -8685,7 +8688,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -8702,7 +8705,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -8791,7 +8794,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8802,7 +8805,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11972,7 +11975,7 @@ packages:
       '@open-draft/until': 1.0.3
       '@types/debug': 4.1.12
       '@xmldom/xmldom': 0.8.10
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       headers-polyfill: 3.2.5
       outvariant: 1.4.3
       strict-event-emitter: 0.2.8
@@ -17529,7 +17532,7 @@ packages:
       conventional-changelog-writer: 8.0.1
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.1.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       import-from-esm: 2.0.0
       lodash-es: 4.17.21
       micromatch: 4.0.8
@@ -17596,7 +17599,7 @@ packages:
       '@octokit/plugin-throttling': 9.4.0(@octokit/core@6.1.4)
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       dir-glob: 3.0.1
       globby: 14.1.0
       http-proxy-agent: 7.0.2
@@ -17665,7 +17668,7 @@ packages:
       conventional-changelog-writer: 8.0.1
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.1.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       get-stream: 7.0.1
       import-from-esm: 2.0.0
       into-stream: 7.0.0
@@ -18803,7 +18806,7 @@ packages:
       typescript: '>= 3.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -18822,7 +18825,7 @@ packages:
       typescript: '>= 4.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -18841,7 +18844,7 @@ packages:
       typescript: '>= 4.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -19311,7 +19314,7 @@ packages:
       '@swc-node/sourcemap-support': 0.5.1
       '@swc/core': 1.7.26(@swc/helpers@0.5.13)
       colorette: 2.0.20
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       oxc-resolver: 5.2.0
       pirates: 4.0.7
       tslib: 2.8.1
@@ -20725,7 +20728,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.0.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.0.4)
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -20777,7 +20780,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.1
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20798,7 +20801,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -20819,7 +20822,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 9.0.0
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -20899,7 +20902,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.0.4)
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
@@ -20919,7 +20922,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.3)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.1
       ts-api-utils: 1.3.0(typescript@5.7.3)
       typescript: 5.7.3
@@ -20938,7 +20941,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.8.0(typescript@5.7.3)
       '@typescript-eslint/utils': 8.8.0(eslint@8.57.1)(typescript@5.7.3)
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       ts-api-utils: 1.3.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -20982,7 +20985,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -21003,7 +21006,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -21025,7 +21028,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -21047,7 +21050,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -21069,7 +21072,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 8.14.0
       '@typescript-eslint/visitor-keys': 8.14.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -21091,7 +21094,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 8.8.0
       '@typescript-eslint/visitor-keys': 8.8.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -21432,7 +21435,7 @@ packages:
       '@verdaccio/loaders': 8.0.0-next-8.6
       '@verdaccio/signature': 8.0.0-next-8.7
       '@verdaccio/utils': 8.1.0-next-8.15
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       lodash: 4.17.21
       verdaccio-htpasswd: 13.0.0-next-8.15
     transitivePeerDependencies:
@@ -21451,7 +21454,7 @@ packages:
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.15
       '@verdaccio/utils': 8.1.0-next-8.15
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       js-yaml: 4.1.0
       lodash: 4.17.21
       minimatch: 7.4.6
@@ -21485,7 +21488,7 @@ packages:
     resolution: {integrity: sha512-yuqD8uAZJcgzuNHjV6C438UNT5r2Ai9+SnUlO34AHZdWSYcluO3Zj5R3p5uf+C7YPCE31pUD27wBU74xVbUoBw==}
     engines: {node: '>=18'}
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -21512,7 +21515,7 @@ packages:
       '@verdaccio/core': 8.0.0-next-8.15
       '@verdaccio/logger-prettify': 8.0.0-next-8.2
       colorette: 2.0.20
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21543,7 +21546,7 @@ packages:
       '@verdaccio/core': 8.0.0-next-8.15
       '@verdaccio/url': 13.0.0-next-8.15
       '@verdaccio/utils': 8.1.0-next-8.15
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       express: 4.21.2
       express-rate-limit: 5.5.1
       lodash: 4.17.21
@@ -21561,7 +21564,7 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       '@verdaccio/config': 8.0.0-next-8.15
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       jsonwebtoken: 9.0.2
     transitivePeerDependencies:
       - supports-color
@@ -21577,7 +21580,7 @@ packages:
       '@verdaccio/core': 8.0.0-next-8.15
       '@verdaccio/url': 13.0.0-next-8.15
       '@verdaccio/utils': 8.1.0-next-8.15
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       gunzip-maybe: 1.4.2
       lodash: 4.17.21
       tar-stream: 3.1.7
@@ -21592,7 +21595,7 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.15
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       lodash: 4.17.21
       validator: 13.12.0
     transitivePeerDependencies:
@@ -22819,7 +22822,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22827,7 +22830,7 @@ packages:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -26657,7 +26660,6 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 8.1.1
-    dev: true
 
   /debug@4.4.0(supports-color@9.3.1):
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
@@ -26670,6 +26672,7 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 9.3.1
+    dev: true
 
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
@@ -26914,7 +26917,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -27640,7 +27643,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       esbuild: 0.17.19
     transitivePeerDependencies:
       - supports-color
@@ -27651,7 +27654,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
@@ -27662,7 +27665,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       esbuild: 0.23.0
     transitivePeerDependencies:
       - supports-color
@@ -27672,7 +27675,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       esbuild: 0.24.0
     transitivePeerDependencies:
       - supports-color
@@ -27683,7 +27686,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       esbuild: 0.25.0
     transitivePeerDependencies:
       - supports-color
@@ -28071,7 +28074,7 @@ packages:
         optional: true
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 9.0.0
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.0.0)
@@ -28240,7 +28243,7 @@ packages:
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
       hasown: 2.0.2
-      is-core-module: 2.16.1
+      is-core-module: 2.15.1
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.fromentries: 2.0.8
@@ -28277,7 +28280,7 @@ packages:
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.0.0)
       hasown: 2.0.2
-      is-core-module: 2.16.1
+      is-core-module: 2.15.1
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.fromentries: 2.0.8
@@ -28640,7 +28643,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -28686,7 +28689,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.0
@@ -29662,7 +29665,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -31270,7 +31273,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -31280,7 +31283,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -31308,7 +31311,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@types/http-proxy': 1.17.15
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       http-proxy: 1.18.1(debug@4.4.0)
       is-glob: 4.0.3
       is-plain-object: 5.0.0
@@ -31379,7 +31382,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -31389,7 +31392,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -31398,7 +31401,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -31408,7 +31411,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -31565,7 +31568,7 @@ packages:
     resolution: {integrity: sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==}
     engines: {node: '>=18.20'}
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       import-meta-resolve: 4.1.0
     transitivePeerDependencies:
       - supports-color
@@ -32417,7 +32420,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -32429,7 +32432,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -33495,7 +33498,7 @@ packages:
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookies: 0.9.1
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       delegates: 1.0.0
       depd: 2.0.0
       destroy: 1.2.0
@@ -33526,7 +33529,7 @@ packages:
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookies: 0.9.1
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       delegates: 1.0.0
       depd: 2.0.0
       destroy: 1.2.0
@@ -33557,7 +33560,7 @@ packages:
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookies: 0.9.1
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       delegates: 1.0.0
       depd: 2.0.0
       destroy: 1.2.0
@@ -34937,7 +34940,7 @@ packages:
     resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -35416,7 +35419,7 @@ packages:
     resolution: {integrity: sha512-0mvZ1o5F0GStEzsZIrlGAYmLOtrILwMCh2vHAT1J2qZdyCqgMUo/5FBVk1B54pmCZCDxOS8mMm3MAIW5nCDL3w==}
     dependencies:
       '@vercel/nft': 0.27.3(encoding@0.1.13)
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       fs-extra: 11.3.0
       mlly: 1.6.1
       pkg-types: 1.2.1
@@ -38492,7 +38495,7 @@ packages:
     engines: {node: '>=8.16.0'}
     dependencies:
       '@types/mime-types': 2.1.4
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -40642,6 +40645,17 @@ packages:
       scheduler: 0.23.2
     dev: true
 
+  /react-toastify@11.0.5(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    dependencies:
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /react-transition-group@4.4.5(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -42553,7 +42567,7 @@ packages:
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.3)
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.7.3)
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       env-ci: 11.1.0
       execa: 9.5.2
       figures: 6.1.0
@@ -42664,7 +42678,7 @@ packages:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -43199,7 +43213,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -43212,7 +43226,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -43512,7 +43526,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -43991,7 +44005,7 @@ packages:
     hasBin: true
     dependencies:
       '@adobe/css-tools': 4.3.3
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       glob: 10.4.5
       sax: 1.4.1
       source-map: 0.7.4
@@ -44058,6 +44072,7 @@ packages:
   /supports-color@9.3.1:
     resolution: {integrity: sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==}
     engines: {node: '>=12'}
+    dev: true
 
   /supports-hyperlinks@3.2.0:
     resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
@@ -45454,7 +45469,7 @@ packages:
       bundle-require: 4.2.1(esbuild@0.19.2)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       esbuild: 0.19.2
       execa: 5.1.1
       globby: 11.1.0
@@ -45496,7 +45511,7 @@ packages:
       cac: 6.7.14
       chokidar: 4.0.1
       consola: 3.2.3
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       esbuild: 0.24.0
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -46371,7 +46386,7 @@ packages:
       apache-md5: 1.1.8
       bcryptjs: 2.4.3
       core-js: 3.40.0
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       http-errors: 2.0.0
       unix-crypt-td-js: 1.1.4
     transitivePeerDependencies:
@@ -46402,7 +46417,7 @@ packages:
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       compression: 1.8.0
       cors: 2.8.5
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       envinfo: 7.14.0
       express: 4.21.2
       handlebars: 4.7.8
@@ -46510,7 +46525,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.1.1
       vite: 5.4.18(@types/node@20.12.14)(less@4.3.0)(stylus@0.64.0)
@@ -46532,7 +46547,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.1.1
       vite: 5.4.18(@types/node@18.16.9)(less@4.3.0)(stylus@0.64.0)
@@ -46951,7 +46966,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.4.0(supports-color@9.3.1)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.1
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3


### PR DESCRIPTION
## Description

add inspector for chrom devtools 

Turn on the switch, and then hover the compoent which is loaded by mf , it will auto appear the border, showing the moduleName, mfName, versionOrEntry

And support copy mf info . 

![inspector](https://github.com/user-attachments/assets/4675793d-3bfd-4811-8ac6-25a7aacab730)

Set `localStorage.setItem('mf-inspector-show','all')`, it will auto show the border for all remote react components


![image](https://github.com/user-attachments/assets/608e19e6-5df6-49c9-9ff7-c90ac4205363)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
