### PR TITLE
fix(bridge-react): Add loading in root component to avoid CLS problem

### DIFF
--- a/packages/bridge/bridge-react/src/remote/component.tsx
+++ b/packages/bridge/bridge-react/src/remote/component.tsx
@@ -23,6 +23,7 @@ const RemoteAppWrapper = forwardRef(function (
     className,
     style,
     fallback,
+    loading,
     ...resProps
   } = props;
 
@@ -104,7 +105,9 @@ const RemoteAppWrapper = forwardRef(function (
   // bridge-remote-root
   const rootComponentClassName = `${getRootDomDefaultClassName(moduleName)} ${className || ''}`;
   return (
-    <div className={rootComponentClassName} style={style} ref={rootRef}></div>
+    <div className={rootComponentClassName} style={style} ref={rootRef}>
+      {loading}
+    </div>
   );
 });
 

--- a/packages/bridge/bridge-react/src/remote/create.tsx
+++ b/packages/bridge/bridge-react/src/remote/create.tsx
@@ -44,6 +44,7 @@ function createLazyRemoteComponent<
               providerInfo={exportFn}
               exportName={info.export || 'default'}
               fallback={info.fallback}
+              loading={info.loading}
               ref={ref}
               {...props}
             />


### PR DESCRIPTION
## Description
I've added loading prop inside the root div before the JSX will be rendered to avoid CLS issue
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/module-federation/core/issues/3974
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
