### PR TITLE
fix(dts-plugin): delete compilerOptions.declarationDir

### DIFF
--- a/.changeset/nice-news-carry.md
+++ b/.changeset/nice-news-carry.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+fix(dts-plugin): delete compilerOptions.declarationDir

--- a/packages/dts-plugin/src/core/configurations/remotePlugin.ts
+++ b/packages/dts-plugin/src/core/configurations/remotePlugin.ts
@@ -156,6 +156,9 @@ const readTsConfig = (
   'references' in rawTsConfigJson && delete rawTsConfigJson.references;
 
   rawTsConfigJson.extends = resolvedTsConfigPath;
+  if (rawTsConfigJson.compilerOptions.declarationDir) {
+    delete rawTsConfigJson.compilerOptions.declarationDir;
+  }
   return rawTsConfigJson;
 };
 

--- a/packages/dts-plugin/src/core/configurations/tsconfig.test.json
+++ b/packages/dts-plugin/src/core/configurations/tsconfig.test.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "strict": true,
     "strictNullChecks": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "declarationDir": "dts-dist"
   }
 }


### PR DESCRIPTION
## Description

delete compilerOptions.declarationDir, incase outDir be override 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
