### PR TITLE
chore: release v0.21.2

### DIFF
--- a/.changeset/empty-shrimps-jam.md
+++ b/.changeset/empty-shrimps-jam.md
@@ -1,6 +1,0 @@
----
-'@module-federation/bridge-react': patch
-'@module-federation/modern-js': patch
----
-
-feat: Re-export the exports of the v18/v19/plugin from @module-federation/bridge-react in modernjs

--- a/.changeset/perfect-ravens-pretend.md
+++ b/.changeset/perfect-ravens-pretend.md
@@ -1,7 +1,0 @@
----
-'@module-federation/bridge-react': patch
----
-
-fix: support React Router v6 in peer dependencies
-
-Update react-router peer dependency from "^7" to "^6 || ^7" to fix npm install failures for projects using React Router v6.

--- a/.changeset/steady-maps-dream.md
+++ b/.changeset/steady-maps-dream.md
@@ -1,5 +1,0 @@
----
-'@module-federation/dts-plugin': patch
----
-
-chore: bump koa dependency to 3.0.3 to address CVE-2025-62595

--- a/apps/modernjs/CHANGELOG.md
+++ b/apps/modernjs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/modernjsapp
 
+## 0.1.113
+
+### Patch Changes
+
+- @module-federation/enhanced@0.21.2
+
 ## 0.1.112
 
 ### Patch Changes

--- a/apps/modernjs/package.json
+++ b/apps/modernjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@module-federation/modernjsapp",
   "private": true,
-  "version": "0.1.112",
+  "version": "0.1.113",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/router-demo/router-remote5-2005/CHANGELOG.md
+++ b/apps/router-demo/router-remote5-2005/CHANGELOG.md
@@ -1,5 +1,14 @@
 # remote5
 
+## 1.1.20
+
+### Patch Changes
+
+- Updated dependencies [e98133e]
+- Updated dependencies [dc103ee]
+  - @module-federation/bridge-react@0.21.2
+  - @module-federation/rsbuild-plugin@0.21.2
+
 ## 1.1.19
 
 ### Patch Changes

--- a/apps/router-demo/router-remote5-2005/package.json
+++ b/apps/router-demo/router-remote5-2005/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote5",
   "private": true,
-  "version": "1.1.19",
+  "version": "1.1.20",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/router-demo/router-remote6-2006/CHANGELOG.md
+++ b/apps/router-demo/router-remote6-2006/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [e98133e]
+- Updated dependencies [dc103ee]
+  - @module-federation/bridge-react@0.21.2
+  - @module-federation/rsbuild-plugin@0.21.2
+
 ## 1.1.1
 
 ### Patch Changes

--- a/apps/router-demo/router-remote6-2006/package.json
+++ b/apps/router-demo/router-remote6-2006/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote6",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/website-new/CHANGELOG.md
+++ b/apps/website-new/CHANGELOG.md
@@ -1,5 +1,12 @@
 # website-new
 
+## 1.3.2
+
+### Patch Changes
+
+- @module-federation/rspress-plugin@0.21.2
+- @module-federation/error-codes@0.21.2
+
 ## 1.3.1
 
 ### Patch Changes

--- a/apps/website-new/package.json
+++ b/apps/website-new/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website-new",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "scripts": {
     "dev": "rspress dev",

--- a/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
+++ b/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/bridge-react-webpack-plugin
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/sdk@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/bridge/bridge-react-webpack-plugin/package.json
+++ b/packages/bridge/bridge-react-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react-webpack-plugin",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/bridge-react/CHANGELOG.md
+++ b/packages/bridge/bridge-react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @module-federation/bridge-react
 
+## 0.21.2
+
+### Patch Changes
+
+- e98133e: feat: Re-export the exports of the v18/v19/plugin from @module-federation/bridge-react in modernjs
+- dc103ee: fix: support React Router v6 in peer dependencies
+
+  Update react-router peer dependency from "^7" to "^6 || ^7" to fix npm install failures for projects using React Router v6.
+
+  - @module-federation/sdk@0.21.2
+  - @module-federation/bridge-shared@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/bridge/bridge-react/package.json
+++ b/packages/bridge/bridge-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/bridge/bridge-shared/CHANGELOG.md
+++ b/packages/bridge/bridge-shared/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/bridge-shared
 
+## 0.21.2
+
 ## 0.21.1
 
 ## 0.21.0

--- a/packages/bridge/bridge-shared/package.json
+++ b/packages/bridge/bridge-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-shared",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/vue3-bridge/CHANGELOG.md
+++ b/packages/bridge/vue3-bridge/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/bridge-vue3
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/runtime@0.21.2
+- @module-federation/sdk@0.21.2
+- @module-federation/bridge-shared@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/bridge/vue3-bridge/package.json
+++ b/packages/bridge/vue3-bridge/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/module-federation/core.git",
     "directory": "packages/bridge/vue3-bridge"
   },
