### PR TITLE
fix(enhanced): add esm export for runtime entry to fix vite resolution

### DIFF
--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -54,7 +54,7 @@
     },
     "./runtime": {
       "types": "./dist/src/runtime.d.ts",
-      "import": "./dist/src/runtime.js",
+      "import": "./dist/src/runtime.mjs",
       "require": "./dist/src/runtime.js"
     },
     "./prefetch": {

--- a/packages/enhanced/tsdown.config.mts
+++ b/packages/enhanced/tsdown.config.mts
@@ -29,4 +29,21 @@ export default defineConfig([
       dts: '.d.ts',
     }),
   },
+  {
+    name: 'enhanced-runtime-esm',
+    cwd: import.meta.dirname,
+    entry: ['src/runtime.ts'],
+    tsconfig: 'tsconfig.lib.json',
+    outDir: 'dist/src',
+    format: ['esm'],
+    external: [/^[^./]/, /package\.json$/],
+    sourcemap: true,
+    clean: false,
+    dts: false,
+    skipNodeModulesBundle: true,
+    unbundle: false,
+    outExtensions: () => ({
+      js: '.mjs',
+    }),
+  }
 ]);

--- a/packages/enhanced/tsdown.config.mts
+++ b/packages/enhanced/tsdown.config.mts
@@ -45,5 +45,5 @@ export default defineConfig([
     outExtensions: () => ({
       js: '.mjs',
     }),
-  }
+  },
 ]);


### PR DESCRIPTION

This change adds an ESM export for the runtime entry in @module-federation/enhanced to resolve Vite compatibility issues where it couldn't properly resolve the module.

- Modified `packages/enhanced/package.json` to include `.mjs` import for the runtime entry.
- Updated `packages/enhanced/tsdown.config.mts` to build the ESM runtime entry with `.mjs` extension.

Fixes #4680


Change-Id: If3915f016731bb1a3612ec4e4c9c2cc2cd84ecca

## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue
#4680 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
