### PR TITLE
fix(runtime-core): add useIn while using unloading registered shared

### DIFF
--- a/.changeset/tiny-chicken-protect.md
+++ b/.changeset/tiny-chicken-protect.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime-core': patch
+---
+
+fix(runtime-core): add useIn while using unloading registered shared

--- a/packages/runtime-core/src/shared/index.ts
+++ b/packages/runtime-core/src/shared/index.ts
@@ -199,6 +199,7 @@ export class SharedHandler {
         if (gShared) {
           gShared.lib = factory;
           gShared.loaded = true;
+          addUseIn(gShared);
         }
         return factory as () => T;
       };


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

add useIn while using unloading registered shared
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/module-federation/core/issues/3864
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
