### PR TITLE
fix: the `exposes.requires` type in manifest.json should be array instead of object

### DIFF
--- a/.changeset/six-lies-hang.md
+++ b/.changeset/six-lies-hang.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/manifest': patch
+---
+
+fix: the requires type in manifest.exposes shoule be array instead of object

--- a/packages/manifest/src/ModuleHandler.ts
+++ b/packages/manifest/src/ModuleHandler.ts
@@ -34,7 +34,7 @@ export function getExposeItem({
     id: composeKeyWithSeparator(name, exposeModuleName),
     name: exposeModuleName,
     // @ts-ignore to deduplicate
-    requires: new Set(),
+    requires: [],
     file: path.relative(process.cwd(), file.import[0]),
     assets: {
       js: {

--- a/packages/manifest/src/ModuleHandler.ts
+++ b/packages/manifest/src/ModuleHandler.ts
@@ -122,7 +122,7 @@ class ModuleHandler {
         if (exposesMap[getFileNameWithOutExt(issuerName)]) {
           const expose = exposesMap[getFileNameWithOutExt(issuerName)];
           // @ts-ignore use Set to deduplicate
-          expose.requires.add(pkgName);
+          expose.requires.push(pkgName);
           // @ts-ignore use Set to deduplicate
           sharedMap[pkgName].usedIn.add(expose.path);
         }
@@ -135,7 +135,7 @@ class ModuleHandler {
             if (exposesMap[getFileNameWithOutExt(exposeModName)]) {
               const expose = exposesMap[getFileNameWithOutExt(exposeModName)];
               // @ts-ignore to deduplicate
-              expose.requires.add(pkgName);
+              expose.requires.push(pkgName);
               // @ts-ignore to deduplicate
               sharedMap[pkgName].usedIn.add(expose.path);
             }

--- a/packages/manifest/src/StatsManager.ts
+++ b/packages/manifest/src/StatsManager.ts
@@ -379,7 +379,7 @@ class StatsManager {
               exposesMap[exposeKey].assets = assets;
             }
             exposesMap[exposeKey].requires = Array.from(
-              exposesMap[exposeKey].requires,
+              new Set(exposesMap[exposeKey].requires),
             );
           });
           resolve();


### PR DESCRIPTION
## Description
fix: the `exposes.requires` type in manifest.json should be array instead of object

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
