### PR TITLE
fix(sdk): change NameTransformSymbol to literal type for TS <5.7.0

### DIFF
--- a/packages/sdk/src/constant.ts
+++ b/packages/sdk/src/constant.ts
@@ -12,7 +12,7 @@ export const NameTransformMap = {
   [NameTransformSymbol.AT]: 'scope_',
   [NameTransformSymbol.HYPHEN]: '_',
   [NameTransformSymbol.SLASH]: '__',
-};
+} as const;
 
 export const EncodedNameTransformMap = {
   [NameTransformMap[NameTransformSymbol.AT]]: NameTransformSymbol.AT,


### PR DESCRIPTION
## Description

In TS versions before 5.7.0, `NameTransformSymbol` throws an error due to:

TS1170: A computed property name in a type literal must refer to an expression whose type is a literal type or a 'unique symbol' type

This is solved by converting `NameTransformSymbol` to a literal type with `as const`

## Related Issue

Addresses #4013 


## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
