### PR TITLE
Fix typo in quick-start documentation

### DIFF
--- a/apps/website-new/docs/zh/guide/start/quick-start.mdx
+++ b/apps/website-new/docs/zh/guide/start/quick-start.mdx
@@ -167,7 +167,7 @@ export default createModuleFederationConfig({
 
 ## 总结
 
-通过上面的流程你已经基于 Module Federation 完成了一个「生产者」导出一个组件给到「消费者」使用，并在过程中初步使用和了解了：Module Fderation 插件中的 remotes、exposes、shared 的配置。
+通过上面的流程你已经基于 Module Federation 完成了一个「生产者」导出一个组件给到「消费者」使用，并在过程中初步使用和了解了：Module Federation 插件中的 remotes、exposes、shared 的配置。
 
 如果你希望了解如何直接在 Webpack、Rspack 构建工具上导出和消费远程模块可以参考：[Rspack Plugin](../basic/rspack)、[Webpack Plugin](../basic/webpack)
 


### PR DESCRIPTION
This pull request makes a minor documentation change to the summary section of the Chinese quick start guide for Module Federation. There are no substantive changes to content or code, only a typo correction.