### PR TITLE
fix(modernjs)!: ship .mjs files for correct ESM output

### DIFF
--- a/.changeset/brave-beans-exist.md
+++ b/.changeset/brave-beans-exist.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js': minor
+---
+
+fix(modernjs)!: ship .mjs files for correct ESM output

--- a/packages/modernjs/modern.config.ts
+++ b/packages/modernjs/modern.config.ts
@@ -1,6 +1,0 @@
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
-
-export default defineConfig({
-  buildPreset: 'modern-js-universal',
-  plugins: [moduleTools()],
-});

--- a/packages/modernjs/package.json
+++ b/packages/modernjs/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "modern-module build"
+    "build": "rslib build"
   },
   "repository": {
     "type": "git",
@@ -20,60 +20,60 @@
   "exports": {
     ".": {
       "types": "./dist/types/cli/index.d.ts",
-      "import": "./dist/esm/cli/index.js",
+      "import": "./dist/esm/cli/index.mjs",
       "require": "./dist/cjs/cli/index.js"
     },
     "./runtime": {
       "types": "./dist/types/runtime/index.d.ts",
-      "default": "./dist/esm/runtime/index.js"
+      "default": "./dist/esm/runtime/index.mjs"
     },
     "./react": {
       "types": "./dist/types/react/index.d.ts",
-      "default": "./dist/esm/react/index.js"
+      "default": "./dist/esm/react/index.mjs"
     },
     "./react-v18": {
       "types": "./dist/types/react/v18.d.ts",
-      "default": "./dist/esm/react/v18.js"
+      "default": "./dist/esm/react/v18.mjs"
     },
     "./react-v19": {
       "types": "./dist/types/react/v19.d.ts",
-      "default": "./dist/esm/react/v19.js"
+      "default": "./dist/esm/react/v19.mjs"
     },
     "./react-plugin": {
       "types": "./dist/types/react/plugin.d.ts",
-      "default": "./dist/esm/react/plugin.js"
+      "default": "./dist/esm/react/plugin.mjs"
     },
     "./ssr-dev-plugin": {
       "types": "./dist/types/ssr-runtime/devPlugin.d.ts",
-      "default": "./dist/esm/ssr-runtime/devPlugin.js"
+      "default": "./dist/esm/ssr-runtime/devPlugin.mjs"
     },
     "./ssr-inject-data-fetch-function-plugin": {
       "types": "./dist/types/ssr-runtime/injectDataFetchFunctionPlugin.d.ts",
-      "default": "./dist/esm/ssr-runtime/injectDataFetchFunctionPlugin.js"
+      "default": "./dist/esm/ssr-runtime/injectDataFetchFunctionPlugin.mjs"
     },
     "./config-plugin": {
       "types": "./dist/types/cli/configPlugin.d.ts",
-      "import": "./dist/esm/cli/configPlugin.js",
+      "import": "./dist/esm/cli/configPlugin.mjs",
       "require": "./dist/cjs/cli/configPlugin.js"
     },
     "./ssr-plugin": {
       "types": "./dist/types/cli/ssrPlugin.d.ts",
-      "import": "./dist/esm/cli/ssrPlugin.js",
+      "import": "./dist/esm/cli/ssrPlugin.mjs",
       "require": "./dist/cjs/cli/ssrPlugin.js"
     },
     "./shared-strategy": {
       "types": "./dist/types/cli/mfRuntimePlugins/shared-strategy.d.ts",
-      "import": "./dist/esm/cli/mfRuntimePlugins/shared-strategy.js",
+      "import": "./dist/esm/cli/mfRuntimePlugins/shared-strategy.mjs",
       "require": "./dist/cjs/cli/mfRuntimePlugins/shared-strategy.js"
     },
     "./resolve-entry-ipv4": {
       "types": "./dist/types/cli/mfRuntimePlugins/resolve-entry-ipv4.d.ts",
-      "import": "./dist/esm/cli/mfRuntimePlugins/resolve-entry-ipv4.js",
+      "import": "./dist/esm/cli/mfRuntimePlugins/resolve-entry-ipv4.mjs",
       "require": "./dist/cjs/cli/mfRuntimePlugins/resolve-entry-ipv4.js"
     },
     "./inject-node-fetch": {
       "types": "./dist/types/cli/mfRuntimePlugins/inject-node-fetch.d.ts",
-      "import": "./dist/esm/cli/mfRuntimePlugins/inject-node-fetch.js",
+      "import": "./dist/esm/cli/mfRuntimePlugins/inject-node-fetch.mjs",
       "require": "./dist/cjs/cli/mfRuntimePlugins/inject-node-fetch.js"
     },
     "./data-fetch-server-plugin": {
@@ -153,6 +153,7 @@
   },
   "devDependencies": {
     "@module-federation/manifest": "workspace:*",
+    "@rslib/core": "^0.18.1",
     "@modern-js/core": "2.68.2",
     "@rsbuild/core": "1.3.21",
     "@modern-js/app-tools": "2.68.2",

--- a/packages/modernjs/rslib.config.ts
+++ b/packages/modernjs/rslib.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig } from '@rslib/core';
+
+const sharedLibOptions = {
+  bundle: false,
+  externalHelpers: true,
+  outBase: 'src',
+} as const;
+
+export default defineConfig({
+  source: {
+    entry: {
+      index: ['./src/**/*.{ts,tsx,js,jsx}', '!./src/**/*.spec.*'],
+    },
+  },
+  lib: [
+    {
+      ...sharedLibOptions,
+      format: 'cjs',
+      syntax: 'es2019',
+      dts: false,
+      output: {
+        distPath: {
+          root: './dist/cjs',
+        },
+      },
+    },
+    {
+      ...sharedLibOptions,
+      format: 'esm',
+      syntax: 'es5',
+      dts: false,
+      output: {
+        distPath: {
+          root: './dist/esm',
+        },
+      },
+    },
+    {
+      ...sharedLibOptions,
+      format: 'esm',
+      syntax: 'es2019',
+      dts: {
+        distPath: './dist/types',
+      },
+      output: {
+        distPath: {
+          root: './dist/esm-node',
+        },
+      },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3457,6 +3457,9 @@ importers:
       '@rsbuild/core':
         specifier: 1.3.21
         version: 1.3.21
+      '@rslib/core':
+        specifier: ^0.18.1
+        version: 0.18.1(typescript@5.5.2)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.11
@@ -12900,6 +12903,10 @@ packages:
     resolution: {integrity: sha512-mGbPAAApgjmQUl4J7WAt20aV04a26TyS21GDEpOGXFEQG5FqmZnSJ6FqB8K19HgTKioBT1+fF/Ctl5bGGao/EA==}
     dev: true
 
+  /@module-federation/error-codes@0.21.4:
+    resolution: {integrity: sha512-ClpL5MereWNXh+EgDjz7w4RrC1JlisQTvXDa1gLxpviHafzNDfdViVmuhi9xXVuj+EYo8KU70Y999KHhk9424Q==}
+    dev: true
+
   /@module-federation/inject-external-runtime-core-plugin@0.15.0(@module-federation/runtime-tools@0.15.0):
     resolution: {integrity: sha512-D6+FO2oj2Gr6QpfWv3i9RI9VJM2IFCMiFQKg5zOpKw1qdrPRWb35fiXAXGjw9RrVgrZz0Z1b9OP4zC9hfbpnQQ==}
     peerDependencies:
@@ -13164,6 +13171,13 @@ packages:
       '@module-federation/sdk': 0.21.2
     dev: true
 
+  /@module-federation/runtime-core@0.21.4:
+    resolution: {integrity: sha512-SGpmoOLGNxZofpTOk6Lxb2ewaoz5wMi93AFYuuJB04HTVcngEK+baNeUZ2D/xewrqNIJoMY6f5maUjVfIIBPUA==}
+    dependencies:
+      '@module-federation/error-codes': 0.21.4
+      '@module-federation/sdk': 0.21.4
+    dev: true
+
   /@module-federation/runtime-tools@0.1.6:
     resolution: {integrity: sha512-7ILVnzMIa0Dlc0Blck5tVZG1tnk1MmLnuZpLOMpbdW+zl+N6wdMjjHMjEZFCUAJh2E5XJ3BREwfX8Ets0nIkLg==}
     dependencies:
@@ -13221,6 +13235,13 @@ packages:
     dependencies:
       '@module-federation/runtime': 0.21.2
       '@module-federation/webpack-bundler-runtime': 0.21.2
+    dev: true
+
+  /@module-federation/runtime-tools@0.21.4:
+    resolution: {integrity: sha512-RzFKaL0DIjSmkn76KZRfzfB6dD07cvID84950jlNQgdyoQFUGkqD80L6rIpVCJTY/R7LzR3aQjHnoqmq4JPo3w==}
+    dependencies:
+      '@module-federation/runtime': 0.21.4
+      '@module-federation/webpack-bundler-runtime': 0.21.4
     dev: true
 
   /@module-federation/runtime-tools@0.5.1:
@@ -13303,6 +13324,14 @@ packages:
       '@module-federation/sdk': 0.21.2
     dev: true
 
+  /@module-federation/runtime@0.21.4:
+    resolution: {integrity: sha512-wgvGqryurVEvkicufJmTG0ZehynCeNLklv8kIk5BLIsWYSddZAE+xe4xov1kgH5fIJQAoQNkRauFFjVNlHoAkA==}
+    dependencies:
+      '@module-federation/error-codes': 0.21.4
+      '@module-federation/runtime-core': 0.21.4
+      '@module-federation/sdk': 0.21.4
+    dev: true
+
   /@module-federation/runtime@0.5.1:
     resolution: {integrity: sha512-xgiMUWwGLWDrvZc9JibuEbXIbhXg6z2oUkemogSvQ4LKvrl/n0kbqP1Blk669mXzyWbqtSp6PpvNdwaE1aN5xQ==}
     dependencies:
@@ -13345,6 +13374,10 @@ packages:
 
   /@module-federation/sdk@0.21.2:
     resolution: {integrity: sha512-t2vHSJ1a9zjg7LLJoEghcytNLzeFCqOat5TbXTav5dgU0xXw82Cf0EfLrxiJL6uUpgbtyvUdqqa2DVAvMPjiiA==}
+    dev: true
+
+  /@module-federation/sdk@0.21.4:
+    resolution: {integrity: sha512-tzvhOh/oAfX++6zCDDxuvioHY4Jurf8vcfoCbKFxusjmyKr32GPbwFDazUP+OPhYCc3dvaa9oWU6X/qpUBLfJw==}
     dev: true
 
   /@module-federation/sdk@0.5.1:
@@ -13440,6 +13473,13 @@ packages:
     dependencies:
       '@module-federation/runtime': 0.21.2
       '@module-federation/sdk': 0.21.2
+    dev: true
+
+  /@module-federation/webpack-bundler-runtime@0.21.4:
+    resolution: {integrity: sha512-dusmR3uPnQh9u9ChQo3M+GLOuGFthfvnh7WitF/a1eoeTfRmXqnMFsXtZCUK+f/uXf+64874Zj/bhAgbBcVHZA==}
+    dependencies:
+      '@module-federation/runtime': 0.21.4
+      '@module-federation/sdk': 0.21.4
     dev: true
 
   /@module-federation/webpack-bundler-runtime@0.5.1:
@@ -18336,6 +18376,18 @@ packages:
       jiti: 2.6.1
     dev: true
 
+  /@rsbuild/core@1.6.8:
+    resolution: {integrity: sha512-sVdzmrLV5hQtSTd2NqWNQg/KX30R4UatA8d6FHnpO2r44CJv+HXow3sjtYMhpmB+z3GIxidwcvLpmRbZcq+/+Q==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+    dependencies:
+      '@rspack/core': 1.6.4(@swc/helpers@0.5.17)
+      '@rspack/lite-tapable': 1.1.0
+      '@swc/helpers': 0.5.17
+      core-js: 3.47.0
+      jiti: 2.6.1
+    dev: true
+
   /@rsbuild/plugin-assets-retry@1.3.0(@rsbuild/core@1.4.3):
     resolution: {integrity: sha512-qBo1dIiedkpeBSChB/sQmK8ZpVqrK7AoBqBeu/u+DoeiCct9z2BJ2UIFRCan3rFNtF7cU99ZGOYP+JxTo7ghqg==}
     peerDependencies:
@@ -19203,6 +19255,26 @@ packages:
       typescript: 5.8.3
     dev: true
 
+  /@rslib/core@0.18.1(typescript@5.5.2):
+    resolution: {integrity: sha512-eDDz6y8anIAF17gQJBDfH6l/JTidkXANYAFq8iuymFQg/wE2PEKyBNC2K6n+jg4rT1a7AhuVbHZb5oDumaFopQ==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      typescript: ^5
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@rsbuild/core': 1.6.8
+      rsbuild-plugin-dts: 0.18.1(@rsbuild/core@1.6.8)(typescript@5.5.2)
+      typescript: 5.5.2
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+    dev: true
+
   /@rslib/core@0.9.0(typescript@5.8.3):
     resolution: {integrity: sha512-nWpST4+oPPTi/P4EfYqtmPLAu7AJxDevt8/+D3aULHwYkjZCVn5l3v1/tcvUJImEWsKnquknu3QIjUBNDwLzwg==}
     engines: {node: '>=16.7.0'}
@@ -19324,6 +19396,14 @@ packages:
     dev: true
     optional: true
 
+  /@rspack/binding-darwin-arm64@1.6.4:
+    resolution: {integrity: sha512-qD2C5xwdY2qKEXTZiPJQx1L1kELapOc0AaZDqcAyzXs30d1qTKpx6PdyW3HN+gueKovyWZwMMYfz6RxcMCnaDQ==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rspack/binding-darwin-x64@0.7.5:
     resolution: {integrity: sha512-teLK0TB1x0CsvaaiCopsFx4EvJe+/Hljwii6R7C9qOZs5zSOfbT/LQ202eA0sAGodCncARCGaXVrsekbrRYqeA==}
     cpu: [x64]
@@ -19401,6 +19481,14 @@ packages:
 
   /@rspack/binding-darwin-x64@1.6.0-beta.1:
     resolution: {integrity: sha512-Ulb7Jyyvuf28BwPXZKSbglaSK/19b32ItWT+pgswhbFsnfhzAQQd7Jo7TUEvHNHAdVDiES8VFlrnOhOSnwEOLg==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rspack/binding-darwin-x64@1.6.4:
+    resolution: {integrity: sha512-IHceyLDxeubqIrGz4gUqJavnygTij4vtDDE2Fkgobz7hkTJwGtD5mxBKbVNRqGvhrasVw0h9rEjR7tdbDSiUhQ==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -19490,6 +19578,14 @@ packages:
     dev: true
     optional: true
 
+  /@rspack/binding-linux-arm64-gnu@1.6.4:
+    resolution: {integrity: sha512-Ldpoz2wWnBaL2+XKLIOyCZMkAkd4pk/L24EVgma3SpRtwgenLEr10bQupvwGAK5OLkjayslOTZmRiAv0FH5o/w==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rspack/binding-linux-arm64-musl@0.7.5:
     resolution: {integrity: sha512-6RcxG42mLM01Pa6UYycACu/Nu9qusghAPUJumb8b8x5TRIDEtklYC5Ck6Rmagm+8E0ucMude2E/D4rMdIFcS3A==}
     cpu: [arm64]
@@ -19567,6 +19663,14 @@ packages:
 
   /@rspack/binding-linux-arm64-musl@1.6.0-beta.1:
     resolution: {integrity: sha512-JAXVKHQieN4Ruvs7MstvsPUtRBSAROqJ0abCh4rXdV+FzncKp/ZkdfjQploDhBWtWfU8rPvIjaxeZcPfHMI5/A==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rspack/binding-linux-arm64-musl@1.6.4:
+    resolution: {integrity: sha512-3fLMSDK5yMjKmx7iFbYG3P3A0xNdtmNu09v5P6hzq65tkJ3dflIt3p8DvtOTURtuSgQZV2A1LDd9hpIXdnigqA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -19656,6 +19760,14 @@ packages:
     dev: true
     optional: true
 
+  /@rspack/binding-linux-x64-gnu@1.6.4:
+    resolution: {integrity: sha512-5YzXUKLnaiqND05CDgkKE0WNRtC1ulkVncYs78xPikonzZmgVXa8eRaTPOZC6ZjpLR0eTsg+MSesLUsPUu27hA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rspack/binding-linux-x64-musl@0.7.5:
     resolution: {integrity: sha512-dDgi/ThikMy1m4llxPeEXDCA2I8F8ezFS/eCPLZGU2/J1b4ALwDjuRsMmo+VXSlFCKgIt98V6h1woeg7nu96yg==}
     cpu: [x64]
@@ -19739,6 +19851,14 @@ packages:
     dev: true
     optional: true
 
+  /@rspack/binding-linux-x64-musl@1.6.4:
+    resolution: {integrity: sha512-KcSFla8a9bXG1mmV5oQ1R5h/dSXfd41/qHOsNuLqho2UCX8CVh4dezUA153dj7p1S4yOhTy6VZZi6C1szweE9A==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rspack/binding-wasm32-wasi@1.4.11:
     resolution: {integrity: sha512-hiYxHZjaZ17wQtXyLCK0IdtOvMWreGVTiGsaHCxyeT+SldDG+r16bXNjmlqfZsjlfl1mkAqKz1dg+mMX28OTqw==}
     cpu: [wasm32]
@@ -19765,6 +19885,15 @@ packages:
 
   /@rspack/binding-wasm32-wasi@1.6.0-beta.1:
     resolution: {integrity: sha512-PaKEjXOkYprSFlgdgVm/P3pv2E8nAQx9WSGgPmMVIAtxo3Cyz0wwFf0f1Bp9wCw0KkIWgi+9lz8oXNkgKZilug==}
+    cpu: [wasm32]
+    requiresBuild: true
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    dev: true
+    optional: true
+
+  /@rspack/binding-wasm32-wasi@1.6.4:
+    resolution: {integrity: sha512-mfFJbDJkRy5I1iW3m0JlWbc0X8pjVd+GRUz5nhbccwEhSQOc27ao3evf7XPU4aaDxud1B3UEqYiRcRmtm1BrjA==}
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
@@ -19855,6 +19984,14 @@ packages:
     dev: true
     optional: true
 
+  /@rspack/binding-win32-arm64-msvc@1.6.4:
+    resolution: {integrity: sha512-QtIqxsfeTSS1lwfaPGrPFfJ9ir/3aWZv5t3iAgYj/CNUA8MTKWt4vQKcco7NRIGK4ZLMI+dgJBFtvd/lUDMQsw==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rspack/binding-win32-ia32-msvc@0.7.5:
     resolution: {integrity: sha512-hEcHRwJIzpZsePr+5x6V/7TGhrPXhSZYG4sIhsrem1za9W+qqCYYLZ7KzzbRODU07QaAH2RxjcA1bf8F2QDYAQ==}
     cpu: [ia32]
@@ -19938,6 +20075,14 @@ packages:
     dev: true
     optional: true
 
+  /@rspack/binding-win32-ia32-msvc@1.6.4:
+    resolution: {integrity: sha512-HXEWGDllgh0jFwjGhkGcLqb0dzXbc/rA8vQr2JcSdC41p1DTzLgO215jWdKSIvzCzhyPh3VeQkXk76hjFB2cLQ==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rspack/binding-win32-x64-msvc@0.7.5:
     resolution: {integrity: sha512-PpVpP6J5/2b4T10hzSUwjLvmdpAOj3ozARl1Nrf/lsbYwhiXivoB8Gvoy/xe/Xpgr732Dk9VCeeW8rreWOOUVQ==}
     cpu: [x64]
@@ -20015,6 +20160,14 @@ packages:
 
   /@rspack/binding-win32-x64-msvc@1.6.0-beta.1:
     resolution: {integrity: sha512-/WBzhed0Cu0o9XQ9caGgWwzyNnnPKlENlExa2aGbRCbB14/+CwfhCyETyKlc/ID+dtlV/eHKTC9cckUNI8NpTQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rspack/binding-win32-x64-msvc@1.6.4:
+    resolution: {integrity: sha512-MAO5rOnGYoeuT2LPn/P7JVJCi3d78XoXgOq3tkGh6qXhvhkjsBRtYluWCzACXQpXfFHEWYd7uT5yHoZgxiVuoA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -20172,6 +20325,21 @@ packages:
       '@rspack/binding-win32-arm64-msvc': 1.6.0-beta.1
       '@rspack/binding-win32-ia32-msvc': 1.6.0-beta.1
       '@rspack/binding-win32-x64-msvc': 1.6.0-beta.1
+    dev: true
+
+  /@rspack/binding@1.6.4:
+    resolution: {integrity: sha512-vUxc/zUdsCuyysOvP4CTdIYxsZPb2jIXST5vrLABiTPIaHpXZ0hVdgKif2XPJwJeuCVS6w25xvyPN0mBCU0MvQ==}
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.6.4
+      '@rspack/binding-darwin-x64': 1.6.4
+      '@rspack/binding-linux-arm64-gnu': 1.6.4
+      '@rspack/binding-linux-arm64-musl': 1.6.4
+      '@rspack/binding-linux-x64-gnu': 1.6.4
+      '@rspack/binding-linux-x64-musl': 1.6.4
+      '@rspack/binding-wasm32-wasi': 1.6.4
+      '@rspack/binding-win32-arm64-msvc': 1.6.4
+      '@rspack/binding-win32-ia32-msvc': 1.6.4
+      '@rspack/binding-win32-x64-msvc': 1.6.4
     dev: true
 
   /@rspack/core@0.7.5(@swc/helpers@0.5.13):
@@ -20341,6 +20509,21 @@ packages:
       '@swc/helpers': 0.5.17
     dev: true
 
+  /@rspack/core@1.6.4(@swc/helpers@0.5.17):
+    resolution: {integrity: sha512-5F1+MQD8rfbFbUHnaiZe4jqOu9pnSb+PliqQvi0lj+uvpMpcS3sJDIs/mz6P1u87lfkfBXChIT4zSLAzeOgMWw==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@module-federation/runtime-tools': 0.21.4
+      '@rspack/binding': 1.6.4
+      '@rspack/lite-tapable': 1.1.0
+      '@swc/helpers': 0.5.17
+    dev: true
+
   /@rspack/dev-server@1.1.1(@rspack/core@1.3.9)(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.98.0):
     resolution: {integrity: sha512-9r7vOml2SrFA8cvbcJdSan9wHEo1TPXezF22+s5jvdyAAywg8w7HqDol6TPVv64NUonP1DOdyLxZ+6UW6WZiwg==}
     engines: {node: '>= 18.12.0'}
@@ -20369,6 +20552,10 @@ packages:
   /@rspack/lite-tapable@1.0.1:
     resolution: {integrity: sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==}
     engines: {node: '>=16.0.0'}
+
+  /@rspack/lite-tapable@1.1.0:
+    resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
+    dev: true
 
   /@rspack/plugin-react-refresh@0.7.5(react-refresh@0.14.2):
     resolution: {integrity: sha512-ROI9lrmfIH+Z9lbBaP3YMhbD2R3rlm9SSzi/9WzzkQU6KK911S1D+sL2ByeJ7ipZafbHvMPWTmC2aQEvjhwQig==}
@@ -29405,6 +29592,11 @@ packages:
     resolution: {integrity: sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==}
     requiresBuild: true
 
+  /core-js@3.47.0:
+    resolution: {integrity: sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==}
+    requiresBuild: true
+    dev: true
+
   /core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -35076,7 +35268,7 @@ packages:
     resolution: {integrity: sha512-uVXGYq19bcsX7Q/53VqXQjCKXw0eUMHlFGDLTaqzgj/ckverfhZQvXyA6ecFBaF9XUH16jfCTCyALYi0lJcagg==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
-      '@rspack/core': 0.x || 1.x
+      '@rspack/core': link:../rspack/packages/rspack
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -38165,12 +38357,6 @@ packages:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-
-  /magic-string@0.30.18:
-    resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-    dev: true
 
   /magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -46715,11 +46901,32 @@ packages:
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.5.16
-      magic-string: 0.30.18
+      magic-string: 0.30.21
       picocolors: 1.1.1
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       tsconfig-paths: 4.2.0
       typescript: 5.8.3
+    dev: true
+
+  /rsbuild-plugin-dts@0.18.1(@rsbuild/core@1.6.8)(typescript@5.5.2):
+    resolution: {integrity: sha512-2nj8zlMxyEkc4Z7wFo1zn1R2SQNyUSH1+g0hx5RKP0yJJojRovYbENjLf6ixFo7RwUU0PhS9EnuiiKqHPt8+FA==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      '@rsbuild/core': 1.x
+      '@typescript/native-preview': 7.x
+      typescript: ^5
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 1.6.8
+      typescript: 5.5.2
     dev: true
 
   /rsbuild-plugin-dts@0.9.0(@rsbuild/core@1.3.21)(typescript@5.8.3):
@@ -46761,7 +46968,7 @@ packages:
       '@rsbuild/core': 1.4.0-beta.2
       magic-string: 0.30.17
       picocolors: 1.1.1
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       tsconfig-paths: 4.2.0
       typescript: 5.8.3
     dev: true


### PR DESCRIPTION
## Description

change build tool to Rslib so the output ESM code can be appended with `.mjs` automatically. the previous ESM output is not correct so Storybook v10 can't using `import()` to load it.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
