### PR TITLE
fix: allow extensions other than `.js` for non-manifest entries

### DIFF
--- a/.changeset/bright-beds-obey.md
+++ b/.changeset/bright-beds-obey.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime-core': patch
+---
+
+Allow extensions other than .js for non-manifest entries

--- a/packages/runtime-core/src/utils/tool.ts
+++ b/packages/runtime-core/src/utils/tool.ts
@@ -34,7 +34,7 @@ export function isRemoteInfoWithEntry(
 }
 
 export function isPureRemoteEntry(remote: RemoteWithEntry): boolean {
-  return !remote.entry.includes('.json') && remote.entry.includes('.js');
+  return !remote.entry.includes('.json');
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description

Currently, all remote entries must have `.json` or `.js` in their name - in RN & when working on MF in Metro, the output usually ends with `.bundle` and this limitation gets in the way in runtime. 

I'm marking this as a fix since there is no trace of having this as an actual requirement

## Related Issue

n/a

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
