### PR TITLE
fix(metro-core): workflow build of metro plugins

### DIFF
--- a/.github/actions/android-e2e/action.yaml
+++ b/.github/actions/android-e2e/action.yaml
@@ -37,6 +37,10 @@ runs:
       run: pnpm install --frozen-lockfile
       shell: bash
 
+    - name: Build Metro packages
+      run: npx nx run-many --targets=build --projects=tag:type:metro --parallel=4
+      shell: bash
+
     - name: Install Maestro CLI
       run: |
         curl -Ls "https://get.maestro.mobile.dev" | bash

--- a/.github/actions/ios-e2e/action.yaml
+++ b/.github/actions/ios-e2e/action.yaml
@@ -35,6 +35,10 @@ runs:
       run: pnpm install --frozen-lockfile
       shell: bash
 
+    - name: Build Metro packages
+      run: npx nx run-many --targets=build --projects=tag:type:metro --parallel=4
+      shell: bash
+
     - name: Install Maestro CLI and iOS Utilities
       run: |
         curl -Ls "https://get.maestro.mobile.dev" | bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -139,7 +139,7 @@ jobs:
     secrets: inherit
 
   e2e-metro:
-    needs: [checkout-install, build-metro]
+    needs: checkout-install
     uses: ./.github/workflows/e2e-metro.yml
     secrets: inherit
 

--- a/.github/workflows/e2e-metro.yml
+++ b/.github/workflows/e2e-metro.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        app_name: [example-host]
+        app_name: [metro-example-host]
     env:
       ANDROID_EMULATOR_API_LEVEL: 28
       ANDROID_EMULATOR_TARGET: default
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        app_name: [example-host]
+        app_name: [metro-example-host]
     env:
       RUBY_VERSION: 2.7.6
       MAESTRO_VERSION: 1.39.13

--- a/apps/metro-example-host/package.json
+++ b/apps/metro-example-host/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "example-host",
+  "name": "metro-example-host",
   "version": "0.0.1",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Description

Fix Metro E2E test failures in CI by adding build step for Metro packages and fixing package name mismatch.

**Android Error:** `ERR_MODULE_NOT_FOUND` - Missing `dist/` folder in `@module-federation/metro-plugin-rnef`
**iOS Error:** `rnef.config not found` - Path mismatch between package name and directory

**Changes:**
- Added build step to `android-e2e` and `ios-e2e` actions to build Metro packages before running tests
- Renamed package from `example-host` to `metro-example-host` to match directory structure
- Updated workflow matrix to use `metro-example-host`
- Removed unnecessary `build-metro` dependency from e2e-metro job

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes failing CI:
- https://github.com/module-federation/core/actions/runs/18640445561/job/53138439700
- https://github.com/module-federation/core/actions/runs/18640445561/job/53138439786

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
