### PR TITLE
fix(rsbuild-plugin): add more MF packages to source.include

### DIFF
--- a/packages/rsbuild-plugin/src/cli/index.ts
+++ b/packages/rsbuild-plugin/src/cli/index.ts
@@ -232,10 +232,7 @@ export const pluginModuleFederation = (
       // adding to include and let SWC transform it
       config.source.include = [
         ...(config.source.include || []),
-        /@module-federation\/webpack-bundler-runtime/,
-        /@module-federation\/runtime/,
-        /@module-federation\/runtime-core/,
-        /@module-federation\/sdk/,
+        /@module-federation[\\/]/,
       ];
 
       return config;


### PR DESCRIPTION
## Description

Add all `@module-federation/*` packages to `source.include` to avoid browser compatibility issues.

This change is to fix a syntax issue introduced in `@module-federation/error-codes` in 0.20.0:

<img width="1096" height="343" alt="Screenshot 2025-10-12 at 17 47 59" src="https://github.com/user-attachments/assets/90fa7868-f11e-4f33-84f8-cd49eb2e672a" />

## Related Issue

- The same as Rsbuild's built-in plugin: https://github.com/web-infra-dev/rsbuild/pull/4698

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
