### PR TITLE
feat: support env vars to add cors when use serve command

### DIFF
--- a/.changeset/poor-penguins-build.md
+++ b/.changeset/poor-penguins-build.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': patch
+---
+
+feat: support env vars to add cors when use serve command

--- a/packages/modernjs/src/server/staticMiddleware.ts
+++ b/packages/modernjs/src/server/staticMiddleware.ts
@@ -59,4 +59,20 @@ const createStaticMiddleware = (options: {
   };
 };
 
-export { createStaticMiddleware };
+const createCorsMiddleware = (): MiddlewareHandler => {
+  return async (c, next) => {
+    const pathname = c.req.path;
+    // If the request is only for a static file
+    if (path.extname(pathname)) {
+      c.header('Access-Control-Allow-Origin', '*');
+      c.header(
+        'Access-Control-Allow-Methods',
+        'GET, POST, PUT, DELETE, PATCH, OPTIONS',
+      );
+      c.header('Access-Control-Allow-Headers', '*');
+    }
+    return next();
+  };
+};
+
+export { createStaticMiddleware, createCorsMiddleware };


### PR DESCRIPTION
## Description

Modern.js support `serve` command to mock production in local. But when the user executes the `serve` command,  cors headers are not automatically added.

However, providers need cors headers for consumers. So we add an environment variable to allow developers to automatically add cross-origin headers at this time. 

It should be noted that this environment variable should not be used in the production environment, `*` is not a secure configuration option for `Access-Control-Allow-Origin`.

Examples:

```
MODERN_MF_AUTO_CORS=true modern serve
```

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
