### PR TITLE
chore(dts-plugin): check types archive url and optimize the error msg

### DIFF
--- a/.changeset/silly-experts-begin.md
+++ b/.changeset/silly-experts-begin.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+chore(dts-plugin): check types archive url and optimize the error msg

--- a/packages/dts-plugin/src/core/lib/archiveHandler.test.ts
+++ b/packages/dts-plugin/src/core/lib/archiveHandler.test.ts
@@ -298,7 +298,7 @@ describe('archiveHandler', () => {
       // Only verify the URL and responseType
       const axiosGetMock = vi.mocked(axios.get);
       const [[url, options]] = axiosGetMock.mock.calls;
-      expect(url).toBe(fileToDownload);
+      expect(url).toBe(new URL(fileToDownload).href);
       expect(options.responseType).toBe('arraybuffer');
     });
 

--- a/packages/dts-plugin/src/core/lib/archiveHandler.ts
+++ b/packages/dts-plugin/src/core/lib/archiveHandler.ts
@@ -60,7 +60,7 @@ export const downloadTypesArchive = (hostOptions: Required<HostOptions>) => {
 
     while (retries++ < hostOptions.maxRetries) {
       try {
-        const url = fileToDownload;
+        const url = new URL(fileToDownload).href;
         const response = await axiosGet(url, {
           responseType: 'arraybuffer',
           timeout: hostOptions.timeout,
@@ -107,7 +107,7 @@ export const downloadTypesArchive = (hostOptions: Required<HostOptions>) => {
         );
         if (retries >= hostOptions.maxRetries) {
           logger.error(
-            `Failed to download ${fileToDownload}, you can set FEDERATION_DEBUG=true to see detail message.`,
+            `Failed to download types archive from "${fileToDownload}". Set FEDERATION_DEBUG=true for details.`,
           );
           if (hostOptions.abortOnError !== false) {
             throw error;


### PR DESCRIPTION
## Description

check types archive url and optimize the error msg

before

```
[ Module Federation DTS ] Failed to download /@mf-types.zip, you can set FEDERATION_DEBUG=true to see detail message. 
```

after
```
Failed to download types archive from "/@mf-types.zip". Set FEDERATION_DEBUG=true for details.
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
