### PR TITLE
fix(nextjs-mf): use matchRemoteWithNameAndExpose for beforeRequest cache-busting

### DIFF
--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "fast-glob": "^3.2.11",
     "@module-federation/runtime": "workspace:*",
+    "@module-federation/runtime-core": "workspace:*",
     "@module-federation/sdk": "workspace:*",
     "@module-federation/enhanced": "workspace:*",
     "@module-federation/node": "workspace:*",

--- a/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
+++ b/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
@@ -1,4 +1,5 @@
 import { ModuleFederationRuntimePlugin } from '@module-federation/runtime';
+import { matchRemoteWithNameAndExpose } from '@module-federation/runtime-core';
 
 export default function (): ModuleFederationRuntimePlugin {
   return {
@@ -92,12 +93,10 @@ export default function (): ModuleFederationRuntimePlugin {
     beforeRequest: function (args: any) {
       const options = args.options;
       const id = args.id;
-      const remoteName = id.split('/').shift();
-      const remote = options.remotes.find(function (remote: any) {
-        return remote.name === remoteName;
-      });
-      if (!remote) return args;
-      if (remote && remote.entry && remote.entry.includes('?t=')) {
+      const match = matchRemoteWithNameAndExpose(options.remotes, id);
+      if (!match) return args;
+      const remote = match.remote;
+      if (remote.entry && remote.entry.includes('?t=')) {
         return args;
       }
       remote.entry = remote.entry + '?t=' + Date.now();


### PR DESCRIPTION
## Summary

The `beforeRequest` hook in `next-internal-plugin` appends a cache-busting `?t=` parameter to remote entry URLs. However, it uses `id.split('/').shift()` to extract the remote name, which has two bugs:

1. **Alias mismatch**: `args.id` uses the remote's alias, but the lookup only checks `remote.name`. When alias differs from name, `find()` returns `undefined` and cache-busting is silently skipped.

2. **Scoped name/alias breakage**: For scoped identifiers like `@scope/remote/widget`, `split('/').shift()` yields `@scope` — not `@scope/remote`. This means any remote with a scoped name or alias never gets cache-busted.

This causes stale `mf-manifest.json` to be served from browser/CDN cache after deployments for affected remotes.

## Change

Replace the broken `split('/').shift()` + `find()` approach with the canonical `matchRemoteWithNameAndExpose` from `@module-federation/runtime-core`. This function uses `startsWith` + boundary checking to correctly handle scoped names, scoped aliases, and all edge cases — and is already the standard approach used elsewhere in the runtime (e.g. `getRemoteModuleAndOptions`).

```diff
+import { matchRemoteWithNameAndExpose } from '@module-federation/runtime-core';

 beforeRequest: function (args: any) {
   const options = args.options;
   const id = args.id;
-  const remoteName = id.split('/').shift();
-  const remote = options.remotes.find(function (remote: any) {
-    return remote.name === remoteName;
-  });
-  if (!remote) return args;
+  const match = matchRemoteWithNameAndExpose(options.remotes, id);
+  if (!match) return args;
+  const remote = match.remote;
   if (remote.entry && remote.entry.includes('?t=')) {
     return args;
   }
   remote.entry = remote.entry + '?t=' + Date.now();
   return args;
 },
```

Also adds `@module-federation/runtime-core` as a direct dependency in `nextjs-mf/package.json` (already a transitive dep via `@module-federation/runtime`).

## Reproduction

1. Register a remote with a scoped alias different from its name:
   ```js
   registerRemotes([
     { name: 'my-provider', alias: '@scope/my-remote', entry: 'https://cdn.example.com/mf-manifest.json' }
   ]);
   ```
2. Load via alias: `loadRemote('@scope/my-remote/some-module')`
3. Observe `mf-manifest.json` request has **no** `?t=` parameter
4. With the fix, `?t=` is correctly appended

Fixes #4659