### PR TITLE
fix(rsbuild-plugin): set output.emitAssets as true

### DIFF
--- a/.changeset/light-tools-sparkle.md
+++ b/.changeset/light-tools-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rsbuild-plugin': patch
+---
+
+fix(rsbuild-plugin): set output.emitAssets as true

--- a/packages/rsbuild-plugin/src/utils/ssr.ts
+++ b/packages/rsbuild-plugin/src/utils/ssr.ts
@@ -100,6 +100,7 @@ export function createSSRREnvConfig(
         ssrDir,
       ),
     },
+    emitAssets: true,
   };
   return ssrEnvConfig;
 }


### PR DESCRIPTION
## Description

Rspress set output.emitAssets as `false` when in `node` target . If not set `true`, the rspress ssr static asset will no be emitted which cause resource 404

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
