### PR TITLE
fix(bridge-react): call preloadAssets after getting assets

### DIFF
--- a/.changeset/shiny-pigs-tap.md
+++ b/.changeset/shiny-pigs-tap.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/bridge-react': patch
+---
+
+fix(bridge-react): call preloadAssets after getting assets

--- a/packages/bridge/bridge-react/src/lazy/data-fetch/prefetch.ts
+++ b/packages/bridge/bridge-react/src/lazy/data-fetch/prefetch.ts
@@ -44,19 +44,25 @@ export async function prefetch(options: PrefetchOptions) {
   if (preloadComponentResource) {
     const remoteInfo = helpers.utils.getRemoteInfo(remote);
 
-    instance.remoteHandler.hooks.lifecycle.generatePreloadAssets.emit({
-      origin: instance,
-      preloadOptions: {
-        remote,
-        preloadConfig: {
-          nameOrAlias: remote.name,
-          exposes: [expose],
+    Promise.resolve(
+      instance.remoteHandler.hooks.lifecycle.generatePreloadAssets.emit({
+        origin: instance,
+        preloadOptions: {
+          remote,
+          preloadConfig: {
+            nameOrAlias: remote.name,
+            exposes: [expose],
+          },
         },
-      },
-      remote,
-      remoteInfo,
-      globalSnapshot,
-      remoteSnapshot,
+        remote,
+        remoteInfo,
+        globalSnapshot,
+        remoteSnapshot,
+      }),
+    ).then((assets) => {
+      if (assets) {
+        helpers.utils.preloadAssets(remoteInfo, instance, assets);
+      }
     });
   }
 


### PR DESCRIPTION
## Description

call preloadAssets after getting assets

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
