### PR TITLE
Fix worker runtime chunk regressing web worker builds

### DIFF
--- a/apps/runtime-demo/3005-runtime-host/cypress/e2e/app.cy.ts
+++ b/apps/runtime-demo/3005-runtime-host/cypress/e2e/app.cy.ts
@@ -77,4 +77,10 @@ describe('3005-runtime-host/', () => {
       });
     });
   });
+
+  describe('web worker check', () => {
+    it('should display value returned from worker', () => {
+      cy.get('.worker-actual').contains('Actual worker response: 1');
+    });
+  });
 });

--- a/apps/runtime-demo/3005-runtime-host/src/Root.tsx
+++ b/apps/runtime-demo/3005-runtime-host/src/Root.tsx
@@ -5,6 +5,7 @@ import WebpackPng from './webpack.png';
 import WebpackSvg from './webpack.svg';
 import { WebpackPngRemote, WebpackSvgRemote } from './Remote1';
 import Remote2 from './Remote2';
+import WorkerDemo from './components/WorkerDemo';
 
 const Root = () => (
   <div>
@@ -85,6 +86,32 @@ const Root = () => (
           </td>
           <td>
             <Remote2 />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>check worker entry</h3>
+    <table border={1} cellPadding={5}>
+      <thead>
+        <tr>
+          <td></td>
+          <td>Test case</td>
+          <td>Expected</td>
+          <td>Actual</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>✅</td>
+          <td>
+            Build with Web Worker entry should return value via dynamic import
+          </td>
+          <td>
+            <div className="worker-expected">Expected worker response: 1</div>
+          </td>
+          <td>
+            <WorkerDemo />
           </td>
         </tr>
       </tbody>

--- a/apps/runtime-demo/3005-runtime-host/src/components/WorkerDemo.tsx
+++ b/apps/runtime-demo/3005-runtime-host/src/components/WorkerDemo.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+export function WorkerDemo() {
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const worker = new Worker(
+        new URL('../worker/worker.ts', import.meta.url),
+        {
+          type: 'module',
+          name: 'mf-worker-demo',
+        },
+      );
+
+      worker.onmessage = (event) => {
+        setResult(event.data?.answer ?? null);
+      };
+
+      worker.onerror = (event) => {
+        setError(event.message ?? 'Worker error');
+      };
+
+      worker.postMessage({ value: 'foo' });
+
+      return () => {
+        worker.terminate();
+      };
+    } catch (err) {
+      setError((err as Error).message);
+    }
+
+    return undefined;
+  }, []);
+
+  return (
+    <div>
+      <div className="worker-expected">Expected worker response: 1</div>
+      <div className="worker-actual">
+        Actual worker response: {result ?? 'n/a'}
+      </div>
+      {error ? <div className="worker-error">Worker error: {error}</div> : null}
+    </div>
+  );
+}
+
+export default WorkerDemo;

--- a/apps/runtime-demo/3005-runtime-host/src/worker/map.ts
+++ b/apps/runtime-demo/3005-runtime-host/src/worker/map.ts
@@ -1,0 +1,4 @@
+export const workerMap: Record<string, string> = {
+  foo: '1',
+  bar: '2',
+};

--- a/apps/runtime-demo/3005-runtime-host/src/worker/worker.ts
+++ b/apps/runtime-demo/3005-runtime-host/src/worker/worker.ts
@@ -1,0 +1,10 @@
+/// <reference lib="webworker" />
+
+self.onmessage = async (event: MessageEvent<{ value: string }>) => {
+  const module = await import('./map');
+  const value = event.data.value;
+
+  self.postMessage({
+    answer: module.workerMap[value] ?? null,
+  });
+};

--- a/apps/runtime-demo/3005-runtime-host/webpack.config.js
+++ b/apps/runtime-demo/3005-runtime-host/webpack.config.js
@@ -99,6 +99,7 @@ module.exports = composePlugins(withNx(), withReact(), (config, context) => {
     scriptType: 'text/javascript',
   };
   config.optimization = {
+    ...(config.optimization ?? {}),
     runtimeChunk: false,
     minimize: false,
     moduleIds: 'named',


### PR DESCRIPTION
## Summary\n- reassign non-initial entrypoints to their own runtime when runtimeChunk is configured as single or object\n- add a runtime-demo worker example with a Cypress assertion so we can guard the scenario\n\nFixes #4085\n\n## Testing\n- pnpm nx run enhanced:build\n- pnpm nx run 3005-runtime-host:build --configuration=production