### PR TITLE
fix(enhanced): remove unused create-schema-validation 

### DIFF
--- a/packages/enhanced/src/lib/container/ContainerPlugin.ts
+++ b/packages/enhanced/src/lib/container/ContainerPlugin.ts
@@ -17,8 +17,6 @@ import type {
 import type { containerPlugin } from '@module-federation/sdk';
 import FederationRuntimePlugin from './runtime/FederationRuntimePlugin';
 import FederationModulesPlugin from './runtime/FederationModulesPlugin';
-import checkOptions from '../../schemas/container/ContainerPlugin.check';
-import schema from '../../schemas/container/ContainerPlugin';
 import FederationRuntimeDependency from './runtime/FederationRuntimeDependency';
 import type { OptimizationSplitChunksCacheGroup } from 'webpack/lib/optimize/SplitChunksPlugin';
 import type { Falsy } from 'webpack/declarations/WebpackOptions';
@@ -30,15 +28,6 @@ const ModuleDependency = require(
 const EntryDependency = require(
   normalizeWebpackPath('webpack/lib/dependencies/EntryDependency'),
 ) as typeof import('webpack/lib/dependencies/EntryDependency');
-
-const createSchemaValidation = require(
-  normalizeWebpackPath('webpack/lib/util/create-schema-validation'),
-) as typeof import('webpack/lib/util/create-schema-validation');
-
-// const validate = createSchemaValidation(checkOptions, () => schema, {
-//   name: 'Container Plugin',
-//   baseDataPath: 'options',
-// });
 
 const PLUGIN_NAME = 'ContainerPlugin';
 

--- a/packages/enhanced/src/lib/container/ContainerReferencePlugin.ts
+++ b/packages/enhanced/src/lib/container/ContainerReferencePlugin.ts
@@ -19,26 +19,10 @@ import type {
 } from '@module-federation/sdk';
 import FederationRuntimePlugin from './runtime/FederationRuntimePlugin';
 import FederationModulesPlugin from './runtime/FederationModulesPlugin';
-import schema from '../../schemas/container/ContainerReferencePlugin';
-import checkOptions from '../../schemas/container/ContainerReferencePlugin.check';
 
 const { ExternalsPlugin } = require(
   normalizeWebpackPath('webpack'),
 ) as typeof import('webpack');
-
-const createSchemaValidation = require(
-  normalizeWebpackPath('webpack/lib/util/create-schema-validation'),
-) as typeof import('webpack/lib/util/create-schema-validation');
-
-// const validate = createSchemaValidation(
-//   //eslint-disable-next-line
-//   checkOptions,
-//   () => schema,
-//   {
-//     name: 'Container Reference Plugin',
-//     baseDataPath: 'options',
-//   },
-// );
 
 const slashCode = '/'.charCodeAt(0);
 


### PR DESCRIPTION



## Description
webpack v5.106.0 removed `webpack/lib/util/create-schema-validation`. Enhanced container plugins referenced it even though validation is disabled, so remove the unused import to avoid runtime resolution failures.
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue
#4646 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
