### PR TITLE
[codex] shared-tree-shaking follow-up fixes

### DIFF
--- a/.github/workflows/e2e-shared-tree-shaking.yml
+++ b/.github/workflows/e2e-shared-tree-shaking.yml
@@ -51,7 +51,7 @@ jobs:
         id: check-ci
         run: |
           ci_status=0
-          node tools/scripts/ci-is-affected.mjs --appName=shared-tree-shaking-with-server-host || ci_status=$?
+          node tools/scripts/ci-is-affected.mjs --appName=shared-tree-shaking-no-server-host,shared-tree-shaking-no-server-provider,shared-tree-shaking-with-server-host,shared-tree-shaking-with-server-provider || ci_status=$?
           if [ "$ci_status" -eq 0 ]; then
             echo "run-e2e=true" >> "$GITHUB_OUTPUT"
           elif [ "$ci_status" -eq 1 ]; then

--- a/apps/shared-tree-shaking/no-server/host/package.json
+++ b/apps/shared-tree-shaking/no-server/host/package.json
@@ -50,9 +50,9 @@
     "lint-staged": "~13.1.0",
     "prettier": "~3.3.3",
     "rimraf": "~3.0.2",
-    "typescript": "~5.0.4",
+    "typescript": "5.9.3",
     "fs-extra": "^11.1.1",
-    "ts-node": "~10.8.1",
-    "tsconfig-paths": "~3.14.1"
+    "ts-node": "10.9.2",
+    "tsconfig-paths": "4.2.0"
   }
 }

--- a/apps/shared-tree-shaking/no-server/provider/package.json
+++ b/apps/shared-tree-shaking/no-server/provider/package.json
@@ -47,6 +47,8 @@
     "lint-staged": "~13.1.0",
     "prettier": "~3.3.3",
     "rimraf": "~3.0.2",
-    "typescript": "~5.0.4"
+    "ts-node": "10.9.2",
+    "tsconfig-paths": "4.2.0",
+    "typescript": "5.9.3"
   }
 }

--- a/apps/shared-tree-shaking/with-server/host/modern.config.ts
+++ b/apps/shared-tree-shaking/with-server/host/modern.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
   },
   output: {
     assetPrefix: publicPath,
+    disableTsChecker: true,
     distPath: {
       root: isSecondarySharedTreeShaking ? 'dist-test' : 'dist',
     },

--- a/apps/shared-tree-shaking/with-server/host/package.json
+++ b/apps/shared-tree-shaking/with-server/host/package.json
@@ -54,9 +54,9 @@
     "lint-staged": "~13.1.0",
     "prettier": "~3.3.3",
     "rimraf": "~3.0.2",
-    "typescript": "~5.0.4",
+    "typescript": "5.9.3",
     "fs-extra": "^11.1.1",
-    "ts-node": "~10.8.1",
-    "tsconfig-paths": "~3.14.1"
+    "ts-node": "10.9.2",
+    "tsconfig-paths": "4.2.0"
   }
 }

--- a/apps/shared-tree-shaking/with-server/provider/package.json
+++ b/apps/shared-tree-shaking/with-server/provider/package.json
@@ -46,6 +46,8 @@
     "lint-staged": "~13.1.0",
     "prettier": "~3.3.3",
     "rimraf": "~3.0.2",
