### PR TITLE
feat(dts-plugin): added flag to fetch types

### DIFF
--- a/.changeset/large-actors-fly.md
+++ b/.changeset/large-actors-fly.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/dts-plugin': minor
+'@module-federation/sdk': minor
+---
+
+added flag to fetch types from remote when building in production.

--- a/packages/dts-plugin/src/core/configurations/hostPlugin.test.ts
+++ b/packages/dts-plugin/src/core/configurations/hostPlugin.test.ts
@@ -43,6 +43,7 @@ describe('hostPlugin', () => {
           runtimePkgs: [],
           remoteTypeUrls: {},
           timeout: 60000,
+          typesOnBuild: false,
         });
 
         expect(mapRemotesToDownload).toStrictEqual({
@@ -70,6 +71,7 @@ describe('hostPlugin', () => {
           runtimePkgs: [],
           remoteTypeUrls: {},
           timeout: 60000,
+          typesOnBuild: false,
         };
 
         const { hostOptions, mapRemotesToDownload } =

--- a/packages/dts-plugin/src/core/configurations/hostPlugin.ts
+++ b/packages/dts-plugin/src/core/configurations/hostPlugin.ts
@@ -19,6 +19,7 @@ const defaultOptions = {
   runtimePkgs: [],
   remoteTypeUrls: {},
   timeout: 60000,
+  typesOnBuild: false,
 } satisfies Partial<HostOptions>;
 
 const buildZipUrl = (hostOptions: Required<HostOptions>, url: string) => {

--- a/packages/dts-plugin/src/plugins/ConsumeTypesPlugin.ts
+++ b/packages/dts-plugin/src/plugins/ConsumeTypesPlugin.ts
@@ -15,6 +15,7 @@ import type { Compiler, WebpackPluginInstance } from 'webpack';
 export const DEFAULT_CONSUME_TYPES = {
   abortOnError: false,
   consumeAPITypes: true,
+  typesOnBuild: false,
 };
 
 export const normalizeConsumeTypesOptions = ({
@@ -99,11 +100,6 @@ export class ConsumeTypesPlugin implements WebpackPluginInstance {
   apply(compiler: Compiler) {
     const { dtsOptions, pluginOptions, fetchRemoteTypeUrlsResolve } = this;
 
-    if (isPrd()) {
-      fetchRemoteTypeUrlsResolve(undefined);
-      return;
-    }
-
     const dtsManagerOptions = normalizeConsumeTypesOptions({
       context: compiler.context,
       dtsOptions,
@@ -111,6 +107,11 @@ export class ConsumeTypesPlugin implements WebpackPluginInstance {
     });
 
     if (!dtsManagerOptions) {
+      fetchRemoteTypeUrlsResolve(undefined);
+      return;
+    }
+
+    if (isPrd() && !dtsManagerOptions.host.typesOnBuild) {
       fetchRemoteTypeUrlsResolve(undefined);
       return;
     }

--- a/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
+++ b/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
@@ -156,6 +156,7 @@ export interface DtsHostOptions {
   runtimePkgs?: string[];
   remoteTypeUrls?: (() => Promise<RemoteTypeUrls>) | RemoteTypeUrls;
   timeout?: number;
+  typesOnBuild?: boolean;
 }
 
 export interface DtsRemoteOptions {


### PR DESCRIPTION
@module-federation/enhanced/rspack dts-plugin should allow fetching remote types in NODE_ENV=production #3573

fix #3573

## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
