### PR TITLE
docs(runtime): document missing low-level runtime APIs

### DIFF
--- a/apps/website-new/docs/en/guide/runtime/runtime-api.mdx
+++ b/apps/website-new/docs/en/guide/runtime/runtime-api.mdx
@@ -425,6 +425,175 @@ function registerPlugins(plugins: ModuleFederationRuntimePlugin[]) {}
   </Tab>
 </Tabs>
 
+## registerGlobalPlugins
+
+- type
+
+```typescript
+function registerGlobalPlugins(plugins: ModuleFederationRuntimePlugin[]): void {}
+```
+
+Registers plugins on the global federation state instead of on a single current instance.
+
+Use this when you want a plugin to be picked up by all future runtime instances, such as:
+
+- shared instrumentation
+- environment-wide policy
+- host-wide defaults
+
+Global plugins are deduplicated by `plugin.name`.
+
+```ts
+import {
+  registerGlobalPlugins,
+  createInstance,
+} from '@module-federation/enhanced/runtime';
+import runtimePlugin from './runtime-plugin';
+
+registerGlobalPlugins([runtimePlugin()]);
+
+const mf = createInstance({
+  name: 'mf_host',
+  remotes: [
+    {
+      name: 'sub1',
+      entry: 'http://localhost:2001/mf-manifest.json',
+    },
+  ],
+});
+```
+
+For predictable behavior, register global plugins before creating or using runtime instances.
+
+## getRemoteInfo
+
+- type
+
+```typescript
+function getRemoteInfo(remote: Remote): RemoteInfo {}
+```
+
+Normalizes a remote definition into the runtime shape used internally by the loader.
+
+This helper fills in defaults such as:
+
+- `type`
+- `entryGlobalName`
+- `shareScope`
+
+```ts
+import { getRemoteInfo } from '@module-federation/enhanced/runtime';
+
+const remoteInfo = getRemoteInfo({
+  name: 'sub1',
+  entry: 'http://localhost:2001/mf-manifest.json',
+});
+
+console.log(remoteInfo.entryGlobalName);
+console.log(remoteInfo.shareScope);
+```
+
+This is a low-level helper. Most applications should configure remotes through `createInstance`, `registerRemotes`, or the build plugin.
+
+## getRemoteEntry
+
+- type
+
+```typescript
+function getRemoteEntry(params: {
+  origin: ModuleFederation;
+  remoteInfo: RemoteInfo;
+  remoteEntryExports?: RemoteEntryExports;
+  getEntryUrl?: (url: string) => string;
+}): Promise<RemoteEntryExports | false | void> {}
+```
+
+Loads a remote entry and returns its entry exports.
+
+This is mainly useful for low-level tooling, debugging, custom loaders, or advanced runtime integrations. Most applications should prefer `loadRemote`.
+
+```ts
+import {
+  createInstance,
+  getRemoteInfo,
+  getRemoteEntry,
+} from '@module-federation/enhanced/runtime';
+
+const mf = createInstance({
+  name: 'mf_host',
+  remotes: [],
+});
+
+const remoteInfo = getRemoteInfo({
+  name: 'sub1',
+  entry: 'http://localhost:2001/mf-manifest.json',
+});
+
+const remoteEntryExports = await getRemoteEntry({
+  origin: mf,
+  remoteInfo,
+});
+```
+
+## loadScript
+
+- type
+
+```typescript
+function loadScript(
+  url: string,
+  info: {
+    attrs?: Record<string, any>;
+    createScriptHook?: CreateScriptHookDom;
+  },
+): Promise<void> {}
+```
+
+Low-level browser helper that injects and loads a remote entry script.
+
+Use it only when you need to work below `loadRemote` / `getRemoteEntry`, for example in custom script loading flows.
+
+```ts
+import { loadScript } from '@module-federation/enhanced/runtime';
+
+await loadScript('http://localhost:2001/remoteEntry.js', {
+  attrs: {
+    crossorigin: 'anonymous',
+  },
+});
+```
+
+## loadScriptNode
+
+- type
+
+```typescript
+function loadScriptNode(
+  url: string,
+  info: {
+    attrs?: Record<string, any>;
+    loaderHook?: {
+      createScriptHook?: CreateScriptHookNode;
+    };
+  },
+): Promise<void> {}
+```
+
+Low-level Node.js helper that loads a remote entry into the current process.
+
+Use it only in Node-side integrations or custom loaders. In browser code, use `loadScript` instead.
+
+```ts
+import { loadScriptNode } from '@module-federation/enhanced/runtime';
+
+await loadScriptNode('http://localhost:2001/remoteEntry.js', {
+  attrs: {
+    name: 'sub1',
+    globalName: 'sub1',
+  },
+});
+```
+
 ## registerShared
 
 ### details

