### PR TITLE
Security: Global runtime environment object is mutable and exposed by reference

### DIFF
--- a/packages/treeshake-server/src/utils/runtimeEnv.ts
+++ b/packages/treeshake-server/src/utils/runtimeEnv.ts
@@ -1,9 +1,10 @@
 export type RuntimeEnv = Record<string, string | undefined>;
 
-let runtimeEnv: RuntimeEnv = {};
+let runtimeEnv: RuntimeEnv = Object.freeze({}) as RuntimeEnv;
 
 export const setRuntimeEnv = (env: RuntimeEnv) => {
-  runtimeEnv = env;
+  runtimeEnv = Object.freeze({ ...env }) as RuntimeEnv;
 };
 
-export const getRuntimeEnv = (): RuntimeEnv => runtimeEnv;
+export const getRuntimeEnv = (): RuntimeEnv =>
+  Object.freeze({ ...runtimeEnv }) as RuntimeEnv;


### PR DESCRIPTION
## Problem

`setRuntimeEnv` stores a process-global object and `getRuntimeEnv` returns the same object reference. In long-lived server processes, this can cause cross-request state contamination and accidental or malicious mutation by downstream code, potentially altering security-sensitive runtime behavior.

**Severity**: `medium`
**File**: `packages/treeshake-server/src/utils/runtimeEnv.ts`

## Solution

Clone and freeze runtime env on write/read (`Object.freeze({...env})`), avoid returning mutable references, and scope environment state per request/context instead of global module state where feasible.

## Changes

- `packages/treeshake-server/src/utils/runtimeEnv.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
