### PR TITLE
fix(dts-plugin): api type file should not related with manifest config

### DIFF
--- a/.changeset/fuzzy-lamps-confess.md
+++ b/.changeset/fuzzy-lamps-confess.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/dts-plugin': patch
+'@module-federation/manifest': patch
+---
+
+fix(dts-plugin): api type file should not related with manifest config

--- a/packages/dts-plugin/src/core/lib/utils.ts
+++ b/packages/dts-plugin/src/core/lib/utils.ts
@@ -33,18 +33,14 @@ export const validateOptions = (options: HostOptions) => {
 };
 
 export function retrieveTypesAssetsInfo(options: RemoteOptions) {
-  const { moduleFederationConfig } = options;
   let apiTypesPath = '';
   let zipTypesPath = '';
-
-  let zipPrefix = '';
 
   try {
     const { tsConfig, remoteOptions, mapComponentsToExpose } =
       retrieveRemoteConfig(options);
     if (!Object.keys(mapComponentsToExpose).length || !tsConfig.files.length) {
       return {
-        zipPrefix,
         apiTypesPath,
         zipTypesPath,
         zipName: '',
@@ -58,22 +54,7 @@ export function retrieveTypesAssetsInfo(options: RemoteOptions) {
       apiTypesPath = retrieveMfAPITypesPath(tsConfig, remoteOptions);
     }
 
-    if (
-      typeof moduleFederationConfig.manifest === 'object' &&
-      moduleFederationConfig.manifest.filePath
-    ) {
-      zipPrefix = moduleFederationConfig.manifest.filePath;
-    } else if (
-      typeof moduleFederationConfig.manifest === 'object' &&
-      moduleFederationConfig.manifest.fileName
-    ) {
-      zipPrefix = path.dirname(moduleFederationConfig.manifest.fileName);
-    } else if (moduleFederationConfig.filename) {
-      zipPrefix = path.dirname(moduleFederationConfig.filename);
-    }
-
     return {
-      zipPrefix,
       apiTypesPath,
       zipTypesPath,
       zipName: path.basename(zipTypesPath),
@@ -82,7 +63,6 @@ export function retrieveTypesAssetsInfo(options: RemoteOptions) {
   } catch (err) {
     console.error(ansiColors.red(`Unable to compile federated types, ${err}`));
     return {
-      zipPrefix,
       apiTypesPath: '',
       zipTypesPath: '',
       zipName: '',

--- a/packages/dts-plugin/src/plugins/GenerateTypesPlugin.ts
+++ b/packages/dts-plugin/src/plugins/GenerateTypesPlugin.ts
@@ -162,29 +162,15 @@ export class GenerateTypesPlugin implements WebpackPluginInstance {
         logger.debug('start generating types...');
         await generateTypesAPI({ dtsManagerOptions });
         logger.debug('generate types success!');
-        const config = dtsManagerOptions.remote.moduleFederationConfig;
-        let zipPrefix = '';
-        if (typeof config.manifest === 'object' && config.manifest.filePath) {
-          zipPrefix = config.manifest.filePath;
-        } else if (
-          typeof config.manifest === 'object' &&
-          config.manifest.fileName
-        ) {
-          zipPrefix = path.dirname(config.manifest.fileName);
-        } else if (config.filename) {
-          zipPrefix = path.dirname(config.filename);
-        }
 
         if (isProd) {
-          const zipAssetName = path.join(zipPrefix, zipName);
-          const apiAssetName = path.join(zipPrefix, apiFileName);
           if (
             zipTypesPath &&
-            !compilation.getAsset(zipAssetName) &&
+            !compilation.getAsset(zipName) &&
             fs.existsSync(zipTypesPath)
           ) {
             compilation.emitAsset(
-              zipAssetName,
+              zipName,
               new compiler.webpack.sources.RawSource(
                 fs.readFileSync(zipTypesPath),
                 false,
@@ -194,11 +180,11 @@ export class GenerateTypesPlugin implements WebpackPluginInstance {
 
           if (
             apiTypesPath &&
-            !compilation.getAsset(apiAssetName) &&
+            !compilation.getAsset(apiFileName) &&
             fs.existsSync(apiTypesPath)
           ) {
             compilation.emitAsset(
-              apiAssetName,
+              apiFileName,
               new compiler.webpack.sources.RawSource(
                 fs.readFileSync(apiTypesPath),
                 false,
@@ -212,11 +198,7 @@ export class GenerateTypesPlugin implements WebpackPluginInstance {
           };
           if (zipTypesPath && fs.existsSync(zipTypesPath)) {
             const zipContent = fs.readFileSync(zipTypesPath);
-            const zipOutputPath = path.join(
-              compiler.outputPath,
-              zipPrefix,
-              zipName,
-            );
+            const zipOutputPath = path.join(compiler.outputPath, zipName);
             await new Promise<void>((resolve, reject) => {
               compiler.outputFileSystem.mkdir(
                 path.dirname(zipOutputPath),
@@ -248,11 +230,7 @@ export class GenerateTypesPlugin implements WebpackPluginInstance {
 
           if (apiTypesPath && fs.existsSync(apiTypesPath)) {
             const apiContent = fs.readFileSync(apiTypesPath);
-            const apiOutputPath = path.join(
-              compiler.outputPath,
-              zipPrefix,
-              apiFileName,
-            );
+            const apiOutputPath = path.join(compiler.outputPath, apiFileName);
             await new Promise<void>((resolve, reject) => {
               compiler.outputFileSystem.mkdir(
                 path.dirname(apiOutputPath),

--- a/packages/manifest/src/utils.ts
+++ b/packages/manifest/src/utils.ts
@@ -259,20 +259,17 @@ export function getTypesMetaInfo(
       return defaultTypesMetaInfo;
     }
 
-    const { apiFileName, zipName, zipPrefix } = retrieveTypesAssetsInfo({
+    const { apiFileName, zipName } = retrieveTypesAssetsInfo({
       ...normalizedRemote,
       context,
       moduleFederationConfig: pluginOptions,
     });
 
-    const zip = path.join(zipPrefix, zipName);
-    const api = path.join(zipPrefix, apiFileName);
-
     return {
       path: '',
       name: '',
-      zip,
-      api,
+      zip: zipName,
+      api: apiFileName,
     };
   } catch (err) {
     logger.warn(


### PR DESCRIPTION
## Description

api type file should not related with manifest config

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
