### PR TITLE
fix(metro): add missing changeset and format follow-up for #4576

### DIFF
--- a/.changeset/fix-4576-metro-cache-release.md
+++ b/.changeset/fix-4576-metro-cache-release.md
@@ -1,0 +1,8 @@
+---
+'@module-federation/metro': minor
+'@module-federation/sdk': patch
+---
+
+feat(metro): add manifest SHA-256 bundle hashes and optional cache layer integration for bundle loading.
+
+Credit: originally contributed by @zhongwuzw in #4576.

--- a/packages/metro-core/src/modules/metroCorePlugin.ts
+++ b/packages/metro-core/src/modules/metroCorePlugin.ts
@@ -122,9 +122,7 @@ const MetroCorePlugin: () => ModuleFederationRuntimePlugin = () => {
       // Register bundle hashes with cache layer for integrity verification
       try {
         const cacheLayer = (globalThis as any).__FEDERATION__?.__NATIVE__
-          ?.__CACHE_LAYER__ as
-          | ICacheLayer
-          | undefined;
+          ?.__CACHE_LAYER__ as ICacheLayer | undefined;
         if (!cacheLayer) return args;
 
         const { origin, remoteInfo, remote } = args;


### PR DESCRIPTION
## Summary
- Follow up on #4576 to fix CI formatting failure in `packages/metro-core/src/modules/metroCorePlugin.ts`.
- Add the missing changeset required for the merged metro cache/hash feature work introduced in #4576.
- Credit original feature contribution by @zhongwuzw; this PR only restores release metadata and formatting parity.

## Why
#4576 merged feature-level changes in `@module-federation/metro` and SDK manifest typing updates but did not include a changeset, and the run failed on formatting. This follow-up restores repository contribution/CI expectations so release automation can capture the package changes correctly.

## User/Runtime Impact
- No behavior change beyond formatting.
- Ensures release notes/versioning include:
  - `@module-federation/metro`: `minor`
  - `@module-federation/sdk`: `patch`

## Validation
Ran CI-aligned checks for metro package changes:
- `pnpm exec prettier --check "packages/metro-core/src/modules/metroCorePlugin.ts" ".changeset/fix-4576-metro-cache-release.md"`
- `pnpm run build:packages`
- `pnpm exec turbo run test --filter=@module-federation/metro --filter=@module-federation/metro-plugin-rnef --filter=@module-federation/metro-plugin-rock --filter=@module-federation/metro-plugin-rnc-cli`
- `pnpm exec turbo run lint --filter=@module-federation/metro --filter=@module-federation/metro-plugin-rnef --filter=@module-federation/metro-plugin-rock --filter=@module-federation/metro-plugin-rnc-cli`

## Skipped Checks
- No required metro parity checks were skipped.
- E2E `ci:local` jobs were not run because this follow-up is limited to formatting + changeset metadata (no functional code-path changes).