### PR TITLE
feat(devtools): support runtime-registered react proxies across multiple scopes

### DIFF
--- a/.changeset/fix-chrome-fast-refresh-scope.md
+++ b/.changeset/fix-chrome-fast-refresh-scope.md
@@ -1,5 +1,5 @@
 ---
-"@module-federation/devtools": patch
+"@module-federation/devtools": minor
 ---
 
-Fix devtools fast refresh so scoped React and ReactDOM load without polluting root window globals.
+feat: support proxying runtime-registered React and ReactDOM in devtools fast refresh across multiple share scopes.

--- a/.changeset/fix-chrome-fast-refresh-scope.md
+++ b/.changeset/fix-chrome-fast-refresh-scope.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/devtools": patch
+---
+
+Fix devtools fast refresh so scoped React and ReactDOM load without polluting root window globals.

--- a/packages/chrome-devtools/__tests__/fast-refresh.spec.ts
+++ b/packages/chrome-devtools/__tests__/fast-refresh.spec.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __EAGER_SHARE__,
+  __ENABLE_FAST_REFRESH__,
+  __FEDERATION_DEVTOOLS__,
+} from '../src/template/constant';
+
+const resetWindowState = () => {
+  localStorage.clear();
+
+  const testWindow = window as Record<string, any>;
+
+  delete testWindow.React;
+  delete testWindow.ReactDOM;
+  delete testWindow.scope_react;
+  delete testWindow.scope_react_dom;
+  testWindow.__FEDERATION__ = {
+    __GLOBAL_PLUGIN__: [],
+    __INSTANCES__: [],
+    moduleInfo: {},
+    __SHARE__: {},
+    __MANIFEST_LOADING__: {},
+    __PRELOADED_MAP__: new Map(),
+  };
+  testWindow.__VMOK__ = testWindow.__FEDERATION__;
+};
+
+const stubUmdRequest = ({
+  reactScript = 'window.React = { source: "react" };',
+  reactDomScript = 'window.ReactDOM = { source: "react-dom" };',
+}: {
+  reactScript?: string;
+  reactDomScript?: string;
+} = {}) => {
+  class MockXMLHttpRequest {
+    status = 200;
+    responseText = '';
+    private url = '';
+    private isAsync = true;
+    onload: null | (() => void) = null;
+    onerror: null | (() => void) = null;
+
+    open(_method: string, url: string, async = true) {
+      this.url = url;
+      this.isAsync = async;
+    }
+
+    overrideMimeType() {}
+
+    private hydrateResponse() {
+      this.responseText = this.url.includes('react-dom')
+        ? reactDomScript
+        : reactScript;
+    }
+
+    send() {
+      this.hydrateResponse();
+
+      if (!this.isAsync) {
+        return;
+      }
+
+      queueMicrotask(() => {
+        this.onload?.();
+      });
+    }
+  }
+
+  vi.stubGlobal('XMLHttpRequest', MockXMLHttpRequest as typeof XMLHttpRequest);
+};
+
+const getPlugin = async () => {
+  await import('../src/utils/chrome/fast-refresh');
+  return (window as any).__FEDERATION__.__GLOBAL_PLUGIN__.at(-1);
+};
+
+describe('fast refresh shared scope globals', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    resetWindowState();
+  });
+
+  it('hydrates scope globals from eager share cache on import', async () => {
+    localStorage.setItem(
+      __FEDERATION_DEVTOOLS__,
+      JSON.stringify({
+        [__ENABLE_FAST_REFRESH__]: true,
+        [__EAGER_SHARE__]: ['react', '19.2.0', ['scope']],
+      }),
+    );
+    stubUmdRequest();
+
+    await import('../src/utils/chrome/fast-refresh');
+
+    expect((window as any).scope_react).toEqual({ source: 'react' });
+    expect((window as any).scope_react_dom).toEqual({
+      source: 'react-dom',
+    });
+    expect((window as any).React).toBeUndefined();
+    expect((window as any).ReactDOM).toBeUndefined();
+  });
+
+  it('hydrates every scoped global key when eager share contains multiple scopes', async () => {
+    localStorage.setItem(
+      __FEDERATION_DEVTOOLS__,
+      JSON.stringify({
+        [__ENABLE_FAST_REFRESH__]: true,
+        [__EAGER_SHARE__]: ['react', '19.2.0', ['scope-a', 'scope-b']],
+      }),
+    );
+    stubUmdRequest();
+
+    await import('../src/utils/chrome/fast-refresh');
+
+    expect((window as any).scope_a_react).toEqual({ source: 'react' });
+    expect((window as any).scope_b_react).toEqual({ source: 'react' });
+    expect((window as any).scope_a_react_dom).toEqual({
+      source: 'react-dom',
+    });
+    expect((window as any).scope_b_react_dom).toEqual({
+      source: 'react-dom',
+    });
+    expect((window as any).React).toBeUndefined();
+    expect((window as any).ReactDOM).toBeUndefined();
+  });
+
+  it('prefers scope globals when reusing eager shared react and react-dom', async () => {
+    localStorage.setItem(
+      __FEDERATION_DEVTOOLS__,
+      JSON.stringify({
+        [__ENABLE_FAST_REFRESH__]: true,
+        [__EAGER_SHARE__]: ['react', '19.2.0', ['scope']],
+      }),
+    );
+    stubUmdRequest();
+
+    const plugin = await getPlugin();
+
+    (window as any).React = { source: 'root-react' };
+    (window as any).ReactDOM = { source: 'root-react-dom' };
+    (window as any).scope_react = { source: 'scope-react' };
+    (window as any).scope_react_dom = { source: 'scope-react-dom' };
+
+    const reactShared = {
+      version: '19.2.0',
+      scope: ['scope'],
+      shareConfig: {
+        eager: true,
+      },
+      lib: () => ({ source: 'original-react' }),
+    };
+    plugin.beforeRegisterShare({
+      pkgName: 'react',
+      shared: reactShared,
+      origin: {} as never,
+    });
+
+    const reactDomShared = {
+      version: '19.2.0',
+      scope: ['scope'],
+      shareConfig: {
+        eager: true,
+      },
+      lib: () => ({ source: 'original-react-dom' }),
+    };
+    plugin.beforeRegisterShare({
+      pkgName: 'react-dom',
+      shared: reactDomShared,
+      origin: {} as never,
+    });
+
+    expect(reactShared.lib()).toBe((window as any).scope_react);
+    expect(reactDomShared.lib()).toBe((window as any).scope_react_dom);
+  });
+
+  it('copies async loaded globals into scope globals for react and react-dom', async () => {
+    localStorage.setItem(
+      __FEDERATION_DEVTOOLS__,
+      JSON.stringify({
+        [__ENABLE_FAST_REFRESH__]: true,
+      }),
+    );
+    stubUmdRequest({
+      reactScript: 'window.React = { source: "loaded-react" };',
+      reactDomScript:
+        'window.ReactDOM = { source: "loaded-react-dom", react: window.React };',
+    });
+
+    const plugin = await getPlugin();
+
+    const reactShared: Record<string, any> = {
+      version: '19.2.0',
+      scope: ['scope'],
+      shareConfig: {
+        eager: false,
+      },
+    };
+    plugin.beforeRegisterShare({
+      pkgName: 'react',
+      shared: reactShared,
+      origin: {} as never,
+    });
+
+    const reactDomShared: Record<string, any> = {
+      version: '19.2.0',
+      scope: ['scope'],
+      shareConfig: {
+        eager: false,
+      },
+    };
+    plugin.beforeRegisterShare({
+      pkgName: 'react-dom',
+      shared: reactDomShared,
+      origin: {} as never,
+    });
+
+    const reactFactory = await reactShared.get();
+    expect((window as any).scope_react).toEqual({ source: 'loaded-react' });
+    expect((window as any).React).toBeUndefined();
+    expect(reactFactory()).toBe((window as any).scope_react);
+
+    const reactDomFactory = await reactDomShared.get();
+    expect((window as any).scope_react_dom).toEqual({
+      source: 'loaded-react-dom',
+      react: (window as any).scope_react,
+    });
+    expect((window as any).ReactDOM).toBeUndefined();
+    expect(reactDomFactory()).toBe((window as any).scope_react_dom);
+  });
+});

