### PR TITLE
fix(bridge): exclude __tests__ from published package

### DIFF
--- a/packages/bridge/bridge-react-webpack-plugin/package.json
+++ b/packages/bridge/bridge-react-webpack-plugin/package.json
@@ -13,8 +13,6 @@
   },
   "files": [
     "dist/",
-    "src/",
-    "CHANGELOG.md",
     "README.md"
   ],
   "main": "./dist/index.cjs.js",

--- a/packages/bridge/bridge-react-webpack-plugin/package.json
+++ b/packages/bridge/bridge-react-webpack-plugin/package.json
@@ -11,6 +11,12 @@
     "url": "git+https://github.com/module-federation/core.git",
     "directory": "packages/bridge/bridge-react-webpack-plugin"
   },
+  "files": [
+    "dist/",
+    "src/",
+    "CHANGELOG.md",
+    "README.md"
+  ],
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.cjs.d.ts",

--- a/packages/bridge/bridge-react/package.json
+++ b/packages/bridge/bridge-react/package.json
@@ -14,8 +14,6 @@
   },
   "files": [
     "dist/",
-    "src/",
-    "CHANGELOG.md",
     "README.md"
   ],
   "main": "./dist/index.cjs.js",

--- a/packages/bridge/bridge-react/package.json
+++ b/packages/bridge/bridge-react/package.json
@@ -12,6 +12,12 @@
     "url": "git+https://github.com/module-federation/core.git",
     "directory": "packages/bridge/bridge-react"
   },
+  "files": [
+    "dist/",
+    "src/",
+    "CHANGELOG.md",
+    "README.md"
+  ],
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/bridge/bridge-shared/package.json
+++ b/packages/bridge/bridge-shared/package.json
@@ -13,8 +13,6 @@
   },
   "files": [
     "dist/",
-    "src/",
-    "CHANGELOG.md",
     "README.md"
   ],
   "type": "module",

--- a/packages/bridge/bridge-shared/package.json
+++ b/packages/bridge/bridge-shared/package.json
@@ -11,6 +11,12 @@
     "url": "git+https://github.com/module-federation/core.git",
     "directory": "packages/bridge/bridge-shared"
   },
+  "files": [
+    "dist/",
+    "src/",
+    "CHANGELOG.md",
+    "README.md"
+  ],
   "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/bridge/vue3-bridge/package.json
+++ b/packages/bridge/vue3-bridge/package.json
@@ -17,14 +17,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/",
-    "src/",
-    "CHANGELOG.md",
-    "LICENSE",
     "package.json",
-    "README.md",
-    "tsconfig.json",
-    "tsconfig.node.json",
-    "vite.config.ts"
+    "README.md"
   ],
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Add npm publish file lists for bridge packages to avoid shipping __tests__ and test fixtures.

## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue
#4668 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
