### PR TITLE
fix(runtime-core): enable modern TypeScript plugin

### DIFF
--- a/packages/runtime-core/project.json
+++ b/packages/runtime-core/project.json
@@ -20,7 +20,8 @@
         "compiler": "swc",
         "rollupConfig": "packages/runtime-core/rollup.config.cjs",
         "format": ["cjs", "esm"],
-        "generatePackageJson": false
+        "generatePackageJson": false,
+        "useLegacyTypescriptPlugin": false
       },
       "dependsOn": [
         {


### PR DESCRIPTION
## Summary
- Add `useLegacyTypescriptPlugin: false` to runtime-core package build configuration
- Enables the official `@rollup/plugin-typescript` instead of deprecated `rollup-plugin-typescript2`
- Resolves TypeScript compilation errors during build

## Test plan
- [x] Build succeeds without TypeScript errors
- [x] No breaking changes to package API

🤖 Generated with [Claude Code](https://claude.ai/code)