--- a/apps/website-new/docs/en/guide/runtime/runtime-plugins.mdx
+++ b/apps/website-new/docs/en/guide/runtime/runtime-plugins.mdx
@@ -35,10 +35,11 @@ The function form matters because it lets you:
 
 ## Register a plugin
 
-You can register runtime plugins in two places:
+You can register runtime plugins in three places:
 
 1. Build time, through `runtimePlugins`
-2. Runtime, through `registerPlugins(...)` or `instance.registerPlugins(...)`
+2. Runtime, on a specific instance, through `registerPlugins(...)` or `instance.registerPlugins(...)`
+3. Runtime, globally, through `registerGlobalPlugins(...)`
 
 ### Build-time registration
 
@@ -89,6 +90,34 @@ mf.registerPlugins([
   }),
 ]);
 ```
+
+### Global runtime registration
+
+Use `registerGlobalPlugins(...)` when you want the plugin to be available to all future runtime instances, instead of only one current instance.
+
+This is best suited for shared instrumentation, cross-app policy, or host-wide defaults.
+
+```ts title="bootstrap.ts"
+import {
+  registerGlobalPlugins,
+  createInstance,
+} from '@module-federation/enhanced/runtime';
+import runtimePlugin from './plugins/runtime-plugin';
+
+registerGlobalPlugins([runtimePlugin()]);
+
+const mf = createInstance({
+  name: 'host',
+  remotes: [
+    {
+      name: 'catalog',
+      entry: 'https://registry.example.com/mf-manifest.json',
+    },
+  ],
+});
+```
+
+`registerGlobalPlugins(...)` deduplicates plugins by `name`. In practice, call it before creating or using runtime instances so the global plugins are incorporated consistently.
 
 ## Choose the right hook
 

--- a/apps/website-new/docs/zh/guide/runtime/runtime-api.mdx
+++ b/apps/website-new/docs/zh/guide/runtime/runtime-api.mdx
@@ -428,6 +428,175 @@ function registerPlugins(plugins: ModuleFederationRuntimePlugin[]) {}
   </Tab>
 </Tabs>
 
+## registerGlobalPlugins
+
+- type
+
+```typescript
+function registerGlobalPlugins(plugins: ModuleFederationRuntimePlugin[]): void {}
+```
+
+用于把插件注册到全局 federation 状态，而不是只注册到某一个当前实例。
+
+适合这类场景：
+
+- 通用埋点
+- 环境级统一策略
+- host 级默认插件
+
+全局插件会按 `plugin.name` 去重。
+
+```ts
+import {
+  registerGlobalPlugins,
+  createInstance,
+} from '@module-federation/enhanced/runtime';
+import runtimePlugin from './runtime-plugin';
+
+registerGlobalPlugins([runtimePlugin()]);
+
+const mf = createInstance({
+  name: 'mf_host',
+  remotes: [
+    {
+      name: 'sub1',
+      entry: 'http://localhost:2001/mf-manifest.json',
+    },
+  ],
+});
+```
+
+为了保证行为可预期，建议在创建或使用 runtime 实例之前注册全局插件。
+
+## getRemoteInfo
+
+- type
+
+```typescript
+function getRemoteInfo(remote: Remote): RemoteInfo {}
+```
+
+把 remote 配置归一化为 runtime 内部使用的 `RemoteInfo` 结构。
+
+这个 helper 会补齐一些默认值，比如：
+
+- `type`
+- `entryGlobalName`
+- `shareScope`
+
+```ts
+import { getRemoteInfo } from '@module-federation/enhanced/runtime';
+
+const remoteInfo = getRemoteInfo({
+  name: 'sub1',
+  entry: 'http://localhost:2001/mf-manifest.json',
+});
+
+console.log(remoteInfo.entryGlobalName);
+console.log(remoteInfo.shareScope);
+```
+
+这是一个偏底层的 helper。大多数应用仍然应该优先使用 `createInstance`、`registerRemotes` 或构建插件去管理 remotes。
+
+## getRemoteEntry
+
+- type
+
+```typescript
+function getRemoteEntry(params: {
+  origin: ModuleFederation;
+  remoteInfo: RemoteInfo;
+  remoteEntryExports?: RemoteEntryExports;
+  getEntryUrl?: (url: string) => string;
+}): Promise<RemoteEntryExports | false | void> {}
+```
+
+用于加载 remote entry，并返回对应的 entry exports。
+
+这个 API 更适合底层工具、调试、自定义 loader 或高级 runtime 集成。大多数应用应该优先使用 `loadRemote`。
+
+```ts
+import {
+  createInstance,
+  getRemoteInfo,
+  getRemoteEntry,
+} from '@module-federation/enhanced/runtime';
+
+const mf = createInstance({
+  name: 'mf_host',
+  remotes: [],
+});
+
+const remoteInfo = getRemoteInfo({
+  name: 'sub1',
+  entry: 'http://localhost:2001/mf-manifest.json',
+});
+
+const remoteEntryExports = await getRemoteEntry({
+  origin: mf,
+  remoteInfo,
+});
+```
+
+## loadScript
+
+- type
+
+```typescript
+function loadScript(
+  url: string,
+  info: {
+    attrs?: Record<string, any>;
+    createScriptHook?: CreateScriptHookDom;
+  },
+): Promise<void> {}
+```
+
+浏览器侧的底层 helper，用于插入并加载 remote entry script。
+
+只有在你需要绕过 `loadRemote` / `getRemoteEntry`、自己控制 script 加载流程时才需要直接使用它。
+
+```ts
+import { loadScript } from '@module-federation/enhanced/runtime';
+
+await loadScript('http://localhost:2001/remoteEntry.js', {
+  attrs: {
+    crossorigin: 'anonymous',
+  },
+});
+```
+
+## loadScriptNode
+
+- type
+
+```typescript
+function loadScriptNode(
+  url: string,
+  info: {
+    attrs?: Record<string, any>;
+    loaderHook?: {
+      createScriptHook?: CreateScriptHookNode;
+    };
+  },
+): Promise<void> {}
+```
+
+Node.js 侧的底层 helper，用于把 remote entry 加载到当前进程。
+
+适合 Node 端集成或自定义 loader。浏览器环境请使用 `loadScript`。
+
+```ts
+import { loadScriptNode } from '@module-federation/enhanced/runtime';
+
+await loadScriptNode('http://localhost:2001/remoteEntry.js', {
+  attrs: {
+    name: 'sub1',
+    globalName: 'sub1',
+  },
+});
+```
+
 ## registerShared
 
 ### 详情

--- a/apps/website-new/docs/zh/guide/runtime/runtime-plugins.mdx
+++ b/apps/website-new/docs/zh/guide/runtime/runtime-plugins.mdx
@@ -35,10 +35,11 @@ export default function myRuntimePlugin(): ModuleFederationRuntimePlugin {
 
 ## 注册方式
 
-Runtime 插件可以在两个阶段注册：
+Runtime 插件可以在三个位置注册：
 
 1. 构建期，通过 `runtimePlugins`
-2. 运行时，通过 `registerPlugins(...)` 或 `instance.registerPlugins(...)`
+2. 运行时，在某个实例上，通过 `registerPlugins(...)` 或 `instance.registerPlugins(...)`
+3. 运行时，在全局作用域，通过 `registerGlobalPlugins(...)`
 
 ### 构建期注册
 
@@ -89,6 +90,38 @@ mf.registerPlugins([
   }),
 ]);
 ```
