### PR TITLE
[codex] fix(core): run actionlint from runner temp

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,3 +21,4 @@ jobs:
           NODE_PATH: ${{ runner.temp }}/node_modules
         with:
           matcher: true
+          working-directory: ${{ runner.temp }}


### PR DESCRIPTION
## Summary
This PR fixes the GitHub Actions `actionlint` job failure caused by running `raven-actions/actionlint@v2` from the repository root in a workspace-based monorepo.

## Problem
The action invokes `npm install --no-save --ignore-scripts @actions/tool-cache@3.0.1` during setup. When executed in the repository root, npm reads the workspace manifests and fails with:

- `npm error code EUNSUPPORTEDPROTOCOL`
- `npm error Unsupported URL Type "workspace:": workspace:*`

As a result, the `Lint GitHub Workflows` workflow fails before `actionlint` can run.

## Root Cause
The action's setup step is executed in the current working directory, which was the monorepo root containing workspace dependency declarations.

## Fix
Set `working-directory: ${{ runner.temp }}` on the `raven-actions/actionlint@v2` step in `.github/workflows/actionlint.yml`.

Running in the runner temp directory isolates the setup install from workspace manifests, allowing the action to complete and run `actionlint` normally.

## Scope
This PR contains a single-line workflow change only.

## Validation
- Confirmed the failing log pattern from CI (`EUNSUPPORTEDPROTOCOL` / `workspace:*`).
- Applied the same fix pattern already proven to resolve this failure on another branch.
