### PR TITLE
Fix/retry plugin add query

### DIFF
--- a/.changeset/hungry-countries-sleep.md
+++ b/.changeset/hungry-countries-sleep.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/retry-plugin': patch
+---
+
+fix(retry-plugin): prevent query parameter accumulation across retries

--- a/apps/router-demo/router-host-2000/src/runtime-plugin/retry.ts
+++ b/apps/router-demo/router-host-2000/src/runtime-plugin/retry.ts
@@ -13,13 +13,19 @@ const retryPlugin = () =>
     onError: (params) => {
       console.log('onError', params);
     },
-    manifestDomains: ['https://m1.example.com', 'https://m2.example.com'],
+    manifestDomains: [
+      'https://m1.example.com',
+      'https://m2.example.com',
+      'https://m3.example.com',
+    ],
     domains: [
       'http://localhost:2011',
       'http://localhost:2021',
       'http://localhost:2031',
     ],
-    addQuery: true,
+    addQuery: ({ times, originalQuery }) => {
+      return `${originalQuery}&retry=${times}&retryTimeStamp=${new Date().valueOf()}`;
+    },
     fetchOptions: {
       method: 'GET',
     },

--- a/packages/retry-plugin/src/index.ts
+++ b/packages/retry-plugin/src/index.ts
@@ -93,3 +93,9 @@ export type {
   FetchRetryOptions,
   ScriptRetryOptions,
 } from './types';
+export {
+  getRetryUrl,
+  rewriteWithNextDomain,
+  appendRetryCountQuery,
+  combineUrlDomainWithPathQuery,
+} from './utils';

--- a/packages/retry-plugin/src/script-retry.ts
+++ b/packages/retry-plugin/src/script-retry.ts
@@ -30,17 +30,14 @@ export function scriptRetry<T extends Record<string, any>>({
     while (attempts < retryTimes) {
       try {
         beforeExecuteRetry();
-        // Wait before retries (applies to all retries inside this loop)
         if (retryDelay > 0) {
           await new Promise((resolve) => setTimeout(resolve, retryDelay));
         }
-        // Execute this retry with the computed index (1-based)
         const retryIndex = attempts + 1;
         retryWrapper = await (retryFn as any)({
           ...params,
           getEntryUrl: (url: string) => {
-            const base = lastRequestUrl || url;
-            const next = getRetryUrl(base, {
+            const next = getRetryUrl(url, {
               domains,
               addQuery,
               retryIndex,


### PR DESCRIPTION
## Description
When using [addQuery] option in retry-plugin, query parameters were accumulating across retries instead of being replaced. This caused URLs to grow with each retry attempt:

## Before fix:

```
Retry 1: https://m1.example.com/mf-manifest.json?retry=1&retryTimeStamp=1757484964434
Retry 2: https://m2.example.com/mf-manifest.json?retry=1&retryTimeStamp=1757484964434&retry=2&retryTimeStamp=1757484965475
Retry 3: https://m1.example.com/mf-manifest.json?retry=1&retryTimeStamp=1757484964434&retry=2&retryTimeStamp=1757484965475&retry=3&retryTimeStamp=1757484966521
```

## Solution
Fixed query parameter accumulation while preserving domain rotation functionality:

## After fix:
```
```




<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
