### PR TITLE
fix: DevServer reconnecting when timeout

### DIFF
--- a/packages/dts-plugin/src/server/DevServer.ts
+++ b/packages/dts-plugin/src/server/DevServer.ts
@@ -414,7 +414,7 @@ export class ModuleFederationDevServer {
   private _tryCreateBackgroundBroker(err: any): void {
     if (
       !(
-        err?.code === 'ECONNREFUSED' &&
+        (err?.code === 'ECONNREFUSED' || err?.code === 'ETIMEDOUT') &&
         err.port === Broker.DEFAULT_WEB_SOCKET_PORT
       )
     ) {


### PR DESCRIPTION
## Description
- the DevServer failed to start when receiving timeout error

## Related Issue
https://github.com/module-federation/core/issues/3918

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
