### PR TITLE
fix(dts-plugin): stabilize package test and typings build

### DIFF
--- a/packages/dts-plugin/project.json
+++ b/packages/dts-plugin/project.json
@@ -25,7 +25,10 @@
       "options": {
         "parallel": false,
         "cwd": "packages/dts-plugin",
-        "commands": ["rimraf dist-test", "nx run dts-plugin:test-impl"]
+        "commands": [
+          "node -e \"require('fs').rmSync('dist-test',{recursive:true,force:true,maxRetries:20,retryDelay:50})\"",
+          "nx run dts-plugin:test-impl"
+        ]
       }
     },
     "test-impl": {

--- a/packages/dts-plugin/src/plugins/GenerateTypesPlugin.ts
+++ b/packages/dts-plugin/src/plugins/GenerateTypesPlugin.ts
@@ -172,8 +172,7 @@ export class GenerateTypesPlugin implements WebpackPluginInstance {
             compilation.emitAsset(
               zipName,
               new compiler.webpack.sources.RawSource(
-                fs.readFileSync(zipTypesPath),
-                false,
+                fs.readFileSync(zipTypesPath) as unknown as string,
               ),
             );
           }
@@ -186,8 +185,7 @@ export class GenerateTypesPlugin implements WebpackPluginInstance {
             compilation.emitAsset(
               apiFileName,
               new compiler.webpack.sources.RawSource(
-                fs.readFileSync(apiTypesPath),
-                false,
+                fs.readFileSync(apiTypesPath) as unknown as string,
               ),
             );
           }


### PR DESCRIPTION
## Summary
- Update `GenerateTypesPlugin` to call `RawSource` with the current webpack typing shape, fixing TYPE-001 failures in `dts-plugin` tests.
- Harden `dts-plugin:test` cleanup by replacing `rimraf dist-test` with a retrying `fs.rmSync(...)` cleanup to avoid intermittent `ENOTEMPTY` failures.
- Keep scope limited to `dts-plugin` test/build stability with no API changes.

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run nx:safe -- run dts-plugin:test --skip-nx-cache`
- [x] `pnpm run nx:safe -- run-many --targets=build --projects=tag:type:pkg --parallel=4 --skip-nx-cache`
- [x] `pnpm run nx:safe -- run-many --target=test --projects=tag:type:pkg --parallel=3 --skip-nx-cache`

Made with [Cursor](https://cursor.com)