### PR TITLE
docs: fix vite quick start remote definition in config

### DIFF
--- a/apps/website-new/docs/zh/integrations/build-tool/vite.mdx
+++ b/apps/website-new/docs/zh/integrations/build-tool/vite.mdx
@@ -40,19 +40,19 @@ module.exports = {
     origin: 'http://localhost:2000',
     port: 2000,
   },
-  remotes: {
-    esm_remote: {
-      type: "module",
-      name: "esm_remote",
-      entry: "https://[...]/remoteEntry.js",
-    },
-    var_remote: "var_remote@https://[...]/remoteEntry.js",
-  },
   base: "http://localhost:2000",
   plugins: [
     federation({
       name: 'vite_provider',
       manifest: true,
+      remotes: {
+        esm_remote: {
+          type: "module",
+          name: "esm_remote",
+          entry: "https://[...]/remoteEntry.js",
+        },
+        var_remote: "var_remote@https://[...]/remoteEntry.js",
+      },
       exposes: {
         './button': './src/components/button',
       },


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

The Chinese doc is not consistent with English doc. Fix the wrong version of config in docs which is misleading to the user.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the Vite quick start Chinese docs to define `remotes` inside the `federation()` plugin options instead of at the top-level config. This matches the English guide and prevents misconfiguration.

<sup>Written for commit 945ccae5811c3f18baaf0b2bbaa49bf70b31b22a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

