### PR TITLE
Security: Unvalidated key components used to build CDN/object path

### DIFF
--- a/packages/treeshake-server/src/domain/upload/retrieve-cdn-path.ts
+++ b/packages/treeshake-server/src/domain/upload/retrieve-cdn-path.ts
@@ -1,5 +1,13 @@
 import { SERVER_VERSION } from './constant';
 
+const VALID_KEY_COMPONENT = /^[a-zA-Z0-9._-]+$/;
+
+function assertValidKeyComponent(value: string, name: string) {
+  if (!VALID_KEY_COMPONENT.test(value)) {
+    throw new Error(`Invalid ${name}`);
+  }
+}
+
 export function retrieveCDNPath({
   configHash,
   sharedKey,
@@ -7,5 +15,8 @@ export function retrieveCDNPath({
   configHash: string;
   sharedKey: string;
 }) {
+  assertValidKeyComponent(sharedKey, 'sharedKey');
+  assertValidKeyComponent(configHash, 'configHash');
+
   return `tree-shaking-shared/${SERVER_VERSION}/${sharedKey}/${configHash}`;
 }


### PR DESCRIPTION
## Problem

The CDN path is constructed by directly interpolating `sharedKey` and `configHash` into a storage key string. If either value can be influenced by user input, this can enable path/key injection (e.g., unexpected separators, control chars, or namespace collisions), potentially causing overwrite/read of unintended objects.

**Severity**: `medium`
**File**: `packages/treeshake-server/src/domain/upload/retrieve-cdn-path.ts`

## Solution

Validate and normalize `sharedKey` and `configHash` before use (strict allowlist such as `/^[a-zA-Z0-9._-]+$/`), reject separators like `/` when not explicitly intended, and consider encoding components before concatenation.

## Changes

- `packages/treeshake-server/src/domain/upload/retrieve-cdn-path.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
