### PR TITLE
fix(core): order pkg.pr.new canary publishes by dependency

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -69,7 +69,7 @@ jobs:
             const fixed = new Set((config.fixed || []).flat());
             const roots = ["packages", "apps"];
             const skipDirNames = new Set(["dist", "node_modules", ".git", ".nx"]);
-            const packagePathByName = new Map();
+            const packageMetaByName = new Map();
 
             function walk(dir) {
               if (!fs.existsSync(dir)) return;
@@ -84,9 +84,13 @@ jobs:
                   const pkgDir = path.dirname(fullPath);
                   const pkg = JSON.parse(fs.readFileSync(fullPath, "utf8"));
                   if (fixed.has(pkg.name) && pkg.private !== true) {
-                    const existing = packagePathByName.get(pkg.name);
-                    if (!existing || pkgDir.length < existing.length) {
-                      packagePathByName.set(pkg.name, pkgDir);
+                    const existing = packageMetaByName.get(pkg.name);
+                    if (!existing || pkgDir.length < existing.path.length) {
+                      packageMetaByName.set(pkg.name, {
+                        name: pkg.name,
+                        path: pkgDir,
+                        pkg,
+                      });
                     }
                   }
                 }
@@ -97,9 +101,73 @@ jobs:
               walk(root);
             }
 
-            // Deduplicate by package name and sort for stable output.
-            const sorted = Array.from(packagePathByName.values()).sort();
-            process.stdout.write(JSON.stringify(sorted));
+            const dependencyFields = [
+              "dependencies",
+              "devDependencies",
+              "optionalDependencies",
+              "peerDependencies",
+            ];
+
+            for (const meta of packageMetaByName.values()) {
+              const internalDeps = new Set();
+              for (const field of dependencyFields) {
+                const deps = meta.pkg[field];
+                if (!deps || typeof deps !== "object") continue;
+                for (const depName of Object.keys(deps)) {
+                  if (packageMetaByName.has(depName)) {
+                    internalDeps.add(depName);
+                  }
+                }
+              }
+              meta.internalDeps = internalDeps;
+            }
+
+            const indegreeByName = new Map();
+            const dependentsByName = new Map();
+            for (const [name, meta] of packageMetaByName) {
+              indegreeByName.set(name, meta.internalDeps.size);
+              dependentsByName.set(name, new Set());
+            }
+
+            for (const [name, meta] of packageMetaByName) {
+              for (const depName of meta.internalDeps) {
+                dependentsByName.get(depName).add(name);
+              }
+            }
+
+            const queue = Array.from(indegreeByName.entries())
+              .filter(([, degree]) => degree === 0)
+              .map(([name]) => name)
+              .sort();
+            const orderedNames = [];
+
+            while (queue.length) {
+              const current = queue.shift();
+              orderedNames.push(current);
+              const dependents = Array.from(dependentsByName.get(current) || []).sort();
+              for (const dependent of dependents) {
+                const nextDegree = (indegreeByName.get(dependent) || 0) - 1;
+                indegreeByName.set(dependent, nextDegree);
+                if (nextDegree === 0) {
+                  queue.push(dependent);
+                }
+              }
+              queue.sort();
+            }
+
+            if (orderedNames.length !== packageMetaByName.size) {
+              const remaining = Array.from(packageMetaByName.keys())
+                .filter((name) => !orderedNames.includes(name))
+                .sort((a, b) => {
+                  const pathA = packageMetaByName.get(a).path;
+                  const pathB = packageMetaByName.get(b).path;
+                  return pathA.localeCompare(pathB);
+                });
+              orderedNames.push(...remaining);
+            }
+
+            const orderedPaths = orderedNames.map((name) => packageMetaByName.get(name).path);
+            process.stdout.write(JSON.stringify(orderedPaths));
           ')
 
           echo "paths_json=$paths_json" >> "$GITHUB_OUTPUT"
@@ -131,6 +199,7 @@ jobs:
               "--pnpm",
               "--packageManager=pnpm",
               "--comment=update",
+              "--commentWithSha",
               ...paths,
             ];
 


### PR DESCRIPTION
## Description

This PR ports key improvements from #4320 to the `pkg-pr-new` GitHub workflow.
It addresses two main areas for canary releases:
1.  **Dependency-aware publishing:** Ensures that fixed Changesets packages are published in the correct topological order, respecting internal monorepo dependencies. This prevents issues where dependent packages might be published before their dependencies during a canary release.
2.  **SHA-based comments:** Adds the `--commentWithSha` flag to `pkg.pr.new` publish commands. This uses the commit SHA in release comments, preventing stale alias resolution and ensuring proper versioning for canary releases.

## Related Issue

Ported from changes in #4320.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-89b00108-67eb-455f-b7c2-7a07edf97cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89b00108-67eb-455f-b7c2-7a07edf97cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

