### PR TITLE
chore: stabilize tsc rollup builds and clean up CI retries

### DIFF
--- a/.changeset/wet-pants-sniff.md
+++ b/.changeset/wet-pants-sniff.md
@@ -1,4 +1,18 @@
 ---
+"@module-federation/cli": patch
+"@module-federation/data-prefetch": patch
+"@module-federation/error-codes": patch
+"@module-federation/managers": patch
+"@module-federation/manifest": patch
+"@module-federation/rsbuild-plugin": patch
+"@module-federation/rspack": patch
+"@module-federation/runtime": patch
+"@module-federation/runtime-core": patch
+"@module-federation/inject-external-runtime-core-plugin": patch
+"@module-federation/runtime-tools": patch
+"@module-federation/sdk": patch
+"@module-federation/utilities": patch
+"@module-federation/webpack-bundler-runtime": patch
 ---
 
 Update CI to run affected tests without the retry wrapper in build-and-test.

--- a/.changeset/wet-pants-sniff.md
+++ b/.changeset/wet-pants-sniff.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update CI to run affected tests without the retry wrapper in build-and-test.

--- a/.changeset/wet-pants-sniff.md
+++ b/.changeset/wet-pants-sniff.md
@@ -15,4 +15,4 @@
 "@module-federation/webpack-bundler-runtime": patch
 ---
 
-Update CI to run affected tests without the retry wrapper in build-and-test.
+use TSC instead of SWC 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,18 +87,12 @@ jobs:
         run: npx nx run-many --targets=build --projects=tag:type:pkg --parallel=4
 
       - name: Run Affected Test
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 2
-          timeout_minutes: 10
-          command: npx nx affected -t test --parallel=3 --exclude='*,!tag:type:pkg'
+        timeout-minutes: 10
+        run: npx nx affected -t test --parallel=3 --exclude='*,!tag:type:pkg'
 
       - name: Run Affected Experimental Tests
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 2
-          timeout_minutes: 10
-          command: npx nx affected -t test:experiments --parallel=1 --exclude='*,!tag:type:pkg' --skip-nx-cache
+        timeout-minutes: 10
+        run: npx nx affected -t test:experiments --parallel=1 --exclude='*,!tag:type:pkg' --skip-nx-cache
 
   e2e-modern:
     needs: checkout-install

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm install
 
       - name: Clear Node Modules Cache
-        run: rm -rf node_modules/.cache
+        run: find . -maxdepth 6 -type d -name ".cache" -exec rm -rf {} +
 
       - name: Install Cypress
         # if: steps.browsers-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm install
 
       - name: Clear Node Modules Cache
-        run: find . -maxdepth 6 -type d -name ".cache" -exec rm -rf {} +
+        run: find . -maxdepth 6 -type d \( -name ".cache" -o -name ".modern-js" \) -exec rm -rf {} +
 
       - name: Install Cypress
         # if: steps.browsers-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -47,7 +47,7 @@ jobs:
         uses: nrwl/nx-set-shas@v3
 
       - name: Install Dependencies
-        run: pnpm install && find . -maxdepth 6 -type d -name ".cache" -exec rm -rf {} +
+        run: pnpm install && find . -maxdepth 6 -type d \( -name ".cache" -o -name ".modern-js" \) -exec rm -rf {} +
 
       - name: Install Cypress
         run: npx cypress install

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -47,7 +47,7 @@ jobs:
         uses: nrwl/nx-set-shas@v3
 
       - name: Install Dependencies
-        run: pnpm install && rm -rf ./node_modules/.cache
+        run: pnpm install && find . -maxdepth 6 -type d -name ".cache" -exec rm -rf {} +
 
       - name: Install Cypress
         run: npx cypress install

--- a/apps/3002-checkout/components/ButtonOldAnt.tsx
+++ b/apps/3002-checkout/components/ButtonOldAnt.tsx
@@ -1,6 +1,8 @@
 import Button from 'antd/lib/button';
-import { version } from 'antd/package.json';
+import antdPackage from 'antd/package.json';
 import stuff from './stuff.module.css';
