### PR TITLE
chore: enable trusted publishing for npm packages

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,49 @@
+# https://github.com/stackblitz-labs/pkg.pr.new
+name: Preview Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    if: github.repository == 'module-federation/core'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 25
+
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+
+      # Update npm to the latest version to enable OIDC
+      # Use corepack to install pnpm
+      - name: Setup Package Managers
+        run: |
+          npm install -g npm@latest
+          npm --version
+          npm install -g corepack@latest --force
+          corepack prepare pnpm@8.11.0 --activate
+          corepack enable
+
+      - name: Install deps
+        run: pnpm install
+
+      - name: Build and test Packages
+        run: |
+          git fetch origin main
+          npx nx run-many --targets=build --projects=tag:type:pkg --skip-nx-cache
+          ls -l packages/*/dist packages/*/package.json
+
+      - name: Publish Preview
+        run: pnpx pkg-pr-new publish --compact --pnpm ./packages/*

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -46,4 +46,6 @@ jobs:
           ls -l packages/*/dist packages/*/package.json
 
       - name: Publish Preview
-        run: pnpx pkg-pr-new publish --compact --pnpm ./packages/*
+        run: |
+          npm i -g pkg-pr-new@0.0.58
+          pkg-pr-new publish --compact --pnpm ./packages/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,22 +25,28 @@ jobs:
     name: Release
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 25
 
-      - name: Install Pnpm
-        run: |
-          corepack prepare pnpm@8.11.0 --activate
-          corepack enable
-
       - name: Setup Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'pnpm'
+
+      # Update npm to the latest version to enable OIDC
+      # Use corepack to install pnpm
+      - name: Setup Package Managers
+        run: |
+          npm install -g npm@latest
+          npm --version
+          npm install -g corepack@latest --force
+          corepack prepare pnpm@8.11.0 --activate
+          corepack enable
 
       - name: Install deps
         run: pnpm install
@@ -51,15 +57,17 @@ jobs:
           npx nx run-many --targets=build --projects=tag:type:pkg --skip-nx-cache
           ls -l packages/*/dist packages/*/package.json
 
-      - name: Release
-        uses: module-federation/actions@v2
+      - uses: actions/github-script@v7
+        id: version_to_release
         with:
-          version: ${{ github.event.inputs.version  || 'next' }}
-          branch: ${{ github.event.inputs.branch }}
-          type: 'release'
-          tools: 'changeset'
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          REF: ${{ github.ref }}
+          result-encoding: string
+          script: |
+            const fs = require('fs');
+            const packageJson = JSON.parse(fs.readFileSync('./packages/runtime/package.json', 'utf8'));
+            return 'v' + packageJson.version;
+
+      - name: Publish to npm
+        run: |
+          git tag ${{ steps.version_to_release.outputs.result }}
+          git push origin ${{ steps.version_to_release.outputs.result }}
+          pnpm -r publish --tag ${{ github.event.inputs.npm_tag }} --publish-branch ${{ github.event.inputs.branch }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/rsbuild-plugin/package.json
+++ b/packages/rsbuild-plugin/package.json
@@ -70,7 +70,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
## Description

1. enable trusted publishing for npm packages
2. Use pkg-pr-new to release preview version which will not leave useless preview version in npm versions



## Related Links
* https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
* https://docs.npmjs.com/trusted-publishers
* https://github.com/stackblitz-labs/pkg.pr.new


