### PR TITLE
Improve infrastructure logging across federation plugins

### DIFF
--- a/packages/data-prefetch/src/cli/index.ts
+++ b/packages/data-prefetch/src/cli/index.ts
@@ -2,6 +2,8 @@ import path from 'path';
 import fs from 'fs-extra';
 
 import {
+  bindLoggerToCompiler,
+  createLogger,
   encodeName,
   moduleFederationPlugin,
   MFPrefetchCommon,
@@ -17,6 +19,8 @@ import { SHARED_STRATEGY } from '../constant';
 const { RuntimeGlobals, Template } = require(
   normalizeWebpackPath('webpack'),
 ) as typeof import('webpack');
+
+const logger = createLogger('[ Module Federation Data Prefetch Plugin ]');
 
 export function getFederationGlobalScope(
   runtimeGlobals: typeof RuntimeGlobals,
@@ -35,6 +39,7 @@ export class PrefetchPlugin implements WebpackPluginInstance {
 
   // eslint-disable-next-line max-lines-per-function
   apply(compiler: Compiler) {
+    bindLoggerToCompiler(logger, compiler, 'PrefetchPlugin');
     const { name, exposes } = this.options;
     if (!exposes) {
       return;
@@ -54,7 +59,7 @@ export class PrefetchPlugin implements WebpackPluginInstance {
     }
     if (this.options.shareStrategy !== SHARED_STRATEGY) {
       this.options.shareStrategy = SHARED_STRATEGY;
-      console.warn(
+      logger.warn(
         `[Module Federation Data Prefetch]: Your shared strategy is set to '${SHARED_STRATEGY}', this is a necessary condition for data prefetch`,
       );
     }

--- a/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
+++ b/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
@@ -8,6 +8,7 @@ import { DtsPlugin } from '@module-federation/dts-plugin';
 import { ContainerManager, utils } from '@module-federation/managers';
 import { StatsPlugin } from '@module-federation/manifest';
 import {
+  bindLoggerToCompiler,
   composeKeyWithSeparator,
   type moduleFederationPlugin,
   logger,
@@ -102,6 +103,7 @@ class ModuleFederationPlugin implements WebpackPluginInstance {
    * @returns {void}
    */
   apply(compiler: Compiler): void {
+    bindLoggerToCompiler(logger, compiler, 'EnhancedModuleFederationPlugin');
     const { _options: options } = this;
     // must before ModuleFederationPlugin
     (new RemoteEntryPlugin(options) as unknown as WebpackPluginInstance).apply(

--- a/packages/manifest/src/StatsPlugin.ts
+++ b/packages/manifest/src/StatsPlugin.ts
@@ -1,5 +1,8 @@
 import { Compiler, WebpackPluginInstance } from 'webpack';
-import { moduleFederationPlugin } from '@module-federation/sdk';
+import {
+  bindLoggerToCompiler,
+  moduleFederationPlugin,
+} from '@module-federation/sdk';
 import { ManifestManager } from './ManifestManager';
 import { StatsManager } from './StatsManager';
 import { PLUGIN_IDENTIFIER } from './constants';
@@ -40,6 +43,7 @@ export class StatsPlugin implements WebpackPluginInstance {
   }
 
   apply(compiler: Compiler): void {
+    bindLoggerToCompiler(logger, compiler, PLUGIN_IDENTIFIER);
     if (!this._enable) {
       return;
     }

--- a/packages/nextjs-mf/src/logger.ts
+++ b/packages/nextjs-mf/src/logger.ts
@@ -1,0 +1,5 @@
+import { createLogger } from '@module-federation/sdk';
+
+const logger = createLogger('[ nextjs-mf ]');
+
+export default logger;

--- a/packages/nextjs-mf/src/plugins/CopyFederationPlugin.ts
+++ b/packages/nextjs-mf/src/plugins/CopyFederationPlugin.ts
@@ -1,6 +1,8 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import type { Compilation, Compiler, WebpackPluginInstance } from 'webpack';
+import { bindLoggerToCompiler } from '@module-federation/sdk';
+import logger from '../logger';
 
 /**
  * Plugin to copy build output files.
@@ -23,6 +25,7 @@ class CopyBuildOutputPlugin implements WebpackPluginInstance {
    * @method
    */
   apply(compiler: Compiler): void {
+    bindLoggerToCompiler(logger, compiler, 'CopyBuildOutputPlugin');
     /**
      * Copies files from source to destination.
      * @param {string} source - The source directory.
@@ -78,7 +81,7 @@ class CopyBuildOutputPlugin implements WebpackPluginInstance {
           await copyFiles(sourcePath, serverLoc);
         } catch (error) {
           // If the promise rejects, the file does not exist.
-          console.error(`File at ${sourcePath} does not exist.`);
+          logger.error(`File at ${sourcePath} does not exist.`);
         }
       },
     );

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-client-plugins.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-client-plugins.ts
@@ -3,6 +3,7 @@ import { ChunkCorrelationPlugin } from '@module-federation/node';
 import InvertedContainerPlugin from '../container/InvertedContainerPlugin';
 import type { moduleFederationPlugin } from '@module-federation/sdk';
 import type { NextFederationPluginExtraOptions } from './next-fragments';
+import logger from '../../logger';
 
 /**
  * Applies client-specific plugins.
@@ -37,12 +38,12 @@ export function applyClientPlugins(
 
   // Log a warning if automatic page stitching is enabled, as it is disabled in v7
   if (extraOptions.automaticPageStitching) {
-    console.warn('[nextjs-mf]', 'automatic page stitching is disabled in v7');
+    logger.warn('automatic page stitching is disabled in v7');
   }
 
   // Log an error if a custom library is set, as it is not allowed
   if (options.library) {
-    console.error('[nextjs-mf] you cannot set custom library');
+    logger.error('you cannot set custom library');
   }
 
   // Set the library option to be a window object with the name of the module federation plugin

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
@@ -27,7 +27,9 @@ import {
 } from './apply-server-plugins';
 import { applyClientPlugins } from './apply-client-plugins';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/webpack';
+import { bindLoggerToCompiler } from '@module-federation/sdk';
 import type { moduleFederationPlugin } from '@module-federation/sdk';
+import logger from '../../logger';
 
 import path from 'path';
 /**
@@ -54,6 +56,7 @@ export class NextFederationPlugin {
    * @param compiler The webpack compiler object.
    */
   apply(compiler: Compiler) {
+    bindLoggerToCompiler(logger, compiler, 'NextFederationPlugin');
     process.env['FEDERATION_WEBPACK_PATH'] =
       process.env['FEDERATION_WEBPACK_PATH'] ||
       getWebpackPath(compiler, { framework: 'nextjs' });
@@ -120,9 +123,8 @@ export class NextFederationPlugin {
     const compilerValid = validateCompilerOptions(compiler);
     const pluginValid = validatePluginOptions(this._options);
     const envValid = process.env['NEXT_PRIVATE_LOCAL_WEBPACK'];
-    if (compilerValid === undefined)
-      console.error('Compiler validation failed');
-    if (pluginValid === undefined) console.error('Plugin validation failed');
+    if (compilerValid === undefined) logger.error('Compiler validation failed');
+    if (pluginValid === undefined) logger.error('Plugin validation failed');
     const validCompilerTarget =
       compiler.options.name === 'server' || compiler.options.name === 'client';
     if (!envValid)

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/remove-unnecessary-shared-keys.test.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/remove-unnecessary-shared-keys.test.ts
@@ -1,8 +1,9 @@
+import logger from '../../logger';
 import { removeUnnecessarySharedKeys } from './remove-unnecessary-shared-keys';
 
 describe('removeUnnecessarySharedKeys', () => {
   beforeEach(() => {
-    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+    jest.spyOn(logger, 'warn').mockImplementation(jest.fn());
   });
 
   afterEach(() => {
@@ -19,7 +20,7 @@ describe('removeUnnecessarySharedKeys', () => {
     removeUnnecessarySharedKeys(shared);
 
     expect(shared).toEqual({ lodash: '4.17.21' });
-    expect(console.warn).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
   });
 
   it('should not remove keys that are not in the default share scope', () => {
@@ -31,7 +32,7 @@ describe('removeUnnecessarySharedKeys', () => {
     removeUnnecessarySharedKeys(shared);
 
     expect(shared).toEqual({ lodash: '4.17.21', axios: '0.21.1' });
-    expect(console.warn).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('should not remove keys from an empty object', () => {
@@ -40,6 +41,6 @@ describe('removeUnnecessarySharedKeys', () => {
     removeUnnecessarySharedKeys(shared);
 
     expect(shared).toEqual({});
-    expect(console.warn).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/remove-unnecessary-shared-keys.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/remove-unnecessary-shared-keys.ts
@@ -6,6 +6,7 @@
  * @param {Record<string, unknown>} shared - The shared object to be checked.
  */
 import { DEFAULT_SHARE_SCOPE } from '../../internal';
+import logger from '../../logger';
 
 /**
  * Function to remove unnecessary shared keys from the default share scope.
@@ -22,9 +23,8 @@ export function removeUnnecessarySharedKeys(
      * If the key is found in the default share scope, log a warning and remove the key from the shared object.
      */
     if (DEFAULT_SHARE_SCOPE[key]) {
-      console.warn(
-        `%c[nextjs-mf] You are sharing ${key} from the default share scope. This is not necessary and can be removed.`,
-        'color: red',
+      logger.warn(
+        `You are sharing ${key} from the default share scope. This is not necessary and can be removed.`,
       );
       delete (shared as { [key: string]: unknown })[key];
     }

--- a/packages/nextjs-mf/src/plugins/container/RemoveEagerModulesFromRuntimePlugin.ts
+++ b/packages/nextjs-mf/src/plugins/container/RemoveEagerModulesFromRuntimePlugin.ts
@@ -1,4 +1,6 @@
 import type { Compiler, Compilation, Chunk, Module } from 'webpack';
+import { bindLoggerToCompiler } from '@module-federation/sdk';
+import logger from '../../logger';
 
 /**
  * This plugin removes eager modules from the runtime.
@@ -27,13 +29,17 @@ class RemoveEagerModulesFromRuntimePlugin {
    */
   apply(compiler: Compiler) {
     if (!this.container) {
-      console.warn(
-        '[nextjs-mf]:',
-        'RemoveEagerModulesFromRuntimePlugin container is not defined:',
-        this.container,
+      logger.warn(
+        `RemoveEagerModulesFromRuntimePlugin container is not defined: ${this.container}`,
       );
       return;
     }
+
+    bindLoggerToCompiler(
+      logger,
+      compiler,
+      'RemoveEagerModulesFromRuntimePlugin',
+    );
 
     compiler.hooks.thisCompilation.tap(
       'RemoveEagerModulesFromRuntimePlugin',
@@ -84,7 +90,7 @@ class RemoveEagerModulesFromRuntimePlugin {
   private removeModules(compilation: Compilation, chunk: Chunk) {
     for (const moduleToRemove of this.modulesToProcess) {
       if (this.debug) {
-        console.log('removing', moduleToRemove.constructor.name);
+        logger.info(`removing ${moduleToRemove.constructor.name}`);
       }
 
       if (compilation.chunkGraph.isModuleInChunk(moduleToRemove, chunk)) {

--- a/packages/node/src/plugins/DynamicFilesystemChunkLoadingRuntimeModule.ts
+++ b/packages/node/src/plugins/DynamicFilesystemChunkLoadingRuntimeModule.ts
@@ -23,6 +23,7 @@ import {
   generateInstallChunk,
   generateExternalInstallChunkCode,
 } from './webpackChunkUtilities';
+import { createLogger } from '@module-federation/sdk';
 import {
   fileSystemRunInContextStrategy,
   httpEvalStrategy,
@@ -53,6 +54,9 @@ class DynamicFilesystemChunkLoadingRuntimeModule extends RuntimeModule {
   hooks = {
     strategyCase: new SyncWaterfallHook(['source']),
   };
+  private logger = createLogger(
+    '[ DynamicFilesystemChunkLoadingRuntimeModule ]',
+  );
 
   constructor(
     runtimeRequirements: Set<string>,
@@ -106,8 +110,15 @@ class DynamicFilesystemChunkLoadingRuntimeModule extends RuntimeModule {
     const { chunkGraph, chunk, compilation } = this;
     const { Template } = webpack;
     if (!chunkGraph || !chunk || !compilation) {
-      console.warn('Missing required properties. Returning empty string.');
+      this.logger.warn('Missing required properties. Returning empty string.');
       return '';
+    }
+
+    const infrastructureLogger = compilation.getLogger?.(
+      'DynamicFilesystemChunkLoadingRuntimeModule',
+    );
+    if (infrastructureLogger) {
+      this.logger.setDelegate(infrastructureLogger as any);
     }
 
     const { runtimeTemplate } = compilation;

--- a/packages/node/src/plugins/NodeFederationPlugin.ts
+++ b/packages/node/src/plugins/NodeFederationPlugin.ts
@@ -3,6 +3,7 @@
 import type { Compiler, container } from 'webpack';
 import type { ModuleFederationPluginOptions } from '../types';
 import EntryChunkTrackerPlugin from './EntryChunkTrackerPlugin';
+import { bindLoggerToCompiler, createLogger } from '@module-federation/sdk';
 /**
  * Interface for NodeFederationOptions which extends ModuleFederationPluginOptions
  * @interface
@@ -30,6 +31,7 @@ class NodeFederationPlugin {
   private _options: ModuleFederationPluginOptions;
   private context: Context;
   private useRuntimePlugin?: boolean;
+  private logger = createLogger('[ Node Federation Plugin ]');
 
   /**
    * Create a NodeFederationPlugin.
@@ -52,6 +54,7 @@ class NodeFederationPlugin {
    * @param {Compiler} compiler - The webpack compiler.
    */
   apply(compiler: Compiler) {
+    bindLoggerToCompiler(this.logger, compiler, 'NodeFederationPlugin');
     const { webpack } = compiler;
     const pluginOptions = this.preparePluginOptions();
     this.updateCompilerOptions(compiler);
@@ -100,7 +103,7 @@ class NodeFederationPlugin {
     try {
       return require('@module-federation/enhanced').ModuleFederationPlugin;
     } catch (e) {
-      console.error(
+      this.logger.error(
         "Can't find @module-federation/enhanced, falling back to webpack ModuleFederationPlugin, this may not work",
       );
       if (this.context.ModuleFederationPlugin) {

--- a/packages/rspack/src/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/ModuleFederationPlugin.ts
@@ -6,6 +6,7 @@ import type {
   RspackPluginInstance,
 } from '@rspack/core';
 import {
+  bindLoggerToCompiler,
   composeKeyWithSeparator,
   moduleFederationPlugin,
 } from '@module-federation/sdk';
@@ -16,6 +17,7 @@ import ReactBridgePlugin from '@module-federation/bridge-react-webpack-plugin';
 import path from 'node:path';
 import fs from 'node:fs';
 import { RemoteEntryPlugin } from './RemoteEntryPlugin';
+import logger from './logger';
 
 type ExcludeFalse<T> = T extends undefined | false ? never : T;
 type SplitChunks = Compiler['options']['optimization']['splitChunks'];
@@ -93,6 +95,7 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
   }
 
   apply(compiler: Compiler): void {
+    bindLoggerToCompiler(logger, compiler, PLUGIN_NAME);
     const { _options: options } = this;
 
     if (!options.name) {
@@ -149,7 +152,7 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
         if (err instanceof Error) {
           err.message = `[ ModuleFederationPlugin ]: Manifest will not generate, because: ${err.message}`;
         }
-        console.warn(err);
+        logger.warn(err);
         disableManifest = true;
       }
     }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,7 +7,7 @@ export {
   simpleJoinRemoteEntry,
   inferAutoPublicPath,
 } from './generateSnapshotFromManifest';
-export { logger, createLogger } from './logger';
+export { logger, createLogger, bindLoggerToCompiler } from './logger';
 export type { Logger } from './logger';
 export * from './env';
 export * from './dom';


### PR DESCRIPTION
## Summary
- bind shared SDK logger to webpack/rspack infrastructure logging
- replace direct console usage in Node, data-prefetch, and nextjs-mf plugins with shared loggers
- add infrastructure-aware logging guard to dynamic filesystem runtime module

## Testing
- pnpm build