### PR TITLE
fix(runtime): remove synthetic default import

### DIFF
--- a/.changeset/old-buttons-hope.md
+++ b/.changeset/old-buttons-hope.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+Remove synthetic default import.

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -1,4 +1,4 @@
-import runtimeCore from '@module-federation/runtime-core';
+import * as runtimeCore from '@module-federation/runtime-core';
 
 export * from '@module-federation/runtime-core';
 


### PR DESCRIPTION
## Description

We're using module federation packages in a project with `skipLibCheck` set to `false`, however the type check in that project is failing with recent versions as a result of a couple of issues. One of those issues is that a synthetic default import is used in the `runtime` package due to the fact that the module being imported from doesn't actually specify a default export. This PR updates that import to use `* as` syntax instead to make this more explicit and resolve the type error.

This doesn't show up as as an error here due to the use of the `esModuleInterop` option in the base config, which defaults `allowSyntheticDefaultImports` to `true` as per [the docs](https://www.typescriptlang.org/tsconfig/#allowSyntheticDefaultImports). To avoid this reoccurring in future, the `allowSyntheticDefaultImports` property could be explicitly set to `false`.

The other issue we came across already has a fix raised in https://github.com/module-federation/core/pull/4014 that is yet to be merged.

## Related Issue

Similar to https://github.com/module-federation/core/issues/4013.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
