### PR TITLE
fix(dts-plugin): add dynamic-remote-type-hints-plugin to runtimePlugins if not disable

### DIFF
--- a/.changeset/quiet-bottles-unite.md
+++ b/.changeset/quiet-bottles-unite.md
@@ -1,0 +1,7 @@
+---
+'@module-federation/dts-plugin': patch
+'@module-federation/enhanced': patch
+'@module-federation/rspack': patch
+---
+
+fix(dts-plugin): add dynamic-remote-type-hints-plugin to runtimePlugins if not disable

--- a/packages/dts-plugin/src/plugins/DtsPlugin.ts
+++ b/packages/dts-plugin/src/plugins/DtsPlugin.ts
@@ -37,15 +37,15 @@ export const normalizeDtsOptions = (
 
 export class DtsPlugin implements WebpackPluginInstance {
   options: moduleFederationPlugin.ModuleFederationPluginOptions;
+  clonedOptions: moduleFederationPlugin.ModuleFederationPluginOptions;
   constructor(options: moduleFederationPlugin.ModuleFederationPluginOptions) {
     this.options = options;
+    // Create a shallow clone of the options object to avoid mutating the original
+    this.clonedOptions = { ...options };
   }
 
   apply(compiler: Compiler) {
-    const { options } = this;
-
-    // Create a shallow clone of the options object to avoid mutating the original
-    const clonedOptions = { ...options };
+    const { options, clonedOptions } = this;
 
     // Clean up query parameters in exposes paths without mutating original
     if (options.exposes && typeof options.exposes === 'object') {
@@ -105,5 +105,19 @@ export class DtsPlugin implements WebpackPluginInstance {
       normalizedDtsOptions,
       fetchRemoteTypeUrlsResolve,
     ).apply(compiler);
+  }
+
+  addRuntimePlugins() {
+    const { options, clonedOptions } = this;
+    if (!clonedOptions.runtimePlugins) {
+      return;
+    }
+    if (!options.runtimePlugins) {
+      options.runtimePlugins = [];
+    }
+    clonedOptions.runtimePlugins.forEach((plugin) => {
+      options.runtimePlugins.includes(plugin) ||
+        options.runtimePlugins.push(plugin);
+    });
   }
 }

--- a/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
+++ b/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
@@ -114,7 +114,9 @@ class ModuleFederationPlugin implements WebpackPluginInstance {
     }
 
     if (options.dts !== false) {
-      new DtsPlugin(options).apply(compiler);
+      const dtsPlugin = new DtsPlugin(options);
+      dtsPlugin.apply(compiler);
+      dtsPlugin.addRuntimePlugins();
     }
     if (options.dataPrefetch) {
       new PrefetchPlugin(options).apply(compiler);

--- a/packages/rspack/src/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/ModuleFederationPlugin.ts
@@ -114,8 +114,10 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
     let disableDts = options.dts === false;
 
     if (!disableDts) {
+      const dtsPlugin = new DtsPlugin(options);
       // @ts-ignore
-      new DtsPlugin(options).apply(compiler);
+      dtsPlugin.apply(compiler);
+      dtsPlugin.addRuntimePlugins();
     }
     if (!disableManifest && options.exposes) {
       try {


### PR DESCRIPTION
## Description

add dynamic-remote-type-hints-plugin to runtimePlugins if not disable

## Related Issue
https://github.com/module-federation/core/issues/3737
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
