### PR TITLE
docs: fix up bridge-react loading example

### DIFF
--- a/apps/website-new/docs/en/practice/bridge/react-bridge/load-app.mdx
+++ b/apps/website-new/docs/en/practice/bridge/react-bridge/load-app.mdx
@@ -88,7 +88,7 @@ import { LoadingComponent, ErrorFallback } from '../components/RemoteComponents'
 
 export const Remote1App = createRemoteAppComponent({
   loader: () => loadRemote('remote1/export-app'),
-  loading: LoadingComponent,
+  loading: <LoadingComponent />,
   fallback: ErrorFallback,
 });
 ```

--- a/apps/website-new/docs/zh/practice/bridge/react-bridge/load-app.mdx
+++ b/apps/website-new/docs/zh/practice/bridge/react-bridge/load-app.mdx
@@ -98,7 +98,7 @@ import { LoadingComponent, ErrorFallback } from '../components/RemoteComponents'
 
 export const Remote1App = createRemoteAppComponent({
   loader: () => loadRemote('remote1/export-app'),
-  loading: LoadingComponent,
+  loading: <LoadingComponent />,
   fallback: ErrorFallback,
 });
 ```


### PR DESCRIPTION
## Description

Fix bridge-react loading example. 
Source types in repo require loading to be a node, not a component type.

## Related Issue

Close #4599

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