--- a/packages/chrome-devtools/src/utils/chrome/fast-refresh.ts
+++ b/packages/chrome-devtools/src/utils/chrome/fast-refresh.ts
@@ -1,6 +1,4 @@
 import type { ModuleFederationRuntimePlugin } from '@module-federation/runtime';
-import { loadScript } from '@module-federation/sdk';
-
 import { getUnpkgUrl } from '../index';
 import { definePropertyGlobalVal } from '../sdk';
 import {
@@ -13,13 +11,94 @@ const SUPPORT_PKGS = ['react', 'react-dom'];
 type BeforeRegisterShareArgs = Parameters<
   NonNullable<ModuleFederationRuntimePlugin['beforeRegisterShare']>
 >[0];
+type SupportPkg = (typeof SUPPORT_PKGS)[number];
+type EagerShareInfo = [string, string, Array<string>?];
 
-/**
- * Fetch and execute a UMD module synchronously
- * @param url - URL of the UMD module to load
- * @returns The module exports
- */
-const fetchAndExecuteUmdSync = (url: string): any => {
+const DEFAULT_SHARE_SCOPE = 'default';
+const DEFAULT_GLOBAL_KEY_MAP: Record<SupportPkg, string> = {
+  react: 'React',
+  'react-dom': 'ReactDOM',
+};
+
+const sanitizeWindowKey = (value: string) =>
+  value.replace(/[^a-zA-Z0-9_$]/g, '_');
+
+const getShareScopes = (scope?: Array<string>) =>
+  Array.isArray(scope) && scope.length ? scope : [DEFAULT_SHARE_SCOPE];
+
+const getDefaultGlobalKey = (pkgName: SupportPkg) =>
+  DEFAULT_GLOBAL_KEY_MAP[pkgName];
+
+const getScopedGlobalKey = (scope: string, pkgName: SupportPkg) =>
+  `${sanitizeWindowKey(scope)}_${sanitizeWindowKey(pkgName)}`;
+
+const getWindowValue = (key: string) => (window as Record<string, any>)[key];
+
+const setWindowValue = (key: string, value: unknown) => {
+  (window as Record<string, any>)[key] = value;
+};
+
+const setScopeGlobals = (
+  pkgName: SupportPkg,
+  scopes: Array<string>,
+  source: unknown,
+) => {
+  if (!source) {
+    return source;
+  }
+
+  scopes.forEach((scope) => {
+    setWindowValue(getScopedGlobalKey(scope, pkgName), source);
+  });
+
+  return source;
+};
+
+const getScopeGlobal = (pkgName: SupportPkg, scopes: Array<string>) => {
+  for (const scope of scopes) {
+    const scopeGlobal = getWindowValue(getScopedGlobalKey(scope, pkgName));
+    if (scopeGlobal) {
+      return scopeGlobal;
+    }
+  }
+  return undefined;
+};
+
+const getEagerShareInfo = (eagerShare: unknown) => {
+  if (!Array.isArray(eagerShare) || eagerShare.length < 2) {
+    return null;
+  }
+
+  const [, version, scopes] = eagerShare as EagerShareInfo;
+  if (typeof version !== 'string') {
+    return null;
+  }
+
+  return {
+    version,
+    scopes: getShareScopes(scopes),
+  };
+};
+
+const updateEagerShareInfo = (
+  devtoolsMessage: Record<string, unknown>,
+  pkgName: string,
+  version: string,
+  scopes: Array<string>,
+) => {
+  const existing = getEagerShareInfo(devtoolsMessage[__EAGER_SHARE__]);
+  const mergedScopes = Array.from(
+    new Set([...(existing?.scopes || []), ...scopes]),
+  );
+
+  devtoolsMessage[__EAGER_SHARE__] = [pkgName, version, mergedScopes];
+
+  return {
+    shouldReload: !existing || existing.version !== version,
+  };
+};
+
+const requestUmdSourceSync = (url: string) => {
   try {
     const response = new XMLHttpRequest();
     response.open('GET', url, false);
@@ -27,22 +106,139 @@ const fetchAndExecuteUmdSync = (url: string): any => {
     response.send();
 
     if (response.status === 200) {
-      const scriptContent = response.responseText;
-
-      // Create a new Function constructor to execute the script synchronously
-      const moduleFunction = new Function(scriptContent);
-
-      // Execute the function and return the module exports
-      return moduleFunction(window);
-    } else {
-      throw new Error(
-        `Failed to load module from ${url}: HTTP ${response.status}`,
-      );
+      return response.responseText;
     }
+
+    throw new Error(
+      `Failed to load module from ${url}: HTTP ${response.status}`,
+    );
   } catch (error: any) {
     throw new Error(`Failed to fetch module from ${url}: ${error.message}`);
   }
 };
+
+const requestUmdSource = (url: string) =>
+  new Promise<string>((resolve, reject) => {
+    try {
+      const response = new XMLHttpRequest();
+      response.open('GET', url, true);
+      response.overrideMimeType('text/plain');
+      response.onload = () => {
+        if (response.status === 200) {
+          resolve(response.responseText);
+          return;
+        }
+
+        reject(
+          new Error(
+            `Failed to load module from ${url}: HTTP ${response.status}`,
+          ),
+        );
+      };
+      response.onerror = () => {
+        reject(new Error(`Failed to fetch module from ${url}`));
+      };
+      response.send();
+    } catch (error: any) {
+      reject(new Error(`Failed to fetch module from ${url}: ${error.message}`));
+    }
+  });
+
+const createUmdSandbox = (pkgName: SupportPkg, scopes: Array<string>) => {
+  const sandboxTarget = Object.create(null) as Record<string, any>;
+
+  const sandbox = new Proxy(sandboxTarget, {
+    get(target, key) {
+      if (typeof key === 'symbol') {
+        return Reflect.get(target, key);
+      }
+
+      if (key in target) {
+        return target[key];
+      }
+
+      const value = (window as Record<string, any>)[key];
+      return typeof value === 'function' ? value.bind(window) : value;
+    },
+    set(target, key, value) {
+      target[key as string] = value;
+      return true;
+    },
+    has(target, key) {
+      return key in target || key in window;
+    },
+  }) as Record<string, any>;
+
+  sandboxTarget.window = sandbox;
+  sandboxTarget.self = sandbox;
+  sandboxTarget.globalThis = sandbox;
+  sandboxTarget.global = sandbox;
+  sandboxTarget.document = window.document;
+
+  if (pkgName === 'react-dom') {
+    sandboxTarget.React = getScopeGlobal('react', scopes);
+  }
+
+  return sandbox;
+};
+
+const executeUmdModule = (
+  scriptContent: string,
+  pkgName: SupportPkg,
+  scopes: Array<string>,
+) => {
+  const sandbox = createUmdSandbox(pkgName, scopes);
+
+  const moduleFunction = new Function(
+    'window',
+    'self',
+    'globalThis',
+    'global',
+    'document',
+    'exports',
+    'module',
+    'define',
+    'require',
+    scriptContent,
+  );
+
+  moduleFunction.call(
+    sandbox,
+    sandbox,
+    sandbox,
+    sandbox,
+    sandbox,
+    sandbox.document,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  );
+
+  return sandbox[getDefaultGlobalKey(pkgName)];
+};
+
+const loadUmdModuleSync = (
+  pkgName: SupportPkg,
+  version: string,
+  scopes: Array<string>,
+) =>
+  executeUmdModule(
+    requestUmdSourceSync(getUnpkgUrl(pkgName, version) as string),
+    pkgName,
+    scopes,
+  );
+
+const loadUmdModule = async (
+  pkgName: SupportPkg,
+  version: string,
+  scopes: Array<string>,
+) =>
+  executeUmdModule(
+    await requestUmdSource(getUnpkgUrl(pkgName, version) as string),
+    pkgName,
+    scopes,
+  );
 
 const getDevtoolsMessage = () => {
   const devtoolsMessageStr = localStorage.getItem(__FEDERATION_DEVTOOLS__);
@@ -57,14 +253,15 @@ const getDevtoolsMessage = () => {
 };
 
 const devtoolsMessage = getDevtoolsMessage();
-if (
-  devtoolsMessage?.[__ENABLE_FAST_REFRESH__] &&
-  devtoolsMessage?.[__EAGER_SHARE__]
-) {
-  // eagerShare is [react, 19.0.0]
-  const [, version] = devtoolsMessage[__EAGER_SHARE__] as [string, string];
-  fetchAndExecuteUmdSync(getUnpkgUrl('react', version) as string);
-  fetchAndExecuteUmdSync(getUnpkgUrl('react-dom', version) as string);
+const eagerShareInfo = getEagerShareInfo(devtoolsMessage?.[__EAGER_SHARE__]);
+if (devtoolsMessage?.[__ENABLE_FAST_REFRESH__] && eagerShareInfo) {
+  const { version, scopes } = eagerShareInfo;
+  setScopeGlobals('react', scopes, loadUmdModuleSync('react', version, scopes));
+  setScopeGlobals(
+    'react-dom',
+    scopes,
+    loadUmdModuleSync('react-dom', version, scopes),
+  );
 }
 
 const fastRefreshPlugin = (): ModuleFederationRuntimePlugin => {
@@ -80,6 +277,8 @@ const fastRefreshPlugin = (): ModuleFederationRuntimePlugin => {
       if (!SUPPORT_PKGS.includes(pkgName)) {
         return args;
       }
+      const supportPkgName = pkgName as SupportPkg;
+      const shareScopes = getShareScopes(shared.scope);
 
       let enableFastRefresh = false;
       let devtoolsMessage: Record<string, unknown> = {};
@@ -100,22 +299,38 @@ const fastRefreshPlugin = (): ModuleFederationRuntimePlugin => {
         return args;
       }
 
-      if (shared.shareConfig?.eager) {
+      if (shared.shareConfig?.eager || shared.lib) {
         if (!devtoolsMessage?.[__EAGER_SHARE__]) {
-          const eagerShare: string[] = [];
-          eagerShare.push(pkgName, shared.version);
-          devtoolsMessage[__EAGER_SHARE__] = eagerShare;
+          const eagerShareInfo = updateEagerShareInfo(
+            devtoolsMessage,
+            pkgName,
+            shared.version,
+            shareScopes,
+          );
           localStorage.setItem(
             __FEDERATION_DEVTOOLS__,
             JSON.stringify(devtoolsMessage),
           );
-          window.location.reload();
+          if (eagerShareInfo.shouldReload) {
+            window.location.reload();
+          }
+        } else {
+          updateEagerShareInfo(
+            devtoolsMessage,
+            pkgName,
+            shared.version,
+            shareScopes,
+          );
+          localStorage.setItem(
+            __FEDERATION_DEVTOOLS__,
+            JSON.stringify(devtoolsMessage),
+          );
         }
         if (pkgName === 'react-dom') {
-          shared.lib = () => window.ReactDOM;
+          shared.lib = () => getScopeGlobal(supportPkgName, shareScopes);
         }
         if (pkgName === 'react') {
-          shared.lib = () => window.React;
+          shared.lib = () => getScopeGlobal(supportPkgName, shareScopes);
         }
         return args;
       }
@@ -123,46 +338,48 @@ const fastRefreshPlugin = (): ModuleFederationRuntimePlugin => {
       let get: (() => any) | undefined;
       if (pkgName === 'react') {
         get = () =>
-          loadScript(getUnpkgUrl(pkgName, shared.version) as string, {
-            attrs: {
-              defer: false,
-              async: false,
-              'data-mf-injected': 'true',
-            },
-          }).then(() => {
-            orderResolve();
-          });
+          loadUmdModule(supportPkgName, shared.version, shareScopes)
+            .then((moduleValue) => {
+              setScopeGlobals(supportPkgName, shareScopes, moduleValue);
+              return moduleValue;
+            })
+            .then(() => {
+              orderResolve();
+            });
       }
       if (pkgName === 'react-dom') {
         get = () =>
-          orderPromise.then(() =>
-            loadScript(getUnpkgUrl(pkgName, shared.version) as string, {
-              attrs: { defer: true, async: false },
-            }),
-          );
+          orderPromise
+            .then(() =>
+              loadUmdModule(supportPkgName, shared.version, shareScopes),
+            )
+            .then((result) => {
+              setScopeGlobals(supportPkgName, shareScopes, result);
+              return result;
+            });
       }
 
       if (typeof get === 'function') {
         const finalGet = get;
         if (pkgName === 'react') {
           shared.get = async () => {
-            if (!window.React) {
+            if (!getScopeGlobal(supportPkgName, shareScopes)) {
               await finalGet();
               console.warn(
                 '[Module Federation HMR]: You are using Module Federation Devtools to debug online host, it will cause your project load Dev mode React and ReactDOM. If not in this mode, please disable it in Module Federation Devtools',
               );
             }
-            shared.lib = () => window.React;
-            return () => window.React;
+            shared.lib = () => getScopeGlobal(supportPkgName, shareScopes);
+            return () => getScopeGlobal(supportPkgName, shareScopes);
           };
         }
         if (pkgName === 'react-dom') {
           shared.get = async () => {
-            if (!window.ReactDOM) {
+            if (!getScopeGlobal(supportPkgName, shareScopes)) {
               await finalGet();
             }
-            shared.lib = () => window.ReactDOM;
-            return () => window.ReactDOM;
+            shared.lib = () => getScopeGlobal(supportPkgName, shareScopes);
+            return () => getScopeGlobal(supportPkgName, shareScopes);
           };
         }
       }

--- a/packages/chrome-devtools/src/utils/chrome/fast-refresh.ts
+++ b/packages/chrome-devtools/src/utils/chrome/fast-refresh.ts
@@ -1,8 +1,7 @@
 import type { ModuleFederationRuntimePlugin } from '@module-federation/runtime';
-import type { Shared } from '@module-federation/runtime/types';
-import { loadScript, createScript } from '@module-federation/sdk';
+import { loadScript } from '@module-federation/sdk';
 
-import { isObject, getUnpkgUrl } from '../index';
+import { getUnpkgUrl } from '../index';
 import { definePropertyGlobalVal } from '../sdk';
 import {
   __FEDERATION_DEVTOOLS__,
@@ -11,8 +10,8 @@ import {
 } from '../../template/constant';
 
 const SUPPORT_PKGS = ['react', 'react-dom'];
-type BeforeInitArgs = Parameters<
-  NonNullable<ModuleFederationRuntimePlugin['beforeInit']>
+type BeforeRegisterShareArgs = Parameters<
+  NonNullable<ModuleFederationRuntimePlugin['beforeRegisterShare']>
 >[0];
 
 /**
@@ -63,17 +62,25 @@ if (
   devtoolsMessage?.[__EAGER_SHARE__]
 ) {
   // eagerShare is [react, 19.0.0]
-  const [_name, version] = devtoolsMessage[__EAGER_SHARE__] as [string, string];
+  const [, version] = devtoolsMessage[__EAGER_SHARE__] as [string, string];
   fetchAndExecuteUmdSync(getUnpkgUrl('react', version) as string);
   fetchAndExecuteUmdSync(getUnpkgUrl('react-dom', version) as string);
 }
 
 const fastRefreshPlugin = (): ModuleFederationRuntimePlugin => {
+  let orderResolve: (value?: unknown) => void;
+  const orderPromise = new Promise((resolve) => {
+    orderResolve = resolve;
+  });
+
   return {
     name: 'mf-fast-refresh-plugin',
-    beforeInit({ userOptions, ...args }: BeforeInitArgs) {
-      const shareInfo = userOptions.shared;
-      const twinsShareInfo = args.shareInfo;
+    beforeRegisterShare(args: BeforeRegisterShareArgs) {
+      const { pkgName, shared } = args;
+      if (!SUPPORT_PKGS.includes(pkgName)) {
+        return args;
+      }
+
       let enableFastRefresh = false;
       let devtoolsMessage: Record<string, unknown> = {};
 
@@ -90,115 +97,77 @@ const fastRefreshPlugin = (): ModuleFederationRuntimePlugin => {
       }
 
       if (!enableFastRefresh) {
-        return {
-          userOptions,
-          ...args,
-        };
+        return args;
       }
 
-      if (shareInfo && isObject(shareInfo)) {
-        let orderResolve: (value?: unknown) => void;
-        const orderPromise = new Promise((resolve) => {
-          orderResolve = resolve;
-        });
-        Object.keys(shareInfo).forEach(async (share) => {
-          // @ts-ignore legacy runtime shareInfo[share] is shared , and latest i shard[]
-          const sharedArr: Shared[] = Array.isArray(shareInfo[share])
-            ? shareInfo[share]
-            : [shareInfo[share]];
+      if (shared.shareConfig?.eager) {
+        if (!devtoolsMessage?.[__EAGER_SHARE__]) {
+          const eagerShare: string[] = [];
+          eagerShare.push(pkgName, shared.version);
+          devtoolsMessage[__EAGER_SHARE__] = eagerShare;
+          localStorage.setItem(
+            __FEDERATION_DEVTOOLS__,
+            JSON.stringify(devtoolsMessage),
+          );
+          window.location.reload();
+        }
+        if (pkgName === 'react-dom') {
+          shared.lib = () => window.ReactDOM;
+        }
+        if (pkgName === 'react') {
+          shared.lib = () => window.React;
+        }
+        return args;
+      }
 
-          let twinsSharedArr: Shared[];
-          if (twinsShareInfo) {
-            // @ts-ignore
-            twinsSharedArr = Array.isArray(twinsShareInfo[share])
-              ? twinsShareInfo[share]
-              : [twinsShareInfo[share]];
-          }
-
-          sharedArr.forEach((shared, idx) => {
-            if (!SUPPORT_PKGS.includes(share)) {
-              return;
-            }
-            if (shared.shareConfig?.eager) {
-              if (!devtoolsMessage?.[__EAGER_SHARE__]) {
-                const eagerShare: string[] = [];
-                eagerShare.push(share, shared.version);
-                devtoolsMessage[__EAGER_SHARE__] = eagerShare;
-                localStorage.setItem(
-                  __FEDERATION_DEVTOOLS__,
-                  JSON.stringify(devtoolsMessage),
-                );
-                window.location.reload();
-              }
-              if (share === 'react-dom') {
-                shared.lib = () => window.ReactDOM;
-              }
-              if (share === 'react') {
-                shared.lib = () => window.React;
-              }
-              return;
-            }
-            let get: () => any;
-            if (share === 'react') {
-              get = () =>
-                loadScript(getUnpkgUrl(share, shared.version) as string, {
-                  attrs: {
-                    defer: false,
-                    async: false,
-                    'data-mf-injected': 'true',
-                  },
-                }).then(() => {
-                  orderResolve();
-                });
-            }
-            if (share === 'react-dom') {
-              get = () =>
-                orderPromise.then(() =>
-                  loadScript(getUnpkgUrl(share, shared.version) as string, {
-                    attrs: { defer: true, async: false },
-                  }),
-                );
-            }
-            // @ts-expect-error
-            if (typeof get === 'function') {
-              if (share === 'react') {
-                shared.get = async () => {
-                  if (!window.React) {
-                    await get();
-                    console.warn(
-                      '[Module Federation HMR]: You are using Module Federation Devtools to debug online host, it will cause your project load Dev mode React and ReactDOM. If not in this mode, please disable it in Module Federation Devtools',
-                    );
-                  }
-                  shared.lib = () => window.React;
-                  return () => window.React;
-                };
-              }
-              if (share === 'react-dom') {
-                shared.get = async () => {
-                  if (!window.ReactDOM) {
-                    await get();
-                  }
-                  shared.lib = () => window.ReactDOM;
-                  return () => window.ReactDOM;
-                };
-              }
-              if (twinsShareInfo) {
-                twinsSharedArr[idx].get = shared.get;
-              }
-            }
+      let get: (() => any) | undefined;
+      if (pkgName === 'react') {
+        get = () =>
+          loadScript(getUnpkgUrl(pkgName, shared.version) as string, {
+            attrs: {
+              defer: false,
+              async: false,
+              'data-mf-injected': 'true',
+            },
+          }).then(() => {
+            orderResolve();
           });
-        });
-
-        return {
-          userOptions,
-          ...args,
-        };
-      } else {
-        return {
-          userOptions,
-          ...args,
-        };
       }
+      if (pkgName === 'react-dom') {
+        get = () =>
+          orderPromise.then(() =>
+            loadScript(getUnpkgUrl(pkgName, shared.version) as string, {
+              attrs: { defer: true, async: false },
+            }),
+          );
+      }
+
+      if (typeof get === 'function') {
+        const finalGet = get;
+        if (pkgName === 'react') {
+          shared.get = async () => {
+            if (!window.React) {
+              await finalGet();
+              console.warn(
+                '[Module Federation HMR]: You are using Module Federation Devtools to debug online host, it will cause your project load Dev mode React and ReactDOM. If not in this mode, please disable it in Module Federation Devtools',
+              );
+            }
+            shared.lib = () => window.React;
+            return () => window.React;
+          };
+        }
+        if (pkgName === 'react-dom') {
+          shared.get = async () => {
+            if (!window.ReactDOM) {
+              await finalGet();
+            }
+            shared.lib = () => window.ReactDOM;
+            return () => window.ReactDOM;
+          };
+        }
+      }
+
+      return args;
     },
   };
 };


### PR DESCRIPTION

## Description

This PR updates devtools fast refresh so runtime-registered React and ReactDOM can also be proxied correctly.
It now supports multiple share scopes and avoids falling back to a single root global value.

## Related Issue

N/A

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.