### PR TITLE
feat(runtime-core): expose remote info in loader hooks

### DIFF
--- a/apps/website-new/docs/en/guide/runtime/runtime-plugins.mdx
+++ b/apps/website-new/docs/en/guide/runtime/runtime-plugins.mdx
@@ -126,7 +126,7 @@ const mf = createInstance({
 | Change remote lookup input | `beforeRequest` | You need to rewrite the request before remote resolution starts |
 | Rewrite a resolved entry URL | `afterResolve` | You want to change `remoteInfo.entry` after the runtime has resolved the remote |
 | Customize manifest network requests | `fetch` | You need credentials, headers, retries, or alternate fetch behavior for manifest loading |
-| Customize injected scripts | `createScript` | You need to add attributes like `crossorigin`, timeouts, or custom script elements |
+| Customize injected scripts and links | `createScript`, `createLink` | You need to add attributes like `crossorigin`, timeouts, or custom script/link elements. When available, `remoteInfo` is provided so you can apply per-remote policy. |
 | Align or rewrite share scopes before remote init | `beforeInitContainer`, `initContainerShareScopeMap` | You need to change which share scope a remote initializes against |
 | Override the shared winner | `resolveShare` | You want to force a different shared implementation than the runtime would normally pick |
 | Recover from load failures | `errorLoadRemote` | You need fallback modules, offline behavior, or layered recovery |
@@ -203,9 +203,12 @@ import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/
 export default function fetchManifestWithCredentials(): ModuleFederationRuntimePlugin {
   return {
     name: 'fetch-manifest-with-credentials',
-    fetch(manifestUrl, requestInit) {
+    fetch(manifestUrl, requestInit, remoteInfo) {
       const headers = new Headers(requestInit?.headers);
       headers.set('x-mf-host', 'host');
+      if (remoteInfo?.name) {
+        headers.set('x-mf-remote', remoteInfo.name);
+      }
 
       return fetch(manifestUrl, {
         ...requestInit,

--- a/apps/website-new/docs/zh/guide/runtime/runtime-plugins.mdx
+++ b/apps/website-new/docs/zh/guide/runtime/runtime-plugins.mdx
@@ -130,7 +130,7 @@ const mf = createInstance({
 | 改写 remote 查找输入 | `beforeRequest` | 需要在 remote 解析开始前改写请求内容 |
 | 改写解析后的 entry URL | `afterResolve` | 需要在 runtime 解析出 `remoteInfo.entry` 之后改写最终加载地址 |
 | 自定义 manifest 请求 | `fetch` | 需要加 credentials、headers、重试或自定义 fetch 行为 |
-| 自定义 script 注入 | `createScript` | 需要加 `crossorigin`、timeout、特殊 script 属性 |
+| 自定义 script / link 注入 | `createScript`、`createLink` | 需要加 `crossorigin`、timeout、特殊 script/link 属性；在具备 remote 上下文时会额外提供 `remoteInfo`，便于按 remote 做策略 |
 | 在 remote init 前对齐 / 改写共享池 | `beforeInitContainer`、`initContainerShareScopeMap` | 需要控制 remote 初始化时使用哪个 share scope |
 | 改写 shared 最终命中结果 | `resolveShare` | 需要强制命中某个 shared，而不是用 runtime 默认选择 |
 | 加载失败时兜底 | `errorLoadRemote` | 需要离线兜底、fallback module、分层恢复策略 |
@@ -208,9 +208,12 @@ import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/
 export default function fetchManifestWithCredentials(): ModuleFederationRuntimePlugin {
   return {
     name: 'fetch-manifest-with-credentials',
-    fetch(manifestUrl, requestInit) {
+    fetch(manifestUrl, requestInit, remoteInfo) {
       const headers = new Headers(requestInit?.headers);
       headers.set('x-mf-host', 'host');
+      if (remoteInfo?.name) {
+        headers.set('x-mf-remote', remoteInfo.name);
+      }
 
       return fetch(manifestUrl, {
         ...requestInit,

--- a/packages/runtime-core/__tests__/hooks.spec.ts
+++ b/packages/runtime-core/__tests__/hooks.spec.ts
@@ -164,7 +164,20 @@ describe('hooks', () => {
       plugins: [
         {
           name: 'change-script-attribute',
-          createScript({ url }) {
+          createScript({ url, remoteInfo }) {
+            // Assert remote context is exposed for remoteEntry loads
+            if (url === testRemoteEntry) {
+              expect(remoteInfo).toMatchObject({
+                name: '@loader-hooks/app2',
+                entry: testRemoteEntry,
+              });
+            }
+            if (url === preloadRemoteEntry) {
+              expect(remoteInfo).toMatchObject({
+                name: '@loader-hooks/app3',
+                entry: preloadRemoteEntry,
+              });
+            }
             const script = document.createElement('script');
             script.src = url;
             if (url === testRemoteEntry) {
@@ -203,6 +216,86 @@ describe('hooks', () => {
     reset();
   });
 
+  it('loader createLink hooks expose remoteInfo in preloadRemote', async () => {
+    const remotePublicPath = 'http://localhost:1111/';
+    const reset = addGlobalSnapshot({
+      '@loader-hooks/globalinfo': {
+        globalName: '',
+        buildVersion: '',
+        publicPath: '',
+        remoteTypes: '',
+        shared: [],
+        remoteEntry: '',
+        remoteEntryType: 'global',
+        modules: [],
+        version: '0.0.1',
+        remotesInfo: {
+          '@loader-hooks/app3': {
+            matchedVersion: '0.0.1',
+          },
+        },
+      },
+      '@loader-hooks/app3:0.0.1': {
+        globalName: '@loader-hooks/app3',
+        publicPath: remotePublicPath,
+        remoteTypes: '',
+        shared: [],
+        buildVersion: 'custom',
+        remotesInfo: {},
+        remoteEntryType: 'global',
+        modules: [],
+        version: '0.0.1',
+        remoteEntry: 'resources/hooks/app3/federation-remote-entry.js',
+      },
+    });
+
+    let lastLinkRemoteInfo: any;
+    const INSTANCE = new ModuleFederation({
+      name: '@loader-hooks/globalinfo',
+      remotes: [
+        {
+          name: '@loader-hooks/app3',
+          version: '*',
+        },
+      ],
+      plugins: [
+        {
+          name: 'force-preload-assets',
+          async generatePreloadAssets() {
+            return {
+              cssAssets: ['http://localhost:1111/__virtual__/style.css'],
+              jsAssetsWithoutEntry: [
+                'http://localhost:1111/__virtual__/chunk.js',
+              ],
+              entryAssets: [],
+            } as any;
+          },
+        },
+        {
+          name: 'capture-link-remote-info',
+          createLink({ url, attrs, remoteInfo }) {
+            lastLinkRemoteInfo = remoteInfo;
+            const link = document.createElement('link');
+            link.href = url;
+            if (attrs) {
+              Object.entries(attrs).forEach(([k, v]) => {
+                link.setAttribute(k, String(v));
+              });
+            }
+            return link;
+          },
+        },
+      ],
+    });
+
+    await INSTANCE.preloadRemote([{ nameOrAlias: '@loader-hooks/app3' }]);
+    expect(lastLinkRemoteInfo).toMatchObject({
+      name: '@loader-hooks/app3',
+    });
+
+    reset();
+  });
+
   it('loader fetch hooks', async () => {
     const data = {
       id: '@loader-hooks/app2',
@@ -234,9 +327,11 @@ describe('hooks', () => {
       statusText: 'OK',
       headers: { 'Content-Type': 'application/json' },
     });
+    let lastFetchRemoteInfo: any;
     const fetchPlugin: () => ModuleFederationRuntimePlugin = () => ({
       name: 'fetch-plugin',
-      fetch(url, options) {
+      fetch(url, options, remoteInfo) {
+        lastFetchRemoteInfo = remoteInfo;
         if (url === 'http://mockxxx.com/loader-fetch-hooks-mf-manifest.json') {
           return Promise.resolve(responseBody);
         }
@@ -258,6 +353,10 @@ describe('hooks', () => {
     );
     assert(res);
     expect(res()).toBe('hello app2');
+    expect(lastFetchRemoteInfo).toMatchObject({
+      name: '@loader-hooks/app2',
+      entry: 'http://mockxxx.com/loader-fetch-hooks-mf-manifest.json',
+    });
   });
 
   it('loaderEntry hooks', async () => {

--- a/packages/runtime-core/src/core.ts
+++ b/packages/runtime-core/src/core.ts
@@ -114,6 +114,12 @@ export class ModuleFederation {
         {
           url: string;
           attrs?: Record<string, any>;
+          /**
+           * The producer(remote) info bound to this resource.
+           * Only present when the loader is invoked in a remote-related context
+           * (e.g. preloadRemote / loading remoteEntry).
+           */
+          remoteInfo?: RemoteInfo;
         },
       ],
       CreateScriptHookReturn
@@ -123,12 +129,18 @@ export class ModuleFederation {
         {
           url: string;
           attrs?: Record<string, any>;
+          /**
+           * The producer(remote) info bound to this resource.
+           * Only present when the loader is invoked in a remote-related context
+           * (e.g. preloadRemote / loading remoteEntry).
+           */
+          remoteInfo?: RemoteInfo;
         },
       ],
       HTMLLinkElement | void
     >(),
     fetch: new AsyncHook<
-      [string, RequestInit],
+      [string, RequestInit, RemoteInfo?],
       Promise<Response> | void | false
     >(),
     loadEntryError: new AsyncHook<

--- a/packages/runtime-core/src/plugins/snapshot/SnapshotHandler.ts
+++ b/packages/runtime-core/src/plugins/snapshot/SnapshotHandler.ts
@@ -12,7 +12,12 @@ import {
   runtimeDescMap,
 } from '@module-federation/error-codes';
 import { Options, Remote } from '../../type';
-import { isRemoteInfoWithEntry, error, optionsToMFContext } from '../../utils';
+import {
+  isRemoteInfoWithEntry,
+  error,
+  optionsToMFContext,
+  getRemoteInfo,
+} from '../../utils';
 import {
   getGlobalSnapshot,
   setGlobalSnapshotInfoByModuleInfo,
@@ -292,7 +297,11 @@ export class SnapshotHandler {
         return manifestJson;
       }
       try {
-        let res = await this.loaderHook.lifecycle.fetch.emit(manifestUrl, {});
+        let res = await this.loaderHook.lifecycle.fetch.emit(
+          manifestUrl,
+          {},
+          getRemoteInfo(moduleInfo),
+        );
         if (!res || !(res instanceof Response)) {
           res = await fetch(manifestUrl, {});
         }

--- a/packages/runtime-core/src/utils/load.ts
+++ b/packages/runtime-core/src/utils/load.ts
@@ -104,12 +104,14 @@ async function loadEntryScript({
   name,
   globalName,
   entry,
+  remoteInfo,
   loaderHook,
   getEntryUrl,
 }: {
   name: string;
   globalName: string;
   entry: string;
+  remoteInfo: RemoteInfo;
   loaderHook: ModuleFederation['loaderHook'];
   getEntryUrl?: (url: string) => string;
 }): Promise<RemoteEntryExports> {
@@ -127,7 +129,11 @@ async function loadEntryScript({
   return loadScript(url, {
     attrs: {},
     createScriptHook: (url, attrs) => {
-      const res = loaderHook.lifecycle.createScript.emit({ url, attrs });
+      const res = loaderHook.lifecycle.createScript.emit({
+        url,
+        attrs,
+        remoteInfo,
+      });
 
       if (!res) return;
 
@@ -190,6 +196,7 @@ async function loadEntryDom({
         entry,
         globalName,
         name,
+        remoteInfo,
         loaderHook,
         getEntryUrl,
       });
@@ -217,7 +224,11 @@ async function loadEntryNode({
     attrs: { name, globalName, type },
     loaderHook: {
       createScriptHook: (url: string, attrs: Record<string, any> = {}) => {
-        const res = loaderHook.lifecycle.createScript.emit({ url, attrs });
+        const res = loaderHook.lifecycle.createScript.emit({
+          url,
+          attrs,
+          remoteInfo,
+        });
 
         if (!res) return;
 

--- a/packages/runtime-core/src/utils/preload.ts
+++ b/packages/runtime-core/src/utils/preload.ts
@@ -108,6 +108,7 @@ export function preloadAssets(
             const res = host.loaderHook.lifecycle.createLink.emit({
               url,
               attrs,
+              remoteInfo,
             });
             if (res instanceof HTMLLinkElement) {
               return res;
@@ -134,6 +135,7 @@ export function preloadAssets(
             const res = host.loaderHook.lifecycle.createLink.emit({
               url,
               attrs,
+              remoteInfo,
             });
             if (res instanceof HTMLLinkElement) {
               return res;
@@ -163,6 +165,7 @@ export function preloadAssets(
             const res = host.loaderHook.lifecycle.createLink.emit({
               url,
               attrs,
+              remoteInfo,
             });
             if (res instanceof HTMLLinkElement) {
               return res;
@@ -188,6 +191,7 @@ export function preloadAssets(
             const res = host.loaderHook.lifecycle.createScript.emit({
               url,
               attrs,
+              remoteInfo,
             });
             if (res instanceof HTMLScriptElement) {
               return res;

--- a/packages/runtime/__tests__/hooks.spec.ts
+++ b/packages/runtime/__tests__/hooks.spec.ts
@@ -166,7 +166,19 @@ describe('hooks', () => {
       plugins: [
         {
           name: 'change-script-attribute',
-          createScript({ url }) {
+          createScript({ url, remoteInfo }) {
+            if (url === testRemoteEntry) {
+              expect(remoteInfo).toMatchObject({
+                name: '@loader-hooks/app2',
+                entry: testRemoteEntry,
+              });
+            }
+            if (url === preloadRemoteEntry) {
+              expect(remoteInfo).toMatchObject({
+                name: '@loader-hooks/app3',
+                entry: preloadRemoteEntry,
+              });
+            }
             const script = document.createElement('script');
             script.src = url;
             if (url === testRemoteEntry) {
@@ -236,9 +248,11 @@ describe('hooks', () => {
       statusText: 'OK',
       headers: { 'Content-Type': 'application/json' },
     });
+    let lastFetchRemoteInfo: any;
     const fetchPlugin: () => ModuleFederationRuntimePlugin = () => ({
       name: 'fetch-plugin',
-      fetch(url, options) {
+      fetch(url, options, remoteInfo) {
+        lastFetchRemoteInfo = remoteInfo;
         if (url === 'http://mockxxx.com/loader-fetch-hooks-mf-manifest.json') {
           return Promise.resolve(responseBody);
         }
@@ -260,6 +274,10 @@ describe('hooks', () => {
     );
     assert(res);
     expect(res()).toBe('hello app2');
+    expect(lastFetchRemoteInfo).toMatchObject({
+      name: '@loader-hooks/app2',
+      entry: 'http://mockxxx.com/loader-fetch-hooks-mf-manifest.json',
+    });
   });
 
   it('loaderEntry hooks', async () => {


### PR DESCRIPTION
## Description

Expose remote info in loader hooks (createScript, createLink) during preloadRemote and DOM/Node remoteEntry loading sequences.  

Also reviewed other loader hooks for remote context exposure and added remoteInfo context to the fetch hook when fetching manifest in SnapshotHandler.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
