### PR TITLE
release v8.8.56

### DIFF
--- a/.changeset/bright-owls-cheer.md
+++ b/.changeset/bright-owls-cheer.md
@@ -1,6 +1,0 @@
----
-"@module-federation/dts-plugin": patch
----
-
-Fix Windows TypeScript type generation by invoking the compiler with
-`execFile` and properly quoted project paths.

--- a/.changeset/mean-dogs-accept.md
+++ b/.changeset/mean-dogs-accept.md
@@ -1,9 +1,0 @@
----
-"@module-federation/runtime-core": patch
----
-
-Fix a race where concurrent `Module.init()` calls could run remote container initialization more than once.
-
-`Module.init()` now deduplicates in-flight initialization with a shared promise so `beforeInitContainer`/`initContainer` logic executes once per module while preserving stable initialized state after completion.
-
-Also adds regression coverage for concurrent initialization behavior.

--- a/.changeset/metro-083-compat.md
+++ b/.changeset/metro-083-compat.md
@@ -1,5 +1,0 @@
----
-"@module-federation/metro": patch
----
-
-Add Metro 0.83 compatibility layer. Metro 0.83 introduced a restrictive `exports` field that only allows `metro/private/*` paths instead of direct `metro/src/*` imports. This adds a `metro-compat` utility that dynamically resolves the correct import path, ensuring compatibility with both Metro 0.82 and 0.83+.

--- a/.changeset/salty-icons-carry.md
+++ b/.changeset/salty-icons-carry.md
@@ -1,5 +1,0 @@
----
-'@module-federation/treeshake-server': patch
----
-
-feat: add tree shaking server

--- a/apps/router-demo/router-remote5-2005/CHANGELOG.md
+++ b/apps/router-demo/router-remote5-2005/CHANGELOG.md
@@ -1,5 +1,12 @@
 # remote5
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/bridge-react@2.0.1
+- @module-federation/rsbuild-plugin@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/apps/router-demo/router-remote5-2005/package.json
+++ b/apps/router-demo/router-remote5-2005/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote5",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/router-demo/router-remote6-2006/CHANGELOG.md
+++ b/apps/router-demo/router-remote6-2006/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/bridge-react@2.0.1
+- @module-federation/rsbuild-plugin@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/apps/router-demo/router-remote6-2006/package.json
+++ b/apps/router-demo/router-remote6-2006/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote6",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/shared-tree-shaking/no-server/host/CHANGELOG.md
+++ b/apps/shared-tree-shaking/no-server/host/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.1
+
+### Patch Changes
+
+- @module-federation/enhanced@2.0.1
+
 ## 1.0.0
 
 ### Major Changes

--- a/apps/shared-tree-shaking/no-server/host/package.json
+++ b/apps/shared-tree-shaking/no-server/host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-no-server-host",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/shared-tree-shaking/no-server/provider/CHANGELOG.md
+++ b/apps/shared-tree-shaking/no-server/provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.1
+
+### Patch Changes
+
+- @module-federation/enhanced@2.0.1
+
 ## 1.0.0
 
 ### Major Changes

--- a/apps/shared-tree-shaking/no-server/provider/package.json
+++ b/apps/shared-tree-shaking/no-server/provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-no-server-provider",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/shared-tree-shaking/with-server/host/CHANGELOG.md
+++ b/apps/shared-tree-shaking/with-server/host/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.1
+
+### Patch Changes
+
+- @module-federation/modern-js-v3@2.0.1
+
 ## 1.0.0
 
 ### Major Changes

--- a/apps/shared-tree-shaking/with-server/host/package.json
+++ b/apps/shared-tree-shaking/with-server/host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-with-server-host",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/shared-tree-shaking/with-server/provider/CHANGELOG.md
+++ b/apps/shared-tree-shaking/with-server/provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.1
+
+### Patch Changes
+
+- @module-federation/modern-js-v3@2.0.1
+
 ## 1.0.0
 
 ### Major Changes

--- a/apps/shared-tree-shaking/with-server/provider/package.json
+++ b/apps/shared-tree-shaking/with-server/provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-with-server-provider",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/website-new/CHANGELOG.md
+++ b/apps/website-new/CHANGELOG.md
@@ -1,5 +1,12 @@
 # website-new
 
