### PR TITLE
fix: set files on runtime-tools pkg

### DIFF
--- a/.changeset/tidy-foxes-fix.md
+++ b/.changeset/tidy-foxes-fix.md
@@ -1,0 +1,8 @@
+---
+"@module-federation/runtime-tools": patch
+---
+
+fix: add files property to package.json to exclude build config from npm publish
+
+Fixes #3873 where .swcrc file was being published to npm causing Jest test failures.
+Only dist/ and README.md will now be included in the published package.

--- a/packages/runtime-tools/package.json
+++ b/packages/runtime-tools/package.json
@@ -12,6 +12,10 @@
     "url": "https://github.com/module-federation/core/",
     "directory": "packages/runtime-tools"
   },
+  "files": [
+    "dist/",
+    "README.md"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Description
This pull request includes a small change to the `packages/runtime-tools/package.json` file. The change specifies which files should be included during publishing by adding a `files` field with `dist/` and `README.md` listed.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
