### PR TITLE
fix(runtime): enable modern TypeScript plugin

### DIFF
--- a/packages/runtime/project.json
+++ b/packages/runtime/project.json
@@ -23,7 +23,8 @@
         "compiler": "swc",
         "rollupConfig": "packages/runtime/rollup.config.cjs",
         "format": ["cjs", "esm"],
-        "generatePackageJson": false
+        "generatePackageJson": false,
+        "useLegacyTypescriptPlugin": false
       },
       "dependsOn": [
         {


### PR DESCRIPTION
## Summary
- Add `useLegacyTypescriptPlugin: false` to runtime package build configuration
- Enables the official `@rollup/plugin-typescript` instead of deprecated `rollup-plugin-typescript2`
- Resolves TypeScript compilation errors during build

## Test plan
- [x] Build succeeds without TypeScript errors
- [x] No breaking changes to package API

🤖 Generated with [Claude Code](https://claude.ai/code)