### PR TITLE
fix(modernjs): prioritize dev.port over server.port for publicPath

### DIFF
--- a/packages/modernjs-v3/src/cli/configPlugin.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.ts
@@ -340,7 +340,7 @@ export function patchBundlerConfig(options: {
 
   if (isDev() && chain.output.get('publicPath') === 'auto') {
     // TODO: only in dev temp
-    const port = modernjsConfig.server?.port || 8080;
+    const port = modernjsConfig.dev?.port || modernjsConfig.server?.port || 8080;
     const publicPath = `http://localhost:${port}/`;
     chain.output.publicPath(publicPath);
   }


### PR DESCRIPTION
This commit modifies the calculation of publicPath in configPlugin.ts of @module-federation/modernjs-v3 to prioritize dev.port over server.port, ensuring that the dev server port is preferred when available.



## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
