### PR TITLE
fix(rsbuild-plugin): judge options from orignal userConfig

### DIFF
--- a/.changeset/nice-windows-stare.md
+++ b/.changeset/nice-windows-stare.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rsbuild-plugin': patch
+---
+
+fix(rsbuild-plugin): judge options from orignal userConfig

--- a/packages/rsbuild-plugin/src/cli/index.ts
+++ b/packages/rsbuild-plugin/src/cli/index.ts
@@ -178,13 +178,17 @@ export const pluginModuleFederation = (
       if (moduleFederationOptions.exposes) {
         config.dev ||= {};
         config.server ||= {};
+        const userConfig = api.getRsbuildConfig('original');
 
         // Allow remote modules to be loaded by setting CORS headers
         // This is required for MF to work properly across different origins
         config.server.headers ||= {};
         if (
           !config.server.headers['Access-Control-Allow-Origin'] &&
-          !config.server.cors
+          !(
+            typeof userConfig.server?.cors === 'object' &&
+            userConfig.server.cors.origin
+          )
         ) {
           const corsWarnMsgs = [
             'Detect that CORS options are not set, mf Rsbuild plugin will add default cors header: server.headers["Access-Control-Allow-Headers"] = "*". It is recommended to specify an allowlist of trusted origins in "server.cors" instead.',


### PR DESCRIPTION
## Description

* judge options from orignal userConfig
* wanring if not set server.cors.origin ( for most users , online consumer + local provider is quite normal , so need to set origin option to avoid cors )

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