-  "version": "0.21.1",
+  "version": "0.21.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/chrome-devtools/CHANGELOG.md
+++ b/packages/chrome-devtools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/devtools
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/sdk@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/chrome-devtools/package.json
+++ b/packages/chrome-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/devtools",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/cli
 
+## 0.21.2
+
+### Patch Changes
+
+- Updated dependencies [4cada54]
+  - @module-federation/dts-plugin@0.21.2
+  - @module-federation/sdk@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/cli",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "type": "commonjs",
   "description": "Module Federation CLI",
   "homepage": "https://module-federation.io",

--- a/packages/create-module-federation/CHANGELOG.md
+++ b/packages/create-module-federation/CHANGELOG.md
@@ -1,5 +1,7 @@
 # create-module-federation
 
+## 0.21.2
+
 ## 0.21.1
 
 ## 0.21.0

--- a/packages/create-module-federation/package.json
+++ b/packages/create-module-federation/package.json
@@ -3,7 +3,7 @@
   "description": "Create a new Module Federation project",
   "public": true,
   "sideEffects": false,
-  "version": "0.21.1",
+  "version": "0.21.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/data-prefetch/CHANGELOG.md
+++ b/packages/data-prefetch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/data-prefetch
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/runtime@0.21.2
+- @module-federation/sdk@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/data-prefetch/package.json
+++ b/packages/data-prefetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@module-federation/data-prefetch",
   "description": "Module Federation Data Prefetch",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "type": "module",
   "author": "nieyan <nyqykk@foxmail.com>",
   "homepage": "https://github.com/module-federation/core",

--- a/packages/dts-plugin/CHANGELOG.md
+++ b/packages/dts-plugin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/dts-plugin
 
+## 0.21.2
+
+### Patch Changes
+
+- 4cada54: chore: bump koa dependency to 3.0.3 to address CVE-2025-62595
+  - @module-federation/sdk@0.21.2
+  - @module-federation/managers@0.21.2
+  - @module-federation/third-party-dts-extractor@0.21.2
+  - @module-federation/error-codes@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/dts-plugin/package.json
+++ b/packages/dts-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/dts-plugin",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "author": "hanric <hanric.zhang@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @module-federation/enhanced
 
+## 0.21.2
+
+### Patch Changes
+
+- Updated dependencies [4cada54]
+  - @module-federation/dts-plugin@0.21.2
+  - @module-federation/cli@0.21.2
+  - @module-federation/manifest@0.21.2
+  - @module-federation/rspack@0.21.2
+  - @module-federation/sdk@0.21.2
+  - @module-federation/runtime-tools@0.21.2
+  - @module-federation/managers@0.21.2
+  - @module-federation/bridge-react-webpack-plugin@0.21.2
+  - @module-federation/data-prefetch@0.21.2
+  - @module-federation/error-codes@0.21.2
+  - @module-federation/inject-external-runtime-core-plugin@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/enhanced",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "repository": {

--- a/packages/error-codes/CHANGELOG.md
+++ b/packages/error-codes/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/error-codes
 
+## 0.21.2
+
 ## 0.21.1
 
 ## 0.21.0

--- a/packages/error-codes/package.json
+++ b/packages/error-codes/package.json
@@ -4,7 +4,7 @@
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "public": true,
   "sideEffects": false,
-  "version": "0.21.1",
+  "version": "0.21.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/esbuild/CHANGELOG.md
+++ b/packages/esbuild/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/esbuild
 
+## 0.0.85
+
+### Patch Changes
+
+- @module-federation/sdk@0.21.2
+
 ## 0.0.84
 
 ### Patch Changes

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/esbuild",
-  "version": "0.0.84",
+  "version": "0.0.85",
   "author": "Zack Jackson (@ScriptedAlchemy)",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/managers/CHANGELOG.md
