### PR TITLE
fix: update metro host maestro lodash assertions for main CI

### DIFF
--- a/apps/metro-example-host/e2e/flows/core.yaml
+++ b/apps/metro-example-host/e2e/flows/core.yaml
@@ -10,7 +10,7 @@ appId: com.mf.example.host
 - copyTextFrom:
     id: 'host-lodash'
 - assertTrue:
-    condition: ${maestro.copiedText === "4.16.6"}
+    condition: ${maestro.copiedText === "4.17.23"}
 
 # Check Mini App Info
 - assertNotVisible:
@@ -22,7 +22,7 @@ appId: com.mf.example.host
 - copyTextFrom:
     id: 'mini-lodash'
 - assertTrue:
-    condition: ${maestro.copiedText === "4.17.21"}
+    condition: ${maestro.copiedText === "4.17.23"}
 
 # Check Nested Mini App Info
 - assertVisible:
@@ -30,4 +30,4 @@ appId: com.mf.example.host
 - copyTextFrom:
     id: 'nested-mini-lodash'
 - assertTrue:
-    condition: ${maestro.copiedText === "4.16.6"}
+    condition: ${maestro.copiedText === "4.17.23"}


### PR DESCRIPTION
## Summary
- Fix failing `e2e-metro / e2e-matrix-android (example-host)` on `main` by updating stale Maestro assertions.
- `apps/metro-example-host/e2e/flows/core.yaml` expected old lodash values (`4.16.6`/`4.17.21`) while app dependencies were bumped to `4.17.23`.
- Align all host/mini/nested lodash assertions to `4.17.23` so the e2e flow reflects current runtime output.

## Test plan
- [x] Verified failing GitHub Actions job/log: `Build Affected Packages` run `21932848412`, job `e2e-metro / e2e-matrix-android (example-host)`.
- [x] Confirmed failure snippet: Maestro `Assertion is false: false is true` in `core` flow.
- [ ] Re-run `Build Affected Packages` on this PR and confirm metro Android e2e job passes.

Made with [Cursor](https://cursor.com)