### PR TITLE
fix(esbuild): enable modern TypeScript plugin

### DIFF
--- a/packages/esbuild/project.json
+++ b/packages/esbuild/project.json
@@ -37,7 +37,8 @@
           "rollup",
           "../../resolve/esm-resolver.mjs"
         ],
-        "generatePackageJson": false
+        "generatePackageJson": false,
+        "useLegacyTypescriptPlugin": false
       },
       "dependsOn": [
         {


### PR DESCRIPTION
## Summary
- Add \`useLegacyTypescriptPlugin: false\` to $pkg package build configuration
- Enables the official \`@rollup/plugin-typescript\` instead of deprecated \`rollup-plugin-typescript2\`
- Resolves TypeScript compilation errors during build

## Test plan
- [x] Build succeeds without TypeScript errors
- [x] No breaking changes to package API

🤖 Generated with [Claude Code](https://claude.ai/code)