### PR TITLE
fix(cli): enable modern TypeScript plugin

### DIFF
--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -16,7 +16,8 @@
         "rollupConfig": "packages/cli/rollup.config.js",
         "compiler": "swc",
         "format": ["cjs"],
-        "generatePackageJson": false
+        "generatePackageJson": false,
+        "useLegacyTypescriptPlugin": false
       }
     },
     "lint": {


### PR DESCRIPTION
## Summary
- Add `useLegacyTypescriptPlugin: false` to cli package build configuration
- Enables the official `@rollup/plugin-typescript` instead of deprecated `rollup-plugin-typescript2`
- Resolves TypeScript compilation errors during build

## Test plan
- [x] Build succeeds without TypeScript errors
- [x] No breaking changes to package API

🤖 Generated with [Claude Code](https://claude.ai/code)