-    "typescript": "~5.0.4"
+    "ts-node": "10.9.2",
+    "tsconfig-paths": "4.2.0",
+    "typescript": "5.9.3"
   }
 }

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -21,50 +21,37 @@ function _toPropertyKey(t) {
   return 'symbol' == typeof i ? i : i + '';
 }
 function _defineProperty(e, r, t) {
-  return (
-    (r = _toPropertyKey(r)) in e
-      ? Object.defineProperty(e, r, {
-          value: t,
-          enumerable: !0,
-          configurable: !0,
-          writable: !0,
-        })
-      : (e[r] = t),
-    e
-  );
+  return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
 }
 function ownKeys(e, r) {
   var t = Object.keys(e);
   if (Object.getOwnPropertySymbols) {
     var o = Object.getOwnPropertySymbols(e);
-    (r &&
-      (o = o.filter(function (r) {
-        return Object.getOwnPropertyDescriptor(e, r).enumerable;
-      })),
-      t.push.apply(t, o));
+    r && (o = o.filter(function (r) {
+      return Object.getOwnPropertyDescriptor(e, r).enumerable;
+    })), t.push.apply(t, o);
   }
   return t;
 }
 function _objectSpread2(e) {
   for (var r = 1; r < arguments.length; r++) {
     var t = null != arguments[r] ? arguments[r] : {};
-    r % 2
-      ? ownKeys(Object(t), !0).forEach(function (r) {
-          _defineProperty(e, r, t[r]);
-        })
-      : Object.getOwnPropertyDescriptors
-        ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t))
-        : ownKeys(Object(t)).forEach(function (r) {
-            Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r));
-          });
+    r % 2 ? ownKeys(Object(t), !0).forEach(function (r) {
+      _defineProperty(e, r, t[r]);
+    }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) {
+      Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r));
+    });
   }
   return e;
 }
 function getHighestReleaseType(releases) {
   if (releases.length === 0) {
-    throw new Error(
-      `Large internal Changesets error when calculating highest release type in the set of releases. Please contact the maintainers`,
-    );
+    throw new Error(`Large internal Changesets error when calculating highest release type in the set of releases. Please contact the maintainers`);
   }
   let highestReleaseType = 'none';
   for (let release of releases) {
@@ -88,15 +75,10 @@ function getCurrentHighestVersion(packageGroup, packagesByName) {
   for (let pkgName of packageGroup) {
     let pkg = packagesByName.get(pkgName);
     if (!pkg) {
-      console.error(
-        `FATAL ERROR IN CHANGESETS! We were unable to version for package group: ${pkgName} in package group: ${packageGroup.toString()}`,
-      );
+      console.error(`FATAL ERROR IN CHANGESETS! We were unable to version for package group: ${pkgName} in package group: ${packageGroup.toString()}`);
       throw new Error(`fatal: could not resolve linked packages`);
     }
-    if (
-      highestVersion === undefined ||
-      semverGt(pkg.packageJson.version, highestVersion)
-    ) {
+    if (highestVersion === undefined || semverGt(pkg.packageJson.version, highestVersion)) {
       highestVersion = pkg.packageJson.version;
     }
   }
@@ -121,19 +103,13 @@ function applyLinks(releases, packagesByName, linked) {
   // We do this for each set of linked packages
   for (let linkedPackages of linked) {
     // First we filter down to all the relevant releases for one set of linked packages
-    let releasingLinkedPackages = [...releases.values()].filter(
-      (release) =>
-        linkedPackages.includes(release.name) && release.type !== 'none',
-    );
+    let releasingLinkedPackages = [...releases.values()].filter(release => linkedPackages.includes(release.name) && release.type !== 'none');
 
     // If we proceed any further we do extra work with calculating highestVersion for things that might
     // not need one, as they only have workspace based packages
     if (releasingLinkedPackages.length === 0) continue;
     let highestReleaseType = getHighestReleaseType(releasingLinkedPackages);
-    let highestVersion = getCurrentHighestVersion(
-      linkedPackages,
-      packagesByName,
-    );
+    let highestVersion = getCurrentHighestVersion(linkedPackages, packagesByName);
 
     // Finally, we update the packages so all of them are on the highest version
     for (let linkedPackage of releasingLinkedPackages) {
@@ -157,9 +133,7 @@ function incrementVersion(release, preInfo) {
   if (preInfo !== undefined && preInfo.state.mode !== 'exit') {
     let preVersion = preInfo.preVersions.get(release.name);
     if (preVersion === undefined) {
-      throw new InternalError(
-        `preVersion for ${release.name} does not exist when preState is defined`,
-      );
+      throw new InternalError(`preVersion for ${release.name} does not exist when preState is defined`);
     }
     // why are we adding this ourselves rather than passing 'pre' + versionType to semver.inc?
     // because semver.inc with prereleases is confusing and this seems easier
@@ -185,7 +159,7 @@ function determineDependents({
   packagesByName,
   dependencyGraph,
   preInfo,
-  config,
+  config
 }) {
   let updated = false;
   // NOTE this is intended to be called recursively
@@ -197,109 +171,90 @@ function determineDependents({
     // pkgDependents will be a list of packages that depend on nextRelease ie. ['avatar-group', 'comment']
     const pkgDependents = dependencyGraph.get(nextRelease.name);
     if (!pkgDependents) {
-      throw new Error(
-        `Error in determining dependents - could not find package in repository: ${nextRelease.name}`,
-      );
+      throw new Error(`Error in determining dependents - could not find package in repository: ${nextRelease.name}`);
     }
-    pkgDependents
-      .map((dependent) => {
-        let type;
-        const dependentPackage = packagesByName.get(dependent);
-        if (!dependentPackage) throw new Error('Dependency map is incorrect');
-        if (
-          shouldSkipPackage(dependentPackage, {
-            ignore: config.ignore,
-            allowPrivatePackages: config.privatePackages.version,
-          })
-        ) {
-          type = 'none';
-        } else {
-          const dependencyVersionRanges = getDependencyVersionRanges(
-            dependentPackage.packageJson,
+    pkgDependents.map(dependent => {
+      let type;
+      const dependentPackage = packagesByName.get(dependent);
+      if (!dependentPackage) throw new Error('Dependency map is incorrect');
+      if (shouldSkipPackage(dependentPackage, {
+        ignore: config.ignore,
+        allowPrivatePackages: config.privatePackages.version
+      })) {
+        type = 'none';
+      } else {
+        const dependencyVersionRanges = getDependencyVersionRanges(dependentPackage.packageJson, nextRelease);
+        for (const {
+          depType,
+          versionRange
+        } of dependencyVersionRanges) {
+          if (nextRelease.type === 'none') {
+            continue;
+          } else if (shouldBumpMajor({
+            dependent,
+            depType,
+            versionRange,
+            releases,
             nextRelease,
-          );
-          for (const { depType, versionRange } of dependencyVersionRanges) {
-            if (nextRelease.type === 'none') {
-              continue;
-            } else if (
-              shouldBumpMajor({
-                dependent,
-                depType,
-                versionRange,
-                releases,
-                nextRelease,
-                preInfo,
-                onlyUpdatePeerDependentsWhenOutOfRange:
-                  config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-                    .onlyUpdatePeerDependentsWhenOutOfRange,
-              })
-            ) {
-              type = 'major';
-            } else if (
-              (!releases.has(dependent) ||
-                releases.get(dependent).type === 'none') &&
-              (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-                .updateInternalDependents === 'always' ||
-                !semverSatisfies(
-                  incrementVersion(nextRelease, preInfo),
-                  versionRange,
-                ))
-            ) {
-              switch (depType) {
-                case 'dependencies':
-                case 'optionalDependencies':
-                case 'peerDependencies':
-                  if (type !== 'major' && type !== 'minor') {
-                    type = 'patch';
-                  }
-                  break;
-                case 'devDependencies': {
+            preInfo,
+            onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
+          })) {
+            type = 'major';
+          } else if ((!releases.has(dependent) || releases.get(dependent).type === 'none') && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === 'always' || !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange))) {
+            switch (depType) {
+              case 'dependencies':
+              case 'optionalDependencies':
+              case 'peerDependencies':
+                if (type !== 'major' && type !== 'minor') {
+                  type = 'patch';
+                }
+                break;
+              case 'devDependencies':
+                {
                   // We don't need a version bump if the package is only in the devDependencies of the dependent package
-                  if (
-                    type !== 'major' &&
-                    type !== 'minor' &&
-                    type !== 'patch'
-                  ) {
+                  if (type !== 'major' && type !== 'minor' && type !== 'patch') {
                     type = 'none';
                   }
                 }
-              }
             }
           }
         }
-        if (releases.has(dependent) && releases.get(dependent).type === type) {
-          type = undefined;
-        }
-        return {
-          name: dependent,
-          type,
-          pkgJSON: dependentPackage.packageJson,
-        };
-      })
-      .filter((dependentItem) => !!dependentItem.type)
-      .forEach(({ name, type, pkgJSON }) => {
-        // At this point, we know if we are making a change
-        updated = true;
-        const existing = releases.get(name);
-        // For things that are being given a major bump, we check if we have already
-        // added them here. If we have, we update the existing item instead of pushing it on to search.
-        // It is safe to not add it to pkgsToSearch because it should have already been searched at the
-        // largest possible bump type.
+      }
+      if (releases.has(dependent) && releases.get(dependent).type === type) {
+        type = undefined;
+      }
+      return {
+        name: dependent,
+        type,
+        pkgJSON: dependentPackage.packageJson
+      };
+    }).filter(dependentItem => !!dependentItem.type).forEach(({
+      name,
+      type,
+      pkgJSON
+    }) => {
+      // At this point, we know if we are making a change
+      updated = true;
+      const existing = releases.get(name);
+      // For things that are being given a major bump, we check if we have already
+      // added them here. If we have, we update the existing item instead of pushing it on to search.
+      // It is safe to not add it to pkgsToSearch because it should have already been searched at the
+      // largest possible bump type.
 
-        if (existing && type === 'major' && existing.type !== 'major') {
-          existing.type = 'major';
-          pkgsToSearch.push(existing);
-        } else {
-          let newDependent = {
-            name,
-            type,
-            oldVersion: pkgJSON.version,
-            changesets: [],
-          };
-          pkgsToSearch.push(newDependent);
-          releases.set(name, newDependent);
-        }
-      });
+      if (existing && type === 'major' && existing.type !== 'major') {
+        existing.type = 'major';
+        pkgsToSearch.push(existing);
+      } else {
+        let newDependent = {
+          name,
+          type,
+          oldVersion: pkgJSON.version,
+          changesets: []
+        };
+        pkgsToSearch.push(newDependent);
+        releases.set(name, newDependent);
+      }
+    });
   }
   return updated;
 }
@@ -310,36 +265,26 @@ function determineDependents({
   dependency lists. For example, a package that is both a peerDepenency and a devDependency.
 */
 function getDependencyVersionRanges(dependentPkgJSON, dependencyRelease) {
-  const DEPENDENCY_TYPES = [
-    'dependencies',
-    'devDependencies',
-    'peerDependencies',
-    'optionalDependencies',
-  ];
+  const DEPENDENCY_TYPES = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
   const dependencyVersionRanges = [];
   for (const type of DEPENDENCY_TYPES) {
     var _dependentPkgJSON$typ;
-    const versionRange =
-      (_dependentPkgJSON$typ = dependentPkgJSON[type]) === null ||
-      _dependentPkgJSON$typ === void 0
-        ? void 0
-        : _dependentPkgJSON$typ[dependencyRelease.name];
+    const versionRange = (_dependentPkgJSON$typ = dependentPkgJSON[type]) === null || _dependentPkgJSON$typ === void 0 ? void 0 : _dependentPkgJSON$typ[dependencyRelease.name];
     if (!versionRange) continue;
     if (versionRange.startsWith('workspace:')) {
       dependencyVersionRanges.push({
         depType: type,
         versionRange:
-          // intentionally keep other workspace ranges untouched
-          // this has to be fixed but this should only be done when adding appropriate tests
-          versionRange === 'workspace:*'
-            ? // workspace:* actually means the current exact version, and not a wildcard similar to a reguler * range
-              dependencyRelease.oldVersion
-            : versionRange.replace(/^workspace:/, ''),
+        // intentionally keep other workspace ranges untouched
+        // this has to be fixed but this should only be done when adding appropriate tests
+        versionRange === 'workspace:*' ?
+        // workspace:* actually means the current exact version, and not a wildcard similar to a reguler * range
+        dependencyRelease.oldVersion : versionRange.replace(/^workspace:/, '')
       });
     } else {
       dependencyVersionRanges.push({
         depType: type,
-        versionRange,
+        versionRange
       });
     }
   }
@@ -352,7 +297,7 @@ function shouldBumpMajor({
   releases,
   nextRelease,
   preInfo,
-  onlyUpdatePeerDependentsWhenOutOfRange,
+  onlyUpdatePeerDependentsWhenOutOfRange
 }) {
   //disable major bump due to peer dep
   if (depType === 'peerDependencies') {
@@ -361,88 +306,71 @@ function shouldBumpMajor({
   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
   return (
     //@ts-ignore
-    depType === 'peerDependencies' &&
-    nextRelease.type !== 'none' &&
-    nextRelease.type !== 'patch' &&
+    depType === 'peerDependencies' && nextRelease.type !== 'none' && nextRelease.type !== 'patch' && (
     // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
     // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
-    (!onlyUpdatePeerDependentsWhenOutOfRange ||
-      !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange)) &&
+    !onlyUpdatePeerDependentsWhenOutOfRange || !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange)) && (
     // bump major only if the dependent doesn't already has a major release.
-    (!releases.has(dependent) ||
-      (releases.has(dependent) && releases.get(dependent).type !== 'major'))
+    !releases.has(dependent) || releases.has(dependent) && releases.get(dependent).type !== 'major')
   );
 }
 
 // This function takes in changesets and returns one release per
 function flattenReleases(changesets, packagesByName, config) {
   let releases = new Map();
-  changesets.forEach((changeset) => {
+  changesets.forEach(changeset => {
     changeset.releases
-      // Filter out skipped packages because they should not trigger a release
-      // If their dependencies need updates, they will be added to releases by `determineDependents()` with release type `none`
-      .filter(
-        ({ name }) =>
-          !shouldSkipPackage(packagesByName.get(name), {
-            ignore: config.ignore,
-            allowPrivatePackages: config.privatePackages.version,
-          }),
-      )
-      .forEach(({ name, type }) => {
-        let release = releases.get(name);
-        let pkg = packagesByName.get(name);
-        if (!pkg) {
-          throw new Error(
-            `"${changeset.id}" changeset mentions a release for a package "${name}" but such a package could not be found.`,
-          );
+    // Filter out skipped packages because they should not trigger a release
+    // If their dependencies need updates, they will be added to releases by `determineDependents()` with release type `none`
+    .filter(({
+      name
+    }) => !shouldSkipPackage(packagesByName.get(name), {
+      ignore: config.ignore,
+      allowPrivatePackages: config.privatePackages.version
+    })).forEach(({
+      name,
+      type
+    }) => {
+      let release = releases.get(name);
+      let pkg = packagesByName.get(name);
+      if (!pkg) {
+        throw new Error(`"${changeset.id}" changeset mentions a release for a package "${name}" but such a package could not be found.`);
+      }
+      if (!release) {
+        release = {
+          name,
+          type,
+          oldVersion: pkg.packageJson.version,
+          changesets: [changeset.id]
+        };
+      } else {
+        if (type === 'major' || (release.type === 'patch' || release.type === 'none') && (type === 'minor' || type === 'patch')) {
+          release.type = type;
         }
-        if (!release) {
-          release = {
-            name,
-            type,
-            oldVersion: pkg.packageJson.version,
-            changesets: [changeset.id],
-          };
-        } else {
-          if (
-            type === 'major' ||
-            ((release.type === 'patch' || release.type === 'none') &&
-              (type === 'minor' || type === 'patch'))
-          ) {
-            release.type = type;
-          }
-          // Check whether the bumpType will change
-          // If the bumpType has changed recalc newVersion
-          // push new changeset to releases
-          release.changesets.push(changeset.id);
-        }
-        releases.set(name, release);
-      });
+        // Check whether the bumpType will change
+        // If the bumpType has changed recalc newVersion
+        // push new changeset to releases
+        release.changesets.push(changeset.id);
+      }
+      releases.set(name, release);
+    });
   });
   return releases;
 }
 function matchFixedConstraint(releases, packagesByName, config) {
   let updated = false;
   for (let fixedPackages of config.fixed) {
-    let releasingFixedPackages = [...releases.values()].filter(
-      (release) =>
-        fixedPackages.includes(release.name) && release.type !== 'none',
-    );
+    let releasingFixedPackages = [...releases.values()].filter(release => fixedPackages.includes(release.name) && release.type !== 'none');
     if (releasingFixedPackages.length === 0) continue;
     let highestReleaseType = getHighestReleaseType(releasingFixedPackages);
-    let highestVersion = getCurrentHighestVersion(
-      fixedPackages,
-      packagesByName,
-    );
+    let highestVersion = getCurrentHighestVersion(fixedPackages, packagesByName);
 
     // Finally, we update the packages so all of them are on the highest version
     for (let pkgName of fixedPackages) {
-      if (
-        shouldSkipPackage(packagesByName.get(pkgName), {
-          ignore: config.ignore,
-          allowPrivatePackages: config.privatePackages.version,
-        })
-      ) {
+      if (shouldSkipPackage(packagesByName.get(pkgName), {
+        ignore: config.ignore,
+        allowPrivatePackages: config.privatePackages.version
+      })) {
         continue;
       }
       let release = releases.get(pkgName);
@@ -452,7 +380,7 @@ function matchFixedConstraint(releases, packagesByName, config) {
           name: pkgName,
           type: highestReleaseType,
           oldVersion: highestVersion,
-          changesets: [],
+          changesets: []
         });
         continue;
       }
@@ -470,8 +398,7 @@ function matchFixedConstraint(releases, packagesByName, config) {
 }
 function getPreVersion(version) {
   let parsed = semverParse(version);
-  let preVersion =
-    parsed.prerelease[1] === undefined ? -1 : parsed.prerelease[1];
+  let preVersion = parsed.prerelease[1] === undefined ? -1 : parsed.prerelease[1];
   if (typeof preVersion !== 'number') {
     throw new InternalError('preVersion is not a number');
   }
@@ -484,43 +411,29 @@ function getSnapshotSuffix(template, snapshotParameters) {
     commit: snapshotParameters.commit,
     tag: snapshotParameters.tag,
     timestamp: snapshotRefDate.getTime().toString(),
-    datetime: snapshotRefDate
-      .toISOString()
-      .replace(/\.\d{3}Z$/, '')
-      .replace(/[^\d]/g, ''),
+    datetime: snapshotRefDate.toISOString().replace(/\.\d{3}Z$/, '').replace(/[^\d]/g, '')
   };
 
   // We need a special handling because we need to handle a case where `--snapshot` is used without any template,
   // and the resulting version needs to be composed without a tag.
   if (!template) {
-    return [placeholderValues.tag, placeholderValues.datetime]
-      .filter(Boolean)
-      .join('-');
+    return [placeholderValues.tag, placeholderValues.datetime].filter(Boolean).join('-');
   }
   const placeholders = Object.keys(placeholderValues);
   if (!template.includes(`{tag}`) && placeholderValues.tag !== undefined) {
-    throw new Error(
-      `Failed to compose snapshot version: "{tag}" placeholder is missing, but the snapshot parameter is defined (value: '${placeholderValues.tag}')`,
-    );
+    throw new Error(`Failed to compose snapshot version: "{tag}" placeholder is missing, but the snapshot parameter is defined (value: '${placeholderValues.tag}')`);
   }
   return placeholders.reduce((prev, key) => {
     return prev.replace(new RegExp(`\\{${key}\\}`, 'g'), () => {
       const value = placeholderValues[key];
       if (value === undefined) {
-        throw new Error(
-          `Failed to compose snapshot version: "{${key}}" placeholder is used without having a value defined!`,
-        );
+        throw new Error(`Failed to compose snapshot version: "{${key}}" placeholder is used without having a value defined!`);
       }
       return value;
     });
   }, template);
 }
-function getSnapshotVersion(
-  release,
-  preInfo,
-  useCalculatedVersion,
-  snapshotSuffix,
-) {
+function getSnapshotVersion(release, preInfo, useCalculatedVersion, snapshotSuffix) {
   if (release.type === 'none') {
     return release.oldVersion;
   }
@@ -534,9 +447,7 @@ function getSnapshotVersion(
    *
    * You can set `snapshot.useCalculatedVersion` flag to true to use calculated versions if you don't care about the above problem.
    */
-  const baseVersion = useCalculatedVersion
-    ? incrementVersion(release, preInfo)
-    : `0.0.0`;
+  const baseVersion = useCalculatedVersion ? incrementVersion(release, preInfo) : `0.0.0`;
   return `${baseVersion}-${snapshotSuffix}`;
 }
 function getNewVersion(release, preInfo) {
@@ -545,70 +456,36 @@ function getNewVersion(release, preInfo) {
   }
   return incrementVersion(release, preInfo);
 }
-function assembleReleasePlan(
-  changesets,
-  packages,
-  config,
-  // intentionally not using an optional parameter here so the result of `readPreState` has to be passed in here
-  preState,
-  // snapshot: undefined            ->  not using snaphot
-  // snapshot: { tag: undefined }   ->  --snapshot (empty tag)
-  // snapshot: { tag: "canary" }    ->  --snapshot canary
-  snapshot,
-) {
+function assembleReleasePlan(changesets, packages, config,
+// intentionally not using an optional parameter here so the result of `readPreState` has to be passed in here
+preState,
+// snapshot: undefined            ->  not using snaphot
+// snapshot: { tag: undefined }   ->  --snapshot (empty tag)
+// snapshot: { tag: "canary" }    ->  --snapshot canary
+snapshot) {
   // TODO: remove `refined*` in the next major version of this package
   // just use `config` and `snapshot` parameters directly, typed as: `config: Config, snapshot?: SnapshotReleaseParameters`
-  const refinedConfig = config.snapshot
-    ? config
-    : _objectSpread2(
-        _objectSpread2({}, config),
-        {},
-        {
-          snapshot: {
-            prereleaseTemplate: null,
-            useCalculatedVersion:
-              config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-                .useCalculatedVersionForSnapshots,
-          },
-        },
-      );
-  const refinedSnapshot =
-    typeof snapshot === 'string'
-      ? {
-          tag: snapshot,
-        }
-      : typeof snapshot === 'boolean'
-        ? {
-            tag: undefined,
-          }
-        : snapshot;
-  let packagesByName = new Map(
-    packages.packages.map((x) => [x.packageJson.name, x]),
-  );
-  const relevantChangesets = getRelevantChangesets(
-    changesets,
-    packagesByName,
-    refinedConfig,
-    preState,
-  );
-  const preInfo = getPreInfo(
-    changesets,
-    packagesByName,
-    refinedConfig,
-    preState,
-  );
+  const refinedConfig = config.snapshot ? config : _objectSpread2(_objectSpread2({}, config), {}, {
+    snapshot: {
+      prereleaseTemplate: null,
+      useCalculatedVersion: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.useCalculatedVersionForSnapshots
+    }
+  });
+  const refinedSnapshot = typeof snapshot === 'string' ? {
+    tag: snapshot
+  } : typeof snapshot === 'boolean' ? {
+    tag: undefined
+  } : snapshot;
+  let packagesByName = new Map(packages.packages.map(x => [x.packageJson.name, x]));
+  const relevantChangesets = getRelevantChangesets(changesets, packagesByName, refinedConfig, preState);
+  const preInfo = getPreInfo(changesets, packagesByName, refinedConfig, preState);
 
   // releases is, at this point a list of all packages we are going to releases,
   // flattened down to one release per package, having a reference back to their
   // changesets, and with a calculated new versions
-  let releases = flattenReleases(
-    relevantChangesets,
-    packagesByName,
-    refinedConfig,
-  );
+  let releases = flattenReleases(relevantChangesets, packagesByName, refinedConfig);
   let dependencyGraph = getDependentsGraph(packages, {
-    bumpVersionsWithWorkspaceProtocolOnly:
-      refinedConfig.bumpVersionsWithWorkspaceProtocolOnly,
+    bumpVersionsWithWorkspaceProtocolOnly: refinedConfig.bumpVersionsWithWorkspaceProtocolOnly
   });
   let releasesValidated = false;
   while (releasesValidated === false) {
@@ -618,27 +495,15 @@ function assembleReleasePlan(
       packagesByName,
       dependencyGraph,
       preInfo,
-      config: refinedConfig,
+      config: refinedConfig
     });
 
     // `releases` might get mutated here
-    let fixedConstraintUpdated = matchFixedConstraint(
-      releases,
-      packagesByName,
-      refinedConfig,
-    );
-    let linksUpdated = applyLinks(
-      releases,
-      packagesByName,
-      refinedConfig.linked,
-    );
-    releasesValidated =
-      !linksUpdated && !dependentAdded && !fixedConstraintUpdated;
+    let fixedConstraintUpdated = matchFixedConstraint(releases, packagesByName, refinedConfig);
+    let linksUpdated = applyLinks(releases, packagesByName, refinedConfig.linked);
+    releasesValidated = !linksUpdated && !dependentAdded && !fixedConstraintUpdated;
   }
-  if (
-    (preInfo === null || preInfo === void 0 ? void 0 : preInfo.state.mode) ===
-    'exit'
-  ) {
+  if ((preInfo === null || preInfo === void 0 ? void 0 : preInfo.state.mode) === 'exit') {
     for (let pkg of packages.packages) {
       // If a package had a prerelease, but didn't trigger a version bump in the regular release,
       // we want to give it a patch release.
@@ -650,15 +515,12 @@ function assembleReleasePlan(
             name: pkg.packageJson.name,
             type: 'patch',
             oldVersion: pkg.packageJson.version,
-            changesets: [],
+            changesets: []
           });
-        } else if (
-          existingRelease.type === 'none' &&
-          !shouldSkipPackage(pkg, {
-            ignore: refinedConfig.ignore,
-            allowPrivatePackages: refinedConfig.privatePackages.version,
-          })
-        ) {
+        } else if (existingRelease.type === 'none' && !shouldSkipPackage(pkg, {
+          ignore: refinedConfig.ignore,
+          allowPrivatePackages: refinedConfig.privatePackages.version
+        })) {
           existingRelease.type = 'patch';
         }
       }
@@ -666,31 +528,15 @@ function assembleReleasePlan(
   }
 
   // Caching the snapshot version here and use this if it is snapshot release
-  const snapshotSuffix =
-    refinedSnapshot &&
-    getSnapshotSuffix(
-      refinedConfig.snapshot.prereleaseTemplate,
-      refinedSnapshot,
-    );
+  const snapshotSuffix = refinedSnapshot && getSnapshotSuffix(refinedConfig.snapshot.prereleaseTemplate, refinedSnapshot);
   return {
     changesets: relevantChangesets,
-    releases: [...releases.values()].map((incompleteRelease) => {
-      return _objectSpread2(
-        _objectSpread2({}, incompleteRelease),
-        {},
-        {
-          newVersion: snapshotSuffix
-            ? getSnapshotVersion(
-                incompleteRelease,
-                preInfo,
-                refinedConfig.snapshot.useCalculatedVersion,
-                snapshotSuffix,
-              )
-            : getNewVersion(incompleteRelease, preInfo),
-        },
-      );
+    releases: [...releases.values()].map(incompleteRelease => {
+      return _objectSpread2(_objectSpread2({}, incompleteRelease), {}, {
+        newVersion: snapshotSuffix ? getSnapshotVersion(incompleteRelease, preInfo, refinedConfig.snapshot.useCalculatedVersion, snapshotSuffix) : getNewVersion(incompleteRelease, preInfo)
+      });
     }),
-    preState: preInfo === null || preInfo === void 0 ? void 0 : preInfo.state,
+    preState: preInfo === null || preInfo === void 0 ? void 0 : preInfo.state
   };
 }
 function getRelevantChangesets(changesets, packagesByName, config, preState) {
@@ -700,41 +546,29 @@ function getRelevantChangesets(changesets, packagesByName, config, preState) {
     const skippedPackages = [];
     const notSkippedPackages = [];
     for (const release of changeset.releases) {
-      if (
-        shouldSkipPackage(packagesByName.get(release.name), {
-          ignore: config.ignore,
-          allowPrivatePackages: config.privatePackages.version,
-        })
-      ) {
+      if (shouldSkipPackage(packagesByName.get(release.name), {
+        ignore: config.ignore,
+        allowPrivatePackages: config.privatePackages.version
+      })) {
         skippedPackages.push(release.name);
       } else {
         notSkippedPackages.push(release.name);
       }
     }
     if (skippedPackages.length > 0 && notSkippedPackages.length > 0) {
-      throw new Error(
-        `Found mixed changeset ${changeset.id}\n` +
-          `Found ignored packages: ${skippedPackages.join(' ')}\n` +
-          `Found not ignored packages: ${notSkippedPackages.join(' ')}\n` +
-          'Mixed changesets that contain both ignored and not ignored packages are not allowed',
-      );
+      throw new Error(`Found mixed changeset ${changeset.id}\n` + `Found ignored packages: ${skippedPackages.join(' ')}\n` + `Found not ignored packages: ${notSkippedPackages.join(' ')}\n` + 'Mixed changesets that contain both ignored and not ignored packages are not allowed');
     }
   }
   if (preState && preState.mode !== 'exit') {
     let usedChangesetIds = new Set(preState.changesets);
-    return changesets.filter(
-      (changeset) => !usedChangesetIds.has(changeset.id),
-    );
+    return changesets.filter(changeset => !usedChangesetIds.has(changeset.id));
   }
   return changesets;
 }
 function getHighestPreVersion(packageGroup, packagesByName) {
   let highestPreVersion = 0;
   for (let pkg of packageGroup) {
-    highestPreVersion = Math.max(
-      getPreVersion(packagesByName.get(pkg).packageJson.version),
-      highestPreVersion,
-    );
+    highestPreVersion = Math.max(getPreVersion(packagesByName.get(pkg).packageJson.version), highestPreVersion);
   }
   return highestPreVersion;
 }
@@ -742,28 +576,20 @@ function getPreInfo(changesets, packagesByName, config, preState) {
   if (preState === undefined) {
     return;
   }
-  let updatedPreState = _objectSpread2(
-    _objectSpread2({}, preState),
-    {},
-    {
-      changesets: changesets.map((changeset) => changeset.id),
-      initialVersions: _objectSpread2({}, preState.initialVersions),
-    },
-  );
+  let updatedPreState = _objectSpread2(_objectSpread2({}, preState), {}, {
+    changesets: changesets.map(changeset => changeset.id),
+    initialVersions: _objectSpread2({}, preState.initialVersions)
+  });
   for (const [, pkg] of packagesByName) {
     if (updatedPreState.initialVersions[pkg.packageJson.name] === undefined) {
-      updatedPreState.initialVersions[pkg.packageJson.name] =
-        pkg.packageJson.version;
+      updatedPreState.initialVersions[pkg.packageJson.name] = pkg.packageJson.version;
     }
   }
   // Populate preVersion
   // preVersion is the map between package name and its next pre version number.
   let preVersions = new Map();
   for (const [, pkg] of packagesByName) {
-    preVersions.set(
-      pkg.packageJson.name,
-      getPreVersion(pkg.packageJson.version),
-    );
+    preVersions.set(pkg.packageJson.name, getPreVersion(pkg.packageJson.version));
   }
   for (let fixedGroup of config.fixed) {
     let highestPreVersion = getHighestPreVersion(fixedGroup, packagesByName);
@@ -779,7 +605,7 @@ function getPreInfo(changesets, packagesByName, config, preState) {
   }
   return {
     state: updatedPreState,
-    preVersions,
+    preVersions
   };
 }
 

--- a/packages/enhanced/src/lib/sharing/ConsumeSharedPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/ConsumeSharedPlugin.ts
@@ -460,7 +460,18 @@ class ConsumeSharedPlugin {
     compiler.hooks.thisCompilation.tap(
       PLUGIN_NAME,
       (compilation: Compilation, { normalModuleFactory }) => {
-        compilation.dependencyFactories.set(
+        const dependencyFactories =
+          (compilation as Compilation & {
+            dependencyFactories?: Map<unknown, unknown>;
+          }).dependencyFactories ||
+          new Map<unknown, unknown>();
+        (
+          compilation as Compilation & {
+            dependencyFactories?: Map<unknown, unknown>;
+          }
+        ).dependencyFactories = dependencyFactories;
+
+        dependencyFactories.set(
           ConsumeSharedFallbackDependency,
           normalModuleFactory,
         );

--- a/packages/enhanced/src/lib/sharing/tree-shaking/CollectSharedEntryPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/tree-shaking/CollectSharedEntryPlugin.ts
@@ -84,34 +84,51 @@ class CollectSharedEntryPlugin {
   apply(compiler: Compiler): void {
     const { sharedOptions } = this;
     const { _collectedEntries: collectedEntries } = this;
+    const tappedFactories = new WeakSet<object>();
+    const tapNormalModuleFactory = (normalModuleFactory: any) => {
+      if (
+        !normalModuleFactory ||
+        typeof normalModuleFactory !== 'object' ||
+        tappedFactories.has(normalModuleFactory)
+      ) {
+        return;
+      }
+      if (!normalModuleFactory.hooks?.module?.tap) {
+        return;
+      }
+      tappedFactories.add(normalModuleFactory);
+      normalModuleFactory.hooks.module.tap(
+        'CollectSharedEntryPlugin',
+        (module, { resource }) => {
+          if (!resource || !('rawRequest' in module)) {
+            return module;
+          }
+          const matchedSharedOption = sharedOptions.find(
+            (item) => item[0] === (module.rawRequest as string),
+          );
+          if (!matchedSharedOption) {
+            return module;
+          }
+          const [sharedName] = matchedSharedOption;
+          const sharedVersion = inferPkgVersionFromResource(resource);
+          if (!sharedVersion) {
+            return module;
+          }
+          collectedEntries[sharedName] ||= { requests: [] };
+          collectedEntries[sharedName].requests.push([resource, sharedVersion]);
+          return module;
+        },
+      );
+    };
+
+    (compiler.hooks as any).normalModuleFactory?.tap?.(
+      'CollectSharedEntryPlugin',
+      tapNormalModuleFactory,
+    );
     compiler.hooks.compilation.tap(
       'CollectSharedEntryPlugin',
-      (_compilation, { normalModuleFactory }) => {
-        normalModuleFactory.hooks.module.tap(
-          'CollectSharedEntryPlugin',
-          (module, { resource }, resolveData) => {
-            if (!resource || !('rawRequest' in module)) {
-              return module;
-            }
-            const matchedSharedOption = sharedOptions.find(
-              (item) => item[0] === (module.rawRequest as string),
-            );
-            if (!matchedSharedOption) {
-              return module;
-            }
-            const [sharedName, _] = matchedSharedOption;
-            const sharedVersion = inferPkgVersionFromResource(resource);
-            if (!sharedVersion) {
-              return module;
-            }
-            collectedEntries[sharedName] ||= { requests: [] };
-            collectedEntries[sharedName].requests.push([
-              resource,
-              sharedVersion,
-            ]);
-            return module;
-          },
-        );
+      (_compilation, params) => {
+        tapNormalModuleFactory(params?.normalModuleFactory);
       },
     );
 

--- a/packages/enhanced/src/lib/sharing/tree-shaking/IndependentSharedPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/tree-shaking/IndependentSharedPlugin.ts
@@ -58,6 +58,39 @@ const resolveOutputDir = (outputDir: string, shareName?: string) => {
   return shareName ? path.join(outputDir, encodeName(shareName)) : outputDir;
 };
 
+const resolveShareRequest = (shareName: string, shareConfig?: SharedConfig) => {
+  const request =
+    shareConfig?.request ||
+    shareConfig?.import ||
+    shareConfig?.packageName ||
+    shareConfig?.shareKey ||
+    shareName;
+  return typeof request === 'string' && request ? request : null;
+};
+
+const resolveShareVersion = (
+  context: string,
+  shareName: string,
+  shareConfig?: SharedConfig,
+) => {
+  if (typeof shareConfig?.version === 'string' && shareConfig.version) {
+    return shareConfig.version;
+  }
+  const request = resolveShareRequest(shareName, shareConfig);
+  if (!request) {
+    return null;
+  }
+  try {
+    const pkgJsonPath = require.resolve(`${request}/package.json`, {
+      paths: [context],
+    });
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+    return typeof pkg?.version === 'string' && pkg.version ? pkg.version : null;
+  } catch {
+    return null;
+  }
+};
+
 export interface IndependentSharePluginOptions {
   name: string;
   shared: moduleFederationPlugin.Shared;
@@ -246,7 +279,20 @@ export default class IndependentSharedPlugin {
         if (!shareConfig.treeShaking) {
           return;
         }
-        const shareRequests = shareRequestsMap[shareName].requests;
+        const fallbackRequest = resolveShareRequest(shareName, shareConfig);
+        const fallbackVersion = resolveShareVersion(
+          parentCompiler.context,
+          shareName,
+          shareConfig,
+        );
+        const shareRequests =
+          shareRequestsMap[shareName]?.requests ||
+          (fallbackRequest && fallbackVersion
+            ? [[fallbackRequest, fallbackVersion] as [string, string]]
+            : []);
+        if (!shareRequests.length) {
+          return;
+        }
         await Promise.all(
           shareRequests.map(async ([request, version]) => {
             const sharedConfig = sharedOptions.find(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,7 +956,7 @@ importers:
         version: 0.80.0(@babel/core@7.28.6)
       '@react-native/eslint-config':
         specifier: 0.80.0
-        version: 0.80.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4)))(prettier@2.8.8)(typescript@5.0.4)
+        version: 0.80.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)))(prettier@2.8.8)(typescript@5.0.4)
       '@react-native/metro-config':
         specifier: 0.80.0
         version: 0.80.0(@babel/core@7.28.6)
@@ -992,7 +992,7 @@ importers:
         version: 9.26.0(hono@4.11.10)(jiti@2.6.1)
       jest:
         specifier: ^29.6.3
-        version: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))
+        version: 29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4))
       nodemon:
         specifier: ^3.1.9
         version: 3.1.11
@@ -1044,7 +1044,7 @@ importers:
         version: 0.80.0(@babel/core@7.28.6)
       '@react-native/eslint-config':
         specifier: 0.80.0
-        version: 0.80.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4)))(prettier@2.8.8)(typescript@5.0.4)
+        version: 0.80.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)))(prettier@2.8.8)(typescript@5.0.4)
       '@react-native/metro-config':
         specifier: 0.80.0
         version: 0.80.0(@babel/core@7.28.6)
@@ -1080,7 +1080,7 @@ importers:
         version: 9.26.0(hono@4.11.10)(jiti@2.6.1)
       jest:
         specifier: ^29.6.3
-        version: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))
+        version: 29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4))
       nodemon:
         specifier: ^3.1.9
         version: 3.1.11
@@ -2046,7 +2046,7 @@ importers:
         version: 18.3.7(@types/react@18.3.11)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.9.3))
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
@@ -2095,7 +2095,7 @@ importers:
         version: 18.3.7(@types/react@18.3.11)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.9.3))
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
@@ -2126,7 +2126,7 @@ importers:
         version: 1.2.6(@rsbuild/core@1.7.3)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(vue@3.5.27(typescript@5.9.3))
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.9.3))
       typescript:
         specifier: ^5.4.2
         version: 5.9.3
@@ -2246,7 +2246,7 @@ importers:
         version: 0.5.1
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.9.3))
       typescript:
         specifier: ^5.4.2
         version: 5.9.3
@@ -2569,10 +2569,10 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(typescript@5.9.3)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/plugin-server':
         specifier: 2.68.0
         version: 2.68.0(@babel/traverse@7.29.0)(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2607,14 +2607,14 @@ importers:
         specifier: ~3.0.2
         version: 3.0.2
       ts-node:
-        specifier: ~10.8.1
-        version: 10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4)
+        specifier: 10.9.2
+        version: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3)
       tsconfig-paths:
-        specifier: ~3.14.1
-        version: 3.14.2
+        specifier: 4.2.0
+        version: 4.2.0
       typescript:
-        specifier: ~5.0.4
-        version: 5.0.4
+        specifier: 5.9.3
+        version: 5.9.3
 
   apps/shared-tree-shaking/no-server/provider:
     dependencies:
@@ -2639,13 +2639,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(typescript@5.9.3)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(typescript@5.9.3)
       '@modern-js/plugin-server':
         specifier: 2.68.0
         version: 2.68.0(@babel/traverse@7.29.0)(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2676,9 +2676,15 @@ importers:
       serve:
         specifier: 14.2.5
         version: 14.2.5
+      ts-node:
+        specifier: 10.9.2
+        version: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3)
+      tsconfig-paths:
+        specifier: 4.2.0
+        version: 4.2.0
       typescript:
-        specifier: ~5.0.4
-        version: 5.0.4
+        specifier: 5.9.3
+        version: 5.9.3
 
   apps/shared-tree-shaking/with-server/host:
     dependencies:
@@ -2703,13 +2709,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(typescript@5.9.3)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(typescript@5.9.3)
       '@modern-js/plugin-server':
         specifier: 2.68.0
         version: 2.68.0(@babel/traverse@7.29.0)(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2747,14 +2753,14 @@ importers:
         specifier: 14.2.5
         version: 14.2.5
       ts-node:
-        specifier: ~10.8.1
-        version: 10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4)
+        specifier: 10.9.2
+        version: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3)
       tsconfig-paths:
-        specifier: ~3.14.1
-        version: 3.14.2
+        specifier: 4.2.0
+        version: 4.2.0
       typescript:
-        specifier: ~5.0.4
-        version: 5.0.4
+        specifier: 5.9.3
+        version: 5.9.3
 
   apps/shared-tree-shaking/with-server/provider:
     dependencies:
@@ -2779,13 +2785,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(typescript@5.9.3)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(typescript@5.9.3)
       '@modern-js/plugin-server':
         specifier: 2.68.0
         version: 2.68.0(@babel/traverse@7.29.0)(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2813,9 +2819,15 @@ importers:
       rimraf:
         specifier: ~3.0.2
         version: 3.0.2
+      ts-node:
+        specifier: 10.9.2
+        version: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3)
+      tsconfig-paths:
+        specifier: 4.2.0
+        version: 4.2.0
       typescript:
-        specifier: ~5.0.4
-        version: 5.0.4
+        specifier: 5.9.3
+        version: 5.9.3
 
   apps/website-new:
     dependencies:
@@ -2827,13 +2839,13 @@ importers:
         version: link:../../packages/rspress-plugin
       '@rsbuild/plugin-sass':
         specifier: ^1.5.0
-        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.36.1))
+        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))
       '@rspress/core':
         specifier: 2.0.3
-        version: 2.0.3(@module-federation/runtime-tools@2.1.0)(@types/react@19.2.10)(core-js@3.36.1)(webpack-hot-middleware@2.26.1)
+        version: 2.0.3(@module-federation/runtime-tools@2.1.0)(@types/react@19.2.10)(core-js@3.48.0)(webpack-hot-middleware@2.26.1)
       '@rspress/plugin-llms':
         specifier: 2.0.1
-        version: 2.0.1(@rspress/core@2.0.3(@module-federation/runtime-tools@2.1.0)(@types/react@19.2.10)(core-js@3.36.1)(webpack-hot-middleware@2.26.1))
+        version: 2.0.1(@rspress/core@2.0.3(@module-federation/runtime-tools@2.1.0)(@types/react@19.2.10)(core-js@3.48.0)(webpack-hot-middleware@2.26.1))
       framer-motion:
         specifier: ^10.0.0
         version: 10.18.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -2851,7 +2863,7 @@ importers:
         version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))
       xgplayer:
         specifier: ^3.0.16
-        version: 3.0.23(core-js@3.36.1)
+        version: 3.0.23(core-js@3.48.0)
     devDependencies:
       '@types/node':
         specifier: ^20.19.5
@@ -3660,10 +3672,10 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: 2.70.5
-        version: 2.70.5(@rspack/core@1.7.5(@swc/helpers@0.5.18))(@swc/core@1.15.10(@swc/helpers@0.5.18))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@4.41.0)(typescript@5.8.2)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
+        version: 2.70.5(@rspack/core@1.7.5(@swc/helpers@0.5.18))(@swc/core@1.15.10(@swc/helpers@0.5.18))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@4.41.0)(typescript@5.8.2)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
       '@modern-js/module-tools':
         specifier: 2.70.5
-        version: 2.70.5(@types/node@20.19.5)(typescript@5.8.2)
+        version: 2.70.5(@types/node@22.19.9)(typescript@5.8.2)
       '@modern-js/runtime':
         specifier: 2.70.5
         version: 2.70.5(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@19.2.4)
@@ -3684,7 +3696,7 @@ importers:
         version: 1.4.5(@rsbuild/core@1.3.21)(webpack-hot-middleware@2.26.1)
       '@rslib/core':
         specifier: 0.18.5
-        version: 0.18.5(@microsoft/api-extractor@7.55.2(@types/node@20.19.5))(typescript@5.8.2)
+        version: 0.18.5(@microsoft/api-extractor@7.55.2(@types/node@22.19.9))(typescript@5.8.2)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.11
@@ -3748,10 +3760,10 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.8.2)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4))
+        version: 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.8.2)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4))
       '@modern-js/module-tools':
         specifier: 2.70.5
