### PR TITLE
Share flalback

### DIFF
--- a/apps/3000-home/package.json
+++ b/apps/3000-home/package.json
@@ -11,7 +11,7 @@
     "react-dom": "19.0.0"
   },
   "devDependencies": {
-    "@module-federation/nextjs-mf": "0.0.0-next-20250701105507",
+    "@module-federation/nextjs-mf": "workspace:*",
     "@module-federation/runtime": "workspace:*",
     "webpack": "^5.98.0"
   },

--- a/packages/enhanced/src/lib/sharing/ConsumeSharedPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/ConsumeSharedPlugin.ts
@@ -481,9 +481,13 @@ class ConsumeSharedPlugin {
               }
               const { context, request, contextInfo } = resolveData;
 
-              const match = unresolvedConsumes.get(
-                createLookupKeyForSharing(request, contextInfo.issuerLayer),
-              );
+              const match =
+                unresolvedConsumes.get(
+                  createLookupKeyForSharing(request, contextInfo.issuerLayer),
+                ) ||
+                unresolvedConsumes.get(
+                  createLookupKeyForSharing(request, undefined),
+                );
 
               // First check direct match with original request
               if (match !== undefined) {
@@ -511,12 +515,19 @@ class ConsumeSharedPlugin {
 
                 // Try to match with module path after node_modules
                 if (modulePathAfterNodeModules) {
-                  const moduleMatch = unresolvedConsumes.get(
-                    createLookupKeyForSharing(
-                      modulePathAfterNodeModules,
-                      contextInfo.issuerLayer,
-                    ),
-                  );
+                  const moduleMatch =
+                    unresolvedConsumes.get(
+                      createLookupKeyForSharing(
+                        modulePathAfterNodeModules,
+                        contextInfo.issuerLayer,
+                      ),
+                    ) ||
+                    unresolvedConsumes.get(
+                      createLookupKeyForSharing(
+                        modulePathAfterNodeModules,
+                        undefined,
+                      ),
+                    );
 
                   if (
                     moduleMatch !== undefined &&
@@ -532,12 +543,16 @@ class ConsumeSharedPlugin {
                 }
 
                 // Try to match with the full reconstructed path
-                const reconstructedMatch = unresolvedConsumes.get(
-                  createLookupKeyForSharing(
-                    reconstructed,
-                    contextInfo.issuerLayer,
-                  ),
-                );
+                const reconstructedMatch =
+                  unresolvedConsumes.get(
+                    createLookupKeyForSharing(
+                      reconstructed,
+                      contextInfo.issuerLayer,
+                    ),
+                  ) ||
+                  unresolvedConsumes.get(
+                    createLookupKeyForSharing(reconstructed, undefined),
+                  );
 
                 if (reconstructedMatch !== undefined) {
                   return boundCreateConsumeSharedModule(

--- a/packages/enhanced/test/unit/sharing/ConsumeSharedPlugin.test.ts
+++ b/packages/enhanced/test/unit/sharing/ConsumeSharedPlugin.test.ts
@@ -15,7 +15,8 @@ import { satisfy } from '@module-federation/runtime-tools/runtime-core';
 
 // Create webpack mock
 const webpack = createWebpackMock();
-// Create Module mock
+// Create Module mock - Module class is created but not directly used
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const Module = createModuleMock(webpack);
 // Create ConsumeShared dependencies
 const { MockConsumeSharedDependency, MockConsumeSharedFallbackDependency } =
@@ -31,6 +32,13 @@ jest.mock('@module-federation/sdk/normalize-webpack-path', () => ({
   normalizeWebpackPath: jest.fn((path) => path),
   getWebpackPath: jest.fn(() => 'mocked-webpack-path'),
 }));
+
+// Mock ProvideForSharedDependency
+jest.mock('../../../src/lib/sharing/ProvideForSharedDependency', () => {
+  return jest.fn().mockImplementation(() => {
+    return {};
+  });
+});
 
 // Mock FederationRuntimePlugin
 jest.mock('../../../src/lib/container/runtime/FederationRuntimePlugin', () => {
@@ -78,11 +86,31 @@ jest.mock(
   { virtual: true },
 );
 
+// Mock ProvideForSharedDependency
+jest.mock(
+  '../../../src/lib/sharing/ProvideForSharedDependency',
+  () => {
+    return class ProvideForSharedDependency {
+      // Empty class to satisfy instanceof checks
+    };
+  },
+  { virtual: true },
+);
+
 // Mock resolveMatchedConfigs module
 jest.mock('../../../src/lib/sharing/resolveMatchedConfigs');
 
-// Mock utils module
-jest.mock('../../../src/lib/sharing/utils');
+// Mock utils module - only mock specific functions
+jest.mock('../../../src/lib/sharing/utils', () => {
+  const actual = jest.requireActual('../../../src/lib/sharing/utils');
+  return {
+    ...actual,
+    getDescriptionFile: jest.fn(),
+    addSingletonFilterWarning: jest.fn(),
+    extractPathAfterNodeModules: jest.fn(),
+    testRequestFilters: jest.fn(),
+  };
+});
 
 // Mock ConsumeSharedModule (Restore)
 jest.mock('../../../src/lib/sharing/ConsumeSharedModule', () => {
@@ -107,7 +135,17 @@ const ConsumeSharedPlugin =
 const {
   resolveMatchedConfigs,
 } = require('../../../src/lib/sharing/resolveMatchedConfigs');
-const { getDescriptionFile } = require('../../../src/lib/sharing/utils');
+const {
+  getDescriptionFile,
+  addSingletonFilterWarning,
+  extractPathAfterNodeModules,
+  testRequestFilters,
+} = require('../../../src/lib/sharing/utils');
+// These dependencies are used internally by the plugin through mocks
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const ProvideForSharedDependency = require('../../../src/lib/sharing/ProvideForSharedDependency');
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const ConsumeSharedFallbackDependency = MockConsumeSharedFallbackDependency;
 
 describe('ConsumeSharedPlugin', () => {
   // --- Global beforeEach for default mocks ---
@@ -143,7 +181,6 @@ describe('ConsumeSharedPlugin', () => {
       });
 
       // Test private property is set correctly
-      // @ts-ignore accessing private property for testing
       const consumes = plugin._consumes;
 
       expect(consumes.length).toBe(1);
@@ -160,7 +197,6 @@ describe('ConsumeSharedPlugin', () => {
         },
       });
 
-      // @ts-ignore accessing private property for testing
       const consumes = plugin._consumes;
       const [, config] = consumes[0];
 
@@ -180,7 +216,6 @@ describe('ConsumeSharedPlugin', () => {
         },
       });
 
-      // @ts-ignore accessing private property for testing
       const consumes = plugin._consumes;
       const [, config] = consumes[0];
 
@@ -202,7 +237,6 @@ describe('ConsumeSharedPlugin', () => {
         },
       });
 
-      // @ts-ignore accessing private property for testing
       const consumes = plugin._consumes;
       const [, config] = consumes[0];
 
@@ -663,6 +697,1080 @@ describe('ConsumeSharedPlugin', () => {
     });
   });
 
+  describe('include functionality', () => {
+    let testEnv: any;
+
+    beforeEach(() => {
+      testEnv = createSharingTestEnvironment();
+      mockConsumeSharedModule.mockClear();
+      (getDescriptionFile as jest.Mock).mockReset();
+      (satisfy as jest.Mock).mockReset();
+
+      (resolveMatchedConfigs as jest.Mock).mockReturnValue(
+        Promise.resolve({
+          resolved: new Map(),
+          unresolved: new Map(),
+          prefixed: new Map(),
+        }),
+      );
+    });
+
+    describe('version-based inclusion', () => {
+      it('should include module when package version matches include.version', async () => {
+        const testConfig = {
+          import: './react-fallback',
+          shareScope: 'test-scope',
+          shareKey: 'react',
+          requiredVersion: '^17.0.0',
+          include: {
+            version: '^17.0.0',
+          },
+          request: 'react',
+        };
+        const plugin = new ConsumeSharedPlugin({
+          consumes: { react: testConfig },
+        });
+        plugin.apply(testEnv.compiler);
+        testEnv.simulateCompilation();
+
+        (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(
+          async () => ({
+            resolved: new Map(),
+            unresolved: new Map([['react', testConfig]]),
+            prefixed: new Map(),
+          }),
+        );
+
+        testEnv.mockResolver.resolve.mockImplementationOnce(
+          (ctx, context, request, resolveContext, callback) => {
+            callback(null, '/mock/fallback/react');
+          },
+        );
+
+        (getDescriptionFile as jest.Mock).mockImplementationOnce(
+          (fs, context, files, callback) => {
+            callback(null, { data: { name: 'react', version: '17.0.2' } }, [
+              'package.json',
+            ]);
+          },
+        );
+
+        (satisfy as jest.Mock).mockImplementationOnce(() => true);
+
+        const result = await plugin.createConsumeSharedModule(
+          testEnv.mockCompilation,
+          '/mock/context',
+          'react',
+          testConfig,
+        );
+
+        expect(result).toBeDefined();
+        expect(satisfy).toHaveBeenCalledWith('17.0.2', '^17.0.0');
+        expect(result).toHaveProperty('options', {
+          ...testConfig,
+          importResolved: '/mock/fallback/react',
+        });
+      });
+
+      it('should exclude module when package version does not match include.version', async () => {
+        const testConfig = {
+          import: './react-fallback',
+          shareScope: 'test-scope',
+          shareKey: 'react',
+          requiredVersion: '^17.0.0',
+          include: {
+            version: '^16.0.0',
+          },
+          request: 'react',
+        };
+        const plugin = new ConsumeSharedPlugin({
+          consumes: { react: testConfig },
+        });
+        plugin.apply(testEnv.compiler);
+        testEnv.simulateCompilation();
+
+        (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(
+          async () => ({
+            resolved: new Map(),
+            unresolved: new Map([['react', testConfig]]),
+            prefixed: new Map(),
+          }),
+        );
+
+        testEnv.mockResolver.resolve.mockImplementationOnce(
+          (ctx, context, request, resolveContext, callback) => {
+            callback(null, '/mock/fallback/react');
+          },
+        );
+
+        (getDescriptionFile as jest.Mock).mockImplementationOnce(
+          (fs, context, files, callback) => {
+            callback(null, { data: { name: 'react', version: '17.0.2' } }, [
+              'package.json',
+            ]);
+          },
+        );
+
+        (satisfy as jest.Mock).mockImplementationOnce(() => false);
+
+        const result = await plugin.createConsumeSharedModule(
+          testEnv.mockCompilation,
+          '/mock/context',
+          'react',
+          testConfig,
+        );
+
+        expect(result).toBeUndefined();
+        expect(satisfy).toHaveBeenCalledWith('17.0.2', '^16.0.0');
+      });
+
+      it('should handle fallbackVersion in include configuration', async () => {
+        const testConfig = {
+          import: './react-fallback',
+          shareScope: 'test-scope',
+          shareKey: 'react',
+          requiredVersion: '^17.0.0',
+          include: {
+            version: '^16.0.0',
+            fallbackVersion: '17.0.2',
+          },
+          request: 'react',
+        };
+        const plugin = new ConsumeSharedPlugin({
+          consumes: { react: testConfig },
+        });
+        plugin.apply(testEnv.compiler);
+        testEnv.simulateCompilation();
+
+        (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(
+          async () => ({
+            resolved: new Map(),
+            unresolved: new Map([['react', testConfig]]),
+            prefixed: new Map(),
+          }),
+        );
+
+        testEnv.mockResolver.resolve.mockImplementationOnce(
+          (ctx, context, request, resolveContext, callback) => {
+            callback(null, '/mock/fallback/react');
+          },
+        );
+
+        // Mock getDescriptionFile to return version that doesn't match include
+        (getDescriptionFile as jest.Mock).mockImplementationOnce(
+          (fs, context, files, callback) => {
+            callback(null, { data: { name: 'react', version: '18.0.0' } }, [
+              'package.json',
+            ]);
+          },
+        );
+
+        // First satisfy call returns false (version doesn't match include)
+        // Second satisfy call returns true (fallbackVersion matches include)
+        (satisfy as jest.Mock)
+          .mockImplementationOnce(() => false)
+          .mockImplementationOnce(() => true);
+
+        const result = await plugin.createConsumeSharedModule(
+          testEnv.mockCompilation,
+          '/mock/context',
+          'react',
+          testConfig,
+        );
+
+        expect(result).toBeDefined();
+        expect(satisfy).toHaveBeenCalledWith('18.0.0', '^16.0.0');
+        expect(satisfy).toHaveBeenCalledWith('17.0.2', '^16.0.0');
+      });
+
+      it('should add singleton filter warning when using include.version with singleton', async () => {
+        const testConfig = {
+          import: './react-fallback',
+          shareScope: 'test-scope',
+          shareKey: 'react',
+          requiredVersion: '^17.0.0',
+          singleton: true,
+          include: {
+            version: '^17.0.0',
+          },
+          request: 'react',
+        };
+        const plugin = new ConsumeSharedPlugin({
+          consumes: { react: testConfig },
+        });
+        plugin.apply(testEnv.compiler);
+        testEnv.simulateCompilation();
+
+        (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(
+          async () => ({
+            resolved: new Map(),
+            unresolved: new Map([['react', testConfig]]),
+            prefixed: new Map(),
+          }),
+        );
+
+        testEnv.mockResolver.resolve.mockImplementationOnce(
+          (ctx, context, request, resolveContext, callback) => {
+            callback(null, '/mock/fallback/react');
+          },
+        );
+
+        // Mock getDescriptionFile to return package.json - need to mock twice
+        // Once for checking include.version, second for any other check
+        (getDescriptionFile as jest.Mock)
+          .mockImplementationOnce((fs, context, files, callback) => {
+            callback(null, { data: { name: 'react', version: '17.0.2' } }, [
+              'package.json',
+            ]);
+          })
+          .mockImplementationOnce((fs, context, files, callback) => {
+            callback(
+              null,
+              { data: { name: 'my-app', dependencies: { react: '^17.0.0' } } },
+              ['package.json'],
+            );
+          });
+
+        (satisfy as jest.Mock).mockImplementationOnce(() => true);
+
+        // Mock addSingletonFilterWarning to add a warning
+        (addSingletonFilterWarning as jest.Mock).mockImplementationOnce(
+          (compilation) => {
+            compilation.warnings.push({
+              message:
+                'The module "react" using singleton constraint might not work as expected with include.version filter "^17.0.0".',
+            });
+          },
+        );
+
+        const result = await plugin.createConsumeSharedModule(
+          testEnv.mockCompilation,
+          '/mock/context',
+          'react',
+          testConfig,
+        );
+
+        expect(result).toBeDefined();
+        // Check that a warning was added to compilation
+        expect(testEnv.mockCompilation.warnings).toHaveLength(1);
+        expect(testEnv.mockCompilation.warnings[0].message).toContain(
+          'singleton constraint',
+        );
+      });
+    });
+  });
+
+  describe('required version resolution', () => {
+    let testEnv: any;
+
+    beforeEach(() => {
+      testEnv = createSharingTestEnvironment();
+      jest.clearAllMocks();
+      (getDescriptionFile as jest.Mock).mockReset();
+      (resolveMatchedConfigs as jest.Mock).mockReturnValue(
+        Promise.resolve({
+          resolved: new Map(),
+          unresolved: new Map(),
+          prefixed: new Map(),
+        }),
+      );
+    });
+
+    it('should automatically detect required version from package.json dependencies', async () => {
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          react: {
+            import: './react-fallback',
+            shareScope: 'test-scope',
+          },
+        },
+      });
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      const testConfig = plugin._consumes[0][1];
+
+      testEnv.mockResolver.resolve.mockImplementationOnce(
+        (ctx, context, request, resolveContext, callback) => {
+          callback(null, '/mock/fallback/react');
+        },
+      );
+
+      // Need to mock getDescriptionFile twice - once for required version resolution,
+      // once for any other potential check
+      (getDescriptionFile as jest.Mock)
+        .mockImplementationOnce((fs, context, files, callback) => {
+          callback(
+            null,
+            {
+              data: {
+                name: 'my-app',
+                dependencies: { react: '^17.0.2' },
+              },
+            },
+            ['package.json'],
+          );
+        })
+        .mockImplementationOnce((fs, context, files, callback) => {
+          callback(
+            null,
+            {
+              data: {
+                name: 'my-app',
+                dependencies: { react: '^17.0.2' },
+              },
+            },
+            ['package.json'],
+          );
+        });
+
+      const result = await plugin.createConsumeSharedModule(
+        testEnv.mockCompilation,
+        '/mock/context',
+        'react',
+        testConfig,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.options.requiredVersion).toBe('^17.0.2');
+    });
+
+    it('should handle package self-referencing', async () => {
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          'my-package': {
+            import: './my-package-fallback',
+            shareScope: 'test-scope',
+          },
+        },
+      });
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      const testConfig = plugin._consumes[0][1];
+
+      testEnv.mockResolver.resolve.mockImplementationOnce(
+        (ctx, context, request, resolveContext, callback) => {
+          callback(null, '/mock/fallback/my-package');
+        },
+      );
+
+      // Mock getDescriptionFile to return package.json with same name
+      (getDescriptionFile as jest.Mock).mockImplementationOnce(
+        (fs, context, files, callback) => {
+          callback(
+            null,
+            {
+              data: {
+                name: 'my-package',
+                version: '1.0.0',
+              },
+            },
+            ['package.json'],
+          );
+        },
+      );
+
+      const result = await plugin.createConsumeSharedModule(
+        testEnv.mockCompilation,
+        '/mock/context',
+        'my-package',
+        testConfig,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.options.requiredVersion).toBeUndefined();
+    });
+
+    it('should warn when unable to determine required version', async () => {
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          react: {
+            import: './react-fallback',
+            shareScope: 'test-scope',
+          },
+        },
+      });
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      const testConfig = plugin._consumes[0][1];
+
+      testEnv.mockResolver.resolve.mockImplementationOnce(
+        (ctx, context, request, resolveContext, callback) => {
+          callback(null, '/mock/fallback/react');
+        },
+      );
+
+      // Mock getDescriptionFile to return error
+      (getDescriptionFile as jest.Mock).mockImplementationOnce(
+        (fs, context, files, callback) => {
+          callback(new Error('File not found'), null, null);
+        },
+      );
+
+      const result = await plugin.createConsumeSharedModule(
+        testEnv.mockCompilation,
+        '/mock/context',
+        'react',
+        testConfig,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.options.requiredVersion).toBeUndefined();
+      expect(testEnv.mockCompilation.warnings).toHaveLength(1);
+      expect(testEnv.mockCompilation.warnings[0].message).toContain(
+        'Unable to read description file',
+      );
+    });
+
+    it('should extract package name from scoped packages', async () => {
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          '@scope/package': {
+            import: './@scope/package-fallback',
+            shareScope: 'test-scope',
+          },
+        },
+      });
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      const testConfig = plugin._consumes[0][1];
+
+      testEnv.mockResolver.resolve.mockImplementationOnce(
+        (ctx, context, request, resolveContext, callback) => {
+          callback(null, '/mock/fallback/@scope/package');
+        },
+      );
+
+      (getDescriptionFile as jest.Mock)
+        .mockImplementationOnce((fs, context, files, callback) => {
+          callback(
+            null,
+            {
+              data: {
+                name: 'my-app',
+                dependencies: { '@scope/package': '^2.0.0' },
+              },
+            },
+            ['package.json'],
+          );
+        })
+        .mockImplementationOnce((fs, context, files, callback) => {
+          callback(
+            null,
+            {
+              data: {
+                name: 'my-app',
+                dependencies: { '@scope/package': '^2.0.0' },
+              },
+            },
+            ['package.json'],
+          );
+        });
+
+      const result = await plugin.createConsumeSharedModule(
+        testEnv.mockCompilation,
+        '/mock/context',
+        '@scope/package',
+        testConfig,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.options.requiredVersion).toBe('^2.0.0');
+    });
+  });
+
+  describe('node modules path reconstruction', () => {
+    let testEnv: any;
+
+    beforeEach(() => {
+      testEnv = createSharingTestEnvironment();
+      jest.clearAllMocks();
+      // Set up the default mock implementation
+      (resolveMatchedConfigs as jest.Mock).mockImplementation(async () => ({
+        resolved: new Map(),
+        unresolved: new Map(),
+        prefixed: new Map(),
+      }));
+    });
+
+    it('should handle relative path requests with node_modules reconstruction', async () => {
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          react: {
+            import: 'react',
+            shareScope: 'test-scope',
+            nodeModulesReconstructedLookup: true,
+          },
+        },
+      });
+
+      // Mock extractPathAfterNodeModules to return the module name
+      (extractPathAfterNodeModules as jest.Mock).mockImplementation((path) => {
+        if (path.includes('node_modules/react')) {
+          return 'react';
+        }
+        return null;
+      });
+
+      // createLookupKeyForSharing is not mocked, so it should work correctly
+
+      // Mock resolveMatchedConfigs to return config in unresolved map
+      // This must be done BEFORE simulateCompilation
+      (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(async () => ({
+        resolved: new Map(),
+        unresolved: new Map([['react', plugin._consumes[0][1]]]),
+        prefixed: new Map(),
+      }));
+
+      // Add mock for resolver to resolve the import
+      testEnv.mockResolver.resolve.mockImplementationOnce(
+        (
+          _ctx: any,
+          _context: any,
+          _request: any,
+          _resolveContext: any,
+          callback: any,
+        ) => {
+          callback(null, '/mock/node_modules/react');
+        },
+      );
+
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      // Wait for the promise to resolve
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Mock the factorize hook call with a relative path that resolves to node_modules
+      const result = await testEnv.normalModuleFactory.factorize({
+        context: '/mock/src/components',
+        request: '../../node_modules/react',
+        dependencies: [{}],
+        contextInfo: {},
+      });
+
+      // Verify the result is a ConsumeSharedModule
+      expect(result).toBeDefined();
+      expect(mockConsumeSharedModule).toHaveBeenCalledWith(
+        expect.any(String), // context
+        expect.objectContaining({
+          request: 'react',
+          shareScope: 'test-scope',
+          nodeModulesReconstructedLookup: true,
+        }),
+      );
+    });
+
+    it('should match prefixed consumes with node_modules paths', async () => {
+      const prefixConfig = {
+        import: 'react-components/',
+        shareScope: 'test-scope',
+        shareKey: 'react-components/',
+        nodeModulesReconstructedLookup: true,
+        request: 'react-components/',
+      };
+
+      // Mock resolveMatchedConfigs to return config in prefixed map
+      // This must be done BEFORE creating the plugin
+      (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(async () => ({
+        resolved: new Map(),
+        unresolved: new Map(),
+        prefixed: new Map([['react-components/', prefixConfig]]),
+      }));
+
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          'react-components/': prefixConfig,
+        },
+      });
+
+      // Mock extractPathAfterNodeModules to return the module path
+      (extractPathAfterNodeModules as jest.Mock).mockImplementation((path) => {
+        if (path.includes('node_modules/react-components/')) {
+          return path.split('node_modules/')[1];
+        }
+        return null;
+      });
+
+      // Mock testRequestFilters to allow all requests
+      (testRequestFilters as jest.Mock).mockImplementation(() => true);
+
+      // Add mock for resolver to resolve the import
+      testEnv.mockResolver.resolve.mockImplementationOnce(
+        (
+          _ctx: any,
+          _context: any,
+          _request: any,
+          _resolveContext: any,
+          callback: any,
+        ) => {
+          callback(null, '/mock/node_modules/react-components/button');
+        },
+      );
+
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      // Wait for the promise to resolve
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Mock the factorize hook call with a relative path that resolves to node_modules
+      await testEnv.normalModuleFactory.factorize({
+        context: '/mock/src/components',
+        request: '../../node_modules/react-components/button',
+        dependencies: [{}],
+        contextInfo: {},
+      });
+
+      expect(mockConsumeSharedModule).toHaveBeenCalledWith(
+        '/mock/src/components',
+        expect.objectContaining({
+          shareKey: 'react-components/button',
+          import: 'react-components/button',
+        }),
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    let testEnv: any;
+
+    beforeEach(() => {
+      testEnv = createSharingTestEnvironment();
+      jest.clearAllMocks();
+    });
+
+    it('should handle import resolution failure', async () => {
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          react: {
+            import: './non-existent-fallback',
+            shareScope: 'test-scope',
+            requiredVersion: '^17.0.0',
+          },
+        },
+      });
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      const testConfig = plugin._consumes[0][1];
+
+      // Mock resolver to return error
+      testEnv.mockResolver.resolve.mockImplementationOnce(
+        (ctx, context, request, resolveContext, callback) => {
+          callback(new Error('Module not found'), null);
+        },
+      );
+
+      const result = await plugin.createConsumeSharedModule(
+        testEnv.mockCompilation,
+        '/mock/context',
+        'react',
+        testConfig,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.options.importResolved).toBeUndefined();
+      expect(testEnv.mockCompilation.errors).toHaveLength(1);
+      // The error is a ModuleNotFoundError instance
+      const error = testEnv.mockCompilation.errors[0];
+      expect(error).toBeDefined();
+    });
+
+    it('should add dependencies to compilation when resolving', async () => {
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          react: {
+            import: './react-fallback',
+            shareScope: 'test-scope',
+            requiredVersion: '^17.0.0',
+          },
+        },
+      });
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      const testConfig = plugin._consumes[0][1];
+
+      const mockFileDeps = new Set(['file1.js']);
+      const mockContextDeps = new Set(['dir1']);
+      const mockMissingDeps = new Set(['missing1.js']);
+
+      testEnv.mockResolver.resolve.mockImplementationOnce(
+        (ctx, context, request, resolveContext, callback) => {
+          // Simulate resolver adding dependencies
+          resolveContext.fileDependencies = mockFileDeps;
+          resolveContext.contextDependencies = mockContextDeps;
+          resolveContext.missingDependencies = mockMissingDeps;
+          callback(null, '/mock/fallback/react');
+        },
+      );
+
+      await plugin.createConsumeSharedModule(
+        testEnv.mockCompilation,
+        '/mock/context',
+        'react',
+        testConfig,
+      );
+
+      expect(
+        testEnv.mockCompilation.contextDependencies.addAll,
+      ).toHaveBeenCalledWith(mockContextDeps);
+      expect(
+        testEnv.mockCompilation.fileDependencies.addAll,
+      ).toHaveBeenCalledWith(mockFileDeps);
+      expect(
+        testEnv.mockCompilation.missingDependencies.addAll,
+      ).toHaveBeenCalledWith(mockMissingDeps);
+    });
+  });
+
+  describe('prefixed consumes with filters', () => {
+    let testEnv: any;
+
+    beforeEach(() => {
+      testEnv = createSharingTestEnvironment();
+      jest.clearAllMocks();
+    });
+
+    it('should apply include and exclude filters to prefixed consumes', async () => {
+      const prefixConfig = {
+        import: '@scope/components/',
+        shareScope: 'test-scope',
+        shareKey: '@scope/components/',
+        include: {
+          request: /^button|input$/,
+        },
+        exclude: {
+          request: /deprecated/,
+        },
+        request: '@scope/components/',
+      };
+
+      // Mock resolveMatchedConfigs BEFORE creating the plugin
+      (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(async () => ({
+        resolved: new Map(),
+        unresolved: new Map(),
+        prefixed: new Map([['@scope/components/', prefixConfig]]),
+      }));
+
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          '@scope/components/': prefixConfig,
+        },
+      });
+
+      // Mock testRequestFilters
+      (testRequestFilters as jest.Mock).mockImplementation(
+        (remainder, include, exclude) => {
+          // Check if remainder matches include pattern and doesn't match exclude
+          if (include && !include.test(remainder)) return false;
+          if (exclude && exclude.test(remainder)) return false;
+          return true;
+        },
+      );
+
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      // Test included path
+      await testEnv.normalModuleFactory.factorize({
+        context: '/mock/context',
+        request: '@scope/components/button',
+        dependencies: [{}],
+        contextInfo: {},
+      });
+
+      expect(mockConsumeSharedModule).toHaveBeenCalledWith(
+        '/mock/context',
+        expect.objectContaining({
+          shareKey: '@scope/components/button',
+        }),
+      );
+
+      // Test excluded path
+      mockConsumeSharedModule.mockClear();
+      await testEnv.normalModuleFactory.factorize({
+        context: '/mock/context',
+        request: '@scope/components/deprecated-button',
+        dependencies: [{}],
+        contextInfo: {},
+      });
+
+      expect(mockConsumeSharedModule).not.toHaveBeenCalled();
+    });
+
+    it('should handle issuerLayer matching in prefixed consumes', async () => {
+      const layeredPrefixConfig = {
+        import: '@ui/',
+        shareScope: 'layered-scope',
+        shareKey: '@ui/',
+        issuerLayer: 'client',
+        request: '@ui/',
+      };
+
+      const nonLayeredPrefixConfig = {
+        import: '@ui/',
+        shareScope: 'default-scope',
+        shareKey: '@ui/',
+        request: '@ui/',
+      };
+
+      // Mock resolveMatchedConfigs BEFORE creating the plugin
+      (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(async () => ({
+        resolved: new Map(),
+        unresolved: new Map(),
+        prefixed: new Map([
+          ['@ui/layered/', layeredPrefixConfig],
+          ['@ui/', nonLayeredPrefixConfig],
+        ]),
+      }));
+
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          '@ui/layered/': layeredPrefixConfig,
+          '@ui/': nonLayeredPrefixConfig,
+        },
+      });
+
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      // Test with issuerLayer='client' - should match layered config
+      await testEnv.normalModuleFactory.factorize({
+        context: '/mock/context',
+        request: '@ui/layered/button',
+        dependencies: [{}],
+        contextInfo: { issuerLayer: 'client' },
+      });
+
+      expect(mockConsumeSharedModule).toHaveBeenCalledWith(
+        '/mock/context',
+        expect.objectContaining({
+          shareScope: 'layered-scope',
+        }),
+      );
+
+      // Test without issuerLayer - should match non-layered config
+      mockConsumeSharedModule.mockClear();
+      await testEnv.normalModuleFactory.factorize({
+        context: '/mock/context',
+        request: '@ui/button',
+        dependencies: [{}],
+        contextInfo: {},
+      });
+
+      expect(mockConsumeSharedModule).toHaveBeenCalledWith(
+        '/mock/context',
+        expect.objectContaining({
+          shareScope: 'default-scope',
+        }),
+      );
+    });
+  });
+
+  describe('FederationRuntimePlugin integration', () => {
+    it('should apply FederationRuntimePlugin and set environment variable', () => {
+      const testEnv = createSharingTestEnvironment();
+      const plugin = new ConsumeSharedPlugin({
+        consumes: { react: '^17.0.0' },
+      });
+
+      // Clear environment variable before test
+      delete process.env['FEDERATION_WEBPACK_PATH'];
+
+      plugin.apply(testEnv.compiler);
+
+      // Check that FederationRuntimePlugin was applied
+      const FederationRuntimePlugin = require('../../../src/lib/container/runtime/FederationRuntimePlugin');
+      expect(FederationRuntimePlugin).toHaveBeenCalled();
+
+      // Check that environment variable was set
+      expect(process.env['FEDERATION_WEBPACK_PATH']).toBe(
+        'mocked-webpack-path',
+      );
+    });
+  });
+
+  describe('layer-specific shareScope patterns', () => {
+    let testEnv: any;
+
+    beforeEach(() => {
+      testEnv = createSharingTestEnvironment();
+      jest.clearAllMocks();
+    });
+
+    it('should handle layer-specific shareScope like Next.js app directory', async () => {
+      // Similar to Next.js app directory pattern where shareScope matches layer
+      const appLayerConfig = {
+        request: 'react',
+        singleton: true,
+        shareKey: 'react',
+        import: 'next/dist/compiled/react',
+        layer: 'appPagesBrowser',
+        issuerLayer: 'appPagesBrowser',
+        shareScope: 'appPagesBrowser', // shareScope matches layer
+        requiredVersion: '^18.2.0',
+      };
+
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          'react-app': appLayerConfig,
+        },
+      });
+
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(async () => ({
+        resolved: new Map(),
+        unresolved: new Map([['(appPagesBrowser)react', appLayerConfig]]),
+        prefixed: new Map(),
+      }));
+
+      const result = await plugin.createConsumeSharedModule(
+        testEnv.mockCompilation,
+        '/mock/context',
+        'react',
+        appLayerConfig,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.options.shareScope).toBe('appPagesBrowser');
+      expect(result.options.layer).toBe('appPagesBrowser');
+    });
+
+    it('should handle multiple layers with different shareScopes', async () => {
+      const pagesDirConfig = {
+        request: 'react',
+        singleton: true,
+        shareKey: 'react',
+        import: 'next/dist/compiled/react',
+        layer: 'pagesDirBrowser',
+        issuerLayer: 'pagesDirBrowser',
+        shareScope: 'default',
+        requiredVersion: '^18.2.0',
+      };
+
+      const appDirConfig = {
+        request: 'react',
+        singleton: true,
+        shareKey: 'react',
+        import: 'next/dist/compiled/react',
+        layer: 'appPagesBrowser',
+        issuerLayer: 'appPagesBrowser',
+        shareScope: 'appPagesBrowser',
+        requiredVersion: '^18.2.0',
+      };
+
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          'react-pages': pagesDirConfig,
+          'react-app': appDirConfig,
+        },
+      });
+
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      // Test pages directory layer
+      (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(async () => ({
+        resolved: new Map(),
+        unresolved: new Map([['(pagesDirBrowser)react', pagesDirConfig]]),
+        prefixed: new Map(),
+      }));
+
+      const pagesResult = await plugin.createConsumeSharedModule(
+        testEnv.mockCompilation,
+        '/mock/context',
+        'react',
+        pagesDirConfig,
+      );
+
+      expect(pagesResult).toBeDefined();
+      expect(pagesResult.options.shareScope).toBe('default');
+
+      // Test app directory layer
+      (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(async () => ({
+        resolved: new Map(),
+        unresolved: new Map([['(appPagesBrowser)react', appDirConfig]]),
+        prefixed: new Map(),
+      }));
+
+      const appResult = await plugin.createConsumeSharedModule(
+        testEnv.mockCompilation,
+        '/mock/context',
+        'react',
+        appDirConfig,
+      );
+
+      expect(appResult).toBeDefined();
+      expect(appResult.options.shareScope).toBe('appPagesBrowser');
+    });
+
+    it('should handle prefixed paths with nodeModulesReconstructedLookup flag', async () => {
+      const prefixConfig = {
+        request: 'next/dist/shared/',
+        shareKey: 'next/dist/shared/',
+        import: 'next/dist/shared/',
+        layer: 'appPagesBrowser',
+        issuerLayer: 'appPagesBrowser',
+        shareScope: 'appPagesBrowser',
+        singleton: true,
+        requiredVersion: '^14.0.0',
+        nodeModulesReconstructedLookup: true,
+        include: {
+          request: /shared-runtime/,
+        },
+      };
+
+      // Mock resolveMatchedConfigs BEFORE creating the plugin
+      (resolveMatchedConfigs as jest.Mock).mockImplementationOnce(async () => ({
+        resolved: new Map(),
+        unresolved: new Map(),
+        prefixed: new Map([['next/dist/shared/', prefixConfig]]),
+      }));
+
+      const plugin = new ConsumeSharedPlugin({
+        consumes: {
+          'next/dist/shared/': prefixConfig,
+        },
+      });
+
+      // Mock testRequestFilters for include filter
+      (testRequestFilters as jest.Mock).mockImplementation(
+        (remainder, include, exclude) => {
+          if (include && !include.test(remainder)) return false;
+          if (exclude && exclude.test(remainder)) return false;
+          return true;
+        },
+      );
+
+      plugin.apply(testEnv.compiler);
+      testEnv.simulateCompilation();
+
+      // Test with a path that should match the include filter
+      await testEnv.normalModuleFactory.factorize({
+        context: '/mock/src',
+        request: 'next/dist/shared/lib/shared-runtime',
+        dependencies: [{}],
+        contextInfo: { issuerLayer: 'appPagesBrowser' },
+      });
+
+      expect(mockConsumeSharedModule).toHaveBeenCalledWith(
+        '/mock/src',
+        expect.objectContaining({
+          shareKey: 'next/dist/shared/lib/shared-runtime',
+          shareScope: 'appPagesBrowser',
+          nodeModulesReconstructedLookup: true,
+        }),
+      );
+    });
+  });
+
   describe('issuerLayer fallback logic (PR #3893)', () => {
     let testEnv: any;
     let plugin: any;
@@ -791,14 +1899,14 @@ describe('ConsumeSharedPlugin', () => {
           mockUnresolvedConsumes.get(layeredLookup) ||
           mockUnresolvedConsumes.get(nonLayeredLookup);
         expect(layeredResult).toBeDefined();
-        expect(layeredResult!.shareScope).toBe('layered-scope');
+        expect(layeredResult?.shareScope).toBe('layered-scope');
 
         // With no issuerLayer - should find non-layered config
         const nonLayeredResult = mockUnresolvedConsumes.get(
           createLookupKeyForSharing('react', undefined),
         );
         expect(nonLayeredResult).toBeDefined();
-        expect(nonLayeredResult!.shareScope).toBe('default');
+        expect(nonLayeredResult?.shareScope).toBe('default');
       });
     });
 

