### PR TITLE
refactor(runtime): reuse the buildId variable

### DIFF
--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -16,7 +16,7 @@ export function getGlobalFederationInstance(
 ): FederationHost | undefined {
   const buildId = getBuilderId();
   return CurrentGlobal.__FEDERATION__.__INSTANCES__.find((GMInstance) => {
-    if (buildId && GMInstance.options.id === getBuilderId()) {
+    if (buildId && GMInstance.options.id === buildId) {
       return true;
     }
 


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

We can reuse the `buildId` unless there are specific concerns.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