-        version: 2.70.5(@types/node@20.19.5)(typescript@5.8.2)
+        version: 2.70.5(@types/node@22.19.9)(typescript@5.8.2)
       '@modern-js/runtime':
         specifier: 3.0.1
         version: 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@18.3.1)
@@ -3772,7 +3784,7 @@ importers:
         version: 1.4.5(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(webpack-hot-middleware@2.26.1)
       '@rslib/core':
         specifier: 0.18.5
-        version: 0.18.5(@microsoft/api-extractor@7.55.2(@types/node@20.19.5))(typescript@5.8.2)
+        version: 0.18.5(@microsoft/api-extractor@7.55.2(@types/node@22.19.9))(typescript@5.8.2)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.11
@@ -25464,20 +25476,6 @@ packages:
   ts-morph@12.0.0:
     resolution: {integrity: sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==}
 
-  ts-node@10.8.2:
-    resolution: {integrity: sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-
   ts-node@10.9.1:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
@@ -25534,9 +25532,6 @@ packages:
   tsconfig-paths-webpack-plugin@4.2.0:
     resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
     engines: {node: '>=10.13.0'}
-
-  tsconfig-paths@3.14.2:
-    resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -29021,6 +29016,39 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@changesets/cli@2.29.8(@types/node@22.19.9)':
+    dependencies:
+      '@changesets/apply-release-plan': 7.0.14
+      '@changesets/assemble-release-plan': link:packages/assemble-release-plan
+      '@changesets/changelog-git': 0.2.1
+      '@changesets/config': 3.1.2
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/get-release-plan': 4.0.14
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.6
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@changesets/write': 0.4.0
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.9)
+      '@manypkg/get-packages': 1.1.3
+      ansi-colors: 4.1.3
+      ci-info: 3.9.0
+      enquirer: 2.4.1
+      fs-extra: 7.0.1
+      mri: 1.2.0
+      p-limit: 2.3.0
+      package-manager-detector: 0.2.11
+      picocolors: 1.1.1
+      resolve-from: 5.0.0
+      semver: 7.6.3
+      spawndamnit: 3.0.1
+      term-size: 2.2.1
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@changesets/config@3.1.2':
     dependencies:
       '@changesets/errors': 0.2.0
@@ -30476,6 +30504,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.5
 
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.9)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.9
+
   '@isaacs/balanced-match@4.0.1': {}
 
   '@isaacs/brace-expansion@5.0.0':
