### PR TITLE
fix(managers): enable modern TypeScript plugin

### DIFF
--- a/packages/managers/project.json
+++ b/packages/managers/project.json
@@ -18,7 +18,8 @@
         "rollupConfig": "packages/managers/rollup.config.js",
         "compiler": "swc",
         "format": ["cjs", "esm"],
-        "generatePackageJson": false
+        "generatePackageJson": false,
+        "useLegacyTypescriptPlugin": false
       }
     },
     "lint": {


### PR DESCRIPTION
## Summary
- Add `useLegacyTypescriptPlugin: false` to managers package build configuration
- Enables the official `@rollup/plugin-typescript` instead of deprecated `rollup-plugin-typescript2`
- Resolves TypeScript compilation errors during build

## Test plan
- [x] Build succeeds without TypeScript errors
- [x] No breaking changes to package API

🤖 Generated with [Claude Code](https://claude.ai/code)