+
+### 全局运行时注册
+
+如果你希望插件对之后创建的所有 runtime 实例都生效，而不是只绑定到某一个当前实例，可以使用 `registerGlobalPlugins(...)`。
+
+适合这类场景：
+
+- 通用埋点
+- 跨应用统一策略
+- host 级默认插件
+
+```ts title="bootstrap.ts"
+import {
+  registerGlobalPlugins,
+  createInstance,
+} from '@module-federation/enhanced/runtime';
+import runtimePlugin from './plugins/runtime-plugin';
+
+registerGlobalPlugins([runtimePlugin()]);
+
+const mf = createInstance({
+  name: 'host',
+  remotes: [
+    {
+      name: 'catalog',
+      entry: 'https://registry.example.com/mf-manifest.json',
+    },
+  ],
+});
+```
+
+`registerGlobalPlugins(...)` 会按 `name` 去重。实践里建议在创建或使用 runtime 实例之前调用，这样全局插件会更稳定地并入实例插件链。
 
 ## 怎么选 hook
 


### PR DESCRIPTION
## Description

Document missing runtime APIs that are publicly exported but were not covered in the docs.

This PR adds `registerGlobalPlugins`, `getRemoteInfo`, `getRemoteEntry`, `loadScript`, and `loadScriptNode` to the runtime API docs in both English and Chinese. It also updates the runtime plugins guide in both locales to explain the difference between instance-scoped plugin registration and global plugin registration.

The goal is to close the gap between the actual runtime surface exported from `@module-federation/enhanced/runtime` and the docs users read when working with runtime plugins and low-level runtime helpers.

Validation run:
- `pnpm exec prettier --check apps/website-new/docs/en/guide/runtime/runtime-api.mdx apps/website-new/docs/zh/guide/runtime/runtime-api.mdx apps/website-new/docs/en/guide/runtime/runtime-plugins.mdx apps/website-new/docs/zh/guide/runtime/runtime-plugins.mdx`

Skipped:
- docs app boot, because the local workspace currently has package export/build artifact mismatches that block `pnpm dev` in `apps/website-new`
- broader tests/typecheck, because this is a docs-only change

## Related Issue

None.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
