### PR TITLE
fix(ci): save turbo cache on pull requests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,7 +86,7 @@ jobs:
         run: node tools/scripts/run-affected-package-tests.mjs
 
       - name: Save Turborepo cache
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && success() && steps.turbo-cache.outputs.cache-hit != 'true' }}
+        if: ${{ success() && steps.turbo-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v5
         with:
           path: .turbo/cache


### PR DESCRIPTION
## Summary
- enable the main CI workflow to save the Turbo cache on successful pull request runs as well as main pushes
- keep the save step gated on successful execution and cache misses only

## Validation
- targeted `actionlint` on `.github/workflows/build-and-test.yml`
