### PR TITLE
fix(bridge-react-webpack-plugin): fix the proxying react-router failed issue in the modernjs projects

### DIFF
--- a/.changeset/fair-hounds-sleep.md
+++ b/.changeset/fair-hounds-sleep.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/bridge-react-webpack-plugin': patch
+'@module-federation/enhanced': patch
+---
+
+fix(bridge): fix the issue where bridge proxy react-router fails in modernjs projects

--- a/packages/bridge/bridge-react-webpack-plugin/src/index.ts
+++ b/packages/bridge/bridge-react-webpack-plugin/src/index.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs';
-import path from 'node:path';
+// import fs from 'node:fs';
+// import path from 'node:path';
 import type { moduleFederationPlugin } from '@module-federation/sdk';
 import { getBridgeRouterAlias } from './utis';
 
@@ -34,27 +34,27 @@ class ReactBridgeAliasChangerPlugin {
   apply(compiler: any) {
     compiler.hooks.afterEnvironment.tap('ReactBridgeAliasPlugin', () => {
       // Gets the path to the node_modules directory
-      const nodeModulesPath = path.resolve(compiler.context, 'node_modules');
-      const targetFilePath = path.join(nodeModulesPath, this.targetFile);
+      // const nodeModulesPath = path.resolve(compiler.context, 'node_modules');
+      // const targetFilePath = path.join(nodeModulesPath, this.targetFile);
 
-      if (fs.existsSync(targetFilePath)) {
-        const originalResolve = compiler.options.resolve || {};
-        const originalAlias = originalResolve.alias || {};
+      // if (fs.existsSync(targetFilePath)) {
+      const originalResolve = compiler.options.resolve || {};
+      const originalAlias = originalResolve.alias || {};
 
-        // Update alias
-        const updatedAlias = {
-          // allow `alias` can be override
-          // [this.alias]: targetFilePath,
-          ...getBridgeRouterAlias(originalAlias['react-router-dom']),
-          ...originalAlias,
-        };
+      // Update alias
+      const updatedAlias = {
+        // allow `alias` can be override
+        // [this.alias]: targetFilePath,
+        ...getBridgeRouterAlias(originalAlias['react-router-dom']),
+        ...originalAlias,
+      };
 
-        // Update the webpack configuration
-        compiler.options.resolve = {
-          ...originalResolve,
-          alias: updatedAlias,
-        };
-      }
+      // Update the webpack configuration
+      compiler.options.resolve = {
+        ...originalResolve,
+        alias: updatedAlias,
+      };
+      // }
     });
   }
 }

--- a/packages/enhanced/src/wrapper/ModuleFederationPlugin.ts
+++ b/packages/enhanced/src/wrapper/ModuleFederationPlugin.ts
@@ -4,8 +4,8 @@ import type IModuleFederationPlugin from '../lib/container/ModuleFederationPlugi
 import type { ResourceInfo } from '@module-federation/manifest';
 
 import { getWebpackPath } from '@module-federation/sdk/normalize-webpack-path';
-import path from 'node:path';
-import fs from 'node:fs';
+// import path from 'node:path';
+// import fs from 'node:fs';
 import ReactBridgePlugin from '@module-federation/bridge-react-webpack-plugin';
 
 export const PLUGIN_NAME = 'ModuleFederationPlugin';
@@ -30,16 +30,13 @@ export default class ModuleFederationPlugin implements WebpackPluginInstance {
     this._mfPlugin!.apply(compiler);
 
     // react bridge plugin
-    const nodeModulesPath = path.resolve(compiler.context, 'node_modules');
-    const reactPath = path.join(
-      nodeModulesPath,
-      '@module-federation/bridge-react',
-    );
+    // const nodeModulesPath = path.resolve(compiler.context, 'node_modules');
+    // const reactPath = path.join(
+    //   nodeModulesPath,
+    //   '@module-federation/bridge-react',
+    // );
     // Check whether react exists
-    if (
-      fs.existsSync(reactPath) &&
-      (!this._options?.bridge || !this._options.bridge.disableAlias)
-    ) {
+    if (this._options?.bridge?.disableAlias !== true) {
       new ReactBridgePlugin({
         moduleFederationOptions: this._options,
       }).apply(compiler);


### PR DESCRIPTION
## Description
fix(bridge-react-webpack-plugin): fix the proxying react-router failed issue in the modernjs projects.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
