### PR TITLE
WIP: add getRetryPath in retry plugin to support users to customize retry path

### DIFF
--- a/.changeset/fuzzy-foxes-perform.md
+++ b/.changeset/fuzzy-foxes-perform.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/retry-plugin': patch
+'@module-federation/runtime-core': patch
+---
+
+feat(retry-plugin): Add getRetryPath support in retry plugin to allow users to customize retry path

--- a/apps/router-demo/router-host-2000/src/App.tsx
+++ b/apps/router-demo/router-host-2000/src/App.tsx
@@ -17,6 +17,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import Remote1AppNew from 'remote1/app';
 import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
 import { Spin } from 'antd';
+import { createInstance } from '@module-federation/enhanced/runtime';
 
 const fallbackPlugin: () => ModuleFederationRuntimePlugin = function () {
   return {
@@ -27,7 +28,7 @@ const fallbackPlugin: () => ModuleFederationRuntimePlugin = function () {
   };
 };
 
-init({
+const mf = createInstance({
   name: 'federation_consumer',
   remotes: [],
   plugins: [

--- a/apps/router-demo/router-host-2000/src/runtime-plugin/retry.ts
+++ b/apps/router-demo/router-host-2000/src/runtime-plugin/retry.ts
@@ -3,8 +3,10 @@ import { RetryPlugin } from '@module-federation/retry-plugin';
 const retryPlugin = () =>
   RetryPlugin({
     fetch: {
-      // url: 'http://localhost:2001/mf-manifest.json',
       // fallback: () => 'http://localhost:2001/mf-manifest.json',
+      getRetryPath: (url) => {
+        return 'http://localhost:2001/mf-manifest.json?test=1';
+      },
     },
     script: {
       retryTimes: 3,
@@ -19,6 +21,9 @@ const retryPlugin = () =>
         return setTimeout(() => {
           resolve(error);
         }, 1000);
+      },
+      getRetryPath: (url) => {
+        return 'http://localhost:2001/remote1.js?test=2';
       },
     },
   });

--- a/packages/retry-plugin/src/index.ts
+++ b/packages/retry-plugin/src/index.ts
@@ -10,33 +10,21 @@ const RetryPlugin: (
   script: scriptOption,
 }) => ({
   name: 'retry-plugin',
-  async fetch(url: string, options: RequestInit) {
-    const _options = {
-      ...options,
-      ...fetchOption?.options,
-    };
-
+  async fetch(manifestUrl: string, options: RequestInit) {
+    const { retryTimes, fallback, getRetryPath } = fetchOption || {};
     if (fetchOption) {
-      if (fetchOption.url) {
-        if (url === fetchOption?.url) {
-          return fetchWithRetry({
-            url: fetchOption.url,
-            options: _options,
-            retryTimes: fetchOption?.retryTimes,
-            fallback: fetchOption?.fallback,
-          });
-        }
-      } else {
-        // or when fetch retry rule is configured, retry for all urls
-        return fetchWithRetry({
-          url,
-          options: _options,
-          retryTimes: fetchOption?.retryTimes,
-          fallback: fetchOption?.fallback,
-        });
-      }
+      fetchWithRetry({
+        manifestUrl,
+        options: {
+          ...options,
+          ...fetchOption?.options,
+        },
+        retryTimes,
+        fallback,
+        getRetryPath,
+      });
     }
-    return fetch(url, options);
+    return fetch(manifestUrl, options);
   },
 
   async loadEntryError({
@@ -56,6 +44,7 @@ const RetryPlugin: (
       retryFn,
       beforeExecuteRetry,
     });
+
     return getRemoteEntryRetry({
       origin,
       remoteInfo,

--- a/packages/retry-plugin/src/types.d.ts
+++ b/packages/retry-plugin/src/types.d.ts
@@ -1,19 +1,19 @@
 import { RemoteInfo } from '@module-federation/runtime/types';
 export interface FetchWithRetryOptions {
-  url?: string;
   options?: RequestInit;
   retryTimes?: number;
   retryDelay?: number;
   fallback?:
     | (() => string)
     | ((url: string | URL | globalThis.Request) => string);
+  getRetryPath?: (url: string) => string;
 }
-
 export interface ScriptWithRetryOptions {
   retryTimes?: number;
   retryDelay?: number;
   moduleName?: Array<string>;
   cb?: (resolve: (value: unknown) => void, error: any) => void;
+  getRetryPath?: (url: string) => string;
 }
 
 export type RetryPluginParams = {
@@ -21,14 +21,10 @@ export type RetryPluginParams = {
   script?: ScriptWithRetryOptions;
 };
 
-export type RequiredFetchWithRetryOptions = Required<
-  Pick<FetchWithRetryOptions, 'url'>
-> &
-  Omit<FetchWithRetryOptions, 'url'>;
-
 export type ScriptCommonRetryOption = {
   scriptOption: ScriptWithRetryOptions;
   moduleInfo: RemoteInfo & { alias?: string };
   retryFn: (...args: any[]) => Promise<any> | (() => Promise<any>);
   beforeExecuteRetry?: (...args: any[]) => void;
+  getRetryPath?: (url: string) => string;
 };

--- a/packages/retry-plugin/src/util.ts
+++ b/packages/retry-plugin/src/util.ts
@@ -27,7 +27,10 @@ export function scriptCommonRetry<T extends (...args: any[]) => void>({
       while (attempts - 1 < retryTimes) {
         try {
           beforeExecuteRetry();
-          retryResponse = await retryFn(...args);
+          retryResponse = await retryFn({
+            ...args[0],
+            getRetryPath: scriptOption?.getRetryPath,
+          });
           break;
         } catch (error) {
           attempts++;

--- a/packages/runtime-core/src/utils/load.ts
+++ b/packages/runtime-core/src/utils/load.ts
@@ -105,11 +105,13 @@ async function loadEntryScript({
   globalName,
   entry,
   loaderHook,
+  getRetryPath,
 }: {
   name: string;
   globalName: string;
   entry: string;
   loaderHook: ModuleFederation['loaderHook'];
+  getRetryPath?: (url: string) => string;
 }): Promise<RemoteEntryExports> {
   const { entryExports: remoteEntryExports } = getRemoteEntryExports(
     name,
@@ -120,7 +122,9 @@ async function loadEntryScript({
     return remoteEntryExports;
   }
 
-  return loadScript(entry, {
+  // if this is a retry request, if user pass the getRetryPath parameter, use the getRetryPath to get the retry url
+  const url = getRetryPath ? getRetryPath(entry) : entry;
+  return loadScript(url, {
     attrs: {},
     createScriptHook: (url, attrs) => {
       const res = loaderHook.lifecycle.createScript.emit({ url, attrs });
@@ -157,10 +161,12 @@ async function loadEntryDom({
   remoteInfo,
   remoteEntryExports,
   loaderHook,
+  getRetryPath,
 }: {
   remoteInfo: RemoteInfo;
   remoteEntryExports?: RemoteEntryExports;
   loaderHook: ModuleFederation['loaderHook'];
+  getRetryPath?: (url: string) => string;
 }) {
   const { entry, entryGlobalName: globalName, name, type } = remoteInfo;
   switch (type) {
@@ -170,7 +176,13 @@ async function loadEntryDom({
     case 'system':
       return loadSystemJsEntry({ entry, remoteEntryExports });
     default:
-      return loadEntryScript({ entry, globalName, name, loaderHook });
+      return loadEntryScript({
+        entry,
+        globalName,
+        name,
+        loaderHook,
+        getRetryPath,
+      });
   }
 }
 
@@ -220,15 +232,14 @@ export function getRemoteEntryUniqueKey(remoteInfo: RemoteInfo): string {
   return composeKeyWithSeparator(name, entry);
 }
 
-export async function getRemoteEntry({
-  origin,
-  remoteEntryExports,
-  remoteInfo,
-}: {
+export async function getRemoteEntry(params: {
   origin: ModuleFederation;
   remoteInfo: RemoteInfo;
   remoteEntryExports?: RemoteEntryExports | undefined;
+  getRetryPath?: (url: string) => string;
 }): Promise<RemoteEntryExports | false | void> {
+  console.log('=====getRemoteEntry', params);
+  const { origin, remoteEntryExports, remoteInfo, getRetryPath } = params;
   const uniqueKey = getRemoteEntryUniqueKey(remoteInfo);
   if (remoteEntryExports) {
     return remoteEntryExports;
@@ -255,7 +266,12 @@ export async function getRemoteEntry({
             : isBrowserEnv();
 
         return isWebEnvironment
-          ? loadEntryDom({ remoteInfo, remoteEntryExports, loaderHook })
+          ? loadEntryDom({
+              remoteInfo,
+              remoteEntryExports,
+              loaderHook,
+              getRetryPath,
+            })
           : loadEntryNode({ remoteInfo, loaderHook });
       });
   }


### PR DESCRIPTION
feat(retry-plugin): add getRetryPath in retry plugin to support uses  to customize retry path.

## Description

Allow rewriting request URLs during retries to switch fallback domains, bust caches, or route traffic.

## New Options:
- Fetch retry:  `fetch.getRetryPath?: (url: string) => string`
- Script retry: `script.getRetryPath?: (url: string) => string`

## Behavior:
Before each retry, the plugin calls getRetryPath(originalUrl) to compute the retry URL. If not provided, the original URL is used.

## Example

```ts
 RetryPlugin({
    fetch: {
      retryTimes: 3,
      getRetryPath: (url) => `${url}?retry_ts=${Date.now()}`,
    },
    script: {
      retryTimes: 3,
      retryDelay: 1000,
      getRetryPath: (url) => url.replace('cdn.a.com', 'cdn.b.com'),
    },
  });
```

## Notes
- Keep getRetryPath pure and fast; avoid throwing.
- Ensure returned URLs are valid and reachable; add version/hash if needed to avoid cache collisions.


<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
