### PR TITLE
fix(rsbuild-plugin): create different temp filepath to prevent invalid manifest.exposes

### DIFF
--- a/.changeset/silver-buttons-wonder.md
+++ b/.changeset/silver-buttons-wonder.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rsbuild-plugin': patch
+---
+
+fix(rsbuild-plugin): create different temp filepath to prevent invalid manifest.exposes

--- a/packages/rsbuild-plugin/src/utils/addDataFetchExposes.ts
+++ b/packages/rsbuild-plugin/src/utils/addDataFetchExposes.ts
@@ -46,15 +46,11 @@ export function addDataFetchExposes(
     return;
   }
 
-  const tempDataFetchFilepath = path.resolve(
-    process.cwd(),
-    `node_modules/${TEMP_DIR}/data-fetch-fallback.ts`,
-  );
+  const tempDataFetch = path.resolve(process.cwd(), `node_modules/${TEMP_DIR}`);
   const content = `export const fetchData=()=>{throw new Error('should not be called')};`;
-  fs.ensureDirSync(path.dirname(tempDataFetchFilepath));
-  fs.writeFileSync(tempDataFetchFilepath, content);
+  fs.ensureDirSync(tempDataFetch);
 
-  Object.keys(exposes).forEach((key) => {
+  Object.keys(exposes).forEach((key, index) => {
     const expose = exposes[key];
     if (typeof expose !== 'string') {
       return;
@@ -63,6 +59,8 @@ export function addDataFetchExposes(
     const dataFetchPath = `${absPath.replace(path.extname(absPath), '')}.${DATA_FETCH_IDENTIFIER}.ts`;
 
     const dataFetchClientPath = `${absPath.replace(path.extname(absPath), '')}.${DATA_FETCH_IDENTIFIER}.client.ts`;
+    const tempFile = path.join(tempDataFetch, `data-fetch-fallback${index}.ts`);
+    fs.writeFileSync(tempFile, content);
 
     const dateFetchClientKey = addDataFetchExpose(
       exposes,
@@ -72,14 +70,14 @@ export function addDataFetchExposes(
     );
     if (!isServer && dateFetchClientKey) {
       exposes[dateFetchClientKey.replace(DATA_FETCH_CLIENT_SUFFIX, '')] =
-        addExcludeDtsSuffix(tempDataFetchFilepath);
+        addExcludeDtsSuffix(tempFile);
       return;
     }
 
     const dataFetchKey = addDataFetchExpose(exposes, key, dataFetchPath);
     if (dataFetchKey && fs.existsSync(dataFetchClientPath)) {
       exposes[`${dataFetchKey}${DATA_FETCH_CLIENT_SUFFIX}`] =
-        addExcludeDtsSuffix(tempDataFetchFilepath);
+        addExcludeDtsSuffix(tempFile);
     }
   });
 }


### PR DESCRIPTION


## Description
create different temp filepath to prevent invalid manifest.exposes
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
