### PR TITLE
fix(module-federation): resolve source map configuration issues and build failures

### DIFF
--- a/.changeset/smart-insects-marry.md
+++ b/.changeset/smart-insects-marry.md
@@ -1,0 +1,20 @@
+---
+'@module-federation/inject-external-runtime-core-plugin': patch
+'@module-federation/webpack-bundler-runtime': patch
+'@module-federation/metro-plugin-rnc-cli': patch
+'@module-federation/rsbuild-plugin': patch
+'@module-federation/data-prefetch': patch
+'@module-federation/runtime-tools': patch
+'@module-federation/runtime-core': patch
+'@module-federation/error-codes': patch
+'@module-federation/nextjs-mf': patch
+'@module-federation/managers': patch
+'@module-federation/manifest': patch
+'@module-federation/esbuild': patch
+'@module-federation/runtime': patch
+'@module-federation/rspack': patch
+'@module-federation/cli': patch
+'@module-federation/sdk': patch
+---
+
+add sourcemaps to fix builds

--- a/packages/cli/rollup.config.js
+++ b/packages/cli/rollup.config.js
@@ -3,6 +3,15 @@ const replace = require('@rollup/plugin-replace');
 const pkg = require('./package.json');
 
 module.exports = (rollupConfig, _projectOptions) => {
+  // Add sourcemap configuration
+  if (Array.isArray(rollupConfig.output)) {
+    rollupConfig.output.forEach((output) => {
+      output.sourcemap = true;
+    });
+  } else if (rollupConfig.output) {
+    rollupConfig.output.sourcemap = true;
+  }
+
   rollupConfig.plugins.push(
     replace({
       __VERSION__: JSON.stringify(pkg.version),

--- a/packages/data-prefetch/.swcrc
+++ b/packages/data-prefetch/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     ".*\\.spec.tsx?$",

--- a/packages/data-prefetch/rollup.config.cjs
+++ b/packages/data-prefetch/rollup.config.cjs
@@ -23,6 +23,7 @@ module.exports = (rollupConfig, _projectOptions) => {
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output = rollupConfig.output.map((c) => ({
       ...c,
+      sourcemap: true,
       manualChunks: (id) => {
         if (id.includes('@swc/helpers')) {
           return 'polyfills';
@@ -42,6 +43,7 @@ module.exports = (rollupConfig, _projectOptions) => {
   } else {
     rollupConfig.output = {
       ...rollupConfig.output,
+      sourcemap: true,
       manualChunks: (id) => {
         if (id.includes('@swc/helpers')) {
           return 'polyfills';

--- a/packages/dts-plugin/.swcrc
+++ b/packages/dts-plugin/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     ".*\\.spec.tsx?$",

--- a/packages/enhanced/.swcrc
+++ b/packages/enhanced/.swcrc
@@ -21,6 +21,7 @@
     "importInterop": "swc"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     ".*\\.spec.tsx?$",

--- a/packages/error-codes/.swcrc
+++ b/packages/error-codes/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     ".*\\.spec.tsx?$",

--- a/packages/error-codes/rollup.config.js
+++ b/packages/error-codes/rollup.config.js
@@ -2,6 +2,7 @@ module.exports = (rollupConfig, projectOptions) => {
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output = rollupConfig.output.map((c) => ({
       ...c,
+      sourcemap: true,
       hoistTransitiveImports: false,
       entryFileNames:
         c.format === 'esm'
@@ -16,7 +17,7 @@ module.exports = (rollupConfig, projectOptions) => {
   } else {
     rollupConfig.output = {
       ...rollupConfig.output,
-
+      sourcemap: true,
       hoistTransitiveImports: false,
       entryFileNames:
         rollupConfig.output.format === 'esm'

--- a/packages/esbuild/.swcrc
+++ b/packages/esbuild/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     ".*\\.spec.tsx?$",

--- a/packages/esbuild/rollup.config.js
+++ b/packages/esbuild/rollup.config.js
@@ -20,6 +20,15 @@ module.exports = (rollupConfig, projectOptions) => {
     delete rollupConfig.input.helpers;
   }
 
+  // Add sourcemap configuration
+  if (Array.isArray(rollupConfig.output)) {
+    rollupConfig.output.forEach((output) => {
+      output.sourcemap = true;
+    });
+  } else if (rollupConfig.output) {
+    rollupConfig.output.sourcemap = true;
+  }
+
   rollupConfig.plugins.push(
     replace({
       preventAssignment: true,

--- a/packages/managers/.swcrc
+++ b/packages/managers/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     "./src/jest-setup.ts$",

--- a/packages/managers/rollup.config.js
+++ b/packages/managers/rollup.config.js
@@ -12,10 +12,12 @@ module.exports = (rollupConfig, _projectOptions) => {
   // Check if rollupConfig.output is an array
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output.forEach((output) => {
+      output.sourcemap = true;
       output.hoistTransitiveImports = false;
     });
   } else if (rollupConfig.output) {
     // If it's not an array, directly set the property
+    rollupConfig.output.sourcemap = true;
     rollupConfig.output.hoistTransitiveImports = false;
   }
 

--- a/packages/manifest/rollup.config.js
+++ b/packages/manifest/rollup.config.js
@@ -4,10 +4,12 @@ module.exports = (rollupConfig, _projectOptions) => {
   // Check if rollupConfig.output is an array
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output.forEach((output) => {
+      output.sourcemap = true;
       output.hoistTransitiveImports = false;
     });
   } else if (rollupConfig.output) {
     // If it's not an array, directly set the property
+    rollupConfig.output.sourcemap = true;
     rollupConfig.output.hoistTransitiveImports = false;
   }
 

--- a/packages/metro-plugin-rnc-cli/project.json
+++ b/packages/metro-plugin-rnc-cli/project.json
@@ -5,6 +5,17 @@
   "projectType": "library",
   "tags": ["type:pkg"],
   "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          {
+            "command": "echo 'No build needed for metro-plugin-rnc-cli - pure JavaScript package'",
+            "forwardAllArgs": false
+          }
+        ]
+      }
+    },
     "lint": {
       "executor": "@nx/eslint:lint"
     }

--- a/packages/nextjs-mf/rollup.config.js
+++ b/packages/nextjs-mf/rollup.config.js
@@ -1,6 +1,15 @@
 const copy = require('rollup-plugin-copy');
 
 module.exports = (rollupConfig, _projectOptions) => {
+  // Add sourcemap configuration
+  if (Array.isArray(rollupConfig.output)) {
+    rollupConfig.output.forEach((output) => {
+      output.sourcemap = true;
+    });
+  } else if (rollupConfig.output) {
+    rollupConfig.output.sourcemap = true;
+  }
+
   rollupConfig.plugins.push(
     copy({
       targets: [{ src: 'packages/sdk/LICENSE', dest: 'dist/packages/sdk' }],

--- a/packages/retry-plugin/.swcrc
+++ b/packages/retry-plugin/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     ".*\\.spec.tsx?$",

--- a/packages/rsbuild-plugin/rollup.config.js
+++ b/packages/rsbuild-plugin/rollup.config.js
@@ -21,6 +21,7 @@ module.exports = (rollupConfig, _projectOptions) => {
   };
 
   rollupConfig.output.forEach((output) => {
+    output.sourcemap = true;
     output.entryFileNames = `[name].${output.format === 'esm' ? 'esm' : 'cjs'}.${
       output.format === 'esm' ? 'mjs' : 'js'
     }`;

--- a/packages/rspack/rollup.config.js
+++ b/packages/rspack/rollup.config.js
@@ -17,6 +17,7 @@ module.exports = (rollupConfig, projectOptions) => {
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output = rollupConfig.output.map((c) => ({
       ...c,
+      sourcemap: true,
       hoistTransitiveImports: false,
       entryFileNames:
         c.format === 'esm'
@@ -30,6 +31,7 @@ module.exports = (rollupConfig, projectOptions) => {
   } else {
     rollupConfig.output = {
       ...rollupConfig.output,
+      sourcemap: true,
       hoistTransitiveImports: false,
       entryFileNames:
         rollupConfig.output.format === 'esm'

--- a/packages/runtime-core/.swcrc
+++ b/packages/runtime-core/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     ".*\\.spec.tsx?$",

--- a/packages/runtime-core/rollup.config.cjs
+++ b/packages/runtime-core/rollup.config.cjs
@@ -22,6 +22,7 @@ module.exports = (rollupConfig, projectOptions) => {
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output = rollupConfig.output.map((c) => ({
       ...c,
+      sourcemap: true,
       manualChunks: (id) => {
         if (id.includes('@swc/helpers')) {
           return 'polyfills';
@@ -41,6 +42,7 @@ module.exports = (rollupConfig, projectOptions) => {
   } else {
     rollupConfig.output = {
       ...rollupConfig.output,
+      sourcemap: true,
       manualChunks: (id) => {
         if (id.includes('@swc/helpers')) {
           return 'polyfills';

--- a/packages/runtime-plugins/inject-external-runtime-core-plugin/.swcrc
+++ b/packages/runtime-plugins/inject-external-runtime-core-plugin/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     "./src/jest-setup.ts$",

--- a/packages/runtime-plugins/inject-external-runtime-core-plugin/rollup.config.cjs
+++ b/packages/runtime-plugins/inject-external-runtime-core-plugin/rollup.config.cjs
@@ -19,6 +19,7 @@ module.exports = (rollupConfig, _projectOptions) => {
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output = rollupConfig.output.map((c) => ({
       ...c,
+      sourcemap: true,
       manualChunks: (id) => {
         if (id.includes('@swc/helpers')) {
           return 'polyfills';
@@ -38,6 +39,7 @@ module.exports = (rollupConfig, _projectOptions) => {
   } else {
     rollupConfig.output = {
       ...rollupConfig.output,
+      sourcemap: true,
       manualChunks: (id) => {
         if (id.includes('@swc/helpers')) {
           return 'polyfills';

--- a/packages/runtime-tools/.swcrc
+++ b/packages/runtime-tools/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     ".*\\.spec.tsx?$",

--- a/packages/runtime-tools/rollup.config.cjs
+++ b/packages/runtime-tools/rollup.config.cjs
@@ -10,6 +10,7 @@ module.exports = function (rollupConfig) {
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output = rollupConfig.output.map(function (c) {
       var outputConfig = Object.assign({}, c, {
+        sourcemap: true,
         hoistTransitiveImports: false,
         entryFileNames:
           c.format === 'cjs'
@@ -29,6 +30,7 @@ module.exports = function (rollupConfig) {
     });
   } else {
     var outputConfig = Object.assign({}, rollupConfig.output, {
+      sourcemap: true,
       hoistTransitiveImports: false,
       entryFileNames:
         rollupConfig.output.format === 'cjs'

--- a/packages/runtime/.swcrc
+++ b/packages/runtime/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     ".*\\.spec.tsx?$",

--- a/packages/runtime/rollup.config.cjs
+++ b/packages/runtime/rollup.config.cjs
@@ -26,6 +26,7 @@ module.exports = (rollupConfig, projectOptions) => {
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output = rollupConfig.output.map((c) => ({
       ...c,
+      sourcemap: true,
       manualChunks: (id) => {
         if (id.includes('@swc/helpers')) {
           return 'polyfills';
@@ -45,6 +46,7 @@ module.exports = (rollupConfig, projectOptions) => {
   } else {
     rollupConfig.output = {
       ...rollupConfig.output,
+      sourcemap: true,
       manualChunks: (id) => {
         if (id.includes('@swc/helpers')) {
           return 'polyfills';

--- a/packages/sdk/.swcrc
+++ b/packages/sdk/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     "./src/jest-setup.ts$",

--- a/packages/sdk/rollup.config.cjs
+++ b/packages/sdk/rollup.config.cjs
@@ -12,6 +12,7 @@ module.exports = (rollupConfig, _projectOptions) => {
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output = rollupConfig.output.map((c) => ({
       ...c,
+      sourcemap: true,
       manualChunks: (id) => {
         if (id.includes('@swc/helpers')) {
           return 'polyfills';
@@ -32,6 +33,7 @@ module.exports = (rollupConfig, _projectOptions) => {
   } else {
     rollupConfig.output = {
       ...rollupConfig.output,
+      sourcemap: true,
       manualChunks: (id) => {
         if (id.includes('@swc/helpers')) {
           return 'polyfills';

--- a/packages/typescript/.swcrc
+++ b/packages/typescript/.swcrc
@@ -20,6 +20,7 @@
     "noInterop": false
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     ".*.spec.tsx?$",

--- a/packages/webpack-bundler-runtime/.swcrc
+++ b/packages/webpack-bundler-runtime/.swcrc
@@ -18,6 +18,7 @@
     "type": "es6"
   },
   "sourceMaps": true,
+  "inputSourceMap": false,
   "exclude": [
     "jest.config.ts",
     ".*\\.test.tsx?$",

--- a/packages/webpack-bundler-runtime/rollup.config.cjs
+++ b/packages/webpack-bundler-runtime/rollup.config.cjs
@@ -11,6 +11,7 @@ module.exports = (rollupConfig, projectOptions) => {
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output = rollupConfig.output.map((c) => ({
       ...c,
+      sourcemap: true,
       hoistTransitiveImports: false,
       entryFileNames:
         c.format === 'cjs'
@@ -25,6 +26,7 @@ module.exports = (rollupConfig, projectOptions) => {
   } else {
     rollupConfig.output = {
       ...rollupConfig.output,
+      sourcemap: true,
       hoistTransitiveImports: false,
       entryFileNames:
         rollupConfig.output.format === 'cjs'


### PR DESCRIPTION
## Summary
- Add sourcemap: true to all rollup.config.js files across packages to enable proper source map generation
- Add inputSourceMap: false to .swcrc files to prevent source map conflicts during compilation
- Configure consistent sourcemap handling for all output formats (ESM/CJS) across the monorepo
- Add build target to metro-plugin-rnc-cli package configuration for completeness

## Changes Made
- **Rollup Configuration**: Updated all rollup.config.js files to enable sourcemap generation
- **SWC Configuration**: Added inputSourceMap: false to all .swcrc files to prevent conflicts
- **Package Configuration**: Added proper build target for metro-plugin-rnc-cli
- **Consistency**: Ensured uniform sourcemap handling across all packages in the monorepo

## Test Plan
- [ ] Verify all packages build successfully with sourcemaps enabled
- [ ] Run package-level tests to ensure no regressions
- [ ] Check that sourcemaps are properly generated in dist folders
- [ ] Validate that the metro-plugin-rnc-cli build target works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)