### PR TITLE
Remove infrastructure log allowlisting

### DIFF
--- a/packages/enhanced/test/ConfigTestCases.template.js
+++ b/packages/enhanced/test/ConfigTestCases.template.js
@@ -24,24 +24,11 @@ const stripAllowedInfrastructureLogs = (stderrOutput) => {
   }
   const remaining = [];
   const lines = stderrOutput.split(/\r?\n/);
-  let skippingStack = false;
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed) {
-      skippingStack = false;
       continue;
     }
-    if (filterInfraStructureErrors.isAllowedLog(trimmed)) {
-      skippingStack = true;
-      continue;
-    }
-    if (
-      skippingStack &&
-      (/^\s*(at\s|\()/i.test(line) || /^<[^>]+>\s*(at\s|\()/i.test(line))
-    ) {
-      continue;
-    }
-    skippingStack = false;
     remaining.push(line);
   }
   const result = remaining.join('\n');

--- a/packages/enhanced/test/helpers/infrastructureLogErrors.js
+++ b/packages/enhanced/test/helpers/infrastructureLogErrors.js
@@ -10,38 +10,6 @@ const PERSISTENCE_CACHE_INVALIDATE_ERROR = (log, config) => {
     return `Pack got invalid because of write to: ${match[1].trim()}`;
   }
 };
-const ALLOWED_PREFIXES = [
-  '[ Module Federation ]',
-  '[ Federation Runtime ]',
-  '[ Module Federation Manifest Plugin ]',
-  '[ Module Federation Bridge React ]',
-  '[ Module Federation Bridge Vue3 ]',
-  '[ Module Federation Bridge ]',
-  '[Module Federation Manifest Plugin]',
-  '[Module Federation Bridge React]',
-  '[Module Federation Bridge Vue3]',
-  '[Module Federation Bridge]',
-];
-
-const normalizeLogEntry = (log) => {
-  let normalized;
-  if (typeof log === 'string') normalized = log;
-  else if (Array.isArray(log)) normalized = log.join(' ');
-  else if (log && typeof log.message === 'string') normalized = log.message;
-  else normalized = String(log ?? '');
-
-  return normalized.replace(/\u001b\[[0-9;]*m/g, '');
-};
-
-const isAllowedLog = (log) => {
-  const normalized = normalizeLogEntry(log).trim();
-  if (!normalized) {
-    return true;
-  }
-  const sanitized = normalized.replace(/^<[^>]+>\s*/, '');
-  return ALLOWED_PREFIXES.some((prefix) => sanitized.startsWith(prefix));
-};
-
 const errorsFilter = [PERSISTENCE_CACHE_INVALIDATE_ERROR];
 
 /**
@@ -52,9 +20,6 @@ const errorsFilter = [PERSISTENCE_CACHE_INVALIDATE_ERROR];
 module.exports = function filterInfraStructureErrors(logs, config) {
   const results = [];
   for (const log of logs) {
-    if (isAllowedLog(log)) {
-      continue;
-    }
     for (const filter of errorsFilter) {
       const result = filter(log, config);
       if (result) results.push({ message: result });
@@ -62,5 +27,3 @@ module.exports = function filterInfraStructureErrors(logs, config) {
   }
   return results;
 };
-
-module.exports.isAllowedLog = (log) => isAllowedLog(log);


### PR DESCRIPTION
## Summary
- drop the infrastructure log allowlist helper so infrastructure log entries are always checked by filters
- simplify stderr log stripping to only remove empty lines

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e728fc039483259b962737ab16d75c