--- a/packages/managers/__tests__/__snapshots__/SharedManager.spec.ts.snap
+++ b/packages/managers/__tests__/__snapshots__/SharedManager.spec.ts.snap
@@ -7,6 +7,6 @@ exports[`SharedManager normalizedOptions 1`] = `
   "requiredVersion": "^18.0.0",
   "shareScope": "default",
   "singleton": false,
-  "version": "19.0.0",
+  "version": "18.3.1",
 }
 `;

--- a/packages/sdk/src/node.ts
+++ b/packages/sdk/src/node.ts
@@ -7,11 +7,21 @@ function importNodeModule<T>(name: string): Promise<T> {
   if (!name) {
     throw new Error('import specifier is required');
   }
+
+  // Debug logging
+  console.log(`[importNodeModule] Attempting to import: ${name}`);
+
   const importModule = new Function('name', `return import(name)`);
   return importModule(name)
-    .then((res: any) => res as T)
+    .then((res: any) => {
+      console.log(`[importNodeModule] Successfully imported: ${name}`);
+      return res as T;
+    })
     .catch((error: any) => {
-      console.error(`Error importing module ${name}:`, error);
+      console.error(
+        `[importNodeModule] Error importing module ${name}:`,
+        error,
+      );
       throw error;
     });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -523,8 +523,8 @@ importers:
         version: 19.0.0(react@19.0.0)
     devDependencies:
       '@module-federation/nextjs-mf':
-        specifier: 0.0.0-next-20250701105507
-        version: 0.0.0-next-20250701105507(@rspack/core@1.3.9)(next@15.3.3)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)(vue-tsc@2.2.10)(webpack@5.98.0)
+        specifier: workspace:*
+        version: link:../../packages/nextjs-mf
       '@module-federation/runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