@@ -30605,6 +30640,41 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
       jest-config: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.5
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -31348,7 +31418,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/app-tools@2.70.5(@rspack/core@1.7.5(@swc/helpers@0.5.18))(@swc/core@1.15.10(@swc/helpers@0.5.18))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@4.41.0)(typescript@5.8.2)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/app-tools@2.70.5(@rspack/core@1.7.5(@swc/helpers@0.5.18))(@swc/core@1.15.10(@swc/helpers@0.5.18))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@4.41.0)(typescript@5.8.2)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/parser': 7.28.6
       '@babel/traverse': 7.28.6
@@ -31361,7 +31431,7 @@ snapshots:
       '@modern-js/plugin-v2': 2.70.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/prod-server': 2.70.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/rsbuild-plugin-esbuild': 2.70.5(@swc/core@1.15.10(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
-      '@modern-js/server': 2.70.5(@babel/traverse@7.28.6)(@rsbuild/core@1.7.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2))(tsconfig-paths@4.2.0)
+      '@modern-js/server': 2.70.5(@babel/traverse@7.28.6)(@rsbuild/core@1.7.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2))(tsconfig-paths@4.2.0)
       '@modern-js/server-core': 2.70.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/server-utils': 2.70.5(@babel/traverse@7.28.6)(@rsbuild/core@1.7.3)
       '@modern-js/types': 2.70.5
