### PR TITLE
Fix minor documentation error for rsbuild consumer example

### DIFF
--- a/apps/website-new/docs/en/guide/start/quick-start.mdx
+++ b/apps/website-new/docs/en/guide/start/quick-start.mdx
@@ -132,7 +132,7 @@ Here is an example of creating an rsbuild consumer project:
 │
 ◇  Next steps ─────╮
 │                  │
-│  cd mf_provider  │
+│  cd mf_consumer  │
 │  npm install     │
 │  npm run dev     │
 │                  │


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

The documentation for creating an rsbuild consumer project contains a small error.

The module federation name is `mf_consumer` (correct).

However, the code-fenced example shows `cd mf_provider`:

<img width="826" height="847" alt="Screenshot 2025-09-17 at 12 03 12" src="https://github.com/user-attachments/assets/7f6a56b3-3f9d-42c3-b90c-430adeea7fe8" />

Published page: https://module-federation.io/guide/start/quick-start.html#create-a-consumer

## Related Issue

N/A

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