@@ -11428,14 +11428,6 @@ packages:
       lodash: 4.17.21
       rslog: 1.2.3
 
-  /@module-federation/bridge-react-webpack-plugin@0.0.0-next-20250701105507:
-    resolution: {integrity: sha512-s03Kx5i6smiqPt4seHWaiO27zy8IZopU39WIB1jVi3Berp29SG08Ww/25/3UvrCMHPdpA5IItihtWRRT/CkR5g==}
-    dependencies:
-      '@module-federation/sdk': 0.0.0-next-20250701105507
-      '@types/semver': 7.5.8
-      semver: 7.6.3
-    dev: true
-
   /@module-federation/bridge-react-webpack-plugin@0.13.1:
     resolution: {integrity: sha512-3RgGd8KcRw5vibnxWa1NUWwfb0tKwn8OvHeQ4GFKzMvDLm+QpCgQd9LeTEBP38wZgGXVtIJR3y5FPnufWswFKw==}
     dependencies:
@@ -11458,25 +11450,6 @@ packages:
       '@module-federation/sdk': 0.9.1
       '@types/semver': 7.5.8
       semver: 7.6.3
-    dev: true
-
-  /@module-federation/cli@0.0.0-next-20250701105507(typescript@5.7.3)(vue-tsc@2.2.10):
-    resolution: {integrity: sha512-MMTsoQ3RwyBBrObhrLovK3YiPY975Zpnre1GNOXYnWu52NlZSFBsudCF0HdqfebAqp74PlcREkmtq70KTo8sKg==}
-    engines: {node: '>=16.0.0'}
-    hasBin: true
-    dependencies:
-      '@modern-js/node-bundle-require': 2.67.6
-      '@module-federation/dts-plugin': 0.0.0-next-20250701105507(typescript@5.7.3)(vue-tsc@2.2.10)
-      '@module-federation/sdk': 0.0.0-next-20250701105507
-      chalk: 3.0.0
-      commander: 11.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - vue-tsc
     dev: true
 
   /@module-federation/cli@0.13.1(typescript@5.4.5)(vue-tsc@2.2.10):
