### PR TITLE
fix(sdk): fix typescript `TS1170` error on Typescript > `5.7.0`

### DIFF
--- a/.changeset/tidy-planets-lie.md
+++ b/.changeset/tidy-planets-lie.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/sdk': patch
+---
+
+Fix a Typescript TS1170 error with the SDK on Typescript > 5.7.0

--- a/packages/sdk/src/constant.ts
+++ b/packages/sdk/src/constant.ts
@@ -7,7 +7,7 @@ export const NameTransformSymbol = {
   AT: '@',
   HYPHEN: '-',
   SLASH: '/',
-};
+} as const;
 export const NameTransformMap = {
   [NameTransformSymbol.AT]: 'scope_',
   [NameTransformSymbol.HYPHEN]: '_',


### PR DESCRIPTION
## Description

Fix for a typescript error on TypeScript 5.7.0 and above on the SDK

## Related Issue

https://github.com/module-federation/core/issues/4183

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
