### PR TITLE
fix(modern-js-plugin): use contenthash instead of chunkhash

### DIFF
--- a/.changeset/ninety-points-impress.md
+++ b/.changeset/ninety-points-impress.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/nextjs-mf': patch
+'@module-federation/node': patch
+---
+
+fix(node): use contenthash instead of chunkhash

--- a/.changeset/sour-dragons-hang.md
+++ b/.changeset/sour-dragons-hang.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/rsbuild-plugin': patch
+'@module-federation/modern-js': patch
+---
+
+fix(modern-js-plugin): use contenthash instead of chunkhash

--- a/apps/node-host/webpack.config.js
+++ b/apps/node-host/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = composePlugins(withNx(), async (config) => {
   config.devtool = false;
   config.target = 'async-node';
   config.output.publicPath = '/testing';
-  config.output.chunkFilename = '[id]-[chunkhash].js';
+  config.output.chunkFilename = '[id]-[contenthash].js';
   config.optimization.chunkIds = 'named';
   await new Promise((r) => setTimeout(r, 400));
   config.module.rules.pop();

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -353,7 +353,7 @@ export function patchBundlerConfig(options: {
       uniqueName &&
       !chunkFileName.includes(uniqueName)
     ) {
-      const suffix = `${encodeName(uniqueName)}-[chunkhash].js`;
+      const suffix = `${encodeName(uniqueName)}-[contenthash].js`;
       chain.output.chunkFilename(chunkFileName.replace('.js', suffix));
     }
   }

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
@@ -62,7 +62,7 @@ export function applyServerPlugins(
 ): void {
   const chunkFileName = compiler.options?.output?.chunkFilename;
   const uniqueName = compiler?.options?.output?.uniqueName || options.name;
-  const suffix = `-[chunkhash].js`;
+  const suffix = `-[contenthash].js`;
 
   // Modify chunk filename to include a unique suffix if not already present
   if (

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -46,7 +46,7 @@ const { ModuleFederationPlugin } = require('@module-federation/enhanced');
 const options = {
   target: 'async-node',
   output: {
-    chunkFilename: '[id]-[chunkhash].js', // important to hash chunks
+    chunkFilename: '[id]-[contenthash].js', // important to hash chunks
   },
   plugins: [
     new ModuleFederationPlugin({

--- a/packages/node/src/plugins/NodeFederationPlugin.ts
+++ b/packages/node/src/plugins/NodeFederationPlugin.ts
@@ -87,7 +87,7 @@ class NodeFederationPlugin {
       uniqueName &&
       !chunkFileName.includes(uniqueName)
     ) {
-      const suffix = `-[chunkhash].js`;
+      const suffix = `-[contenthash].js`;
       compiler.options.output.chunkFilename = chunkFileName.replace(
         '.js',
         suffix,

--- a/packages/node/src/plugins/UniversalFederationPlugin.ts
+++ b/packages/node/src/plugins/UniversalFederationPlugin.ts
@@ -71,7 +71,7 @@ class UniversalFederationPlugin {
       uniqueName &&
       !chunkFileName.includes(uniqueName)
     ) {
-      const suffix = `-[chunkhash].js`;
+      const suffix = `-[contenthash].js`;
       compiler.options.output.chunkFilename = chunkFileName.replace(
         '.js',
         suffix,

--- a/packages/rsbuild-plugin/src/utils/ssr.spec.ts
+++ b/packages/rsbuild-plugin/src/utils/ssr.spec.ts
@@ -138,7 +138,7 @@ describe('patchSSRRspackConfig', () => {
       };
       const patchedConfig = patchSSRRspackConfig(config, mfConfig, 'ssr');
       expect(patchedConfig.output?.chunkFilename).toBe(
-        'js/[name]myApp-[chunkhash].js',
+        'js/[name]myApp-[contenthash].js',
       );
     });
 
@@ -154,7 +154,7 @@ describe('patchSSRRspackConfig', () => {
       const mfConfig: moduleFederationPlugin.ModuleFederationPluginOptions = {}; // No name in mfConfig
       const patchedConfig = patchSSRRspackConfig(config, mfConfig, 'ssr');
       expect(patchedConfig.output?.chunkFilename).toBe(
-        'js/[name]myOutputUniqueName-[chunkhash].js',
+        'js/[name]myOutputUniqueName-[contenthash].js',
       );
     });
 

--- a/packages/rsbuild-plugin/src/utils/ssr.ts
+++ b/packages/rsbuild-plugin/src/utils/ssr.ts
@@ -57,7 +57,7 @@ export function patchSSRRspackConfig(
     uniqueName &&
     !chunkFileName.includes(uniqueName)
   ) {
-    const suffix = `${encodeName(uniqueName)}-[chunkhash].js`;
+    const suffix = `${encodeName(uniqueName)}-[contenthash].js`;
     config.output.chunkFilename = chunkFileName.replace('.js', suffix);
   }
 


### PR DESCRIPTION
## Description

chunkhash can not guarantee filename the same and module id the same.

like below example

```diff
// build 1  a.7e6basdf1.js

exports.ids = ["3"]; exports.modules = {

- 7068:function(){} 
}

// build 2  a.7e6basdf1.js

exports.ids = ["3"]; exports.modules = {
+ 6262:function(){} 
}

```

and if hit the cdn catch, app will crash.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
