### PR TITLE
fix(data-prefetch): enable modern TypeScript plugin

### DIFF
--- a/packages/data-prefetch/project.json
+++ b/packages/data-prefetch/project.json
@@ -17,7 +17,8 @@
         "rollupConfig": "packages/data-prefetch/rollup.config.cjs",
         "compiler": "swc",
         "format": ["cjs", "esm"],
-        "generatePackageJson": false
+        "generatePackageJson": false,
+        "useLegacyTypescriptPlugin": false
       }
     },
     "test": {


### PR DESCRIPTION
## Summary
- Add \`useLegacyTypescriptPlugin: false\` to $pkg package build configuration
- Enables the official \`@rollup/plugin-typescript\` instead of deprecated \`rollup-plugin-typescript2\`
- Resolves TypeScript compilation errors during build

## Test plan
- [x] Build succeeds without TypeScript errors
- [x] No breaking changes to package API

🤖 Generated with [Claude Code](https://claude.ai/code)