### PR TITLE
docs(runtime): add runtime plugins guide

### DIFF
--- a/apps/website-new/docs/en/configure/runtimeplugins.mdx
+++ b/apps/website-new/docs/en/configure/runtimeplugins.mdx
@@ -8,7 +8,7 @@ The `runtimePlugins` configuration is used to add additional plugins needed at r
 - A string representing the path to the specific plugin (absolute/relative path or package name)
 - An array where each element can be either a string or a tuple with [string path, object options]
 
-You can learn more about how to develop `runtimePlugin` details by visiting the [Plugin System](../plugin/dev/index).
+For a task-oriented guide to choosing hooks and building plugins, see [Runtime Plugins](../guide/runtime/runtime-plugins). For the full hook reference, see [Runtime Hooks](../guide/runtime/runtime-hooks). For lower-level plugin authoring details, see the [Plugin System](../plugin/dev/index).
 
 Once set, runtime plugins will be automatically injected and used during the build process.
 

--- a/apps/website-new/docs/en/guide/runtime/_meta.json
+++ b/apps/website-new/docs/en/guide/runtime/_meta.json
@@ -4,12 +4,17 @@
     "name": "index",
     "label": "Overview"
   },
-    {
+  {
     "type": "file",
     "name": "runtime-api",
     "label": "Runtime API"
   },
-    {
+  {
+    "type": "file",
+    "name": "runtime-plugins",
+    "label": "Runtime Plugins"
+  },
+  {
     "type": "file",
     "name": "runtime-hooks",
     "label": "Runtime Hooks"

--- a/apps/website-new/docs/en/guide/runtime/runtime-plugins.mdx
+++ b/apps/website-new/docs/en/guide/runtime/runtime-plugins.mdx
@@ -1,0 +1,272 @@
+# Runtime Plugins
+
+Runtime plugins let you change **runtime behavior** without changing the core runtime itself.
+
+Use them when you need to:
+
+- rewrite remote URLs at runtime
+- customize manifest requests
+- patch script loading
+- override shared resolution
+- add recovery or fallback behavior
+- introduce new remote loading behavior
+
+If you only need to **register** a plugin path in build config, see [`runtimePlugins`](../../configure/runtimeplugins). If you need the full hook list, see [Runtime Hooks](./runtime-hooks).
+
+## Mental model
+
+A runtime plugin is a function that returns a `ModuleFederationRuntimePlugin`:
+
+```ts title="my-runtime-plugin.ts"
+import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
+
+export default function myRuntimePlugin(): ModuleFederationRuntimePlugin {
+  return {
+    name: 'my-runtime-plugin',
+  };
+}
+```
+
+The function form matters because it lets you:
+
+- accept options
+- keep state in a closure
+- reuse the same plugin logic across environments
+
+## Register a plugin
+
+You can register runtime plugins in two places:
+
+1. Build time, through `runtimePlugins`
+2. Runtime, through `registerPlugins(...)` or `instance.registerPlugins(...)`
+
+### Build-time registration
+
+Use build-time registration when the plugin should always be present for that host.
+
+```ts title="module-federation.config.ts"
+const path = require('path');
+
+export default {
+  name: 'host',
+  remotes: {
+    catalog: 'catalog@https://registry.example.com/mf-manifest.json',
+  },
+  runtimePlugins: [
+    [
+      path.resolve(__dirname, './plugins/rewrite-remote-entry.ts'),
+      {
+        fromHost: 'registry.example.com',
+        toHost: 'cdn.example.com',
+      },
+    ],
+  ],
+};
+```
+
+### Runtime registration
+
+Use runtime registration when the plugin depends on user state, environment, feature flags, or data fetched after startup.
+
+```ts title="bootstrap.ts"
+import { createInstance } from '@module-federation/enhanced/runtime';
+import rewriteRemoteEntryPlugin from './plugins/rewrite-remote-entry';
+
+const mf = createInstance({
+  name: 'host',
+  remotes: [
+    {
+      name: 'catalog',
+      entry: 'https://registry.example.com/mf-manifest.json',
+    },
+  ],
+});
+
+mf.registerPlugins([
+  rewriteRemoteEntryPlugin({
+    fromHost: 'registry.example.com',
+    toHost: 'cdn.example.com',
+  }),
+]);
+```
+
+## Choose the right hook
+
+| Job | Hook | Use it when |
+| --- | --- | --- |
+| Change remote lookup input | `beforeRequest` | You need to rewrite the request before remote resolution starts |
+| Rewrite a resolved entry URL | `afterResolve` | You want to change `remoteInfo.entry` after the runtime has resolved the remote |
+| Customize manifest network requests | `fetch` | You need credentials, headers, retries, or alternate fetch behavior for manifest loading |
+| Customize injected scripts | `createScript` | You need to add attributes like `crossorigin`, timeouts, or custom script elements |
+| Align or rewrite share scopes before remote init | `beforeInitContainer`, `initContainerShareScopeMap` | You need to change which share scope a remote initializes against |
+| Override the shared winner | `resolveShare` | You want to force a different shared implementation than the runtime would normally pick |
+| Recover from load failures | `errorLoadRemote` | You need fallback modules, offline behavior, or layered recovery |
+| Implement a new remote loading strategy | `loadEntry` | You want to fully customize how a remote entry is loaded or support a new remote type |
+
+## Recipe: rewrite the resolved remote entry
+
+`afterResolve` is the right hook when the remote has already been resolved and you want to change the final URL before loading continues.
+
+This pattern is useful for:
+
+- CDN indirection
+- environment switching
+- registry-backed routing
+- domain normalization
+
+```ts title="plugins/rewrite-remote-entry.ts"
+import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
+
+interface RewriteRemoteEntryOptions {
+  fromHost: string;
+  toHost: string;
+}
+
+export default function rewriteRemoteEntryPlugin(
+  options: RewriteRemoteEntryOptions,
+): ModuleFederationRuntimePlugin {
+  return {
+    name: 'rewrite-remote-entry',
+    async afterResolve(args) {
+      const entry = args.remoteInfo?.entry;
+      if (!entry) {
+        return args;
+      }
+
+      try {
+        const currentUrl = new URL(entry);
+        if (currentUrl.hostname !== options.fromHost) {
+          return args;
+        }
+
+        const nextUrl = new URL(entry);
+        nextUrl.hostname = options.toHost;
+        args.remoteInfo.entry = nextUrl.toString();
+      } catch {
+        // Ignore non-URL entries and keep the original resolution.
+      }
+
+      return args;
+    },
+  };
+}
+```
+
+Why this hook:
+
+- `beforeRequest` is earlier; the remote is not resolved yet
+- `afterResolve` already gives you `remoteInfo.entry`
+- changing `args.remoteInfo.entry` here keeps the original path, query, and hash intact
+
+:::tip Runtime-only caveat
+
+An `afterResolve` rewrite changes runtime loading behavior. It does not automatically rewrite the remote URL used by type generation or other build-time tooling. If you rely on generated remote types, keep that path aligned separately.
+
+:::
+
+## Recipe: customize manifest fetch
+
+Use `fetch` when the manifest request itself needs custom behavior.
+
+```ts title="plugins/fetch-manifest-with-credentials.ts"
+import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
+
+export default function fetchManifestWithCredentials(): ModuleFederationRuntimePlugin {
+  return {
+    name: 'fetch-manifest-with-credentials',
+    fetch(manifestUrl, requestInit) {
+      const headers = new Headers(requestInit?.headers);
+      headers.set('x-mf-host', 'host');
+
+      return fetch(manifestUrl, {
+        ...requestInit,
+        credentials: 'include',
+        headers,
+      });
+    },
+  };
+}
+```
+
+Use `fetch` for:
+
+- credentials
+- auth headers
+- manifest retries
+- custom proxy logic
+
+If you need a ready-made transport policy, see the built-in retry plugin.
+
+## Recipe: prefer a host-owned shared dependency
+
+`resolveShare` is the hook for overriding the final shared module selection.
+
+The important part: changing `args.scope` or `args.version` alone is not enough. To change the actual winner, replace `args.resolver`.
+
+```ts title="plugins/prefer-host-react.ts"
+import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
+
+export default function preferHostReact(): ModuleFederationRuntimePlugin {
+  return {
+    name: 'prefer-host-react',
+    resolveShare(args) {
+      if (args.pkgName !== 'react') {
+        return args;
+      }
+
+      const hostVersionMap = args.shareScopeMap.default?.react;
+      if (!hostVersionMap) {
+        return args;
+      }
+
+      const preferredShared =
+        hostVersionMap[args.version] ?? Object.values(hostVersionMap)[0];
+      if (!preferredShared) {
+        return args;
+      }
+
+      args.resolver = () => ({
+        shared: preferredShared,
+        useTreesShaking: false,
+      });
+
+      return args;
+    },
+  };
+}
+```
+
+## Failure handling and `shareStrategy`
+
+`errorLoadRemote` is the right place for runtime fallbacks.
+
+One important detail: the behavior changes with `shareStrategy`.
+
+- `version-first` eagerly loads remote entries during startup to initialize shared dependencies
+- `loaded-first` defers remote loading until the remote is actually used
+
+That means:
+
+- with `version-first`, an offline remote can fail early with `lifecycle: 'beforeLoadShare'`
+- with `loaded-first`, the same remote usually fails later, when code actually tries to use it
+
+If you expect remotes to be intermittently unavailable, pair `errorLoadRemote` with a deliberate `shareStrategy`.
+
+## Version-sensitive hooks
+
+The advanced hooks evolve over time. For common hooks like `afterResolve`, `fetch`, `createScript`, and `loadEntry`, prefer checking the installed runtime types when you depend on newer arguments or behaviors.
+
+That is especially relevant when you rely on:
+
+- extra script attributes in `createScript`
+- loader hook details passed into `fetch` or `loadEntry`
+- less-common lifecycle hooks used by built-in plugins
+
+## Related docs
+
+- [`runtimePlugins` config](../../configure/runtimeplugins)
+- [Runtime API](./runtime-api)
+- [Runtime Hooks](./runtime-hooks)
+- [Plugin System](../../plugin/dev/index)
+- [Retry Plugin](../../plugin/plugins/retry-plugin)
+- [Error Load Remote Solutions](../../blog/error-load-remote)

--- a/apps/website-new/docs/zh/configure/runtimeplugins.mdx
+++ b/apps/website-new/docs/zh/configure/runtimeplugins.mdx
@@ -8,7 +8,7 @@
 - 表示具体插件路径的字符串（支持绝对/相对路径、包名）
 - 一个数组，其中每个元素可以是字符串或元组 [字符串路径, 对象配置]
 
-通过「[插件系统](../plugin/dev/index)」了解更多关于如何开发 runtimePlugin 细节。
+如果你想看“怎么选 hook、怎么写常见插件”的任务导向文档，见 [Runtime 插件](../guide/runtime/runtime-plugins)。如果你需要完整 hook 说明，见 [Runtime Hooks](../guide/runtime/runtime-hooks)。更底层的插件开发细节，见「[插件系统](../plugin/dev/index)」。
 
 设置后，运行时插件会自动在构建时注入并使用。
 

--- a/apps/website-new/docs/zh/guide/runtime/_meta.json
+++ b/apps/website-new/docs/zh/guide/runtime/_meta.json
@@ -1,15 +1,20 @@
 [
-     {
+  {
     "type": "file",
     "name": "index",
     "label": "Overview"
   },
-    {
+  {
     "type": "file",
     "name": "runtime-api",
     "label": "Runtime API"
   },
-    {
+  {
+    "type": "file",
+    "name": "runtime-plugins",
+    "label": "Runtime Plugins"
+  },
+  {
     "type": "file",
     "name": "runtime-hooks",
     "label": "Runtime Hooks"

--- a/apps/website-new/docs/zh/guide/runtime/runtime-plugins.mdx
+++ b/apps/website-new/docs/zh/guide/runtime/runtime-plugins.mdx
@@ -1,0 +1,274 @@
+# Runtime 插件
+
+Runtime 插件用于改写 **运行时行为**，而不是改写 runtime 本身。
+
+适合这类场景：
+
+- 运行时改写 remote URL
+- 自定义 manifest 请求
+- 改写 script 注入逻辑
+- 覆盖 shared 最终命中结果
+- 增加容错、回退、恢复逻辑
+- 扩展新的 remote 加载方式
+
+如果你只是想在构建配置里注册插件路径，见 [`runtimePlugins`](../../configure/runtimeplugins)。如果你需要完整 hook 列表，见 [Runtime Hooks](./runtime-hooks)。
+
+## 心智模型
+
+一个 runtime 插件本质上是一个返回 `ModuleFederationRuntimePlugin` 的函数：
+
+```ts title="my-runtime-plugin.ts"
+import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
+
+export default function myRuntimePlugin(): ModuleFederationRuntimePlugin {
+  return {
+    name: 'my-runtime-plugin',
+  };
+}
+```
+
+用函数返回插件实例，而不是直接导出对象，主要有几个好处：
+
+- 可以接收 options
+- 可以通过闭包保存状态
+- 同一份插件逻辑可以复用到不同环境
+
+## 注册方式
+
+Runtime 插件可以在两个阶段注册：
+
+1. 构建期，通过 `runtimePlugins`
+2. 运行时，通过 `registerPlugins(...)` 或 `instance.registerPlugins(...)`
+
+### 构建期注册
+
+如果某个 host 在所有环境都需要这个插件，优先用构建期注册。
+
+```ts title="module-federation.config.ts"
+const path = require('path');
+
+export default {
+  name: 'host',
+  remotes: {
+    catalog: 'catalog@https://registry.example.com/mf-manifest.json',
+  },
+  runtimePlugins: [
+    [
+      path.resolve(__dirname, './plugins/rewrite-remote-entry.ts'),
+      {
+        fromHost: 'registry.example.com',
+        toHost: 'cdn.example.com',
+      },
+    ],
+  ],
+};
+```
+
+### 运行时注册
+
+如果插件依赖用户态、环境变量、特性开关、启动后拿到的数据，适合运行时注册。
+
+```ts title="bootstrap.ts"
+import { createInstance } from '@module-federation/enhanced/runtime';
+import rewriteRemoteEntryPlugin from './plugins/rewrite-remote-entry';
+
+const mf = createInstance({
+  name: 'host',
+  remotes: [
+    {
+      name: 'catalog',
+      entry: 'https://registry.example.com/mf-manifest.json',
+    },
+  ],
+});
+
+mf.registerPlugins([
+  rewriteRemoteEntryPlugin({
+    fromHost: 'registry.example.com',
+    toHost: 'cdn.example.com',
+  }),
+]);
+```
+
+## 怎么选 hook
+
+| 目标 | Hook | 适用场景 |
+| --- | --- | --- |
+| 改写 remote 查找输入 | `beforeRequest` | 需要在 remote 解析开始前改写请求内容 |
+| 改写解析后的 entry URL | `afterResolve` | 需要在 runtime 解析出 `remoteInfo.entry` 之后改写最终加载地址 |
+| 自定义 manifest 请求 | `fetch` | 需要加 credentials、headers、重试或自定义 fetch 行为 |
+| 自定义 script 注入 | `createScript` | 需要加 `crossorigin`、timeout、特殊 script 属性 |
+| 在 remote init 前对齐 / 改写共享池 | `beforeInitContainer`、`initContainerShareScopeMap` | 需要控制 remote 初始化时使用哪个 share scope |
+| 改写 shared 最终命中结果 | `resolveShare` | 需要强制命中某个 shared，而不是用 runtime 默认选择 |
+| 加载失败时兜底 | `errorLoadRemote` | 需要离线兜底、fallback module、分层恢复策略 |
+| 扩展新的 remote 加载方式 | `loadEntry` | 需要完整接管 remote entry 加载过程，或实现新的 remote 类型 |
+
+## 配方：改写解析后的 remote entry
+
+`afterResolve` 适合“remote 已经解析完成，但真正加载前还要改一下最终 URL”这种场景。
+
+典型用途：
+
+- CDN 切流
+- 环境切换
+- 基于注册中心改写地址
+- 域名归一化
+
+```ts title="plugins/rewrite-remote-entry.ts"
+import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
+
+interface RewriteRemoteEntryOptions {
+  fromHost: string;
+  toHost: string;
+}
+
+export default function rewriteRemoteEntryPlugin(
+  options: RewriteRemoteEntryOptions,
+): ModuleFederationRuntimePlugin {
+  return {
+    name: 'rewrite-remote-entry',
+    async afterResolve(args) {
+      const entry = args.remoteInfo?.entry;
+      if (!entry) {
+        return args;
+      }
+
+      try {
+        const currentUrl = new URL(entry);
+        if (currentUrl.hostname !== options.fromHost) {
+          return args;
+        }
+
+        const nextUrl = new URL(entry);
+        nextUrl.hostname = options.toHost;
+        args.remoteInfo.entry = nextUrl.toString();
+      } catch {
+        // 非 URL 场景直接忽略，保留原始解析结果。
+      }
+
+      return args;
+    },
+  };
+}
+```
+
+为什么选这个 hook：
+
+- `beforeRequest` 太早，此时还拿不到解析后的 entry
+- `afterResolve` 已经给出了 `remoteInfo.entry`
+- 在这里改 `args.remoteInfo.entry`，可以保留原始 path / query / hash
+
+:::tip 只影响运行时
+
+`afterResolve` 改写的是运行时加载地址。它不会自动改写类型生成或其他构建期工具使用的 remote URL。  
+如果你依赖远程类型生成，这条链路需要单独保持一致。
+
+:::
+
+## 配方：自定义 manifest fetch
+
+当你需要改 manifest 请求本身时，使用 `fetch`。
+
+```ts title="plugins/fetch-manifest-with-credentials.ts"
+import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
+
+export default function fetchManifestWithCredentials(): ModuleFederationRuntimePlugin {
+  return {
+    name: 'fetch-manifest-with-credentials',
+    fetch(manifestUrl, requestInit) {
+      const headers = new Headers(requestInit?.headers);
+      headers.set('x-mf-host', 'host');
+
+      return fetch(manifestUrl, {
+        ...requestInit,
+        credentials: 'include',
+        headers,
+      });
+    },
+  };
+}
+```
+
+`fetch` 常见用途：
+
+- 带凭证请求
+- 增加鉴权头
+- manifest 重试
+- 自定义代理逻辑
+
+如果你想直接复用现成的传输层恢复策略，可以看内置的 retry 插件。
+
+## 配方：优先使用 host 自己的 shared
+
+`resolveShare` 用来改写 shared 最终选择结果。
+
+关键点：只改 `args.scope`、`args.version` 这类字段，并不会自动改变最终命中项。要真正改掉结果，必须替换 `args.resolver`。
+
+```ts title="plugins/prefer-host-react.ts"
+import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
+
+export default function preferHostReact(): ModuleFederationRuntimePlugin {
+  return {
+    name: 'prefer-host-react',
+    resolveShare(args) {
+      if (args.pkgName !== 'react') {
+        return args;
+      }
+
+      const hostVersionMap = args.shareScopeMap.default?.react;
+      if (!hostVersionMap) {
+        return args;
+      }
+
+      const preferredShared =
+        hostVersionMap[args.version] ?? Object.values(hostVersionMap)[0];
+      if (!preferredShared) {
+        return args;
+      }
+
+      args.resolver = () => ({
+        shared: preferredShared,
+        useTreesShaking: false,
+      });
+
+      return args;
+    },
+  };
+}
+```
+
+## 容错与 `shareStrategy`
+
+做运行时容错时，`errorLoadRemote` 很关键。
+
+但有个经常踩坑的点：它和 `shareStrategy` 强相关。
+
+- `version-first` 会在启动阶段提前加载 remote entry，用来初始化 shared
+- `loaded-first` 则会把 remote 加载延迟到真正访问 remote 时
+
+这意味着：
+
+- 用 `version-first` 时，remote 离线可能会在启动期就以 `lifecycle: 'beforeLoadShare'` 失败
+- 用 `loaded-first` 时，通常会等到真正访问 remote 时才暴露失败
+
+如果你的 remote 存在离线、波动、跨网络访问等情况，建议把 `errorLoadRemote` 和明确的 `shareStrategy` 一起设计。
+
+## 对版本敏感的 hook
+
+高级 hook 的参数和行为会随 runtime 演进。  
+像 `afterResolve`、`fetch`、`createScript`、`loadEntry` 这类 hook，如果你依赖比较新的参数，最好以你本地安装版本的类型定义为准。
+
+尤其要注意这些场景：
+
+- `createScript` 里依赖新增 script attrs
+- `fetch` / `loadEntry` 里依赖更多 loader hook 上下文
+- 使用内置插件里那些文档没完全展开的生命周期 hook
+
+## 相关文档
+
+- [`runtimePlugins` 配置](../../configure/runtimeplugins)
+- [Runtime API](./runtime-api)
+- [Runtime Hooks](./runtime-hooks)
+- [插件系统](../../plugin/dev/index)
+- [Retry 插件](../../plugin/plugins/retry-plugin)
+- [Error Load Remote 的解决方案](../../blog/error-load-remote)


### PR DESCRIPTION
## Description

Add a task-oriented runtime plugins guide to the docs.

The new page explains the runtime plugin mental model, when to register plugins at build time vs runtime, how to choose the right hook for a job, and includes practical recipes for `afterResolve`, `fetch`, and `resolveShare`. It also adds caveats around runtime-only URL rewrites, `shareStrategy`, and version-sensitive hook signatures.

The existing `runtimePlugins` config page now links to the new guide and the hook reference, and the runtime docs nav includes the new page.

Validation run:
- `pnpm exec prettier --check apps/website-new/docs/en/guide/runtime/runtime-plugins.mdx apps/website-new/docs/en/guide/runtime/_meta.json apps/website-new/docs/en/configure/runtimeplugins.mdx`

Skipped:
- docs app boot, because the local workspace currently has package export/build artifact mismatches that block `pnpm dev` in `apps/website-new`
- broader tests/typecheck, because this is a docs-only change

## Related Issue

None.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