@@ -31379,7 +31449,7 @@ snapshots:
       pkg-types: 1.3.1
       std-env: 3.10.0
     optionalDependencies:
-      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2)
+      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2)
       tsconfig-paths: 4.2.0
     transitivePeerDependencies:
       - '@parcel/css'
@@ -31409,57 +31479,6 @@ snapshots:
       - webpack-dev-server
       - webpack-hot-middleware
       - webpack-plugin-serve
-
-  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
-    dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
-      '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/prod-server': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/server': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)
-      '@modern-js/server-core': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/server-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/types': 3.0.1
-      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)
-      '@swc/helpers': 0.5.18
-      es-module-lexer: 1.7.0
-      esbuild: 0.25.5
-      esbuild-register: 3.6.0(esbuild@0.25.5)
-      flatted: 3.3.3
-      mlly: 1.8.0
-      ndepe: 0.1.13(encoding@0.1.13)(rollup@4.57.0)
-      pkg-types: 1.3.1
-      std-env: 3.10.0
-    optionalDependencies:
-      ts-node: 10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4)
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/css'
-      - bufferutil
-      - clean-css
-      - core-js
-      - csso
-      - debug
-      - devcert
-      - encoding
-      - lightningcss
-      - react
-      - react-dom
-      - rollup
-      - supports-color
-      - tslib
-      - typescript
-      - utf-8-validate
-      - webpack
-      - webpack-hot-middleware
 
   '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
