### PR TITLE
Add config case for external runtime ModuleFederation

### DIFF
--- a/packages/enhanced/test/configCases/container/external-runtime-compat/index.js
+++ b/packages/enhanced/test/configCases/container/external-runtime-compat/index.js
@@ -1,0 +1,14 @@
+const instantiateRemote = require('./remote');
+const runtime = require('../../../../../../packages/runtime/dist/index.cjs.cjs');
+
+it('should instantiate ModuleFederation when external runtime constructor is unset', () => {
+  const constructorGetter = runtime.getGlobalFederationConstructor;
+  if (typeof constructorGetter === 'function') {
+    expect(constructorGetter()).toBeUndefined();
+  } else {
+    expect(constructorGetter).toBeUndefined();
+  }
+  const instance = instantiateRemote();
+  expect(instance).toBeInstanceOf(runtime.ModuleFederation);
+  expect(instance.name).toBe('remote-using-module-federation');
+});

--- a/packages/enhanced/test/configCases/container/external-runtime-compat/remote.js
+++ b/packages/enhanced/test/configCases/container/external-runtime-compat/remote.js
@@ -1,0 +1,14 @@
+const runtime = require('../../../../../../packages/runtime/dist/index.cjs.cjs');
+
+module.exports = function instantiateRemote() {
+  const constructor =
+    (typeof runtime.getGlobalFederationConstructor === 'function' &&
+      runtime.getGlobalFederationConstructor()) ||
+    runtime.ModuleFederation;
+
+  if (typeof constructor !== 'function') {
+    throw new Error('ModuleFederationMissing');
+  }
+
+  return new constructor({ name: 'remote-using-module-federation' });
+};

--- a/packages/enhanced/test/configCases/container/external-runtime-compat/test.config.js
+++ b/packages/enhanced/test/configCases/container/external-runtime-compat/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  findBundle() {
+    return './bundle0.js';
+  },
+};

--- a/packages/enhanced/test/configCases/container/external-runtime-compat/webpack.config.js
+++ b/packages/enhanced/test/configCases/container/external-runtime-compat/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  target: 'async-node',
+  mode: 'development',
+  devtool: false,
+};


### PR DESCRIPTION
## Summary
- add enhanced config case covering external runtime compat using ModuleFederation API
- verify external runtime creates ModuleFederation instances without relying on legacy aliases

Fixes #4134