### PR TITLE
fix(storybook-addon): set uniqueName in storybook addon instead of rsbuild plugin

### DIFF
--- a/.changeset/silent-cats-argue.md
+++ b/.changeset/silent-cats-argue.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/storybook-addon': patch
+'@module-federation/rsbuild-plugin': patch
+---
+
+fix(storybook-addon): set uniqueName in storybook addon instead of rsbuild plugin

--- a/packages/rsbuild-plugin/src/cli/index.ts
+++ b/packages/rsbuild-plugin/src/cli/index.ts
@@ -236,7 +236,7 @@ export const pluginModuleFederation = (
         if (!isMFFormat(bundlerConfig)) {
           return;
         } else if (isStoryBook(originalRsbuildConfig)) {
-          bundlerConfig.output!.uniqueName = `${moduleFederationOptions.name}-storybook-host`;
+          return;
         } else {
           // mf
           autoDeleteSplitChunkCacheGroups(

--- a/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
+++ b/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
@@ -76,6 +76,7 @@ export const withModuleFederation = (
             shareStrategy: options.shareStrategy,
           },
         ]);
+        chain.output.uniqueName(`${options.name}-storybook-host`);
       });
     },
   };


### PR DESCRIPTION


## Description

Because rsbuild plugin can be used both in `rslibConfig.lib[index].plugins` and `rslibConfig.plugins` , so need to set 
uniqueName in storybook addon, to prevent not set the uniqueName in time.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