@@ -31512,17 +31531,17 @@ snapshots:
       - webpack
       - webpack-hot-middleware
 
-  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.8.2)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@babel/parser': 7.29.0
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.8.2)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/prod-server': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/server': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2))(tsconfig-paths@4.2.0)
+      '@modern-js/server': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)
       '@modern-js/server-core': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/server-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/types': 3.0.1
@@ -31538,7 +31557,58 @@ snapshots:
       pkg-types: 1.3.1
       std-env: 3.10.0
     optionalDependencies:
-      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2)
+      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3)
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/css'
+      - bufferutil
+      - clean-css
+      - core-js
+      - csso
+      - debug
+      - devcert
+      - encoding
+      - lightningcss
+      - react
+      - react-dom
+      - rollup
+      - supports-color
+      - tslib
+      - typescript
+      - utf-8-validate
+      - webpack
+      - webpack-hot-middleware
+
+  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(core-js@3.48.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.8.2)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.8.2)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/prod-server': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/server': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2))(tsconfig-paths@4.2.0)
+      '@modern-js/server-core': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/server-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/types': 3.0.1
+      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)
+      '@swc/helpers': 0.5.18
+      es-module-lexer: 1.7.0
+      esbuild: 0.25.5
+      esbuild-register: 3.6.0(esbuild@0.25.5)
+      flatted: 3.3.3
+      mlly: 1.8.0
+      ndepe: 0.1.13(encoding@0.1.13)(rollup@4.57.0)
+      pkg-types: 1.3.1
+      std-env: 3.10.0
+    optionalDependencies:
+      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2)
       tsconfig-paths: 4.2.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -31797,6 +31867,57 @@ snapshots:
       - webpack
       - webpack-hot-middleware
 
