### PR TITLE
docs: var host + esm remote (vite) varFilename description

### DIFF
--- a/apps/website-new/docs/en/guide/basic/plugins/vite.mdx
+++ b/apps/website-new/docs/en/guide/basic/plugins/vite.mdx
@@ -51,7 +51,10 @@ module.exports = {
           name: "esm_remote",
           entry: "https://[...]/remoteEntry.js",
         },
-        var_remote: "var_remote@https://[...]/remoteEntry.js",
+        // by default @module-federation/vite plugin generates esm remoteEntry.js file
+        // if your remote uses vite and you need to connect it as `type: "var"`
+        // you can set `varFilename: "varRemoteEntry.js"` option in remote's config
+        var_remote: "var_remote@https://[...]/varRemoteEntry.js",
       },
       exposes: {
         './button': './src/components/button',


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

If we build `remote` application using `@module-federation/vite`, it generates esm `remoteEntry.js` file, thus we are not able to import it in `host` application with "old fashion way" ([see example](https://webpack.js.org/concepts/module-federation/))

It becomes a huge problem when we are not able to rewrite our `host` application (this is my case, I don't control `host` application at all).

~~Therefore I've come up with some workaround (see docs changes).~~

~~I've tested it with webpack/vite, with buildtime/runtime usages and it works like a charm.~~

~~If you like this solution I will add Chinese translation too.~~

**UPD:**

`@module-federation/vite` now supports `varFilename` option (https://github.com/module-federation/vite/pull/353), so we can use it instead of workaround

If you want I could add Chinese translation too

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/originjs/vite-plugin-federation/issues/368
https://github.com/module-federation/vite/issues/247

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
