### PR TITLE
fix: include request warning logs in ProvideSharedPlugin

### DIFF
--- a/packages/enhanced/src/lib/sharing/ProvideSharedPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/ProvideSharedPlugin.ts
@@ -249,22 +249,6 @@ class ProvideSharedPlugin {
                     (originalPrefixConfig.shareKey || configuredPrefix) +
                     remainder;
 
-                  // Validate singleton usage when using include.request
-                  if (
-                    originalPrefixConfig.include?.request &&
-                    originalPrefixConfig.singleton
-                  ) {
-                    addSingletonFilterWarning(
-                      compilation,
-                      finalShareKey,
-                      'include',
-                      'request',
-                      originalPrefixConfig.include.request,
-                      originalRequestString,
-                      resource,
-                    );
-                  }
-
                   // Validate singleton usage when using exclude.request
                   if (
                     originalPrefixConfig.exclude?.request &&


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
Removed the inclusion of request warning logs in ProvideSharedPlugin.

<!--- Describe your changes in detail -->
This change removes the logic that included request warning logs within the ProvideSharedPlugin implementation. This helps reduce unnecessary log noise and streamlines the plugin’s output.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
