### PR TITLE
docs(website-new): fix code formatting on Federation Runtime example

### DIFF
--- a/apps/website-new/docs/en/guide/basic/runtime.mdx
+++ b/apps/website-new/docs/en/guide/basic/runtime.mdx
@@ -46,7 +46,7 @@ init({
       entry: "http://localhost:3006/remoteEntry.js",
       alias: "app2"
     },
-{
+    {
       name: "@demo/app4",
       entry: "http://localhost:3006/remoteEntry.mjs",
       alias: "app2",


### PR DESCRIPTION
## Description

This fixes a minor formatting issue on the Federation Runtime docs where a brace isn't indented properly.

## Related Issue

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
