### PR TITLE
docs: update heading from "AI Skills" to "Skills" in documentation

### DIFF
--- a/apps/website-new/docs/en/guide/ai/skill.mdx
+++ b/apps/website-new/docs/en/guide/ai/skill.mdx
@@ -1,4 +1,4 @@
-# AI Skills
+# Skills
 
 Module Federation provides a set of **Agent Skills** — loadable instruction sets for AI coding assistants that give them built-in knowledge of Module Federation 2.0 internals. These skills help you diagnose configuration issues, resolve type errors, detect shared dependency conflicts, and more, all within your editor.
 

--- a/apps/website-new/docs/zh/guide/ai/skill.mdx
+++ b/apps/website-new/docs/zh/guide/ai/skill.mdx
@@ -1,4 +1,4 @@
-# AI Skills
+# Skills
 
 Module Federation 提供了一组 **Agent Skills** —— 可被 AI 编程助手加载的指令集，让其具备 Module Federation 2.0 内部原理的专业知识。这些技能可以帮助你诊断配置问题、解决类型错误、检测共享依赖冲突等，所有操作均可在你的编辑器中完成。
 


### PR DESCRIPTION
## Description

update heading from "AI Skills" to "Skills" in documentation

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
