### PR TITLE
feat(runtime): support getInstance finder callback

### DIFF
--- a/.changeset/get-instance-finder.md
+++ b/.changeset/get-instance-finder.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': minor
+---
+
+feat(runtime): support finder callbacks in getInstance

--- a/.changeset/get-instance-finder.md
+++ b/.changeset/get-instance-finder.md
@@ -1,5 +1,6 @@
 ---
 '@module-federation/runtime': minor
+'website-new': patch
 ---
 
-feat(runtime): support finder callbacks in getInstance
+feat(runtime): support finder callbacks in `getInstance` and clarify runtime instance API usage.

--- a/apps/website-new/docs/en/guide/runtime/runtime-api.mdx
+++ b/apps/website-new/docs/en/guide/runtime/runtime-api.mdx
@@ -232,8 +232,9 @@ If you are not using the build plugin, you can switch from `init` to [createInst
 
 ## getInstance
 
-- Type: `getInstance(): ModuleFederation`
-- Retrieves the `ModuleFederation` instance created by the build plugin
+- Type: `getInstance(): ModuleFederation | null`
+- Type: `getInstance(finder: (instance: ModuleFederation) => boolean): ModuleFederation | null`
+- Retrieves the `ModuleFederation` instance created by the build plugin, or the first registered instance that matches a finder callback
 
 When the build plugin is used, you can call `getInstance` to retrieve the `ModuleFederation` instance created by the build plugin.
 
@@ -242,6 +243,14 @@ import { getInstance } from '@module-federation/enhanced/runtime';
 
 const mfInstance = getInstance();
 mfInstance.loadRemote('remote/util');
+```
+
+If you need a specific registered instance, pass a finder callback. The runtime will iterate over the registered instances and return the first match.
+
+```ts
+const targetInstance = getInstance(
+  (instance) => instance.name === 'remote-host',
+);
 ```
 
 If the build plugin is not used, calling `getInstance` will throw an exception. In this case, you need to use the [createInstance](#createinstance) to create a new instance.

--- a/apps/website-new/docs/en/guide/runtime/runtime-api.mdx
+++ b/apps/website-new/docs/en/guide/runtime/runtime-api.mdx
@@ -1,10 +1,13 @@
 # Runtime API
 
 import { Steps, Tab, Tabs, Badge, Aside } from '@theme';
-import Collapse from '@components/Collapse'
-import Runtime from '@components/en/runtime/index';
+import Collapse from '@components/Collapse';
 
-<Runtime />
+MF runtime APIs are built around the `ModuleFederation` instance. Except for [createInstance](#createinstance), which creates and returns a new instance, the other APIs run against an existing runtime instance.
+
+The default instance is usually created automatically by the build plugin, or initialized manually through [init](#init). When calling runtime APIs, you do not need to pass a `ModuleFederation` instance explicitly. They automatically use the default instance from the runtime.
+
+It is important to note that the new instance created by [createInstance](#createinstance) does not replace the default instance, but it is added to the global instance registry. You can later retrieve it through [getInstance](#getinstance) with a finder callback.
 
 ## createInstance
 
@@ -12,9 +15,7 @@ Used to create ModuleFederation instance.
 
 * When to use `createInstance`?
 
-  To ensure the uniqueness of the ModuleFederation instance, after the build plugin creates an instance, it will be stored in memory. The exported APIs all first obtain the ModuleFederation instance from memory and then call the APIs of the ModuleFederation instance. This is also why APIs like loadRemote can be used directly from the `@module-federation/enhanced/runtime` package and inherently understand what application container they are attached to.
-
-  This singleton pattern works for most scenarios, but in the following cases, you need to use `createInstance`:
+  The default instance pattern works for most scenarios, but in the following cases, you need to use `createInstance`:
 
   - No build plugin is used  (Only use runtime)
   - Multiple ModuleFederation instances need to be created with different configurations for each instance
@@ -42,16 +43,20 @@ mf.loadRemote('sub1/util').then((m) => m.add(1, 2, 3));
 
 :::warning Warning
 
-`init` is still supported, but choose it based on how you want instances to be managed.
+`init` is used to initialize a runtime instance, but it does not always create a new `ModuleFederation` instance.
 
-Unlike [createInstance](#createinstance), `init` does not always create a fresh instance. It first looks up an existing instance by `name` and `version`. If a matching instance is found, it reuses that instance and merges the new options by calling `instance.initOptions(options)`. If no matching instance exists, it falls back to creating one.
+When `init` is called, the runtime first looks for an existing instance by `name` and `version`. If a matching instance is found, it will be reused, and the new options will be merged through `instance.initOptions(options)`. If no matching instance is found, a new instance will be created.
 
-Use `init` when you want repeated calls for the same host to reuse and extend a single runtime instance. Use [createInstance](#createinstance) when you need guaranteed isolation and a brand-new instance every time. If you only need the instance created by the build plugin, use [getInstance](#getinstance).
+Therefore, `init` is more suitable when the same host may be initialized multiple times and you want to reuse and extend the same runtime instance.
+
+- If you need to create a completely independent new instance, use [createInstance](#createinstance).
+
+- If you only want to access the instance created by the build plugin, use [getInstance](#getinstance).
 
 :::
 
 - Type: `init(options: InitOptions): ModuleFederation`
-- Used for dynamically registering `Vmok` modules at runtime.
+- Used to initialize or reuse a `ModuleFederation` runtime instance
 - InitOptions:
 
 <Collapse>
@@ -234,26 +239,34 @@ If you are not using the build plugin, you can switch from `init` to [createInst
 
 - Type: `getInstance(): ModuleFederation | null`
 - Type: `getInstance(finder: (instance: ModuleFederation) => boolean): ModuleFederation | null`
-- Retrieves the `ModuleFederation` instance created by the build plugin, or the first registered instance that matches a finder callback
+- Retrieves the default `ModuleFederation` instance, or the first registered instance that matches a finder callback
 
-When the build plugin is used, you can call `getInstance` to retrieve the `ModuleFederation` instance created by the build plugin.
+When the build plugin or [init](#init) creates the default instance, you can call `getInstance()` to retrieve it.
 
 ```ts
 import { getInstance } from '@module-federation/enhanced/runtime';
 
 const mfInstance = getInstance();
+if (!mfInstance) {
+  throw new Error('Module Federation instance is not initialized');
+}
+
 mfInstance.loadRemote('remote/util');
 ```
 
-If you need a specific registered instance, pass a finder callback. The runtime will iterate over the registered instances and return the first match.
+Instances created by [createInstance](#createinstance) do not replace the default instance, but they are still registered globally. You can pass a finder callback to `getInstance` to retrieve one later even if you did not keep the returned reference.
+
+The finder callback works like `Array.prototype.find`: the runtime iterates over the registered instances and returns the first match. If no matching instance exists, `getInstance` returns `null`.
 
 ```ts
 const targetInstance = getInstance(
   (instance) => instance.name === 'remote-host',
 );
-```
 
-If the build plugin is not used, calling `getInstance` will throw an exception. In this case, you need to use the [createInstance](#createinstance) to create a new instance.
+if (targetInstance) {
+  targetInstance.loadRemote('remote/util');
+}
+```
 
 ## registerRemotes
 

--- a/apps/website-new/docs/zh/guide/runtime/runtime-api.mdx
+++ b/apps/website-new/docs/zh/guide/runtime/runtime-api.mdx
@@ -235,8 +235,9 @@ plugins: [mfRuntimePlugin()]
 
 ## getInstance
 
-- Type: `getInstance(): ModuleFederation`
-- 获取构建插件创建的 `ModuleFederation` 实例
+- Type: `getInstance(): ModuleFederation | null`
+- Type: `getInstance(finder: (instance: ModuleFederation) => boolean): ModuleFederation | null`
+- 获取构建插件创建的 `ModuleFederation` 实例，或者返回首个匹配 finder 回调的已注册实例
 
 当使用了构建插件后，可以调用 `getInstance` 获取构建插件创建的 `ModuleFederation` 实例。
 
@@ -245,6 +246,14 @@ import { getInstance } from '@module-federation/enhanced/runtime';
 
 const mfInstance = getInstance();
 mfInstance.loadRemote('remote/util');
+```
+
+如果你需要拿到某个特定的已注册实例，可以传入一个 finder 回调。运行时会遍历当前已注册的实例并返回第一个匹配项。
+
+```ts
+const targetInstance = getInstance(
+  (instance) => instance.name === 'remote-host',
+);
 ```
 
 如果没有使用构建插件，调用 `getInstance` 会抛出异常，此时你需要使用 [createInstance](#createinstance) 来创建一个新的实例。

--- a/apps/website-new/docs/zh/guide/runtime/runtime-api.mdx
+++ b/apps/website-new/docs/zh/guide/runtime/runtime-api.mdx
@@ -1,10 +1,13 @@
 # Runtime API
 
 import { Steps, Tab, Tabs, Badge, Aside } from '@theme';
-import Collapse from '@components/Collapse'
-import Runtime from '@components/zh/runtime/index';
+import Collapse from '@components/Collapse';
 
-<Runtime />
+MF 的运行时 API 围绕 `ModuleFederation` 实例展开。除 [createInstance](#createinstance) 会创建并返回新的实例外，其他 API 都会基于运行时中的已有实例执行对应操作。
+
+默认实例通常由构建插件自动创建，也可以通过 [init](#init) 手动初始化。调用运行时 API 时，无需显式传入 `ModuleFederation` 实例，它们会自动使用运行时中的默认实例。
+
+需要注意的是，[createInstance](#createinstance) 创建的新实例不会替换默认实例，但会被加入全局实例列表。后续可以通过 [getInstance](#getinstance) 配合 finder 回调重新获取该实例。
 
 ## createInstance
 
@@ -12,14 +15,11 @@ import Runtime from '@components/zh/runtime/index';
 
 * 什么时候使用 `createInstance` ？
 
-  为了保证 `ModuleFederation` 实例的唯一性，我们在构建插件创建实例后，会将其存储到内存中，导出的 API 都是先从内存中获取 `ModuleFederation` 实例，然后再调用 `ModuleFederation` 实例的 API。这也是为什么 `loadRemote` 等 API 可以直接使用的原因。
-
-  这种单例模式适用于大多数场景，但如果在以下场景，你需要使用 `createInstance`：
+  默认实例模式适用于大多数场景，但如果在以下场景，你需要使用 `createInstance`：
 
   - 没有使用构建插件（纯运行时场景）
   - 需要创建多个 ModuleFederation 实例，每个实例的配置不同
   - 希望使用 ModuleFederation 分治特性，封装相应的 API 提供给其他项目使用
-
 
 * `createInstance` 每次都会创建一个全新的 `ModuleFederation` 实例，并将其注册到全局实例列表中。它不会根据 `name` / `version` 查找已有实例，也不会把新配置合并到已有实例上。
 
@@ -43,18 +43,21 @@ mf.loadRemote('sub1/util').then((m) => m.add(1, 2, 3));
 
 :::warning Warning
 
-`init` 仍然受支持，但需要根据你希望如何管理实例来选择是否使用它。
+`init` 用于初始化运行时实例，但它并不总是创建新的 `ModuleFederation` 实例。
 
-它与 [createInstance](#createinstance) 的核心区别在于：`init` 不会每次都创建新实例，而是会先根据 `name` 和 `version` 查找已有实例。如果找到了匹配实例，就复用该实例，并通过 `instance.initOptions(options)` 合并新的配置；只有在找不到匹配实例时，才会退回到创建新实例。
+调用 `init` 时，运行时会先根据 `name` 和 `version` 查找已有实例。若找到匹配实例，则复用该实例，并通过 `instance.initOptions(options)` 合并本次传入的配置；若未找到匹配实例，才会创建新的实例。
 
-当你希望同一个 host 的多次调用复用并扩展同一个运行时实例时，适合使用 `init`。当你需要严格隔离、确保每次都拿到全新实例时，请使用 [createInstance](#createinstance)。如果你只是想获取构建插件创建的实例，请使用 [getInstance](#getinstance)。
+因此，`init` 更适合用于同一个 host 多次初始化，并希望复用、扩展同一个运行时实例的场景。
+
+- 如果你需要创建一个完全独立的新实例，请使用 [createInstance](#createinstance)。
+
+- 如果你只是想获取由构建插件创建的实例，请使用 [getInstance](#getinstance)。
 
 :::
 
 - Type: `init(options: InitOptions): ModuleFederation`
-- 用于运行时动态注册 `Vmok` 模块
+- 用于初始化或复用 `ModuleFederation` 运行时实例
 - InitOptions:
-
 
 <Collapse>
 ```ts
@@ -237,26 +240,34 @@ plugins: [mfRuntimePlugin()]
 
 - Type: `getInstance(): ModuleFederation | null`
 - Type: `getInstance(finder: (instance: ModuleFederation) => boolean): ModuleFederation | null`
-- 获取构建插件创建的 `ModuleFederation` 实例，或者返回首个匹配 finder 回调的已注册实例
+- 获取默认的 `ModuleFederation` 实例，或者返回首个匹配 finder 回调的已注册实例
 
-当使用了构建插件后，可以调用 `getInstance` 获取构建插件创建的 `ModuleFederation` 实例。
+当使用构建插件或 [init](#init) 创建默认实例后，可以调用 `getInstance()` 获取这个默认实例。
 
 ```ts
 import { getInstance } from '@module-federation/enhanced/runtime';
 
 const mfInstance = getInstance();
+if (!mfInstance) {
+  throw new Error('Module Federation instance is not initialized');
+}
+
 mfInstance.loadRemote('remote/util');
 ```
 
-如果你需要拿到某个特定的已注册实例，可以传入一个 finder 回调。运行时会遍历当前已注册的实例并返回第一个匹配项。
+通过 [createInstance](#createinstance) 创建的实例不会替换默认实例，但仍然会注册到全局实例列表中。所以即使你没有保存它的返回值，也可以通过给 `getInstance` 传入 finder 回调把它找回来。
+
+finder 回调的行为和 `Array.prototype.find` 类似：运行时会遍历当前已注册的实例，并返回第一个匹配项。如果没有找到匹配实例，`getInstance` 会返回 `null`。
 
 ```ts
 const targetInstance = getInstance(
   (instance) => instance.name === 'remote-host',
 );
-```
 
-如果没有使用构建插件，调用 `getInstance` 会抛出异常，此时你需要使用 [createInstance](#createinstance) 来创建一个新的实例。
+if (targetInstance) {
+  targetInstance.loadRemote('remote/util');
+}
+```
 
 ## registerRemotes
 

--- a/packages/runtime/__tests__/api.spec.ts
+++ b/packages/runtime/__tests__/api.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createInstance, init } from '../src';
+import { createInstance, getInstance, init } from '../src';
 
 // eslint-disable-next-line max-lines-per-function
 describe('api', () => {
@@ -54,6 +54,7 @@ describe('api', () => {
         },
       ],
     });
+    expect(FM2).toBe(FM1);
     // merge remotes
     expect(FM1.options.remotes).toEqual(
       expect.arrayContaining([
@@ -82,6 +83,41 @@ describe('api', () => {
       remotes: [],
     });
     expect(FM3).not.toBe(FM4);
+  });
+
+  it('returns the default instance when no finder is provided', () => {
+    const defaultInstance = init({
+      name: '@federation/default-instance',
+      remotes: [],
+    });
+
+    createInstance({
+      name: '@federation/secondary-instance',
+      remotes: [],
+    });
+
+    expect(getInstance()).toBe(defaultInstance);
+  });
+
+  it('finds the first matching registered instance', () => {
+    const firstInstance = createInstance({
+      name: '@federation/find-first',
+      remotes: [],
+    });
+    const matchingInstance = createInstance({
+      name: '@federation/find-target',
+      remotes: [],
+    });
+
+    expect(getInstance((instance) => instance === firstInstance)).toBe(
+      firstInstance,
+    );
+    expect(
+      getInstance((instance) => instance.name === '@federation/find-target'),
+    ).toBe(matchingInstance);
+    expect(
+      getInstance((instance) => instance.name === '@federation/missing'),
+    ).toBe(null);
   });
 
   it('generates an id for runtime-created instances', () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -36,9 +36,6 @@ export function createInstance(options: UserOptions) {
 }
 
 let FederationInstance: ModuleFederation | null = null;
-/**
- * @deprecated Use createInstance or getInstance instead
- */
 export function init(options: UserOptions): ModuleFederation {
   // Retrieve the same instance with the same name
   const instance = getGlobalFederationInstance(options.name, options.version);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,7 @@
 import {
   ModuleFederation,
   type UserOptions,
+  CurrentGlobal,
   getGlobalFederationConstructor,
   setGlobalFederationInstance,
   assert,
@@ -109,8 +110,16 @@ export function registerPlugins(
   return FederationInstance.registerPlugins.apply(FederationInstance, args);
 }
 
-export function getInstance() {
-  return FederationInstance;
+export function getInstance(): ModuleFederation | null;
+export function getInstance(
+  finder: (instance: ModuleFederation) => boolean,
+): ModuleFederation | null;
+export function getInstance(finder?: (instance: ModuleFederation) => boolean) {
+  if (!finder) {
+    return FederationInstance;
+  }
+
+  return CurrentGlobal.__FEDERATION__.__INSTANCES__.find(finder) || null;
 }
 
 export function registerShared(


### PR DESCRIPTION
## Description

This PR adds a callback finder for the `getInstance` method. This allows users to find instances using a callback function, providing more flexibility in instance retrieval.

Key changes:
- Implemented callback finder in `getInstance`.
- Added comprehensive unit tests for the new functionality.
- Updated documentation in both English and Chinese.
- Included changeset for versioning.

## Related Issue

Related to #4702

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.