+## 1.3.13
+
+### Patch Changes
+
+- @module-federation/rspress-plugin@2.0.1
+- @module-federation/error-codes@2.0.1
+
 ## 1.3.12
 
 ### Patch Changes

--- a/apps/website-new/package.json
+++ b/apps/website-new/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website-new",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "private": true,
   "scripts": {
     "dev": "rspress dev",

--- a/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
+++ b/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/bridge-react-webpack-plugin
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/sdk@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/bridge/bridge-react-webpack-plugin/package.json
+++ b/packages/bridge/bridge-react-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react-webpack-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/bridge-react/CHANGELOG.md
+++ b/packages/bridge/bridge-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/bridge-react
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/sdk@2.0.1
+- @module-federation/bridge-shared@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/bridge/bridge-react/package.json
+++ b/packages/bridge/bridge-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/bridge/bridge-shared/CHANGELOG.md
+++ b/packages/bridge/bridge-shared/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/bridge-shared
 
+## 2.0.1
+
 ## 2.0.0
 
 ## 0.24.1

--- a/packages/bridge/bridge-shared/package.json
+++ b/packages/bridge/bridge-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-shared",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/vue3-bridge/CHANGELOG.md
+++ b/packages/bridge/vue3-bridge/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/bridge-vue3
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/runtime@2.0.1
+- @module-federation/sdk@2.0.1
+- @module-federation/bridge-shared@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/bridge/vue3-bridge/package.json
+++ b/packages/bridge/vue3-bridge/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/module-federation/core.git",
     "directory": "packages/bridge/vue3-bridge"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/chrome-devtools/CHANGELOG.md
+++ b/packages/chrome-devtools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/devtools
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/sdk@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/chrome-devtools/package.json
+++ b/packages/chrome-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/devtools",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/cli
 
+## 2.0.1
+
+### Patch Changes
+
+- Updated dependencies [d1e6488]
+  - @module-federation/dts-plugin@2.0.1
+  - @module-federation/sdk@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "commonjs",
   "description": "Module Federation CLI",
   "homepage": "https://module-federation.io",

--- a/packages/create-module-federation/CHANGELOG.md
+++ b/packages/create-module-federation/CHANGELOG.md
@@ -1,5 +1,7 @@
 # create-module-federation
 
+## 2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/create-module-federation/package.json
+++ b/packages/create-module-federation/package.json
@@ -3,7 +3,7 @@
   "description": "Create a new Module Federation project",
   "public": true,
   "sideEffects": false,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/data-prefetch/CHANGELOG.md
+++ b/packages/data-prefetch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/data-prefetch
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/runtime@2.0.1
+- @module-federation/sdk@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/data-prefetch/package.json
+++ b/packages/data-prefetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@module-federation/data-prefetch",
   "description": "Module Federation Data Prefetch",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "author": "nieyan <nyqykk@foxmail.com>",
   "homepage": "https://github.com/module-federation/core",

--- a/packages/dts-plugin/CHANGELOG.md
+++ b/packages/dts-plugin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @module-federation/dts-plugin
 
+## 2.0.1
+
+### Patch Changes
+
+- d1e6488: Fix Windows TypeScript type generation by invoking the compiler with
+  `execFile` and properly quoted project paths.
+  - @module-federation/sdk@2.0.1
+  - @module-federation/managers@2.0.1
+  - @module-federation/third-party-dts-extractor@2.0.1
+  - @module-federation/error-codes@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/dts-plugin/package.json
+++ b/packages/dts-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/dts-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "hanric <hanric.zhang@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @module-federation/enhanced
 
+## 2.0.1
+
+### Patch Changes
+
+- Updated dependencies [d1e6488]
+  - @module-federation/dts-plugin@2.0.1
+  - @module-federation/cli@2.0.1
+  - @module-federation/manifest@2.0.1
+  - @module-federation/rspack@2.0.1
+  - @module-federation/data-prefetch@2.0.1
+  - @module-federation/runtime-tools@2.0.1
+  - @module-federation/inject-external-runtime-core-plugin@2.0.1
+  - @module-federation/sdk@2.0.1
+  - @module-federation/managers@2.0.1
+  - @module-federation/bridge-react-webpack-plugin@2.0.1
+  - @module-federation/error-codes@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/enhanced",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "repository": {

--- a/packages/error-codes/CHANGELOG.md
+++ b/packages/error-codes/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/error-codes
 
+## 2.0.1
+
 ## 2.0.0
 
 ## 0.24.1

--- a/packages/error-codes/package.json
+++ b/packages/error-codes/package.json
@@ -4,7 +4,7 @@
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "public": true,
   "sideEffects": false,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/esbuild/CHANGELOG.md
+++ b/packages/esbuild/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/esbuild
 
+## 0.0.96
+
+### Patch Changes
+
+- @module-federation/sdk@2.0.1
+
 ## 0.0.95
 
 ### Patch Changes

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/esbuild",
-  "version": "0.0.95",
+  "version": "0.0.96",
   "author": "Zack Jackson (@ScriptedAlchemy)",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/managers/CHANGELOG.md
+++ b/packages/managers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/managers
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/sdk@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/managers/package.json
+++ b/packages/managers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/managers",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "description": "Provide managers for helping handle mf data .",
   "keywords": [

--- a/packages/manifest/CHANGELOG.md
+++ b/packages/manifest/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/manifest
 
+## 2.0.1
+
+### Patch Changes
+
+- Updated dependencies [d1e6488]
+  - @module-federation/dts-plugin@2.0.1
+  - @module-federation/sdk@2.0.1
+  - @module-federation/managers@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/manifest",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "description": "Provide manifest/stats for webpack/rspack MF project .",
   "keywords": [

--- a/packages/metro-core/CHANGELOG.md
+++ b/packages/metro-core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/metro
 
+## 2.0.1
+
+### Patch Changes
+
+- 0f05d1e: Add Metro 0.83 compatibility layer. Metro 0.83 introduced a restrictive `exports` field that only allows `metro/private/*` paths instead of direct `metro/src/*` imports. This adds a `metro-compat` utility that dynamically resolves the correct import path, ensuring compatibility with both Metro 0.82 and 0.83+.
+  - @module-federation/runtime@2.0.1
+  - @module-federation/sdk@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/metro-core/package.json
+++ b/packages/metro-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Module Federation for Metro bundler",
   "keywords": [
     "module-federation",

--- a/packages/metro-plugin-rnc-cli/CHANGELOG.md
+++ b/packages/metro-plugin-rnc-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/metro-plugin-rnc-cli
 
+## 2.0.1
+
+### Patch Changes
+
+- Updated dependencies [0f05d1e]
+  - @module-federation/metro@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/metro-plugin-rnc-cli/package.json
+++ b/packages/metro-plugin-rnc-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro-plugin-rnc-cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Metro Module Federation plugin for React Native Enterprise Framework (RNEF)",
   "keywords": [
     "rnc",

--- a/packages/metro-plugin-rnef/CHANGELOG.md
+++ b/packages/metro-plugin-rnef/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/metro-plugin-rnef
 
+## 2.0.1
+
+### Patch Changes
+
+- Updated dependencies [0f05d1e]
+  - @module-federation/metro@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/metro-plugin-rnef/package.json
+++ b/packages/metro-plugin-rnef/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro-plugin-rnef",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Metro Module Federation plugin for React Native Enterprise Framework (RNEF)",
   "keywords": [
     "rnef",

--- a/packages/modernjs-v3/CHANGELOG.md
+++ b/packages/modernjs-v3/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @module-federation/modern-js-v3
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/cli@2.0.1
+- @module-federation/enhanced@2.0.1
+- @module-federation/bridge-react@2.0.1
+- @module-federation/runtime@2.0.1
+- @module-federation/node@2.7.32
+- @module-federation/rsbuild-plugin@2.0.1
+- @module-federation/sdk@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/modernjs-v3/package.json
+++ b/packages/modernjs-v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/modern-js-v3",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "files": [
     "dist/",
     "types.d.ts",

--- a/packages/modernjs/CHANGELOG.md
+++ b/packages/modernjs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @module-federation/modern-js
 
+## 2.70.6
+
+### Patch Changes
+
+- @module-federation/cli@2.0.1
+- @module-federation/enhanced@2.0.1
+- @module-federation/bridge-react@2.0.1
+- @module-federation/runtime@2.0.1
+- @module-federation/node@2.7.32
+- @module-federation/rsbuild-plugin@2.0.1
+- @module-federation/sdk@2.0.1
+
 ## 0.24.2
 
 ### Patch Changes

--- a/packages/modernjs/package.json
+++ b/packages/modernjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/modern-js",
-  "version": "2.70.5",
+  "version": "2.70.6",
   "files": [
     "dist/",
     "types.d.ts",

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/nextjs-mf
 
+## 8.8.56
+
+### Patch Changes
+
+- @module-federation/enhanced@2.0.1
+- @module-federation/runtime@2.0.1
+- @module-federation/node@2.7.32
+- @module-federation/webpack-bundler-runtime@2.0.1
+- @module-federation/sdk@2.0.1
+
 ## 8.8.55
 
 ### Patch Changes

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "8.8.55",
+  "version": "8.8.56",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/node
 
+## 2.7.32
+
+### Patch Changes
+
+- @module-federation/enhanced@2.0.1
+- @module-federation/runtime@2.0.1
+- @module-federation/sdk@2.0.1
+
 ## 2.7.31
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "2.7.31",
+  "version": "2.7.32",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "exports": {

--- a/packages/retry-plugin/CHANGELOG.md
+++ b/packages/retry-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/retry-plugin
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/sdk@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/retry-plugin/package.json
+++ b/packages/retry-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/retry-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "danpeen <dapeen.feng@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/rsbuild-plugin/CHANGELOG.md
+++ b/packages/rsbuild-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/rsbuild-plugin
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/enhanced@2.0.1
+- @module-federation/node@2.7.32
+- @module-federation/sdk@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/rsbuild-plugin/package.json
+++ b/packages/rsbuild-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rsbuild-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Module Federation plugin for Rsbuild",
   "homepage": "https://module-federation.io",
   "bugs": {

--- a/packages/rspack/CHANGELOG.md
+++ b/packages/rspack/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @module-federation/rspack
 
+## 2.0.1
+
+### Patch Changes
+
+- Updated dependencies [d1e6488]
+  - @module-federation/dts-plugin@2.0.1
+  - @module-federation/manifest@2.0.1
+  - @module-federation/runtime-tools@2.0.1
+  - @module-federation/inject-external-runtime-core-plugin@2.0.1
+  - @module-federation/sdk@2.0.1
+  - @module-federation/managers@2.0.1
+  - @module-federation/bridge-react-webpack-plugin@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rspack",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "keywords": [
     "Module Federation",

--- a/packages/rspress-plugin/CHANGELOG.md
+++ b/packages/rspress-plugin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/rspress-plugin
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/enhanced@2.0.1
+- @module-federation/rsbuild-plugin@2.0.1
+- @module-federation/sdk@2.0.1
+- @module-federation/error-codes@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/rspress-plugin/package.json
+++ b/packages/rspress-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rspress-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "Module Federation plugin for Rspress",
   "keywords": [

--- a/packages/runtime-core/CHANGELOG.md
+++ b/packages/runtime-core/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @module-federation/runtime
 
+## 2.0.1
+
+### Patch Changes
+
+- 5fa878e: Fix a race where concurrent `Module.init()` calls could run remote container initialization more than once.
+
+  `Module.init()` now deduplicates in-flight initialization with a shared promise so `beforeInitContainer`/`initContainer` logic executes once per module while preserving stable initialized state after completion.
+
+  Also adds regression coverage for concurrent initialization behavior.
+
+  - @module-federation/sdk@2.0.1
+  - @module-federation/error-codes@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs.cjs",

--- a/packages/runtime-plugins/inject-external-runtime-core-plugin/CHANGELOG.md
+++ b/packages/runtime-plugins/inject-external-runtime-core-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/inject-external-runtime-core-plugin
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/runtime-tools@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/runtime-plugins/inject-external-runtime-core-plugin/package.json
+++ b/packages/runtime-plugins/inject-external-runtime-core-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/inject-external-runtime-core-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "license": "MIT",
   "description": "A sdk for support module federation",

--- a/packages/runtime-tools/CHANGELOG.md
+++ b/packages/runtime-tools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/runtime-tools
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/runtime@2.0.1
+- @module-federation/webpack-bundler-runtime@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/runtime-tools/package.json
+++ b/packages/runtime-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-tools",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "main": "./dist/index.cjs.cjs",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/runtime
 
+## 2.0.1
+
+### Patch Changes
+
+- Updated dependencies [5fa878e]
+  - @module-federation/runtime-core@2.0.1
+  - @module-federation/sdk@2.0.1
+  - @module-federation/error-codes@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs.cjs",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/sdk
 
+## 2.0.1
+
 ## 2.0.0
 
 ## 0.24.1

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "license": "MIT",
   "description": "A sdk for support module federation",

--- a/packages/storybook-addon/CHANGELOG.md
+++ b/packages/storybook-addon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/storybook-addon
 
+## 6.0.1
+
+### Patch Changes
+
+- @module-federation/enhanced@2.0.1
+- @module-federation/sdk@2.0.1
+
 ## 6.0.0
 
 ### Major Changes

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/storybook-addon",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Storybook addon to consume remote module federated apps/components",
   "type": "module",
   "license": "MIT",
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "@rsbuild/core": "2.0.0-beta.2",
-    "@module-federation/sdk": "^2.0.0",
+    "@module-federation/sdk": "^2.0.1",
     "@nx/react": ">= 16.0.0",
     "@nx/webpack": ">= 16.0.0",
     "@nx/module-federation": ">= 16.0.0",

--- a/packages/third-party-dts-extractor/CHANGELOG.md
+++ b/packages/third-party-dts-extractor/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/third-party-dts-extractor
 
+## 2.0.1
+
 ## 2.0.0
 
 ## 0.24.1

--- a/packages/third-party-dts-extractor/package.json
+++ b/packages/third-party-dts-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/third-party-dts-extractor",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "files": [
     "dist/",
     "README.md"

--- a/packages/treeshake-frontend/CHANGELOG.md
+++ b/packages/treeshake-frontend/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @module-federation/treeshake-frontend
+
+## 2.0.1

--- a/packages/treeshake-frontend/package.json
+++ b/packages/treeshake-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/treeshake-frontend",
-  "version": "0.23.0",
+  "version": "2.0.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build && rslib build",

--- a/packages/treeshake-server/CHANGELOG.md
+++ b/packages/treeshake-server/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @module-federation/treeshake-server
+
+## 2.0.1
+
+### Patch Changes
+
+- 3cf5f3e: feat: add tree shaking server

--- a/packages/treeshake-server/package.json
+++ b/packages/treeshake-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/treeshake-server",
-  "version": "0.23.0",
+  "version": "2.0.1",
   "description": "Build service powered by Hono that installs dependencies, builds with Rspack, and uploads artifacts.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/utilities
 
+## 3.1.84
+
+### Patch Changes
+
+- @module-federation/sdk@2.0.1
+
 ## 3.1.83
 
 ### Patch Changes

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/utilities",
-  "version": "3.1.83",
+  "version": "3.1.84",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",

--- a/packages/webpack-bundler-runtime/CHANGELOG.md
+++ b/packages/webpack-bundler-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/webpack-bundler-runtime
 
+## 2.0.1
+
+### Patch Changes
+
+- @module-federation/runtime@2.0.1
+- @module-federation/sdk@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/webpack-bundler-runtime/package.json
+++ b/packages/webpack-bundler-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/webpack-bundler-runtime",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "license": "MIT",
   "description": "Module Federation Runtime for webpack",


### PR DESCRIPTION
## Summary
- Prepare release branch `release-v8.8.56` from latest `main`
- Apply `pnpm changeset version` to bump package versions and update changelogs
- Ready for review and merge; no release workflow has been run

## Notes
- This PR is for release branch preparation only.
- Publishing/release execution is intentionally not performed.

Made with [Cursor](https://cursor.com)