### PR TITLE
fix(bridge-react): restore complete type generation for bridge components

### DIFF
--- a/packages/bridge/bridge-react/src/__tests__/types.test.ts
+++ b/packages/bridge/bridge-react/src/__tests__/types.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Type tests to verify that bridge component types are correctly generated
+ * These tests ensure that the TypeScript compiler can properly infer types
+ */
+
+import { createBridgeComponent } from '../provider/versions/legacy';
+import { createBridgeComponent as createBridgeComponentV18 } from '../provider/versions/v18';
+import type { BridgeComponent } from '../types';
+
+// Test component props interface
+interface WidgetProps {
+  text: string;
+  number: number;
+}
+
+// Mock component for testing
+const MockWidget: React.ComponentType<WidgetProps> = () => null;
+
+describe('Bridge Component Types', () => {
+  it('should have correct return type for legacy createBridgeComponent', () => {
+    const WidgetBridge = createBridgeComponent({
+      rootComponent: MockWidget,
+    });
+
+    const bridgeInstance = WidgetBridge();
+
+    // Type assertions to verify the interface
+    expect(typeof bridgeInstance.render).toBe('function');
+    expect(typeof bridgeInstance.destroy).toBe('function');
+    expect(bridgeInstance.rawComponent).toBe(MockWidget);
+    expect(typeof bridgeInstance.__BRIDGE_FN__).toBe('function');
+
+    // Verify the bridge instance matches the BridgeComponent interface
+    const typedInstance: BridgeComponent<WidgetProps> = bridgeInstance;
+    expect(typedInstance).toBeDefined();
+  });
+
+  it('should have correct return type for v18 createBridgeComponent', () => {
+    const WidgetBridge = createBridgeComponentV18({
+      rootComponent: MockWidget,
+    });
+
+    const bridgeInstance = WidgetBridge();
+
+    // Type assertions to verify the interface
+    expect(typeof bridgeInstance.render).toBe('function');
+    expect(typeof bridgeInstance.destroy).toBe('function');
+    expect(bridgeInstance.rawComponent).toBe(MockWidget);
+    expect(typeof bridgeInstance.__BRIDGE_FN__).toBe('function');
+
+    // Verify the bridge instance matches the BridgeComponent interface
+    const typedInstance: BridgeComponent<WidgetProps> = bridgeInstance;
+    expect(typedInstance).toBeDefined();
+  });
+
+  it('should properly infer component props types', () => {
+    const WidgetBridge = createBridgeComponent({
+      rootComponent: MockWidget,
+    });
+
+    const bridgeInstance = WidgetBridge();
+
+    // Test that __BRIDGE_FN__ accepts the correct props type
+    bridgeInstance.__BRIDGE_FN__({ text: 'test', number: 42 });
+
+    // This should cause a TypeScript error if types are incorrect:
+    // bridgeInstance.__BRIDGE_FN__({ text: 'test' }); // missing 'number'
+    // bridgeInstance.__BRIDGE_FN__({ text: 'test', number: 'invalid' }); // wrong type
+  });
+});
+
+// Type-only tests (these will be checked by TypeScript compiler)
+type TestBridgeComponentType = ReturnType<
+  typeof createBridgeComponent<WidgetProps>
+>;
+type TestBridgeInstanceType = ReturnType<TestBridgeComponentType>;
+
+// Verify that the bridge instance has all required properties
+type RequiredProperties = keyof BridgeComponent<WidgetProps>;
+const requiredProps: RequiredProperties[] = [
+  'render',
+  'destroy',
+  'rawComponent',
+  '__BRIDGE_FN__',
+];
+
+// Verify that rawComponent has the correct type
+type RawComponentType = TestBridgeInstanceType['rawComponent'];
+const _rawComponentTypeCheck: RawComponentType = MockWidget;
+
+// Verify that __BRIDGE_FN__ has the correct signature
+type BridgeFnType = TestBridgeInstanceType['__BRIDGE_FN__'];
+const _bridgeFnTypeCheck: BridgeFnType = (args: WidgetProps) => {};