+  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.1.0)(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+    dependencies:
+      '@modern-js/flight-server-transform-plugin': 3.0.1
+      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)
+      '@rsbuild/plugin-assets-retry': 1.5.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))
+      '@rsbuild/plugin-react': 1.4.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(webpack-hot-middleware@2.26.1)
+      '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))
+      '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))
+      '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))
+      '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(typescript@5.9.3)(webpack-hot-middleware@2.26.1)
+      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(tslib@2.8.1)(typescript@5.9.3)
+      '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))
+      '@swc/core': 1.15.10(@swc/helpers@0.5.18)
+      '@swc/helpers': 0.5.18
+      autoprefixer: 10.4.24(postcss@8.5.6)
+      browserslist: 4.28.1
+      core-js: 3.48.0
+      cssnano: 6.1.2(postcss@8.5.6)
+      html-minifier-terser: 7.2.0
+      lodash: 4.17.23
+      postcss: 8.5.6
+      postcss-custom-properties: 13.3.12(postcss@8.5.6)
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.5.6)
+      postcss-font-variant: 5.0.0(postcss@8.5.6)
+      postcss-initial: 4.0.1(postcss@8.5.6)
+      postcss-media-minmax: 5.0.0(postcss@8.5.6)
+      postcss-nesting: 12.1.5(postcss@8.5.6)
+      postcss-page-break: 3.0.4(postcss@8.5.6)
+      rspack-manifest-plugin: 5.2.1(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))
+      ts-deepmerge: 7.0.3
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/css'
+      - clean-css
+      - csso
+      - esbuild
+      - lightningcss
+      - react
+      - react-dom
+      - supports-color
+      - tslib
+      - typescript
+      - webpack
+      - webpack-hot-middleware
+
   '@modern-js/core@2.70.2':
     dependencies:
       '@modern-js/node-bundle-require': 2.70.2
@@ -31878,7 +31999,7 @@ snapshots:
       - debug
       - supports-color
 
-  '@modern-js/module-tools@2.70.5(@types/node@20.19.5)(typescript@5.8.2)':
+  '@modern-js/module-tools@2.70.5(@types/node@22.19.9)(typescript@5.8.2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@ast-grep/napi': 0.35.0
@@ -31886,7 +32007,7 @@ snapshots:
       '@babel/types': 7.28.6
       '@modern-js/core': 2.70.5
       '@modern-js/plugin': 2.70.5
-      '@modern-js/plugin-changeset': 2.70.5(@types/node@20.19.5)
+      '@modern-js/plugin-changeset': 2.70.5(@types/node@22.19.9)
       '@modern-js/plugin-i18n': 2.70.5
       '@modern-js/swc-plugins': 0.6.11(@swc/helpers@0.5.18)
       '@modern-js/types': 2.70.5
@@ -31945,9 +32066,9 @@ snapshots:
       - '@types/node'
       - debug
 
-  '@modern-js/plugin-changeset@2.70.5(@types/node@20.19.5)':
+  '@modern-js/plugin-changeset@2.70.5(@types/node@22.19.9)':
     dependencies:
-      '@changesets/cli': 2.29.8(@types/node@20.19.5)
+      '@changesets/cli': 2.29.8(@types/node@22.19.9)
       '@changesets/git': 2.0.0
       '@changesets/read': 0.6.6
       '@modern-js/plugin-i18n': 2.70.5
@@ -32512,7 +32633,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modern-js/server@2.70.5(@babel/traverse@7.28.6)(@rsbuild/core@1.7.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2))(tsconfig-paths@4.2.0)':
+  '@modern-js/server@2.70.5(@babel/traverse@7.28.6)(@rsbuild/core@1.7.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2))(tsconfig-paths@4.2.0)':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/register': 7.28.6(@babel/core@7.28.6)
@@ -32529,7 +32650,7 @@ snapshots:
       path-to-regexp: 6.3.0
       ws: 8.18.0
     optionalDependencies:
-      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2)
+      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2)
       tsconfig-paths: 4.2.0
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -32539,32 +32660,6 @@ snapshots:
       - react
       - react-dom
       - supports-color
-      - utf-8-validate
-
-  '@modern-js/server@3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)':
-    dependencies:
-      '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/server-core': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/server-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/types': 3.0.1
-      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@swc/helpers': 0.5.18
-      axios: 1.13.6
-      connect-history-api-fallback: 2.0.0
-      http-compression: 1.0.6
-      minimatch: 3.1.2
-      path-to-regexp: 6.3.0
-      ws: 8.19.0
-    optionalDependencies:
-      ts-node: 10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4)
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - bufferutil
-      - core-js
-      - debug
-      - react
-      - react-dom
       - utf-8-validate
 
   '@modern-js/server@3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)':
@@ -32593,7 +32688,7 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@modern-js/server@3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2))(tsconfig-paths@4.2.0)':
+  '@modern-js/server@3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)':
     dependencies:
       '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/server-core': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -32608,7 +32703,33 @@ snapshots:
       path-to-regexp: 6.3.0
       ws: 8.19.0
     optionalDependencies:
-      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2)
+      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3)
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - bufferutil
+      - core-js
+      - debug
+      - react
+      - react-dom
+      - utf-8-validate
+
+  '@modern-js/server@3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2))(tsconfig-paths@4.2.0)':
+    dependencies:
+      '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/server-core': 3.0.1(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/server-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/types': 3.0.1
+      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@swc/helpers': 0.5.18
+      axios: 1.13.6
+      connect-history-api-fallback: 2.0.0
+      http-compression: 1.0.6
+      minimatch: 3.1.2
+      path-to-regexp: 6.3.0
+      ws: 8.19.0
+    optionalDependencies:
+      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2)
       tsconfig-paths: 4.2.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -36577,6 +36698,27 @@ snapshots:
       - supports-color
       - typescript
 
+  '@react-native/eslint-config@0.80.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)))(prettier@2.8.8)(typescript@5.0.4)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.28.6)(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
+      '@react-native/eslint-plugin': 0.80.0
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4)
+      eslint: 9.26.0(hono@4.11.10)(jiti@2.6.1)
+      eslint-config-prettier: 8.10.2(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
+      eslint-plugin-eslint-comments: 3.2.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
+      eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.28.6)(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1)))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)))(typescript@5.0.4)
+      eslint-plugin-react: 7.37.2(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
+      eslint-plugin-react-native: 4.1.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
+      prettier: 2.8.8
+    transitivePeerDependencies:
+      - jest
+      - supports-color
+      - typescript
+
   '@react-native/eslint-plugin@0.80.0': {}
 
   '@react-native/gradle-plugin@0.80.0': {}
@@ -37133,16 +37275,6 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.36.1)':
-    dependencies:
-      '@rspack/core': 2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18)
-      '@swc/helpers': 0.5.18
-      jiti: 2.6.1
-    optionalDependencies:
-      core-js: 3.36.1
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
   '@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)':
     dependencies:
       '@rspack/core': 2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18)
@@ -37466,14 +37598,6 @@ snapshots:
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.36.1))(webpack-hot-middleware@2.26.1)':
-    dependencies:
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.36.1)
-      '@rspack/plugin-react-refresh': 1.6.0(react-refresh@0.18.0)(webpack-hot-middleware@2.26.1)
-      react-refresh: 0.18.0
-    transitivePeerDependencies:
-      - webpack-hot-middleware
-
   '@rsbuild/plugin-react@1.4.5(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)
@@ -37530,9 +37654,9 @@ snapshots:
       reduce-configs: 1.1.1
       sass-embedded: 1.97.3
 
-  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.36.1))':
+  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.36.1)
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.6
@@ -37633,6 +37757,20 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
+  '@rsbuild/plugin-svgr@1.3.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(typescript@5.9.3)(webpack-hot-middleware@2.26.1)':
+    dependencies:
+      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)
+      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(webpack-hot-middleware@2.26.1)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
+      deepmerge: 4.3.1
+      loader-utils: 3.3.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+      - webpack-hot-middleware
+
   '@rsbuild/plugin-toml@1.1.1(@rsbuild/core@1.7.2)':
     dependencies:
       toml: 3.0.0
@@ -37690,6 +37828,19 @@ snapshots:
       json5: 2.2.3
       reduce-configs: 1.1.1
       ts-checker-rspack-plugin: 1.2.6(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(tslib@2.8.1)(typescript@5.8.2)
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - tslib
+      - typescript
+
+  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(tslib@2.8.1)(typescript@5.9.3)':
+    dependencies:
+      deepmerge: 4.3.1
+      json5: 2.2.3
+      reduce-configs: 1.1.1
+      ts-checker-rspack-plugin: 1.2.6(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.18))(tslib@2.8.1)(typescript@5.9.3)
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)
     transitivePeerDependencies:
@@ -37837,12 +37988,12 @@ snapshots:
       '@microsoft/api-extractor': 7.55.2(@types/node@22.19.9)
       typescript: 5.9.3
 
-  '@rslib/core@0.18.5(@microsoft/api-extractor@7.55.2(@types/node@20.19.5))(typescript@5.8.2)':
+  '@rslib/core@0.18.5(@microsoft/api-extractor@7.55.2(@types/node@22.19.9))(typescript@5.8.2)':
     dependencies:
       '@rsbuild/core': 1.7.3
