### PR TITLE
fix(bridge-vue3): fix route processing for relative paths and default…

### DIFF
--- a/.changeset/fix-vue3-bridge-relative-path-navigation.md
+++ b/.changeset/fix-vue3-bridge-relative-path-navigation.md
@@ -1,0 +1,11 @@
+---
+'@module-federation/bridge-vue3': patch
+---
+
+fix(bridge-vue3): fix route processing for relative paths and default child routes with basename
+
+Two issues in `routeUtils` are fixed:
+
+1. **Relative child paths no longer get double-prefixed.** `prefixPath` now skips paths that don't start with `/`, letting Vue Router resolve them against the already-prefixed parent. This prevents breakage with nested route children like `path: 'history'` or `path: ':id?'`.
+
+2. **Default child routes (`path: ''`) no longer cause infinite recursion.** `flatRoutesMap` now stores arrays of candidates per path, and child matching skips the current parent route and uses the child's `name` when available. This correctly handles the case where a parent and its default child resolve to the same absolute path.

--- a/packages/bridge/vue3-bridge/__tests__/routeUtils.test.ts
+++ b/packages/bridge/vue3-bridge/__tests__/routeUtils.test.ts
@@ -543,7 +543,7 @@ describe('routeUtils', () => {
       expect(dashboardRoute?.path).toBe('/app/dashboard');
     });
 
