### PR TITLE
Update getpublicpath.mdx

### DIFF
--- a/apps/website-new/docs/en/configure/getpublicpath.mdx
+++ b/apps/website-new/docs/en/configure/getpublicpath.mdx
@@ -13,6 +13,10 @@ In the example below, `getPublicPath` is set. When other consumers load this pro
 ```getPublicPath``` Must be a function as a string.
 :::
 
+:::tip NOTE
+If you're using module federation webpack plugin and want to set a dynamic publicPath, you should set `__webpack_public_path__ = window.cdn_prefix` statement in `getPublicPath` function body.
+:::
+
 ```ts title="rspack.config.ts"
 module.exports = {
   plugins: [


### PR DESCRIPTION
Using getPublicPath with Webpack Module Federation Plugin

## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
A tip for getPublicPath config in webpack plugin

```js
module.exports = {
  plugins: [
    new ModuleFederation({
      name: 'provider',
      exposes: {
        './Button': './src/components/Button.tsx',
      },
      // ...
      getPublicPath: `function() {__webpack_public_path = "https:" + window.navigator.cdn_host + "/resource/app/"}`,
    }),
  ],
};
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