--- a/packages/bridge/bridge-react/src/index.ts
+++ b/packages/bridge/bridge-react/src/index.ts
@@ -39,6 +39,7 @@ export type {
   RenderFnParams,
   RemoteComponentProps,
   RemoteModule,
+  BridgeComponent,
 } from './types';
 export type {
   DataFetchParams,

--- a/packages/bridge/bridge-react/src/provider/versions/bridge-base.tsx
+++ b/packages/bridge/bridge-react/src/provider/versions/bridge-base.tsx
@@ -10,6 +10,7 @@ import type {
   DestroyParams,
   RenderParams,
   CreateRootOptions,
+  BridgeComponent,
 } from '../../types';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import { RouterContext } from '../context';
@@ -21,7 +22,7 @@ export function createBaseBridgeComponent<T>({
   defaultRootOptions,
   ...bridgeInfo
 }: ProviderFnParams<T>) {
-  return () => {
+  return (): BridgeComponent<T> => {
     const rootMap = new Map<any, RootType>();
     const instance = federationRuntime.instance;
     LoggerInstance.debug(
@@ -121,6 +122,13 @@ export function createBaseBridgeComponent<T>({
           rootMap.delete(dom);
         }
         instance?.bridgeHook?.lifecycle?.afterBridgeDestroy?.emit(info);
+      },
+
+      rawComponent: bridgeInfo.rootComponent,
+      __BRIDGE_FN__: (args: T) => {
+        LoggerInstance.debug('Bridge function called with args:', args);
+        // This function provides access to the bridge component for type inference
+        // It's primarily used for TypeScript type checking and development tools
       },
     };
   };

--- a/packages/bridge/bridge-react/src/types.ts
+++ b/packages/bridge/bridge-react/src/types.ts
@@ -127,6 +127,16 @@ export interface RemoteComponentParams<
 }
 
 /**
+ * Interface for a bridge component instance
+ */
+export interface BridgeComponent<T = any> {
+  render: (info: RenderFnParams & { [key: string]: unknown }) => Promise<void>;
+  destroy: (info: DestroyParams) => void;
+  rawComponent: React.ComponentType<T>;
+  __BRIDGE_FN__: (args: T) => void;
+}
+
+/**
  * Interface for a remote module provider
  */
 export interface RemoteModule {

--- a/packages/bridge/bridge-react/src/v18.ts
+++ b/packages/bridge/bridge-react/src/v18.ts
@@ -6,4 +6,9 @@ export type {
   RootType,
   DestroyParams,
   RenderParams,
+  RenderFnParams,
+  RemoteComponentParams,
+  RemoteComponentProps,
+  RemoteModule,
+  BridgeComponent,
 } from './types';

--- a/packages/bridge/bridge-react/src/v19.ts
+++ b/packages/bridge/bridge-react/src/v19.ts
@@ -6,4 +6,9 @@ export type {
   RootType,
   DestroyParams,
   RenderParams,
+  RenderFnParams,
+  RemoteComponentParams,
+  RemoteComponentProps,
+  RemoteModule,
+  BridgeComponent,
 } from './types';

--- a/packages/bridge/bridge-react/vite.config.ts
+++ b/packages/bridge/bridge-react/vite.config.ts
@@ -14,6 +14,15 @@ export default defineConfig({
         '@module-federation/bridge-shared',
         'react-error-boundary',
       ],
+      insertTypesEntry: true,
+      copyDtsFiles: false,
+      include: ['src/**/*'],
+      exclude: [
+        '**/*.spec.ts',
+        '**/*.test.ts',
+        '**/*.spec.tsx',
+        '**/*.test.tsx',
+      ],
     }),
   ],
   build: {


### PR DESCRIPTION
## Fix for Issue #4159: bridge-react (0.21.1): Created types are not correct

### Problem
The TypeScript types generated for `@module-federation/bridge-react` v0.21.1 were incomplete compared to v0.8.10, missing crucial properties like `rawComponent`, `__BRIDGE_FN__`, and proper component props inference.

### Root Cause
- Changes in package structure with version-specific entry points
- Type generation configuration affecting type bundling  
- Missing type exports in version-specific entry points

### Solution
1. **Enhanced Type Exports** - Added missing type exports (`RenderFnParams`, `RemoteComponentParams`, etc.) to all entry points
2. **Updated Bridge Component Interface** - Added new `BridgeComponent<T>` interface with all required properties
3. **Improved Type Generation** - Enhanced vite-plugin-dts configuration for better type bundling
4. **Type Safety Verification** - Added comprehensive type tests

### Changes Made
- `src/v18.ts` & `src/v19.ts`: Added missing type exports
- `src/types.ts`: Added `BridgeComponent<T>` interface  
- `src/provider/versions/bridge-base.tsx`: Enhanced return type with `rawComponent` and `__BRIDGE_FN__`
- `src/index.ts`: Updated main exports for backward compatibility
- `vite.config.ts`: Improved DTS plugin configuration
- `src/__tests__/types.test.ts`: Added type verification tests

### Expected Results
After these changes, generated types will include:
- ✅ Complete bridge interface with `render`, `destroy`, `rawComponent`, and `__BRIDGE_FN__`
- ✅ Proper component props type inference (e.g., `WidgetProps`)
- ✅ Backward compatibility with legacy import patterns
- ✅ Full type safety for both `/v18` and `/v19` imports

### Testing
- Type compilation tests pass
- Component props inference works correctly
- All entry points export complete type definitions

Fixes #4159