@@ -11515,19 +11488,6 @@ packages:
       - typescript
       - utf-8-validate
       - vue-tsc
-    dev: true
-
-  /@module-federation/data-prefetch@0.0.0-next-20250701105507(react-dom@19.0.0)(react@19.0.0):
-    resolution: {integrity: sha512-1QKJA6fenv+P0Fm3MBvoYtsjcAR5O1YG7iJH/8ya4rRTq1FjdZcP1ScvNoFDbuMcx4BnIT0k7e5hRFGrAS470Q==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    dependencies:
-      '@module-federation/runtime': 0.0.0-next-20250701105507
-      '@module-federation/sdk': 0.0.0-next-20250701105507
-      fs-extra: 9.1.0
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
     dev: true
 
   /@module-federation/data-prefetch@0.13.1(react-dom@18.3.1)(react@18.3.1):
@@ -11593,40 +11553,6 @@ packages:
       fs-extra: 9.1.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-    dev: true
-
-  /@module-federation/dts-plugin@0.0.0-next-20250701105507(typescript@5.7.3)(vue-tsc@2.2.10):
-    resolution: {integrity: sha512-V/qcqiL1lBsWWmRMoN90FBACx6CUKQ2je2GDX6YzQNH9ZrHdDMG9Z9Q1w7lSSVbpbXtMNgwNMxSRs6BKlz8+lg==}
-    peerDependencies:
-      typescript: ^4.9.0 || ^5.0.0
-      vue-tsc: '>=1.0.24'
-    peerDependenciesMeta:
-      vue-tsc:
-        optional: true
-    dependencies:
-      '@module-federation/error-codes': 0.0.0-next-20250701105507
-      '@module-federation/managers': 0.0.0-next-20250701105507
-      '@module-federation/sdk': 0.0.0-next-20250701105507
-      '@module-federation/third-party-dts-extractor': 0.0.0-next-20250701105507
-      adm-zip: 0.5.16
-      ansi-colors: 4.1.3
-      axios: 1.8.2
-      chalk: 3.0.0
-      fs-extra: 9.1.0
-      isomorphic-ws: 5.0.0(ws@8.18.0)
-      koa: 2.16.1
-      lodash.clonedeepwith: 4.5.0
-      log4js: 6.9.1
-      node-schedule: 2.1.1
-      rambda: 9.4.2
-      typescript: 5.7.3
-      vue-tsc: 2.2.10(typescript@5.7.3)
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /@module-federation/dts-plugin@0.13.1(typescript@5.4.5)(vue-tsc@2.2.10):
@@ -11794,48 +11720,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - debug
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@module-federation/enhanced@0.0.0-next-20250701105507(@rspack/core@1.3.9)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)(vue-tsc@2.2.10)(webpack@5.98.0):
-    resolution: {integrity: sha512-K88m80Y2fv9q7UwqXEQbu3n6buZxI0FfKMi6lMTX57Q1jD8s9XOAuoAswJnF6hunlmlG0v1dxxnDcuTFMzdQ+A==}
-    hasBin: true
-    peerDependencies:
-      typescript: ^4.9.0 || ^5.0.0
-      vue-tsc: '>=1.0.24'
-      webpack: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      vue-tsc:
-        optional: true
-      webpack:
-        optional: true
-    dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 0.0.0-next-20250701105507
-      '@module-federation/cli': 0.0.0-next-20250701105507(typescript@5.7.3)(vue-tsc@2.2.10)
-      '@module-federation/data-prefetch': 0.0.0-next-20250701105507(react-dom@19.0.0)(react@19.0.0)
-      '@module-federation/dts-plugin': 0.0.0-next-20250701105507(typescript@5.7.3)(vue-tsc@2.2.10)
-      '@module-federation/error-codes': 0.0.0-next-20250701105507
-      '@module-federation/inject-external-runtime-core-plugin': 0.0.0-next-20250701105507(@module-federation/runtime-tools@0.0.0-next-20250701105507)
-      '@module-federation/managers': 0.0.0-next-20250701105507
-      '@module-federation/manifest': 0.0.0-next-20250701105507(typescript@5.7.3)(vue-tsc@2.2.10)
-      '@module-federation/rspack': 0.0.0-next-20250701105507(@rspack/core@1.3.9)(typescript@5.7.3)(vue-tsc@2.2.10)
-      '@module-federation/runtime-tools': 0.0.0-next-20250701105507
-      '@module-federation/sdk': 0.0.0-next-20250701105507
-      btoa: 1.2.1
-      schema-utils: 4.3.2
-      typescript: 5.7.3
-      upath: 2.0.1
-      vue-tsc: 2.2.10(typescript@5.7.3)
-      webpack: 5.98.0(@swc/core@1.7.26)(esbuild@0.25.0)(webpack-cli@5.1.4)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - react
-      - react-dom
       - supports-color
       - utf-8-validate
     dev: true
