### PR TITLE
fix(webpack-bundler-runtime): enable modern TypeScript plugin

### DIFF
--- a/packages/utilities/project.json
+++ b/packages/utilities/project.json
@@ -31,7 +31,8 @@
         "external": ["@module-federation/*"],
         "compiler": "swc",
         "format": ["cjs", "esm"],
-        "generatePackageJson": false
+        "generatePackageJson": false,
+        "useLegacyTypescriptPlugin": false
       }
     },
     "lint": {

--- a/packages/webpack-bundler-runtime/project.json
+++ b/packages/webpack-bundler-runtime/project.json
@@ -21,6 +21,7 @@
           "packages/webpack-bundler-runtime/src/constant.ts"
         ],
         "generatePackageJson": false,
+        "useLegacyTypescriptPlugin": false,
         "rollupConfig": "packages/webpack-bundler-runtime/rollup.config.cjs"
       },
       "dependsOn": [


### PR DESCRIPTION
## Summary
- Add \`useLegacyTypescriptPlugin: false\` to $pkg package build configuration
- Enables the official \`@rollup/plugin-typescript\` instead of deprecated \`rollup-plugin-typescript2\`
- Resolves TypeScript compilation errors during build

## Test plan
- [x] Build succeeds without TypeScript errors
- [x] No breaking changes to package API

🤖 Generated with [Claude Code](https://claude.ai/code)