-    it('should prefix nested children with basename when hashRoute is true', () => {
+    it('should keep relative children paths unchanged when hashRoute is true with basename', () => {
       const routes = createNestedRoutes();
       const router = createRouter({
         history: createWebHistory(),
@@ -558,24 +558,26 @@ describe('routeUtils', () => {
 
       const dashboardRoute = result.routes.find((r) => r.name === 'Dashboard');
       expect(dashboardRoute).toBeDefined();
+      // Top-level route should be prefixed
+      expect(dashboardRoute?.path).toBe('/app/dashboard');
 
       if (dashboardRoute?.children) {
         const profileRoute = dashboardRoute.children.find(
           (child) => child.name === 'Profile',
         );
-        // Paths are now properly joined with '/' separator
-        expect(profileRoute?.path).toBe('/app/profile');
+        // Relative children must stay relative — Vue Router resolves them against the parent
+        expect(profileRoute?.path).toBe('profile');
 
         const settingsRoute = dashboardRoute.children.find(
           (child) => child.name === 'Settings',
         );
-        expect(settingsRoute?.path).toBe('/app/settings');
+        expect(settingsRoute?.path).toBe('settings');
 
         if (settingsRoute?.children) {
           const accountRoute = settingsRoute.children.find(
             (child) => child.name === 'Account',
           );
-          expect(accountRoute?.path).toBe('/app/account');
+          expect(accountRoute?.path).toBe('account');
         }
       }
     });
@@ -1296,6 +1298,266 @@ describe('routeUtils', () => {
       targetRouter.push('');
 
       expect(pushSpy).toHaveBeenCalledWith('');
+    });
+  });
+
+  describe('processRoutes with default child routes (path: "")', () => {
+    it('should not crash with children using path: "" (no infinite recursion)', () => {
+      const routes = [
+        {
+          path: '/parent',
+          name: 'parent',
+          component: DashboardComponent,
+          children: [
+            {
+              path: '',
+              name: 'parent-default',
+              component: HomeComponent,
+            },
+            {
+              path: 'child',
+              name: 'child',
+              component: ProfileComponent,
+            },
+          ],
+        },
+      ];
+
+      const router = createRouter({
+        history: createWebHistory(),
+        routes,
+      });
+
+      // Must not throw "Maximum call stack size exceeded"
+      expect(() => processRoutes({ router })).not.toThrow();
+    });
+
+    it('should preserve default child route structure with path: ""', () => {
+      const routes = [
+        {
+          path: '/parent',
+          name: 'parent',
+          component: DashboardComponent,
+          children: [
+            {
+              path: '',
+              name: 'parent-default',
+              component: HomeComponent,
+            },
+            {
+              path: 'other',
+              name: 'other-child',
+              component: ProfileComponent,
+            },
+          ],
+        },
+      ];
+
+      const router = createRouter({
+        history: createWebHistory(),
+        routes,
+      });
+
+      const result = processRoutes({ router });
+
+      const parentRoute = result.routes.find((r) => r.name === 'parent');
+      expect(parentRoute).toBeDefined();
+      expect(parentRoute?.path).toBe('/parent');
+      expect(parentRoute?.children?.length).toBe(2);
+
+      const defaultChild = parentRoute?.children?.find(
+        (c) => c.name === 'parent-default',
+      );
+      expect(defaultChild).toBeDefined();
+      expect(defaultChild?.path).toBe('');
+
+      const otherChild = parentRoute?.children?.find(
+        (c) => c.name === 'other-child',
+      );
+      expect(otherChild).toBeDefined();
+      expect(otherChild?.path).toBe('other');
+    });
+
+    it('should not crash with path: "" children when using hashRoute + basename', () => {
+      const routes = [
+        {
+          path: '/operations',
+          name: 'operations',
+          component: DashboardComponent,
+          children: [
+            {
+              path: '',
+              name: 'operations-default',
+              component: HomeComponent,
+            },
+            {
+              path: 'integrations',
+              name: 'integrations',
+              component: ProfileComponent,
+            },
+          ],
+        },
+      ];
+
+      const router = createRouter({
+        history: createWebHistory(),
+        routes,
+      });
+
+      // Must not throw with hashRoute + basename
+      expect(() =>
+        processRoutes({ router, basename: '/do', hashRoute: true }),
+      ).not.toThrow();
+
+      const result = processRoutes({
+        router,
+        basename: '/do',
+        hashRoute: true,
+      });
+
+      // Top-level route should be prefixed
+      const opsRoute = result.routes.find((r) => r.name === 'operations');
+      expect(opsRoute?.path).toBe('/do/operations');
+
+      // Children should remain relative
+      const defaultChild = opsRoute?.children?.find(
+        (c) => c.name === 'operations-default',
+      );
+      expect(defaultChild?.path).toBe('');
+
+      const integrationsChild = opsRoute?.children?.find(
+        (c) => c.name === 'integrations',
+      );
+      expect(integrationsChild?.path).toBe('integrations');
+    });
+  });
+
+  describe('processRoutes with deeply nested relative children + hashRoute', () => {
+    it('should keep relative children paths when using hashRoute + basename', () => {
+      const routes = [
+        {
+          path: '/climate/measurements/results/:measurementId',
+          name: 'measurement-results',
+          component: DashboardComponent,
+          children: [
+            {
+              path: 'summary',
+              name: 'results-summary',
+              component: HomeComponent,
+            },
+            {
+              path: 'questions',
+              name: 'results-by-question',
+              component: ProfileComponent,
+            },
+          ],
+        },
+      ];
+
+      const router = createRouter({
+        history: createWebHistory(),
+        routes,
+      });
+
+      const result = processRoutes({
+        router,
+        basename: '/do',
+        hashRoute: true,
+      });
+
+      const parentRoute = result.routes.find(
+        (r) => r.name === 'measurement-results',
+      );
+      expect(parentRoute?.path).toBe(
+        '/do/climate/measurements/results/:measurementId',
+      );
+
+      // Children must stay relative — Vue Router resolves them against the parent.
+      // Before the fix they'd incorrectly become '/do/summary', '/do/questions'.
+      const summaryChild = parentRoute?.children?.find(
+        (c) => c.name === 'results-summary',
+      );
+      expect(summaryChild?.path).toBe('summary');
+
+      const questionsChild = parentRoute?.children?.find(
+        (c) => c.name === 'results-by-question',
+      );
+      expect(questionsChild?.path).toBe('questions');
+    });
+
+    it('should keep optional param children relative with hashRoute + basename', () => {
+      const routes = [
+        {
+          path: '/climate/measurements/config',
+          component: DashboardComponent,
+          children: [
+            {
+              path: ':measurementId?/:type?',
+              name: 'config-surveys',
+              component: HomeComponent,
+            },
+          ],
+        },
+      ];
+
+      const router = createRouter({
+        history: createWebHistory(),
+        routes,
+      });
+
+      const result = processRoutes({
+        router,
+        basename: '/do',
+        hashRoute: true,
+      });
+
+      const parentRoute = result.routes.find(
+        (r) => r.path === '/do/climate/measurements/config',
+      );
+      expect(parentRoute).toBeDefined();
+
+      const paramChild = parentRoute?.children?.find(
+        (c) => c.name === 'config-surveys',
+      );
+      // Must stay relative, not become '/do/:measurementId?/:type?' which would match everything
+      expect(paramChild?.path).toBe(':measurementId?/:type?');
+    });
+
+    it('should still prefix absolute children paths with basename in hashRoute', () => {
+      const routes = [
+        {
+          path: '/parent',
+          name: 'parent',
+          component: DashboardComponent,
+          children: [
+            {
+              path: '/absolute-child',
+              name: 'abs-child',
+              component: HomeComponent,
+            },
+          ],
+        },
+      ];
+
+      const router = createRouter({
+        history: createWebHistory(),
+        routes,
+      });
+
+      const result = processRoutes({
+        router,
+        basename: '/app',
+        hashRoute: true,
+      });
+
+      const parentRoute = result.routes.find((r) => r.name === 'parent');
+      expect(parentRoute?.path).toBe('/app/parent');
+
+      // Absolute child paths SHOULD be prefixed
+      const absChild = parentRoute?.children?.find(
+        (c) => c.name === 'abs-child',
+      );
+      expect(absChild?.path).toBe('/app/absolute-child');
     });
   });
 });

--- a/packages/bridge/vue3-bridge/src/routeUtils.ts
+++ b/packages/bridge/vue3-bridge/src/routeUtils.ts
@@ -28,8 +28,13 @@ function addBasenameToNestedRoutes(
    * Join two path segments, collapse multiple slashes, and optionally
    * preserve a trailing slash that was present in the original value.
    * A bare '/' root is never considered an intentional trailing slash.
+   *
+   * Relative paths (not starting with '/') are left untouched — Vue Router
+   * resolves them against the parent route, which already carries the basename.
    */
   const prefixPath = (original: string): string => {
+    if (!original.startsWith('/')) return original;
+
     const hasTrailingSlash = original.length > 1 && original.endsWith('/');
     const normalized =
       `${basename}/${original}`.replace(/\/+/g, '/').replace(/\/$/, '') || '/';
@@ -143,11 +148,15 @@ export function processRoutes(
     );
 
   // Use Map/Set for O(1) lookup performance
-  const flatRoutesMap = new Map<string, VueRouter.RouteRecordNormalized>();
+  // Store arrays because multiple routes can resolve to the same path
+  // (e.g. a parent and a default child with path: '')
+  const flatRoutesMap = new Map<string, VueRouter.RouteRecordNormalized[]>();
   const processedRoutes = new Set<VueRouter.RouteRecordNormalized>();
 
   flatRoutes.forEach((route) => {
-    flatRoutesMap.set(route.path, route);
+    const existing = flatRoutesMap.get(route.path) || [];
+    existing.push(route);
+    flatRoutesMap.set(route.path, existing);
   });
 
   /**
@@ -169,9 +178,20 @@ export function processRoutes(
     for (let j = 0; j < route.children.length; j++) {
       const child = route.children[j];
       const fullPath = normalizePath(prefix, child.path);
-      const childRoute = flatRoutesMap.get(fullPath);
+      const candidates = flatRoutesMap.get(fullPath) || [];
+      // Find a matching route that:
+      // 1. Hasn't been processed yet
+      // 2. Isn't the current parent route (avoids circular references when
+      //    a child with path: '' resolves to the same absolute path)
+      // 3. Matches by name when the child definition specifies one
+      const childRoute = candidates.find(
+        (r) =>
+          !processedRoutes.has(r) &&
+          r !== route &&
+          (child.name == null || r.name === child.name),
+      );
 
-      if (childRoute && !processedRoutes.has(childRoute)) {
+      if (childRoute) {
         // Create a new optimized route object with relative path for nested routes
         const relativeChildRoute: VueRouter.RouteRecordNormalized = {
           ...childRoute,


### PR DESCRIPTION
## Description

Fixes two issues in `routeUtils.ts` for the `bridge-vue3` package when using hash mode with a basename:

1. **Relative child paths were double-prefixed.** `prefixPath` applied the basename to all paths, including relative ones like `path: 'history'` or `path: ':id?'`. Since Vue Router resolves relative paths against the parent (which already carries the basename), this resulted in broken routes. Now `prefixPath` skips paths that don't start with `/`.

2. **Default child routes (`path: ''`) caused infinite recursion.** When a parent and its default child resolve to the same absolute path, `flatRoutesMap` (which stored a single route per path) would match the parent to itself as its own child, creating a circular reference. Now `flatRoutesMap` stores arrays of candidates, and the matching logic skips the current parent route and uses the child's `name` when available to disambiguate.

## Related Issue

Fixes route resolution failures and "No match found" warnings when using `@module-federation/bridge-vue3` with hash-mode routing and a basename, specifically for:
- Nested routes with relative child paths (e.g. `path: 'history'`, `path: ':id?'`)
- Default child routes using `path: ''`

## Video with Issue

https://github.com/user-attachments/assets/8a1310aa-347a-4940-85fc-47939c1251b6

## Demo

https://github.com/user-attachments/assets/63621844-db12-4e30-8e17-afd4ee9ca443

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.