@@ -12074,10 +11958,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@module-federation/error-codes@0.0.0-next-20250701105507:
-    resolution: {integrity: sha512-xgY3uxe1jRc8FlS67iKoDU6njmYu4WXSEqWgaAGLIvRbJCwJ7UVbs3dBD7NwmNUlwtK3kl3FyK0Z3/t05MrZvA==}
-    dev: true
-
   /@module-federation/error-codes@0.13.1:
     resolution: {integrity: sha512-azgGDBnFRfqlivHOl96ZjlFUFlukESz2Rnnz/pINiSqoBBNjUE0fcAZP4X6jgrVITuEg90YkruZa7pW9I3m7Uw==}
 
@@ -12090,14 +11970,6 @@ packages:
 
   /@module-federation/error-codes@0.9.1:
     resolution: {integrity: sha512-q8spCvlwUzW42iX1irnlBTcwcZftRNHyGdlaoFO1z/fW4iphnBIfijzkigWQzOMhdPgzqN/up7XN+g5hjBGBtw==}
-    dev: true
-
-  /@module-federation/inject-external-runtime-core-plugin@0.0.0-next-20250701105507(@module-federation/runtime-tools@0.0.0-next-20250701105507):
-    resolution: {integrity: sha512-wKJw4oo8SHZQ2083fWJNzwiAm9r7LGhjytZzsEhoEYy7JUkowHL7cWwbE56vdq0GdNHsG4VdCjgO44GzqRhmfA==}
-    peerDependencies:
-      '@module-federation/runtime-tools': 0.0.0-next-20250701105507
-    dependencies:
-      '@module-federation/runtime-tools': 0.0.0-next-20250701105507
     dev: true
 
   /@module-federation/inject-external-runtime-core-plugin@0.13.1(@module-federation/runtime-tools@0.13.1):
