### PR TITLE
feat(metro): add Metro 0.83 compatibility layer

### DIFF
--- a/.changeset/metro-083-compat.md
+++ b/.changeset/metro-083-compat.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/metro": patch
+---
+
+Add Metro 0.83 compatibility layer. Metro 0.83 introduced a restrictive `exports` field that only allows `metro/private/*` paths instead of direct `metro/src/*` imports. This adds a `metro-compat` utility that dynamically resolves the correct import path, ensuring compatibility with both Metro 0.82 and 0.83+.

--- a/packages/metro-core/src/commands/bundle-host/index.ts
+++ b/packages/metro-core/src/commands/bundle-host/index.ts
@@ -1,9 +1,8 @@
 import path from 'node:path';
 import util from 'node:util';
-import Server from 'metro/src/Server';
-import type { RequestOptions } from 'metro/src/shared/types';
 import type { ModuleFederationConfigNormalized } from '../../types';
 import { CLIError } from '../../utils/errors';
+import { type RequestOptions, Server } from '../../utils/metro-compat';
 import type { Config } from '../types';
 import { createResolver } from '../utils/create-resolver';
 import { getCommunityCliPlugin } from '../utils/get-community-plugin';
@@ -59,7 +58,10 @@ async function bundleFederatedHost(
     communityCliPlugin.unstable_buildBundleWithConfig;
 
   return buildBundleWithConfig(args, config, {
-    build: async (server: Server, requestOpts: RequestOptions) => {
+    build: async (
+      server: InstanceType<typeof Server>,
+      requestOpts: RequestOptions,
+    ) => {
       // setup enhance middleware to trigger virtual modules setup
       config.server.enhanceMiddleware(server.processRequest, server);
       const resolver = await createResolver(server, args.platform);

--- a/packages/metro-core/src/commands/bundle-remote/index.ts
+++ b/packages/metro-core/src/commands/bundle-remote/index.ts
@@ -3,10 +3,13 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import util from 'node:util';
 import { mergeConfig } from 'metro';
-import Server from 'metro/src/Server';
-import type { OutputOptions, RequestOptions } from 'metro/src/shared/types';
 import type { ModuleFederationConfigNormalized } from '../../types';
 import { CLIError } from '../../utils/errors';
+import {
+  type OutputOptions,
+  type RequestOptions,
+  Server,
+} from '../../utils/metro-compat';
 import type { Config } from '../types';
 import { createModulePathRemapper } from '../utils/create-module-path-remapper';
 import { createResolver } from '../utils/create-resolver';
@@ -43,7 +46,10 @@ interface BundleRequestOptions extends RequestOptions {
   sourceUrl: string;
 }
 
-async function buildBundle(server: Server, requestOpts: BundleRequestOptions) {
+async function buildBundle(
+  server: InstanceType<typeof Server>,
+  requestOpts: BundleRequestOptions,
+) {
   const bundle = await server.build({
     ...Server.DEFAULT_BUNDLE_OPTIONS,
     ...requestOpts,

--- a/packages/metro-core/src/commands/utils/create-resolver.ts
+++ b/packages/metro-core/src/commands/utils/create-resolver.ts
@@ -1,4 +1,4 @@
-import type Server from 'metro/src/Server';
+import type { Server } from '../../utils/metro-compat';
 
 /**
  * Creates a resolver utility that mirrors Metro's bundling resolution behavior.
@@ -14,7 +14,10 @@ import type Server from 'metro/src/Server';
  * @param platform - The target platform for resolution (e.g., 'ios', 'android', null for default)
  * @returns The resolver object with a resolve method that takes source and target paths
  */
-export async function createResolver(server: Server, platform: string | null) {
+export async function createResolver(
+  server: InstanceType<typeof Server>,
+  platform: string | null,
+) {
   const bundler = server.getBundler().getBundler();
   const depGraph = await bundler.getDependencyGraph();
 

--- a/packages/metro-core/src/commands/utils/get-community-plugin.ts
+++ b/packages/metro-core/src/commands/utils/get-community-plugin.ts
@@ -1,7 +1,10 @@
 import type { ConfigT } from 'metro-config';
-import type Server from 'metro/src/Server';
-import type { OutputOptions, RequestOptions } from 'metro/src/shared/types';
 import { CLIError } from '../../utils/errors';
+import type {
+  OutputOptions,
+  RequestOptions,
+  Server,
+} from '../../utils/metro-compat';
 
 interface Command {
   name: string;
@@ -21,7 +24,7 @@ interface CommunityCliPlugin {
     config: ConfigT,
     bundleImpl: {
       build: (
-        server: Server,
+        server: InstanceType<typeof Server>,
         requestOpts: RequestOptions,
       ) => Promise<{ code: string; map: string }>;
       save: (

--- a/packages/metro-core/src/commands/utils/save-bundle-and-map.ts
+++ b/packages/metro-core/src/commands/utils/save-bundle-and-map.ts
@@ -1,8 +1,10 @@
 import { promises as fs } from 'node:fs';
 import util from 'node:util';
 import type { MixedSourceMap } from 'metro-source-map';
-import relativizeSourceMapInline from 'metro/src/lib/relativizeSourceMap';
-import type { OutputOptions } from 'metro/src/shared/types';
+import {
+  type OutputOptions,
+  relativizeSourceMapInline,
+} from '../../utils/metro-compat';
 
 function relativizeSerializedMap(
   map: string,

--- a/packages/metro-core/src/plugin/serializer.ts
+++ b/packages/metro-core/src/plugin/serializer.ts
@@ -1,11 +1,13 @@
 import path from 'node:path';
 import type { Module, ReadOnlyGraph, SerializerOptions } from 'metro';
 import type { SerializerConfigT } from 'metro-config';
-import baseJSBundle from 'metro/src/DeltaBundler/Serializers/baseJSBundle';
-import CountingSet from 'metro/src/lib/CountingSet';
-import bundleToString from 'metro/src/lib/bundleToString';
 import type { ModuleFederationConfigNormalized, Shared } from '../types';
 import { ConfigError } from '../utils/errors';
+import {
+  CountingSet,
+  baseJSBundle,
+  bundleToString,
+} from '../utils/metro-compat';
 
 type CustomSerializer = SerializerConfigT['customSerializer'];
 

--- a/packages/metro-core/src/utils/metro-compat.ts
+++ b/packages/metro-core/src/utils/metro-compat.ts
@@ -1,0 +1,66 @@
+/**
+ * Metro Compatibility Layer
+ *
+ * Provides backwards-compatible imports for Metro 0.82 and 0.83+
+ *
+ * Metro 0.83 introduced a restrictive `exports` field that only allows
+ * `metro/private/*` paths instead of direct `metro/src/*` imports.
+ *
+ * This module dynamically resolves the correct import path based on the
+ * installed Metro version, ensuring compatibility with both versions.
+ */
+
+/**
+ * Attempts to import from Metro 0.83 format first, falls back to 0.82 format
+ */
+function tryImport(metro83Path: string, metro82Path: string) {
+  try {
+    return require(metro83Path);
+  } catch {
+    return require(metro82Path);
+  }
+}
+
+function getDefaultExport(mod: any) {
+  // CJS interop: if the module has a .default that is a function or object, use it
+  // Otherwise return the module itself (already the direct export)
+  if (mod != null && typeof mod === 'object' && 'default' in mod) {
+    return mod.default;
+  }
+  return mod;
+}
+
+// Server class
+export const Server = getDefaultExport(
+  tryImport('metro/private/Server', 'metro/src/Server'),
+);
+
+// DeltaBundler Serializers
+export const baseJSBundle = getDefaultExport(
+  tryImport(
+    'metro/private/DeltaBundler/Serializers/baseJSBundle',
+    'metro/src/DeltaBundler/Serializers/baseJSBundle',
+  ),
+);
+
+// Utility classes
+export const CountingSet = getDefaultExport(
+  tryImport('metro/private/lib/CountingSet', 'metro/src/lib/CountingSet'),
+);
+
+// Bundle utilities
+export const bundleToString = getDefaultExport(
+  tryImport('metro/private/lib/bundleToString', 'metro/src/lib/bundleToString'),
+);
+
+const relativizeSourceMapModule = tryImport(
+  'metro/private/lib/relativizeSourceMap',
+  'metro/src/lib/relativizeSourceMap',
+);
+export const relativizeSourceMapInline =
+  relativizeSourceMapModule.relativizeSourceMapInline ||
+  getDefaultExport(relativizeSourceMapModule);
+
+// Re-export types - these come from metro/src/shared/types in both versions
+// The types themselves are available through the main 'metro' package export
+export type { RequestOptions, OutputOptions } from 'metro/src/shared/types';


### PR DESCRIPTION
## Summary

This changes are from zacharychapple's changes here: https://github.com/module-federation/metro/pull/94 

Trying to fix any issues and test it to unblock RN83 compatibility. I'm seeing the following error when I build on RN81-83: 
```
Package subpath './src/DeltaBundler/Serializers/baseJSBundle' is not defined by "exports" in /Volumes/expo-updates-metro-mf-poc-rn80/node_modules/metro/package.json.
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './src/DeltaBundler/Serializers/baseJSBundle' is not defined by "exports" in /Volumes/workplace/expo-updates-metro-mf-poc-rn80/node_modules/metro/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:314:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:661:9)
    at resolveExports (node:internal/modules/cjs/loader:657:36)
    at Function._findPath (node:internal/modules/cjs/loader:749:31)
    at Function._resolveFilename (node:internal/modules/cjs/loader:1387:27)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1057:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1062:22)
    at Function._load (node:internal/modules/cjs/loader:1211:37)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
error Command failed with exit code 1.
```

Metro 0.83 introduced a restrictive `exports` field that only allows `metro/private/*` paths instead of direct `metro/src/*` imports. This PR adds a compatibility layer that dynamically resolves the correct import path based on the installed Metro version.

## Changes

- Add `src/utils/metro-compat.ts` — compatibility layer with `tryImport()` that attempts `metro/private/*` (0.83+) first, then falls back to `metro/src/*` (0.82)
- Update all direct `metro/src/*` imports across the codebase to use `metro-compat`
- Handle both `.default` and direct CJS exports across Metro versions
- Update type annotations for `Server` to use `InstanceType<typeof Server>` since it's now a runtime-resolved value

## Files Modified

- `src/utils/metro-compat.ts` (new) — compatibility layer
- `src/commands/bundle-host/index.ts`
- `src/commands/bundle-remote/index.ts`
- `src/commands/utils/create-resolver.ts`
- `src/commands/utils/get-community-plugin.ts`
- `src/commands/utils/save-bundle-and-map.ts`
- `src/plugin/serializer.ts`
- `src/utils/vm-manager.ts`

## Testing

- Verified locally with both Metro 0.82 (RN 0.80) and Metro 0.83 (RN 0.83.1)
- Metro packages build successfully
- No peerDependency changes needed (`^0.82.1` already covers 0.83+ via semver)

## Related

- Based on https://github.com/module-federation/metro/pull/94 (submitted to old repo)
- Addresses feedback from @jbroma to submit to the correct repo