### PR TITLE
fix: dts plugin declaration dir

### DIFF
--- a/.changeset/eight-garlics-shop.md
+++ b/.changeset/eight-garlics-shop.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+fix: override inherited declarationDir in tsconfig and add test for declarationDir handling

--- a/packages/dts-plugin/src/core/configurations/remotePlugin.test.ts
+++ b/packages/dts-plugin/src/core/configurations/remotePlugin.test.ts
@@ -53,6 +53,10 @@ describe('hostPlugin', () => {
               remoteOptions.context,
               'dist/@mf-types/compiled-types',
             ),
+            declarationDir: resolve(
+              remoteOptions.context,
+              'dist/@mf-types/compiled-types',
+            ),
             rootDir: resolve(__dirname),
             incremental: true,
             tsBuildInfoFile: resolve(
@@ -120,6 +124,10 @@ describe('hostPlugin', () => {
             noEmit: false,
             declaration: true,
             outDir: resolve(
+              remoteOptions.context,
+              'dist/typesFolder/compiledTypesFolder',
+            ),
+            declarationDir: resolve(
               remoteOptions.context,
               'dist/typesFolder/compiledTypesFolder',
             ),

--- a/packages/dts-plugin/src/core/configurations/remotePlugin.ts
+++ b/packages/dts-plugin/src/core/configurations/remotePlugin.ts
@@ -177,9 +177,10 @@ const readTsConfig = (
   'references' in rawTsConfigJson && delete rawTsConfigJson.references;
 
   rawTsConfigJson.extends = resolvedTsConfigPath;
-  if (rawTsConfigJson.compilerOptions.declarationDir) {
-    delete rawTsConfigJson.compilerOptions.declarationDir;
-  }
+
+  // Force override inherited declarationDir
+  rawTsConfigJson.compilerOptions.declarationDir = outDir;
+
   return rawTsConfigJson;
 };
 

--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.test.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.test.ts
@@ -1,5 +1,5 @@
 import dirTree from 'directory-tree';
-import { mkdirSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import os from 'os';
 import { join, resolve, sep } from 'path';
 import util from 'util';
@@ -204,6 +204,75 @@ describe('typeScriptCompiler', () => {
       expect(args.slice(0, 3)).toEqual(['tsc', '--pretty', 'false']);
       expect(args[3]).toBe('--project');
       expect(args[4]).toEqual(expect.any(String));
+    });
+
+    it('ignores inherited declarationDir', async () => {
+      const projectDir = join(tmpDir, 'declarationDirProject');
+      const srcDir = join(projectDir, 'src');
+      mkdirSync(srcDir, { recursive: true });
+
+      const entryFile = join(srcDir, 'hello.ts');
+      writeFileSync(entryFile, 'export const hello = 1;\n');
+
+      const baseTsConfigPath = join(projectDir, 'tsconfig.json');
+      writeFileSync(
+        baseTsConfigPath,
+        JSON.stringify(
+          {
+            compilerOptions: {
+              target: 'es2017',
+              module: 'esnext',
+              moduleResolution: 'node',
+              declaration: true,
+              emitDeclarationOnly: true,
+              declarationDir: 'decl-dist',
+            },
+            include: ['src'],
+          },
+          null,
+          2,
+        ),
+      );
+
+      const outDir = join(
+        projectDir,
+        'typesRemoteFolder',
+        'compiledTypesFolder',
+      );
+
+      await compileTs(
+        { './hello': entryFile },
+        {
+          extends: baseTsConfigPath,
+          compilerOptions: {
+            target: 'es2017',
+            module: 'esnext',
+            moduleResolution: 'node',
+            strict: true,
+            esModuleInterop: true,
+            emitDeclarationOnly: true,
+            noEmit: false,
+            declaration: true,
+            outDir,
+            declarationDir: outDir,
+            rootDir: projectDir,
+          },
+          files: [entryFile],
+          include: [],
+          exclude: [],
+        },
+        {
+          ...remoteOptions,
+          context: projectDir,
+          tsConfigPath: baseTsConfigPath,
+        },
+      );
+
+      expect(existsSync(join(projectDir, 'decl-dist'))).toBe(false);
+      expect(existsSync(join(outDir, 'src', 'hello.d.ts'))).toBe(true);
+      expect(
+        existsSync(join(projectDir, 'typesRemoteFolder', 'hello.d.ts')),
+      ).toBe(true);
     });
 
     it('filled mapToExpose', async () => {


### PR DESCRIPTION
## Description

fix(dts-plugin): override inherited declarationDir in tsconfig and add test for declarationDir handling


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