@@ -12114,14 +11986,6 @@ packages:
       '@module-federation/runtime-tools': 0.9.1
     dependencies:
       '@module-federation/runtime-tools': 0.9.1
-    dev: true
-
-  /@module-federation/managers@0.0.0-next-20250701105507:
-    resolution: {integrity: sha512-18XN9N8vJ27TUd3n0LM/DFt3NaAm4d7650r0k0CXVouBNzSKPPDcd05/OLXDApIfZ5ry+FY+Ur/QdrFyUIB2Ag==}
-    dependencies:
-      '@module-federation/sdk': 0.0.0-next-20250701105507
-      find-pkg: 2.0.0
-      fs-extra: 9.1.0
     dev: true
 
   /@module-federation/managers@0.13.1:
@@ -12146,23 +12010,6 @@ packages:
       '@module-federation/sdk': 0.9.1
       find-pkg: 2.0.0
       fs-extra: 9.1.0
-    dev: true
-
-  /@module-federation/manifest@0.0.0-next-20250701105507(typescript@5.7.3)(vue-tsc@2.2.10):
-    resolution: {integrity: sha512-QSx3L9XNVt+aJUQrJKt09jhsTF04N+6+voharc5os46ZNij916XSWeJjeyvcsKOocQidzun/Vya9cp3UirOtfw==}
-    dependencies:
-      '@module-federation/dts-plugin': 0.0.0-next-20250701105507(typescript@5.7.3)(vue-tsc@2.2.10)
-      '@module-federation/managers': 0.0.0-next-20250701105507
-      '@module-federation/sdk': 0.0.0-next-20250701105507
-      chalk: 3.0.0
-      find-pkg: 2.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - vue-tsc
     dev: true
 
   /@module-federation/manifest@0.13.1(typescript@5.4.5)(vue-tsc@2.2.10):
