### PR TITLE
feat(storybook)!: only ship ESM outputs, align with Storybook 10.

### DIFF
--- a/.changeset/real-squids-retire.md
+++ b/.changeset/real-squids-retire.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/storybook-addon': major
+---
+
+only ship ESM outputs, align with Storybook 10.

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -2,7 +2,7 @@
   "name": "@module-federation/storybook-addon",
   "version": "4.0.36",
   "description": "Storybook addon to consume remote module federated apps/components",
-  "type": "commonjs",
+  "type": "module",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/storybook-addon/preset.ts
+++ b/packages/storybook-addon/preset.ts
@@ -1,4 +1,4 @@
-import { withModuleFederation } from './src/utils/with-module-federation-enhanced-rsbuild';
+import { withModuleFederation } from './src/utils/with-module-federation-enhanced-rsbuild.js';
 
 import type { RsbuildConfig } from '@rsbuild/core';
 import type { moduleFederationPlugin } from '@module-federation/sdk';
@@ -18,4 +18,4 @@ export default {
     });
   },
 };
-export { PLUGIN_NAME } from './src/utils/with-module-federation-enhanced-rsbuild';
+export { PLUGIN_NAME } from './src/utils/with-module-federation-enhanced-rsbuild.js';

--- a/packages/storybook-addon/src/index.ts
+++ b/packages/storybook-addon/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/storybook-addon';
+export * from './lib/storybook-addon.js';

--- a/packages/storybook-addon/src/lib/storybook-addon.spec.ts
+++ b/packages/storybook-addon/src/lib/storybook-addon.spec.ts
@@ -1,4 +1,4 @@
-import { Preset, webpack } from './storybook-addon';
+import { Preset, webpack } from './storybook-addon.js';
 import { Configuration, container } from 'webpack';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 

--- a/packages/storybook-addon/src/lib/storybook-addon.ts
+++ b/packages/storybook-addon/src/lib/storybook-addon.ts
@@ -9,8 +9,8 @@ import {
 } from 'webpack';
 import { logger } from '@storybook/node-logger';
 import { normalizeStories } from '@storybook/core/common';
-import withModuleFederation from '../utils/with-module-federation';
-import { correctImportPath } from '../utils/correctImportPath';
+import withModuleFederation from '../utils/with-module-federation.js';
+import { correctImportPath } from '../utils/correctImportPath.js';
 
 import type { moduleFederationPlugin } from '@module-federation/sdk';
 import type { ModuleFederationConfig } from '@nx/webpack';

--- a/packages/storybook-addon/src/utils/correctImportPath.spec.ts
+++ b/packages/storybook-addon/src/utils/correctImportPath.spec.ts
@@ -1,4 +1,4 @@
-import { correctImportPath } from './correctImportPath';
+import { correctImportPath } from './correctImportPath.js';
 
 describe(`${correctImportPath.name}()`, () => {
   afterEach(() => {

--- a/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
+++ b/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
 import { TEMP_DIR } from '@module-federation/sdk';
 
-import { correctImportPath } from './correctImportPath';
+import { correctImportPath } from './correctImportPath.js';
 
 import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core';
 import type { moduleFederationPlugin } from '@module-federation/sdk';

--- a/packages/storybook-addon/tsconfig.json
+++ b/packages/storybook-addon/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "esnext",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
## Description

only ship ESM outputs, align with Storybook 10.

in Storybook 10 https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#from-version-9x-to-1000, it's only to only ship ESM for the ecosystem.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
