### PR TITLE
fix(retry-plugin): add autoParseResponse to auto-select JSON or text based on file extension

### DIFF
--- a/.changeset/thirty-cooks-dream.md
+++ b/.changeset/thirty-cooks-dream.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/retry-plugin': patch
+---
+
+fix(retry-plugin): add autoParseResponse to auto-select JSON or text based on file extension

--- a/packages/retry-plugin/src/fetch-retry.ts
+++ b/packages/retry-plugin/src/fetch-retry.ts
@@ -9,6 +9,18 @@ import {
 import logger from './logger';
 import { getRetryUrl, combineUrlDomainWithPathQuery } from './utils';
 
+function autoParseResponse(url: string, response: Response) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.pathname.endsWith('.js')) {
+      return response.text();
+    }
+    return response.json();
+  } catch (error) {
+    return response.json();
+  }
+}
+
 async function fetchRetry(
   params: FetchRetryOptions,
   lastRequestUrl?: string,
@@ -63,7 +75,7 @@ async function fetchRetry(
         `${PLUGIN_IDENTIFIER}: Request failed: ${response.status} ${response.statusText || ''} | url: ${requestUrl}`,
       );
     }
-    await responseClone.json().catch((error) => {
+    await autoParseResponse(requestUrl, responseClone).catch((error) => {
       throw new Error(
         `${PLUGIN_IDENTIFIER}: JSON parse failed: ${(error as Error)?.message || String(error)} | url: ${requestUrl}`,
       );


### PR DESCRIPTION

## Description
add autoParseResponse to auto-select JSON or text based on file extension
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