-      rsbuild-plugin-dts: 0.18.5(@microsoft/api-extractor@7.55.2(@types/node@20.19.5))(@rsbuild/core@1.7.3)(typescript@5.8.2)
+      rsbuild-plugin-dts: 0.18.5(@microsoft/api-extractor@7.55.2(@types/node@22.19.9))(@rsbuild/core@1.7.3)(typescript@5.8.2)
     optionalDependencies:
-      '@microsoft/api-extractor': 7.55.2(@types/node@20.19.5)
+      '@microsoft/api-extractor': 7.55.2(@types/node@22.19.9)
       typescript: 5.8.2
     transitivePeerDependencies:
       - '@typescript/native-preview'
@@ -38485,13 +38636,13 @@ snapshots:
       - supports-color
       - webpack-hot-middleware
 
-  '@rspress/core@2.0.3(@module-federation/runtime-tools@2.1.0)(@types/react@19.2.10)(core-js@3.36.1)(webpack-hot-middleware@2.26.1)':
+  '@rspress/core@2.0.3(@module-federation/runtime-tools@2.1.0)(@types/react@19.2.10)(core-js@3.48.0)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.10)(react@19.2.4)
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.36.1)
-      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.36.1))(webpack-hot-middleware@2.26.1)
-      '@rspress/shared': 2.0.3(@module-federation/runtime-tools@2.1.0)(core-js@3.36.1)
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)
+      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0))(webpack-hot-middleware@2.26.1)
+      '@rspress/shared': 2.0.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)
       '@shikijs/rehype': 3.21.0
       '@types/unist': 3.0.3
       '@unhead/react': 2.1.4(react@19.2.4)
@@ -38536,9 +38687,9 @@ snapshots:
       - supports-color
       - webpack-hot-middleware
 
-  '@rspress/plugin-llms@2.0.1(@rspress/core@2.0.3(@module-federation/runtime-tools@2.1.0)(@types/react@19.2.10)(core-js@3.36.1)(webpack-hot-middleware@2.26.1))':
+  '@rspress/plugin-llms@2.0.1(@rspress/core@2.0.3(@module-federation/runtime-tools@2.1.0)(@types/react@19.2.10)(core-js@3.48.0)(webpack-hot-middleware@2.26.1))':
     dependencies:
-      '@rspress/core': 2.0.3(@module-federation/runtime-tools@2.1.0)(@types/react@19.2.10)(core-js@3.36.1)(webpack-hot-middleware@2.26.1)
+      '@rspress/core': 2.0.3(@module-federation/runtime-tools@2.1.0)(@types/react@19.2.10)(core-js@3.48.0)(webpack-hot-middleware@2.26.1)
       remark-mdx: 3.1.1
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -38546,17 +38697,6 @@ snapshots:
       unist-util-visit: 5.1.0
     transitivePeerDependencies:
       - supports-color
-
-  '@rspress/shared@2.0.3(@module-federation/runtime-tools@2.1.0)(core-js@3.36.1)':
-    dependencies:
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@2.1.0)(core-js@3.36.1)
-      '@shikijs/rehype': 3.21.0
-      gray-matter: 4.0.3
-      lodash-es: 4.17.23
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - core-js
 
   '@rspress/shared@2.0.3(@module-federation/runtime-tools@2.1.0)(core-js@3.48.0)':
     dependencies:
@@ -44597,6 +44737,21 @@ snapshots:
       - supports-color
       - ts-node
 
+  create-jest@29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   create-require@1.1.1: {}
 
   cron-parser@4.9.0:
@@ -46095,7 +46250,7 @@ snapshots:
       eslint: 9.26.0(hono@4.11.10)(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1)))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1)))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1)))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.1(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
       eslint-plugin-react: 7.37.2(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
@@ -46140,7 +46295,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1)))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1)))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -46310,7 +46465,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1)))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1)))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -46346,6 +46501,17 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4)
       jest: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4))
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)))(typescript@5.0.4):
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4)
+      eslint: 9.26.0(hono@4.11.10)(jiti@2.6.1)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4))(eslint@9.26.0(hono@4.11.10)(jiti@2.6.1))(typescript@5.0.4)
+      jest: 29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -49253,6 +49419,25 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-config@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.6
@@ -49342,6 +49527,68 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.5
       ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.6)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.0
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.5
+      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.6)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.0
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.9
+      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -49622,6 +49869,18 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4)):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -52595,6 +52854,14 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.38
       ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3)
+
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.9.3)):
+    dependencies:
+      lilconfig: 3.1.3
+      yaml: 2.8.2
+    optionalDependencies:
+      postcss: 8.4.38
+      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.9.3)
 
   postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.4.5)):
     dependencies:
@@ -56020,12 +56287,12 @@ snapshots:
       '@microsoft/api-extractor': 7.55.2(@types/node@22.19.9)
       typescript: 5.9.3
 
-  rsbuild-plugin-dts@0.18.5(@microsoft/api-extractor@7.55.2(@types/node@20.19.5))(@rsbuild/core@1.7.3)(typescript@5.8.2):
+  rsbuild-plugin-dts@0.18.5(@microsoft/api-extractor@7.55.2(@types/node@22.19.9))(@rsbuild/core@1.7.3)(typescript@5.8.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.7.3
     optionalDependencies:
-      '@microsoft/api-extractor': 7.55.2(@types/node@20.19.5)
+      '@microsoft/api-extractor': 7.55.2(@types/node@22.19.9)
       typescript: 5.8.2
 
   rsbuild-plugin-dts@0.9.2(@microsoft/api-extractor@7.55.2(@types/node@22.19.9))(@rsbuild/core@1.4.0-beta.2)(typescript@5.9.3):
@@ -57464,6 +57731,33 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
+  tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.9.3)):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 2.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.4.38
+      postcss-import: 15.1.0(postcss@8.4.38)
+      postcss-js: 4.1.0(postcss@8.4.38)
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.9.3))
+      postcss-nested: 6.2.0(postcss@8.4.38)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.8
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - ts-node
+
   tailwindcss@3.4.16(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.6.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -58114,26 +58408,6 @@ snapshots:
       '@ts-morph/common': 0.11.1
       code-block-writer: 10.1.1
 
-  ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.0.4):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.5
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.0.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.10(@swc/helpers@0.5.18)
-
   ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@14.18.33)(typescript@4.9.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -58216,27 +58490,6 @@ snapshots:
       '@swc/core': 1.15.10(@swc/helpers@0.5.18)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.8.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.5
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.8.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.10(@swc/helpers@0.5.18)
-    optional: true
-
   ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.5)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -58257,6 +58510,27 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.10(@swc/helpers@0.5.18)
 
+  ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.0.4):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.19.9
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.0.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.10(@swc/helpers@0.5.18)
+    optional: true
+
   ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -58272,6 +58546,48 @@ snapshots:
       diff: 4.0.4
       make-error: 1.3.6
       typescript: 5.6.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.10(@swc/helpers@0.5.18)
+    optional: true
+
+  ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.8.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.19.9
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.8.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.10(@swc/helpers@0.5.18)
+    optional: true
+
+  ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@22.19.9)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.19.9
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -58304,13 +58620,6 @@ snapshots:
       enhanced-resolve: 5.19.0
       tapable: 2.3.0
       tsconfig-paths: 4.2.0
-
-  tsconfig-paths@3.14.2:
-    dependencies:
-      '@types/json5': 0.0.29
-      json5: 1.0.2
-      minimist: 1.2.8
-      strip-bom: 3.0.0
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -60352,19 +60661,19 @@ snapshots:
     dependencies:
       os-paths: 4.4.0
 
-  xgplayer-subtitles@3.0.23(core-js@3.36.1):
+  xgplayer-subtitles@3.0.23(core-js@3.48.0):
     dependencies:
-      core-js: 3.36.1
+      core-js: 3.48.0
       eventemitter3: 4.0.7
 
-  xgplayer@3.0.23(core-js@3.36.1):
+  xgplayer@3.0.23(core-js@3.48.0):
     dependencies:
-      core-js: 3.36.1
+      core-js: 3.48.0
       danmu.js: 1.2.1
       delegate: 3.2.0
       downloadjs: 1.4.7
       eventemitter3: 4.0.7
-      xgplayer-subtitles: 3.0.23(core-js@3.36.1)
+      xgplayer-subtitles: 3.0.23(core-js@3.48.0)
 
   xml-name-validator@4.0.0: {}
 

--- a/tools/scripts/ci-local.mjs
+++ b/tools/scripts/ci-local.mjs
@@ -464,7 +464,7 @@ const jobs = [
       setupE2E(),
       step('Check CI conditions', async (ctx) => {
         ctx.state.shouldRun = await ciIsAffected(
-          'shared-tree-shaking-with-server-host',
+          'shared-tree-shaking-no-server-host,shared-tree-shaking-no-server-provider,shared-tree-shaking-with-server-host,shared-tree-shaking-with-server-provider',
           ctx,
         );
       }),


### PR DESCRIPTION
## Summary
- widen shared-tree-shaking CI gating so the grouped E2E job considers every served app in the topology
- carry forward local shared-tree-shaking fixture toolchain updates and fallback compiler hardening from the follow-up investigation
- include the local lockfile and formatting changes that were still unpushed after #4485 merged

## Validation
- `git diff --cached --check` before commit
- targeted local investigation and rebuilds for shared-tree-shaking fixtures and `@module-federation/enhanced`

## Known gap
- this is intentionally a draft PR
- the shared-tree-shaking no-server path was still not fully green locally during the follow-up investigation, with the remaining failure surfacing in the fallback compiler path for the provider build
