### PR TITLE
chore: clear node_modules cache after pnpm install

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
+      - name: Clear Node Modules Cache
+        run: rm -rf node_modules/.cache
+
       - name: Install Cypress
         # if: steps.browsers-cache.outputs.cache-hit != 'true'
         run: npx cypress install


### PR DESCRIPTION
## Summary
- Add step to remove `node_modules/.cache` directory after dependency installation
- Prevents potential caching issues that could cause build failures or inconsistent behavior in CI
- Ensures clean cache state for each CI run

## Test plan
- [x] Workflow file syntax is valid
- [x] Step is correctly positioned after `pnpm install`
- [x] No breaking changes to existing CI behavior

## Details
This change adds a simple `rm -rf node_modules/.cache` command after the `pnpm install` step in the build-and-test workflow. This helps prevent cache-related issues that can sometimes cause intermittent build failures in CI environments.

🤖 Generated with [Claude Code](https://claude.ai/code)