### PR TITLE
Fix spaces in path for TypeScript compilation

### DIFF
--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.ts
@@ -186,7 +186,7 @@ export const compileTs = async (
           : undefined,
     });
     const execPromise = util.promisify(exec);
-    const cmd = `npx ${remoteOptions.compilerInstance} --project ${tempTsConfigJsonPath}`;
+    const cmd = `npx ${remoteOptions.compilerInstance} --project '${tempTsConfigJsonPath}'`;
     try {
       await execPromise(cmd, {
         cwd:


### PR DESCRIPTION
## Description

Directories with spaces inside of them were failing during TypeScript compilation, as it would generate a command such as `npx tsc --project my-cool path/tsconfig.json`, and `tsc` cannot accept both a project argument and files (the `path/tsconfig.json` portion).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
Unsure if required.

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