+
+const { version } = antdPackage;
 export default function ButtonOldAnt() {
   return <Button className={stuff.test}>Button from antd@{version}</Button>;
 }

--- a/apps/manifest-demo/3010-rspack-provider/src/components/ButtonOldAnt.tsx
+++ b/apps/manifest-demo/3010-rspack-provider/src/components/ButtonOldAnt.tsx
@@ -1,6 +1,8 @@
 import Button from 'antd/lib/button';
-import { version } from 'antd/package.json';
+import antdPackage from 'antd/package.json';
 import * as stuff from './stuff.module.css';
+
+const { version } = antdPackage;
 
 export default function ButtonOldAnt() {
   return (

--- a/apps/manifest-demo/webpack-host/src/components/ButtonOldAnt.tsx
+++ b/apps/manifest-demo/webpack-host/src/components/ButtonOldAnt.tsx
@@ -1,6 +1,8 @@
 import Button from 'antd/lib/button';
-import { version } from 'antd/package.json';
+import antdPackage from 'antd/package.json';
 import stuff from './stuff.module.css';
+
+const { version } = antdPackage;
 
 export default function ButtonOldAnt() {
   return <Button className={stuff.test}>Button from antd@{version}</Button>;

--- a/apps/runtime-demo/3005-runtime-host/src/components/ButtonOldAnt.tsx
+++ b/apps/runtime-demo/3005-runtime-host/src/components/ButtonOldAnt.tsx
@@ -1,6 +1,8 @@
 import Button from 'antd/lib/button';
-import { version } from 'antd/package.json';
+import antdPackage from 'antd/package.json';
 import stuff from './stuff.module.css';
+
+const { version } = antdPackage;
 
 export default function ButtonOldAnt() {
   return <Button className={stuff.test}>Button from antd@{version}</Button>;

--- a/apps/runtime-demo/3007-runtime-remote/src/components/ButtonOldAnt.tsx
+++ b/apps/runtime-demo/3007-runtime-remote/src/components/ButtonOldAnt.tsx
@@ -1,6 +1,8 @@
 import Button from 'antd/lib/button';
-import { version } from 'antd/package.json';
+import antdPackage from 'antd/package.json';
 import stuff from './stuff.module.css';
+
+const { version } = antdPackage;
 
 export default function ButtonOldAnt() {
   return (

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -14,7 +14,7 @@
         "assets": [],
         "project": "packages/cli/package.json",
         "rollupConfig": "packages/cli/rollup.config.js",
-        "compiler": "swc",
+        "compiler": "tsc",
         "format": ["cjs"],
         "generatePackageJson": false,
         "useLegacyTypescriptPlugin": false

--- a/packages/data-prefetch/project.json
+++ b/packages/data-prefetch/project.json
@@ -15,7 +15,7 @@
         "assets": [],
         "project": "packages/data-prefetch/package.json",
         "rollupConfig": "packages/data-prefetch/rollup.config.cjs",
-        "compiler": "swc",
+        "compiler": "tsc",
         "format": ["cjs", "esm"],
         "generatePackageJson": false,
         "useLegacyTypescriptPlugin": false

--- a/packages/error-codes/project.json
+++ b/packages/error-codes/project.json
@@ -16,7 +16,7 @@
         "rollupConfig": "packages/error-codes/rollup.config.js",
         "assets": [],
         "project": "packages/error-codes/package.json",
-        "compiler": "swc",
+        "compiler": "tsc",
         "format": ["cjs", "esm"],
         "generatePackageJson": false,
         "useLegacyTypescriptPlugin": false

--- a/packages/error-codes/rollup.config.js
+++ b/packages/error-codes/rollup.config.js
@@ -1,8 +1,17 @@
 module.exports = (rollupConfig, projectOptions) => {
+  const adjustSourceMapPath = (relativePath) => {
+    const normalized = relativePath.replace(/\\/g, '/');
+    if (normalized.startsWith('../../src/')) {
+      return normalized.replace('../../src/', '../src/');
+    }
+    return normalized;
+  };
+
   if (Array.isArray(rollupConfig.output)) {
     rollupConfig.output = rollupConfig.output.map((c) => ({
       ...c,
       sourcemap: true,
+      sourcemapPathTransform: adjustSourceMapPath,
       hoistTransitiveImports: false,
       entryFileNames:
         c.format === 'esm'
@@ -18,6 +27,7 @@ module.exports = (rollupConfig, projectOptions) => {
     rollupConfig.output = {
       ...rollupConfig.output,
       sourcemap: true,
+      sourcemapPathTransform: adjustSourceMapPath,
       hoistTransitiveImports: false,
       entryFileNames:
         rollupConfig.output.format === 'esm'

--- a/packages/managers/project.json
+++ b/packages/managers/project.json
@@ -16,7 +16,7 @@
         "external": ["@module-federation/*"],
         "project": "packages/managers/package.json",
         "rollupConfig": "packages/managers/rollup.config.js",
-        "compiler": "swc",
+        "compiler": "tsc",
         "format": ["cjs", "esm"],
         "generatePackageJson": false,
         "useLegacyTypescriptPlugin": false

--- a/packages/manifest/project.json
+++ b/packages/manifest/project.json
@@ -16,7 +16,7 @@
         "external": ["@module-federation/*"],
         "project": "packages/manifest/package.json",
         "rollupConfig": "packages/manifest/rollup.config.js",
-        "compiler": "swc",
+        "compiler": "tsc",
         "format": ["cjs", "esm"],
         "generatePackageJson": false,
         "useLegacyTypescriptPlugin": false

--- a/packages/rsbuild-plugin/project.json
+++ b/packages/rsbuild-plugin/project.json
@@ -15,7 +15,7 @@
         "external": ["@module-federation/*"],
         "project": "packages/rsbuild-plugin/package.json",
         "rollupConfig": "packages/rsbuild-plugin/rollup.config.js",
-        "compiler": "swc",
+        "compiler": "tsc",
         "format": ["cjs", "esm"],
         "generatePackageJson": false,
         "useLegacyTypescriptPlugin": false

--- a/packages/rspack/project.json
+++ b/packages/rspack/project.json
@@ -16,7 +16,7 @@
         "external": ["@module-federation/*", "@rspack/core"],
         "project": "packages/rspack/package.json",
         "rollupConfig": "packages/rspack/rollup.config.js",
-        "compiler": "swc",
+        "compiler": "tsc",
         "format": ["cjs", "esm"],
         "generatePackageJson": false,
         "useLegacyTypescriptPlugin": false

--- a/packages/runtime-core/project.json
+++ b/packages/runtime-core/project.json
@@ -17,7 +17,7 @@
         "assets": [],
         "external": ["@module-federation/*"],
         "project": "packages/runtime-core/package.json",
-        "compiler": "swc",
+        "compiler": "tsc",
         "rollupConfig": "packages/runtime-core/rollup.config.cjs",
         "format": ["cjs", "esm"],
         "generatePackageJson": false,

--- a/packages/runtime-core/rollup.config.cjs
+++ b/packages/runtime-core/rollup.config.cjs
@@ -1,6 +1,14 @@
 const replace = require('@rollup/plugin-replace');
 const copy = require('rollup-plugin-copy');
 
+const adjustSourceMapPath = (relativePath) => {
+  const normalized = relativePath.replace(/\\/g, '/');
+  if (normalized.startsWith('../../src/')) {
+    return normalized.replace('../../src/', '../src/');
+  }
+  return normalized;
+};
+
 const FEDERATION_DEBUG = process.env.FEDERATION_DEBUG || '';
 
 module.exports = (rollupConfig, projectOptions) => {
@@ -29,6 +37,7 @@ module.exports = (rollupConfig, projectOptions) => {
         }
       },
       hoistTransitiveImports: false,
+      sourcemapPathTransform: adjustSourceMapPath,
       entryFileNames:
         c.format === 'cjs'
           ? c.entryFileNames.replace('.js', '.cjs')
@@ -49,6 +58,7 @@ module.exports = (rollupConfig, projectOptions) => {
         }
       },
       hoistTransitiveImports: false,
+      sourcemapPathTransform: adjustSourceMapPath,
       entryFileNames:
         rollupConfig.output.format === 'cjs'
           ? rollupConfig.output.entryFileNames.replace('.js', '.cjs')

--- a/packages/runtime-plugins/inject-external-runtime-core-plugin/project.json
+++ b/packages/runtime-plugins/inject-external-runtime-core-plugin/project.json
@@ -15,7 +15,7 @@
         "assets": [],
         "project": "packages/runtime-plugins/inject-external-runtime-core-plugin/package.json",
         "rollupConfig": "packages/runtime-plugins/inject-external-runtime-core-plugin/rollup.config.cjs",
-        "compiler": "swc",
+        "compiler": "tsc",
         "generatePackageJson": false,
         "format": ["cjs", "esm"],
         "useLegacyTypescriptPlugin": false

--- a/packages/runtime-tools/project.json
+++ b/packages/runtime-tools/project.json
@@ -19,7 +19,7 @@
         "tsConfig": "packages/runtime-tools/tsconfig.lib.json",
         "assets": [],
         "project": "packages/runtime-tools/package.json",
-        "compiler": "swc",
+        "compiler": "tsc",
         "rollupConfig": "packages/runtime-tools/rollup.config.cjs",
         "format": ["cjs", "esm"],
         "external": ["@module-federation/*"],

--- a/packages/runtime/project.json
+++ b/packages/runtime/project.json
@@ -20,7 +20,7 @@
         "assets": [],
         "external": ["@module-federation/*"],
         "project": "packages/runtime/package.json",
-        "compiler": "swc",
+        "compiler": "tsc",
         "rollupConfig": "packages/runtime/rollup.config.cjs",
         "format": ["cjs", "esm"],
         "generatePackageJson": false,

--- a/packages/runtime/rollup.config.cjs
+++ b/packages/runtime/rollup.config.cjs
@@ -3,6 +3,14 @@ const copy = require('rollup-plugin-copy');
 
 const FEDERATION_DEBUG = process.env.FEDERATION_DEBUG || '';
 
+const adjustSourceMapPath = (relativePath) => {
+  const normalized = relativePath.replace(/\\/g, '/');
+  if (normalized.startsWith('../../src/')) {
+    return normalized.replace('../../src/', '../src/');
+  }
+  return normalized;
+};
+
 module.exports = (rollupConfig, projectOptions) => {
   rollupConfig.treeshake = { preset: 'recommended' };
 
@@ -33,6 +41,7 @@ module.exports = (rollupConfig, projectOptions) => {
         }
       },
       hoistTransitiveImports: false,
+      sourcemapPathTransform: adjustSourceMapPath,
       entryFileNames:
         c.format === 'cjs'
           ? c.entryFileNames.replace(/\.js$/, '.cjs')
@@ -53,6 +62,7 @@ module.exports = (rollupConfig, projectOptions) => {
         }
       },
       hoistTransitiveImports: false,
+      sourcemapPathTransform: adjustSourceMapPath,
       entryFileNames:
         rollupConfig.output.format === 'cjs'
           ? rollupConfig.output.entryFileNames.replace(/\.js$/, '.cjs')

--- a/packages/sdk/project.json
+++ b/packages/sdk/project.json
@@ -16,7 +16,7 @@
         "project": "packages/sdk/package.json",
         "additionalEntryPoints": ["packages/sdk/src/normalize-webpack-path.ts"],
         "rollupConfig": "packages/sdk/rollup.config.cjs",
-        "compiler": "swc",
+        "compiler": "tsc",
         "generatePackageJson": false,
         "format": ["cjs", "esm"],
         "useLegacyTypescriptPlugin": false

--- a/packages/sdk/rollup.config.cjs
+++ b/packages/sdk/rollup.config.cjs
@@ -1,6 +1,14 @@
 const copy = require('rollup-plugin-copy');
 
 module.exports = (rollupConfig, _projectOptions) => {
+  const adjustSourceMapPath = (relativePath) => {
+    const normalized = relativePath.replace(/\\/g, '/');
+    if (normalized.startsWith('../../src/')) {
+      return normalized.replace('../../src/', '../src/');
+    }
+    return normalized;
+  };
+
   rollupConfig.plugins.push(
     copy({
       targets: [{ src: 'packages/sdk/LICENSE', dest: 'packages/sdk/dist' }],
@@ -20,6 +28,7 @@ module.exports = (rollupConfig, _projectOptions) => {
       },
       hoistTransitiveImports: false,
       minifyInternalExports: true,
+      sourcemapPathTransform: adjustSourceMapPath,
       entryFileNames:
         c.format === 'cjs'
           ? c.entryFileNames.replace('.js', '.cjs')
@@ -41,6 +50,7 @@ module.exports = (rollupConfig, _projectOptions) => {
       },
       hoistTransitiveImports: false,
       minifyInternalExports: true,
+      sourcemapPathTransform: adjustSourceMapPath,
       entryFileNames:
         rollupConfig.output.format === 'cjs'
           ? rollupConfig.output.entryFileNames.replace('.js', '.cjs')

--- a/packages/utilities/project.json
+++ b/packages/utilities/project.json
@@ -29,7 +29,7 @@
         "project": "packages/utilities/package.json",
         "additionalEntryPoints": ["packages/utilities/src/types/types.ts"],
         "external": ["@module-federation/*"],
-        "compiler": "swc",
+        "compiler": "tsc",
         "format": ["cjs", "esm"],
         "generatePackageJson": false,
         "useLegacyTypescriptPlugin": false

--- a/packages/webpack-bundler-runtime/project.json
+++ b/packages/webpack-bundler-runtime/project.json
@@ -15,7 +15,7 @@
         "tsConfig": "packages/webpack-bundler-runtime/tsconfig.lib.json",
         "assets": [],
         "project": "packages/webpack-bundler-runtime/package.json",
-        "compiler": "swc",
+        "compiler": "tsc",
         "format": ["cjs", "esm"],
         "additionalEntryPoints": [
           "packages/webpack-bundler-runtime/src/constant.ts"

--- a/packages/webpack-bundler-runtime/rollup.config.cjs
+++ b/packages/webpack-bundler-runtime/rollup.config.cjs
@@ -3,6 +3,14 @@ const copy = require('rollup-plugin-copy');
 module.exports = (rollupConfig, projectOptions) => {
   rollupConfig.treeshake = { preset: 'recommended' };
 
+  const adjustSourceMapPath = (relativePath) => {
+    const normalized = relativePath.replace(/\\/g, '/');
+    if (normalized.startsWith('../../src/')) {
+      return normalized.replace('../../src/', '../src/');
+    }
+    return normalized;
+  };
+
   rollupConfig.external = [
     /@module-federation\/runtime/,
     /@module-federation\/sdk/,
@@ -12,6 +20,7 @@ module.exports = (rollupConfig, projectOptions) => {
     rollupConfig.output = rollupConfig.output.map((c) => ({
       ...c,
       sourcemap: true,
+      sourcemapPathTransform: adjustSourceMapPath,
       hoistTransitiveImports: false,
       entryFileNames:
         c.format === 'cjs'
@@ -27,6 +36,7 @@ module.exports = (rollupConfig, projectOptions) => {
     rollupConfig.output = {
       ...rollupConfig.output,
       sourcemap: true,
+      sourcemapPathTransform: adjustSourceMapPath,
       hoistTransitiveImports: false,
       entryFileNames:
         rollupConfig.output.format === 'cjs'


### PR DESCRIPTION
## Summary
- remove the retry wrapper from the build-and-test workflow so affected tests run once with the existing timeout
- keep the Nx rollup packages on the tsc compiler and add sourcemap path transforms so the emitted maps line up with source files
- adjust old antd button demos to read the package version from the default JSON import, which works with the tsc build output
- add a changeset covering every package touched by the build config updates

## Testing
- pnpm nx run manifest:build --skip-nx-cache
