### PR TITLE
fix(utils): enable modern TypeScript plugin

### DIFF
--- a/packages/utilities/project.json
+++ b/packages/utilities/project.json
@@ -31,7 +31,8 @@
         "external": ["@module-federation/*"],
         "compiler": "swc",
         "format": ["cjs", "esm"],
-        "generatePackageJson": false
+        "generatePackageJson": false,
+        "useLegacyTypescriptPlugin": false
       }
     },
     "lint": {


### PR DESCRIPTION
## Summary
- Add \`useLegacyTypescriptPlugin: false\` to $pkg package build configuration
- Enables the official \`@rollup/plugin-typescript\` instead of deprecated \`rollup-plugin-typescript2\`
- Resolves TypeScript compilation errors during build

## Test plan
- [x] Build succeeds without TypeScript errors
- [x] No breaking changes to package API

🤖 Generated with [Claude Code](https://claude.ai/code)