### PR TITLE
fix(rsbuild-plugin): correct ESM output extension

### DIFF
--- a/packages/rsbuild-plugin/package.json
+++ b/packages/rsbuild-plugin/package.json
@@ -15,22 +15,22 @@
   "exports": {
     ".": {
       "types": "./dist/index.cjs.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.esm.mjs",
       "require": "./dist/index.cjs.js"
     },
     "./utils": {
       "types": "./dist/utils.cjs.d.ts",
-      "import": "./dist/utils.esm.js",
+      "import": "./dist/utils.esm.mjs",
       "require": "./dist/utils.cjs.js"
     },
     "./constant": {
       "types": "./dist/constant.cjs.d.ts",
-      "import": "./dist/constant.esm.js",
+      "import": "./dist/constant.esm.mjs",
       "require": "./dist/constant.cjs.js"
     }
   },
   "main": "./dist/index.cjs.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.esm.mjs",
   "typesVersions": {
     "*": {
       ".": [

--- a/packages/rsbuild-plugin/rollup.config.js
+++ b/packages/rsbuild-plugin/rollup.config.js
@@ -16,5 +16,13 @@ module.exports = (rollupConfig, _projectOptions) => {
     utils: 'packages/rsbuild-plugin/src/utils/index.ts',
     constant: 'packages/rsbuild-plugin/src/constant.ts',
   };
+
+  rollupConfig.output.forEach((output) => {
+    output.entryFileNames = `[name].${output.format === 'esm' ? 'esm' : 'cjs'}.${
+      output.format === 'esm' ? 'mjs' : 'js'
+    }`;
+  });
+
+  // rollupConfig
   return rollupConfig;
 };


### PR DESCRIPTION
## Description

Correct ESM output extension, without `type: "module"`, we must set the extension to `.mjs` to comply with the specifications of Node.js.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
