### PR TITLE
fix(rsbuild-plugin): invalid type field

### DIFF
--- a/.changeset/rare-laws-sleep.md
+++ b/.changeset/rare-laws-sleep.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rsbuild-plugin': patch
+---
+
+fix(rsbuild-plugin): invalid type field

--- a/packages/rsbuild-plugin/package.json
+++ b/packages/rsbuild-plugin/package.json
@@ -31,7 +31,7 @@
   },
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.mjs",
-  "types": "./dist/index.cjs.d.ts",
+  "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
       ".": [


### PR DESCRIPTION
## Description

correct rsbuild plugin types field

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
