### PR TITLE
fix(rsbuild-plugin): honor node target environment for MF SSR

### DIFF
--- a/.changeset/friendly-geese-teach.md
+++ b/.changeset/friendly-geese-teach.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rsbuild-plugin': patch
+---
+
+fix(rsbuild-plugin): honor configured node environment and apply MF in node SSR bundles

--- a/packages/rsbuild-plugin/src/cli/index.spec.ts
+++ b/packages/rsbuild-plugin/src/cli/index.spec.ts
@@ -82,4 +82,16 @@ describe('isMFFormat', () => {
     };
     expect(isMFFormat(config as Rspack.Configuration)).toBe(true);
   });
+
+  it('should return true when env name is explicitly marked as MF', () => {
+    const config: Partial<Rspack.Configuration> = {
+      name: 'ssr',
+      output: {
+        library: {
+          type: 'commonjs-module',
+        },
+      },
+    };
+    expect(isMFFormat(config as Rspack.Configuration, ['ssr'])).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- honor `rsbuildOptions.environment` for `target: 'node'` instead of hardcoded `mf`
- force MF plugin handling for the configured node environment so SSR/commonjs bundles are not skipped
- add a patch changeset for `@module-federation/rsbuild-plugin`

## Test plan
- [x] `pnpm nx run rsbuild-plugin:test`
- [x] `pnpm nx run rsbuild-plugin:lint`

Made with [Cursor](https://cursor.com)