@@ -12250,69 +12097,6 @@ packages:
       - vue-tsc
     dev: true
 
-  /@module-federation/nextjs-mf@0.0.0-next-20250701105507(@rspack/core@1.3.9)(next@15.3.3)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)(vue-tsc@2.2.10)(webpack@5.98.0):
-    resolution: {integrity: sha512-o/tZQxf2d5D8aND0vDH/lyaZo1zGea4S4mNROQFbeckgviERTrWRI5lyGOTJFlszQzm6AKylEHk5t3j++SPh7A==}
-    requiresBuild: true
-    peerDependencies:
-      next: ^15 || ^14 || ^13 || ^12
-      styled-jsx: '*'
-    peerDependenciesMeta:
-      next:
-        optional: true
-      styled-jsx:
-        optional: true
-    dependencies:
-      '@module-federation/enhanced': 0.0.0-next-20250701105507(@rspack/core@1.3.9)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)(vue-tsc@2.2.10)(webpack@5.98.0)
-      '@module-federation/node': 0.0.0-next-20250701105507(@rspack/core@1.3.9)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)(vue-tsc@2.2.10)(webpack@5.98.0)
-      '@module-federation/runtime': 0.0.0-next-20250701105507
-      '@module-federation/sdk': 0.0.0-next-20250701105507
-      '@module-federation/webpack-bundler-runtime': 0.0.0-next-20250701105507
-      fast-glob: 3.3.2
-      next: 15.3.3(@babel/core@7.25.2)(react-dom@19.0.0)(react@19.0.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - react
-      - react-dom
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-      - webpack
-    dev: true
-
-  /@module-federation/node@0.0.0-next-20250701105507(@rspack/core@1.3.9)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)(vue-tsc@2.2.10)(webpack@5.98.0):
-    resolution: {integrity: sha512-sccEb/RGz3ioPeYXyYl8UlDHGUe8Hy8BSbuU+yWF0p2nmlRXoRYrmJSB5bDX5w17RETCpWI3wSerQVY3aI3D7Q==}
-    peerDependencies:
-      react: ^16||^17||^18||^19
-      react-dom: ^16||^17||^18||^19
-      webpack: ^5.40.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@module-federation/enhanced': 0.0.0-next-20250701105507(@rspack/core@1.3.9)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)(vue-tsc@2.2.10)(webpack@5.98.0)
-      '@module-federation/runtime': 0.0.0-next-20250701105507
-      '@module-federation/sdk': 0.0.0-next-20250701105507
-      btoa: 1.2.1
-      encoding: 0.1.13
-      node-fetch: 2.7.0(encoding@0.1.13)
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      webpack: 5.98.0(@swc/core@1.7.26)(esbuild@0.25.0)(webpack-cli@5.1.4)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-    dev: true
-
   /@module-federation/node@2.7.2(@rspack/core@1.3.9)(next@15.3.3)(react-dom@19.0.0)(react@19.0.0)(typescript@5.4.5)(vue-tsc@2.2.10)(webpack@5.98.0):
     resolution: {integrity: sha512-NRVF56J0iyWRfCbpW6+HYis2sj8BBNVp8H5jHkIM/NgZt1Ck9Nyd5BVcL/Jys8ku44v8tdDQdnlzl/BjGHp9Yg==}
     peerDependencies:
@@ -12380,36 +12164,6 @@ packages:
       - typescript
       - utf-8-validate
       - vue-tsc
