### PR TITLE
chore(prettier): ignore assemble-release-plan package

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,6 @@ packages/treeshake-server/template/**
 # Task DSL files contain mustache-like placeholders (e.g. `{{assets...}}`)
 # that Prettier currently fails to parse in TSX.
 packages/enhanced/task/**
+
+# Temporarily ignore assemble-release-plan package until build formatting churn is addressed.
+packages/assemble-release-plan/**


### PR DESCRIPTION
## Summary
- add `packages/assemble-release-plan/**` to `.prettierignore`
- stop recurring Prettier churn on generated `assemble-release-plan` source files during package builds

## Why
`pnpm install` + `pnpm build` can rewrite `packages/assemble-release-plan/src/index.ts` as a generated artifact. This creates noisy format deltas unrelated to feature work and can fail formatting gates on otherwise unrelated branches.

This PR intentionally applies a temporary package-level Prettier ignore to unblock CI while we decide on a longer-term fix (for example, preventing tracked source rewrites during build).

## Validation
- `pnpm install`
- `pnpm build`
- `pnpm exec prettier --check packages/assemble-release-plan/src/index.ts`
