### PR TITLE
fix(enhanced): fix garbled version strings in build stats for shared modules

### DIFF
--- a/.changeset/fix-consume-shared-module-garbled-version-display.md
+++ b/.changeset/fix-consume-shared-module-garbled-version-display.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/enhanced": patch
+---
+
+Fix garbled version strings in webpack build stats for shared modules by parsing raw semver strings before passing them to rangeToString in ConsumeSharedModule's identifier and readableIdentifier methods.

--- a/packages/enhanced/src/lib/sharing/ConsumeSharedModule.ts
+++ b/packages/enhanced/src/lib/sharing/ConsumeSharedModule.ts
@@ -26,7 +26,7 @@ import { normalizeConsumeShareOptions } from './utils';
 import { WEBPACK_MODULE_TYPE_CONSUME_SHARED_MODULE } from '../Constants';
 import type { ConsumeOptions } from '@module-federation/sdk';
 
-const { rangeToString, stringifyHoley } = require(
+const { parseRange, rangeToString, stringifyHoley } = require(
   normalizeWebpackPath('webpack/lib/util/semver'),
 ) as typeof import('webpack/lib/util/semver');
 const { AsyncDependenciesBlock, Module, RuntimeGlobals } = require(
@@ -97,7 +97,12 @@ class ConsumeSharedModule extends Module {
       : shareScope;
 
     return `${WEBPACK_MODULE_TYPE_CONSUME_SHARED_MODULE}|${normalizedShareScope}|${shareKey}|${
-      requiredVersion && rangeToString(requiredVersion)
+      requiredVersion &&
+      rangeToString(
+        typeof requiredVersion === 'string'
+          ? parseRange(requiredVersion)
+          : requiredVersion,
+      )
     }|${strictVersion}|${importResolved}|${singleton}|${eager}|${layer}`;
   }
 
@@ -121,7 +126,13 @@ class ConsumeSharedModule extends Module {
       : shareScope;
 
     return `consume shared module (${normalizedShareScope}) ${shareKey}@${
-      requiredVersion ? rangeToString(requiredVersion) : '*'
+      requiredVersion
+        ? rangeToString(
+            typeof requiredVersion === 'string'
+              ? parseRange(requiredVersion)
+              : requiredVersion,
+          )
+        : '*'
     }${strictVersion ? ' (strict)' : ''}${singleton ? ' (singleton)' : ''}${
       importResolved
         ? ` (fallback: ${requestShortener.shorten(importResolved)})`


### PR DESCRIPTION
## Description
Webpack build stats show garbled version strings for shared modules (e.g. `!=6...3.0...3` instead of `^6.30.3`). This happens because `ConsumeSharedModule`'s display methods pass raw semver strings to `rangeToString()`, which expects parsed arrays.

This fix calls `parseRange()` on raw strings before passing them to `rangeToString()` in `identifier()` and `readableIdentifier()`, without changing runtime behavior.

**Before:**
```
consume shared module (default) react@!=1.6...1.4...0 (singleton)
consume shared module (default) react-router-dom@!=6...3.0...3 (singleton)
```

**After:**
```
consume shared module (default) react@^16.14.0 (singleton)
consume shared module (default) react-router-dom@^6.30.3 (singleton)
```

## Related Issue
No existing issue. This bug was introduced in commit e7fada2 3 years ago, which removed `parseRange()` calls as a workaround for [webpack#17756](https://github.com/webpack/webpack/issues/17756). That webpack bug has since been fixed in webpack 5.92.0 (June 2024, [webpack#18459](https://github.com/webpack/webpack/pull/18459)).

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.