-    dev: true
-
-  /@module-federation/rspack@0.0.0-next-20250701105507(@rspack/core@1.3.9)(typescript@5.7.3)(vue-tsc@2.2.10):
-    resolution: {integrity: sha512-ss1rcPuY/rWoUJm15wrp5KNbiIllBaaVdeP6qF6NNt47l2vXKv65aNTDefagmdUybomthWfsrUa+RNV9wkd76A==}
-    peerDependencies:
-      '@rspack/core': '>=0.7'
-      typescript: ^4.9.0 || ^5.0.0
-      vue-tsc: '>=1.0.24'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      vue-tsc:
-        optional: true
-    dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 0.0.0-next-20250701105507
-      '@module-federation/dts-plugin': 0.0.0-next-20250701105507(typescript@5.7.3)(vue-tsc@2.2.10)
-      '@module-federation/inject-external-runtime-core-plugin': 0.0.0-next-20250701105507(@module-federation/runtime-tools@0.0.0-next-20250701105507)
-      '@module-federation/managers': 0.0.0-next-20250701105507
-      '@module-federation/manifest': 0.0.0-next-20250701105507(typescript@5.7.3)(vue-tsc@2.2.10)
-      '@module-federation/runtime-tools': 0.0.0-next-20250701105507
-      '@module-federation/sdk': 0.0.0-next-20250701105507
-      '@rspack/core': 1.3.9(@swc/helpers@0.5.13)
-      btoa: 1.2.1
-      typescript: 5.7.3
-      vue-tsc: 2.2.10(typescript@5.7.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /@module-federation/rspack@0.13.1(@rspack/core@1.3.9)(typescript@5.4.5)(vue-tsc@2.2.10):
@@ -12556,13 +12310,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@module-federation/runtime-core@0.0.0-next-20250701105507:
-    resolution: {integrity: sha512-Lw7mLdmsl3QAJ2Eo7qSXtqR846icxncLVqgkb856rnhlDUNE7GbKs9Jq2xnqu6RgE1TTyrUG99s9I+G1pad0lw==}
-    dependencies:
-      '@module-federation/error-codes': 0.0.0-next-20250701105507
-      '@module-federation/sdk': 0.0.0-next-20250701105507
-    dev: true
-
   /@module-federation/runtime-core@0.13.1:
     resolution: {integrity: sha512-TfyKfkSAentKeuvSsAItk8s5tqQSMfIRTPN2e1aoaq/kFhE+7blps719csyWSX5Lg5Es7WXKMsXHy40UgtBtuw==}
     dependencies:
@@ -12587,13 +12334,6 @@ packages:
     dependencies:
       '@module-federation/error-codes': 0.9.1
       '@module-federation/sdk': 0.9.1
-    dev: true
-
-  /@module-federation/runtime-tools@0.0.0-next-20250701105507:
-    resolution: {integrity: sha512-5jl/Rjd+BSiYA3p7B8VTgiVbvrnHlM41E0n7mxbRUwWkC7fyvjcvM7JaDqsC2D0guL0Ab/anyYSwrrwmk1YV8A==}
-    dependencies:
-      '@module-federation/runtime': 0.0.0-next-20250701105507
-      '@module-federation/webpack-bundler-runtime': 0.0.0-next-20250701105507
     dev: true
 
   /@module-federation/runtime-tools@0.1.6:
@@ -12641,14 +12381,6 @@ packages:
     dependencies:
       '@module-federation/runtime': 0.9.1
       '@module-federation/webpack-bundler-runtime': 0.9.1
-    dev: true
-
-  /@module-federation/runtime@0.0.0-next-20250701105507:
-    resolution: {integrity: sha512-YkjP6TRWIJpSbN7tbwHsPLrCVj86XzjrInQso5o3ds4ONk1P9lIEDMQcPxAYqsilngTR5TwkCV19lQuQ/uWNAQ==}
-    dependencies:
-      '@module-federation/error-codes': 0.0.0-next-20250701105507
-      '@module-federation/runtime-core': 0.0.0-next-20250701105507
-      '@module-federation/sdk': 0.0.0-next-20250701105507
     dev: true
 
   /@module-federation/runtime@0.1.6:
@@ -12699,10 +12431,6 @@ packages:
       '@module-federation/sdk': 0.9.1
     dev: true
 
-  /@module-federation/sdk@0.0.0-next-20250701105507:
-    resolution: {integrity: sha512-ekcIgMbXdwapaGwYsTZwUvroWgxDsnzW8pTBlIfa7XDET+LJlJSZjm8FGi4G1iuj0ekWQlVQWYGJ2KUlhluJrA==}
-    dev: true
-
   /@module-federation/sdk@0.1.6:
     resolution: {integrity: sha512-qifXpyYLM7abUeEOIfv0oTkguZgRZuwh89YOAYIZJlkP6QbRG7DJMQvtM8X2yHXm9PTk0IYNnOJH0vNQCo6auQ==}
     dev: true
@@ -12733,14 +12461,6 @@ packages:
     resolution: {integrity: sha512-YQonPTImgnCqZjE/A+3N2g3J5ypR6kx1tbBzc9toUANKr/dw/S63qlh/zHKzWQzxjjNNVMdXRtTMp07g3kgEWg==}
     dev: true
 
-  /@module-federation/third-party-dts-extractor@0.0.0-next-20250701105507:
-    resolution: {integrity: sha512-+HcvEls6gJ3WYrq8vLQTKpCSt2z5tdX8hsr+UcTxCOjpjux2dx/SOOowp+gMTAmGIVy8P5+66hBrhYY+D9hong==}
-    dependencies:
-      find-pkg: 2.0.0
-      fs-extra: 9.1.0
-      resolve: 1.22.8
-    dev: true
-
   /@module-federation/third-party-dts-extractor@0.13.1:
     resolution: {integrity: sha512-0kWSupoC0aTxFjJZE5TVPNsoZ9kBsZhkvRxFnUW2vDYLgtvgs2dIrDlNlIXYiS/MaQCNHGyvdNepbchKQiwFaw==}
     dependencies:
@@ -12763,13 +12483,6 @@ packages:
       find-pkg: 2.0.0
       fs-extra: 9.1.0
       resolve: 1.22.8
-    dev: true
-
-  /@module-federation/webpack-bundler-runtime@0.0.0-next-20250701105507:
-    resolution: {integrity: sha512-VbLHx3Fgbj6cu2szK5whgC+MHhZqKpjAwRHEhO14Vn0dBBcTVFtB6RNcaxD5mqyzmEZ7DBImCmP3IKya+OV/hA==}
-    dependencies:
-      '@module-federation/runtime': 0.0.0-next-20250701105507
-      '@module-federation/sdk': 0.0.0-next-20250701105507
     dev: true
 
   /@module-federation/webpack-bundler-runtime@0.1.6:
@@ -36840,6 +36553,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    dev: false
 
   /next@15.3.3(@babel/core@7.26.10)(react-dom@19.0.0)(react@19.0.0):
     resolution: {integrity: sha512-JqNj29hHNmCLtNvd090SyRbXJiivQ+58XjCcrC50Crb5g5u2zi7Y2YivbsEfzk6AtVI80akdOQbaMZwWB1Hthw==}
@@ -45491,6 +45205,7 @@ packages:
       '@babel/core': 7.25.2
       client-only: 0.0.1
       react: 19.0.0
+    dev: false
 
   /styled-jsx@5.1.6(@babel/core@7.26.10)(react@19.0.0):
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}


### PR DESCRIPTION
This pull request enhances the `ConsumeSharedPlugin` class in `packages/enhanced/src/lib/sharing/ConsumeSharedPlugin.ts` by improving fallback logic for resolving shared module dependencies. The changes ensure that the plugin attempts to match unresolved dependencies with and without the `issuerLayer` context, increasing the robustness of dependency resolution.

### Enhancements to dependency resolution logic:

* Updated the `match` variable to attempt resolution both with and without the `issuerLayer` context when looking up shared modules. This change ensures fallback behavior in case the `issuerLayer`-specific lookup fails.

* Improved the `moduleMatch` logic to include fallback resolution for module paths after `node_modules`, trying both with and without the `issuerLayer` context.

* Enhanced the `reconstructedMatch` logic to apply the same fallback mechanism for the full reconstructed path, increasing the likelihood of finding a match when the `issuerLayer` is undefined.