+++ b/packages/managers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/managers
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/sdk@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/managers/package.json
+++ b/packages/managers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/managers",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "license": "MIT",
   "description": "Provide managers for helping handle mf data .",
   "keywords": [

--- a/packages/manifest/CHANGELOG.md
+++ b/packages/manifest/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/manifest
 
+## 0.21.2
+
+### Patch Changes
+
+- Updated dependencies [4cada54]
+  - @module-federation/dts-plugin@0.21.2
+  - @module-federation/sdk@0.21.2
+  - @module-federation/managers@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/manifest",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "license": "MIT",
   "description": "Provide manifest/stats for webpack/rspack MF project .",
   "keywords": [

--- a/packages/metro-core/CHANGELOG.md
+++ b/packages/metro-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/metro
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/runtime@0.21.2
+- @module-federation/sdk@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/metro-core/package.json
+++ b/packages/metro-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Module Federation for Metro bundler",
   "keywords": [
     "module-federation",

--- a/packages/metro-plugin-rnc-cli/CHANGELOG.md
+++ b/packages/metro-plugin-rnc-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/metro-plugin-rnc-cli
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/metro@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/metro-plugin-rnc-cli/package.json
+++ b/packages/metro-plugin-rnc-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro-plugin-rnc-cli",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Metro Module Federation plugin for React Native Enterprise Framework (RNEF)",
   "keywords": [
     "rnc",

--- a/packages/metro-plugin-rnef/CHANGELOG.md
+++ b/packages/metro-plugin-rnef/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/metro-plugin-rnef
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/metro@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/metro-plugin-rnef/package.json
+++ b/packages/metro-plugin-rnef/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro-plugin-rnef",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Metro Module Federation plugin for React Native Enterprise Framework (RNEF)",
   "keywords": [
     "rnef",

--- a/packages/modernjs/CHANGELOG.md
+++ b/packages/modernjs/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @module-federation/modern-js
 
+## 0.21.2
+
+### Patch Changes
+
+- e98133e: feat: Re-export the exports of the v18/v19/plugin from @module-federation/bridge-react in modernjs
+- Updated dependencies [e98133e]
+- Updated dependencies [dc103ee]
+  - @module-federation/bridge-react@0.21.2
+  - @module-federation/cli@0.21.2
+  - @module-federation/enhanced@0.21.2
+  - @module-federation/node@2.7.21
+  - @module-federation/rsbuild-plugin@0.21.2
+  - @module-federation/runtime@0.21.2
+  - @module-federation/sdk@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/modernjs/package.json
+++ b/packages/modernjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/modern-js",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "files": [
     "dist/",
     "types.d.ts",

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/nextjs-mf
 
+## 8.8.45
+
+### Patch Changes
+
+- @module-federation/enhanced@0.21.2
+- @module-federation/node@2.7.21
+- @module-federation/runtime@0.21.2
+- @module-federation/webpack-bundler-runtime@0.21.2
+- @module-federation/sdk@0.21.2
+
 ## 8.8.44
 
 ### Patch Changes

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "8.8.44",
+  "version": "8.8.45",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/node
 
+## 2.7.21
+
+### Patch Changes
+
+- @module-federation/enhanced@0.21.2
+- @module-federation/runtime@0.21.2
+- @module-federation/sdk@0.21.2
+
 ## 2.7.20
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "2.7.20",
+  "version": "2.7.21",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "exports": {

--- a/packages/retry-plugin/CHANGELOG.md
+++ b/packages/retry-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/retry-plugin
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/sdk@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/retry-plugin/package.json
+++ b/packages/retry-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/retry-plugin",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "author": "danpeen <dapeen.feng@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/rsbuild-plugin/CHANGELOG.md
+++ b/packages/rsbuild-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/rsbuild-plugin
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/enhanced@0.21.2
+- @module-federation/node@2.7.21
+- @module-federation/sdk@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/rsbuild-plugin/package.json
+++ b/packages/rsbuild-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rsbuild-plugin",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Module Federation plugin for Rsbuild",
   "homepage": "https://module-federation.io",
   "bugs": {

--- a/packages/rspack/CHANGELOG.md
+++ b/packages/rspack/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @module-federation/rspack
 
+## 0.21.2
+
+### Patch Changes
+
+- Updated dependencies [4cada54]
+  - @module-federation/dts-plugin@0.21.2
+  - @module-federation/manifest@0.21.2
+  - @module-federation/sdk@0.21.2
+  - @module-federation/runtime-tools@0.21.2
+  - @module-federation/managers@0.21.2
+  - @module-federation/bridge-react-webpack-plugin@0.21.2
+  - @module-federation/inject-external-runtime-core-plugin@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rspack",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "license": "MIT",
   "keywords": [
     "Module Federation",

--- a/packages/rspress-plugin/CHANGELOG.md
+++ b/packages/rspress-plugin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/rspress-plugin
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/enhanced@0.21.2
+- @module-federation/rsbuild-plugin@0.21.2
+- @module-federation/sdk@0.21.2
+- @module-federation/error-codes@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/rspress-plugin/package.json
+++ b/packages/rspress-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rspress-plugin",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "type": "module",
   "description": "Module Federation plugin for Rspress",
   "keywords": [

--- a/packages/runtime-core/CHANGELOG.md
+++ b/packages/runtime-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/runtime
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/sdk@0.21.2
+- @module-federation/error-codes@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-core",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "type": "module",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs.cjs",

--- a/packages/runtime-plugins/inject-external-runtime-core-plugin/CHANGELOG.md
+++ b/packages/runtime-plugins/inject-external-runtime-core-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/inject-external-runtime-core-plugin
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/runtime-tools@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/runtime-plugins/inject-external-runtime-core-plugin/package.json
+++ b/packages/runtime-plugins/inject-external-runtime-core-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/inject-external-runtime-core-plugin",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "type": "module",
   "license": "MIT",
   "description": "A sdk for support module federation",

--- a/packages/runtime-tools/CHANGELOG.md
+++ b/packages/runtime-tools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/runtime-tools
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/runtime@0.21.2
+- @module-federation/webpack-bundler-runtime@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/runtime-tools/package.json
+++ b/packages/runtime-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-tools",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "type": "module",
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "main": "./dist/index.cjs.cjs",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/runtime
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/sdk@0.21.2
+- @module-federation/error-codes@0.21.2
+- @module-federation/runtime-core@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "type": "module",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs.cjs",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/sdk
 
+## 0.21.2
+
 ## 0.21.1
 
 ## 0.21.0

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/sdk",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "type": "module",
   "license": "MIT",
   "description": "A sdk for support module federation",

--- a/packages/storybook-addon/CHANGELOG.md
+++ b/packages/storybook-addon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/storybook-addon
 
+## 4.0.34
+
+### Patch Changes
+
+- @module-federation/enhanced@0.21.2
+- @module-federation/sdk@0.21.2
+
 ## 4.0.33
 
 ### Patch Changes

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/storybook-addon",
-  "version": "4.0.33",
+  "version": "4.0.34",
   "description": "Storybook addon to consume remote module federated apps/components",
   "type": "commonjs",
   "license": "MIT",
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "@rsbuild/core": "^1.0.1",
-    "@module-federation/sdk": "^0.21.1",
+    "@module-federation/sdk": "^0.21.2",
     "@nx/react": ">= 16.0.0",
     "@nx/webpack": ">= 16.0.0",
     "@storybook/core": ">= 8.2.0",

--- a/packages/third-party-dts-extractor/CHANGELOG.md
+++ b/packages/third-party-dts-extractor/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/third-party-dts-extractor
 
+## 0.21.2
+
 ## 0.21.1
 
 ## 0.21.0

--- a/packages/third-party-dts-extractor/package.json
+++ b/packages/third-party-dts-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/third-party-dts-extractor",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "files": [
     "dist/",
     "README.md"

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/utilities
 
+## 3.1.73
+
+### Patch Changes
+
+- @module-federation/sdk@0.21.2
+
 ## 3.1.72
 
 ### Patch Changes

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/utilities",
-  "version": "3.1.72",
+  "version": "3.1.73",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",

--- a/packages/webpack-bundler-runtime/CHANGELOG.md
+++ b/packages/webpack-bundler-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/webpack-bundler-runtime
 
+## 0.21.2
+
+### Patch Changes
+
+- @module-federation/runtime@0.21.2
+- @module-federation/sdk@0.21.2
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/webpack-bundler-runtime/package.json
+++ b/packages/webpack-bundler-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/webpack-bundler-runtime",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "type": "module",
   "license": "MIT",
   "description": "Module Federation Runtime for webpack",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at release-v0.21.2 -->

## What's Changed

### New Features 🎉
* feat: Re-export the exports of the v18/v19/plugin from `@module-federation/bridge-react` in modernjs  by @danpeen in https://github.com/module-federation/core/pull/4168
### Bug Fixes 🐞
* fix: support React Router v6 in bridge-react peer dependencies by @danpeen in https://github.com/module-federation/core/pull/4167

### Other Changes
* chore: release v0.21.1 by @danpeen in https://github.com/module-federation/core/pull/4152
* chore(dts-plugin): bump koa to 3.0.3 by @ScriptedAlchemy in https://github.com/module-federation/core/pull/4157
* ci: restore build workflow permissions and add actionlint guard by @ScriptedAlchemy in https://github.com/module-federation/core/pull/4158
* chore(deps-dev): bump hono from 3.12.12 to 4.10.2 by @dependabot[bot] in https://github.com/module-federation/core/pull/4156
* chore(deps-dev): bump vite from 5.4.20 to 5.4.21 by @dependabot[bot] in https://github.com/module-federation/core/pull/4149
* chore(deps): bump rexml from 3.4.1 to 3.4.2 in /apps/metro-example-mini by @dependabot[bot] in https://github.com/module-federation/core/pull/4076
* chore(deps): bump lodash and @types/lodash in /apps/metro-example-nested-mini by @dependabot[bot] in https://github.com/module-federation/core/pull/4019


**Full Changelog**: https://github.com/module-federation/core/compare/v0.21.1...v0.21.2