### PR TITLE
chore(manifest): orchestrate cypress e2e via nx target

### DIFF
--- a/.github/workflows/e2e-manifest.yml
+++ b/.github/workflows/e2e-manifest.yml
@@ -46,8 +46,8 @@ jobs:
 
       - name: E2E Test for Manifest Demo Development
         if: steps.check-ci.outcome == 'success'
-        run: pnpm run app:manifest:dev & echo "done" && npx wait-on tcp:3009 && npx wait-on tcp:3012 && npx wait-on http://127.0.0.1:4001/ && npx nx run-many --target=e2e --projects=manifest-webpack-host --parallel=2 && npx kill-port 3013 3009 3010 3011 3012 4001
+        run: npx nx run manifest-webpack-host:e2e
 
       - name: E2E Test for Manifest Demo Production
         if: steps.check-ci.outcome == 'success'
-        run: pnpm run app:manifest:prod & echo "done" && npx wait-on tcp:3009 && npx wait-on tcp:3012 && npx wait-on http://127.0.0.1:4001/ && npx nx run-many --target=e2e --projects=manifest-webpack-host --parallel=1 && npx kill-port 3013 3009 3010 3011 3012 4001
+        run: npx nx run manifest-webpack-host:e2e --configuration=production

--- a/apps/manifest-demo/webpack-host/project.json
+++ b/apps/manifest-demo/webpack-host/project.json
@@ -97,7 +97,8 @@
         "cypressConfig": "apps/manifest-demo/webpack-host/cypress.config.ts",
         "testingType": "e2e",
         "baseUrl": "http://localhost:3013",
-        "browser": "chrome"
+        "browser": "chrome",
+        "devServerTarget": "manifest-webpack-host:serve-all:development"
       },
       "configurations": {
         "development": {
@@ -105,6 +106,9 @@
           "browser": "electron",
           "exit": false,
           "watch": true
+        },
+        "production": {
+          "devServerTarget": "manifest-webpack-host:serve-all:production"
         }
       }
     },
@@ -122,6 +126,56 @@
             "forwardAllArgs": true
           }
         ]
+      }
+    },
+    "serve-all": {
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": true,
+        "commands": [
+          { "command": "nx run 3009-webpack-provider:serve:development" },
+          { "command": "nx run 3010-rspack-provider:serve:development" },
+          {
+            "command": "nx run 3011-rspack-manifest-provider:serve:development"
+          },
+          {
+            "command": "nx run 3012-rspack-js-entry-provider:serve:development"
+          },
+          { "command": "nx run modernjs:serve" },
+          { "command": "nx run manifest-webpack-host:serve:development" }
+        ]
+      },
+      "configurations": {
+        "development": {
+          "parallel": true,
+          "commands": [
+            { "command": "nx run 3009-webpack-provider:serve:development" },
+            { "command": "nx run 3010-rspack-provider:serve:development" },
+            {
+              "command": "nx run 3011-rspack-manifest-provider:serve:development"
+            },
+            {
+              "command": "nx run 3012-rspack-js-entry-provider:serve:development"
+            },
+            { "command": "nx run modernjs:serve" },
+            { "command": "nx run manifest-webpack-host:serve:development" }
+          ]
+        },
+        "production": {
+          "parallel": true,
+          "commands": [
+            { "command": "nx run 3009-webpack-provider:serve:production" },
+            { "command": "nx run 3010-rspack-provider:serve:production" },
+            {
+              "command": "nx run 3011-rspack-manifest-provider:serve:production"
+            },
+            {
+              "command": "nx run 3012-rspack-js-entry-provider:serve:production"
+            },
+            { "command": "nx run modernjs:serve" },
+            { "command": "nx run manifest-webpack-host:serve:production" }
+          ]
+        }
       }
     }
   }

--- a/tools/scripts/manifest-e2e.sh
+++ b/tools/scripts/manifest-e2e.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Orchestrate Manifest demo E2E by starting all required dev servers,
+# waiting for readiness, running Cypress, and cleaning up.
+# Usage: ./tools/scripts/manifest-e2e.sh [development|production]
+
+MODE="${1:-development}"
+export NX_TUI=false
+
+PORTS=(3013 3009 3010 3011 3012 4001)
+
+cleanup() {
+  # Best-effort port cleanup
+  npx --yes kill-port "${PORTS[@]}" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+# Ensure a clean slate
+cleanup
+
+run() {
+  echo "> $*" >&2
+  eval "$@"
+}
+
+if [[ "$MODE" != "development" && "$MODE" != "production" ]]; then
+  echo "Unknown mode: $MODE (expected development|production)" >&2
+  exit 2
+fi
+
+echo "Starting Manifest demo servers in $MODE mode..."
+
+if [[ "$MODE" == "production" ]]; then
+  run "npx nx run 3009-webpack-provider:serve:production" &
+  pids+=("$!")
+  run "npx nx run 3010-rspack-provider:serve:production" &
+  pids+=("$!")
+  run "npx nx run 3011-rspack-manifest-provider:serve:production" &
+  pids+=("$!")
+  run "npx nx run 3012-rspack-js-entry-provider:serve:production" &
+  pids+=("$!")
+  # modernjs serve has no production configuration; the serve command always runs the dev server
+  run "npx nx run modernjs:serve" &
+  pids+=("$!")
+  run "npx nx run manifest-webpack-host:serve:production" &
+  pids+=("$!")
+else
+  run "npx nx run 3009-webpack-provider:serve:development" &
+  pids+=("$!")
+  run "npx nx run 3010-rspack-provider:serve:development" &
+  pids+=("$!")
+  run "npx nx run 3011-rspack-manifest-provider:serve:development" &
+  pids+=("$!")
+  run "npx nx run 3012-rspack-js-entry-provider:serve:development" &
+  pids+=("$!")
+  run "npx nx run modernjs:serve" &
+  pids+=("$!")
+  run "npx nx run manifest-webpack-host:serve:development" &
+  pids+=("$!")
+fi
+
+echo "Waiting for ports to be ready..."
+npx --yes wait-on tcp:3009 tcp:3010 tcp:3011 tcp:3012 http://127.0.0.1:4001/ tcp:3013
+
+echo "Running Cypress E2E for manifest-webpack-host..."
+npx nx run manifest-webpack-host:e2e
+
+echo "E2E complete. Cleaning up."
+


### PR DESCRIPTION
## Summary
- add a reusable Nx target to spin up manifest demo servers
- wire manifest e2e target into CI and provide helper script

## Testing
- not run