### PR TITLE
fix: collect rspack cached modules in manifest

### DIFF
--- a/.changeset/strange-years-cross.md
+++ b/.changeset/strange-years-cross.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/manifest': patch
+---
+
+fix(manifest): collect cached modules since rspack support cache

--- a/packages/manifest/src/StatsManager.ts
+++ b/packages/manifest/src/StatsManager.ts
@@ -335,10 +335,8 @@ class StatsManager {
         chunks: false,
         reasons: true,
       };
-      if (this._bundler === 'webpack') {
-        statsOptions['cached'] = true;
-        statsOptions['cachedModules'] = true;
-      }
+      statsOptions['cached'] = true;
+      statsOptions['cachedModules'] = true;
       const webpackStats = liveStats.toJson(statsOptions);
 
       const filteredModules = this._getFilteredModules(webpackStats);

--- a/packages/manifest/src/StatsManager.ts
+++ b/packages/manifest/src/StatsManager.ts
@@ -335,8 +335,11 @@ class StatsManager {
         chunks: false,
         reasons: true,
       };
-      statsOptions['cached'] = true;
+      if (this._bundler === 'webpack') {
+        statsOptions['cached'] = true;
+      }
       statsOptions['cachedModules'] = true;
+
       const webpackStats = liveStats.toJson(statsOptions);
 
       const filteredModules = this._getFilteredModules(webpackStats);


### PR DESCRIPTION
## Description

Since Rspack support cache feature, the manifest should set `statsOptions.cacheModules` as `true` to collect cached modules, to prevent exposes resources be flushed when modifing code .

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
