### PR TITLE
feat(devtools): add loading trace observability tab

### DIFF
--- a/.changeset/devtools-loading-trace.md
+++ b/.changeset/devtools-loading-trace.md
@@ -1,0 +1,6 @@
+---
+"@module-federation/devtools": minor
+"@module-federation/observability-plugin": minor
+---
+
+Add a Loading Trace panel that can configure and inject the observability plugin, reload the inspected page, stream loading events, and export collected reports.

--- a/packages/chrome-devtools/README.md
+++ b/packages/chrome-devtools/README.md
@@ -4,5 +4,7 @@
 
 - Proxy online Module Federation remote module to local
 - Let proxied remote module get hmr
+- Inject the observability runtime plugin from the Loading Trace tab and export
+  collected loading reports
 
 https://module-federation.io/

--- a/packages/chrome-devtools/__tests__/chrome-tabs.spec.ts
+++ b/packages/chrome-devtools/__tests__/chrome-tabs.spec.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getCurrentTabId, syncActiveTab, TabInfo } from '../src/utils/chrome';
+
+describe('chrome tab helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(globalThis, 'chrome');
+    window.targetTab = undefined as any;
+    TabInfo.currentTabId = 0;
+  });
+
+  it('does not warn when active tab query returns no array', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.stubGlobal('chrome', {
+      tabs: {
+        query: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    await expect(syncActiveTab()).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+    expect(getCurrentTabId()).toBe(0);
+  });
+
+  it('syncs the queried active tab when chrome returns a tab array', async () => {
+    const activeTab = { id: 8080 };
+
+    vi.stubGlobal('chrome', {
+      tabs: {
+        query: vi.fn().mockResolvedValue([activeTab]),
+      },
+    });
+
+    await expect(syncActiveTab()).resolves.toBe(activeTab);
+    expect(window.targetTab).toBe(activeTab);
+    expect(getCurrentTabId()).toBe(8080);
+  });
+});

--- a/packages/chrome-devtools/__tests__/observability-devtools.spec.ts
+++ b/packages/chrome-devtools/__tests__/observability-devtools.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeObservabilityReports } from '../src/utils/chrome/observability';
+import {
+  DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG,
+  normalizeObservabilityDevtoolsConfig,
+} from '../src/utils/chrome/observability-shared';
+
+describe('observability devtools config', () => {
+  it('defaults to development mode with verbose events', () => {
+    expect(normalizeObservabilityDevtoolsConfig()).toMatchObject({
+      enabled: true,
+      level: 'verbose',
+      browser: {
+        enabled: true,
+        mode: 'development',
+      },
+      trace: {
+        printStart: true,
+      },
+    });
+  });
+
+  it('normalizes unsafe values and keeps valid production overrides', () => {
+    expect(
+      normalizeObservabilityDevtoolsConfig({
+        ...DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG,
+        level: 'summary',
+        maxEvents: 5000,
+        browser: {
+          enabled: true,
+          mode: 'production',
+          scope: 'runtime host!',
+        },
+        react: {
+          injectLoadedCallback: true,
+          remoteIds: 'remote/Button, remote/Card',
+        },
+      }),
+    ).toMatchObject({
+      level: 'summary',
+      maxEvents: 1000,
+      browser: {
+        mode: 'production',
+        scope: 'runtime-host-',
+      },
+      react: {
+        injectLoadedCallback: true,
+        remoteIds: ['remote/Button', 'remote/Card'],
+      },
+    });
+  });
+
+  it('merges reports by trace id and keeps newest first', () => {
+    const reports = mergeObservabilityReports(
+      [
+        {
+          traceId: 'a',
+          status: 'pending',
+          startedAt: 1,
+          updatedAt: 1,
+          duration: 0,
+          events: [],
+        },
+      ],
+      [
+        {
+          traceId: 'a',
+          status: 'success',
+          startedAt: 1,
+          updatedAt: 3,
+          duration: 2,
+          events: [],
+        },
+        {
+          traceId: 'b',
+          status: 'pending',
+          startedAt: 2,
+          updatedAt: 2,
+          duration: 0,
+          events: [],
+        },
+      ],
+    );
+
+    expect(reports.map((report) => report.traceId)).toEqual(['a', 'b']);
+    expect(reports[0].status).toBe('success');
+  });
+});

--- a/packages/chrome-devtools/manifest.json
+++ b/packages/chrome-devtools/manifest.json
@@ -18,7 +18,8 @@
         "static/js/post-message-start.js",
         "static/js/fast-refresh.js",
         "static/js/override-remote.js",
-        "static/js/snapshot-plugin.js"
+        "static/js/snapshot-plugin.js",
+        "static/js/observability-plugin.js"
       ],
       "matches": ["<all_urls>"]
     }
@@ -42,7 +43,8 @@
       "js": [
         "static/js/fast-refresh.js",
         "static/js/override-remote.js",
-        "static/js/snapshot-plugin.js"
+        "static/js/snapshot-plugin.js",
+        "static/js/observability-plugin.js"
       ],
       "world": "MAIN",
       "run_at": "document_start"

--- a/packages/chrome-devtools/modern.config.ts
+++ b/packages/chrome-devtools/modern.config.ts
@@ -36,6 +36,8 @@ export default defineConfig({
       config.entry['fast-refresh'] = './src/utils/chrome/fast-refresh.ts';
       config.entry['override-remote'] = './src/utils/chrome/override-remote.ts';
       config.entry['snapshot-plugin'] = './src/utils/chrome/snapshot-plugin.ts';
+      config.entry['observability-plugin'] =
+        './src/utils/chrome/observability-plugin.ts';
       config.entry['post-message'] = './src/utils/chrome/post-message.ts';
       config.entry['post-message-init'] =
         './src/utils/chrome/post-message-init.ts';

--- a/packages/chrome-devtools/package.json
+++ b/packages/chrome-devtools/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@modern-js/runtime": "2.70.8",
     "@arco-design/web-react": "2.66.7",
+    "@module-federation/observability-plugin": "workspace:*",
     "@module-federation/sdk": "workspace:*",
     "ahooks": "3.7.10",
     "dagre": "0.8.5",

--- a/packages/chrome-devtools/src/App.module.scss
+++ b/packages/chrome-devtools/src/App.module.scss
@@ -94,14 +94,14 @@
 }
 
 .activeTab {
-  border-color: rgba(99, 102, 241, 0.65);
+  border-color: rgba(24, 24, 27, 0.28);
   background: linear-gradient(
     135deg,
-    rgba(59, 130, 246, 0.15),
-    rgba(37, 99, 235, 0.1)
+    rgba(24, 24, 27, 0.08),
+    rgba(113, 113, 122, 0.08)
   );
   color: var(--color-text-1, #1e293b);
-  box-shadow: 0 12px 28px rgba(30, 64, 175, 0.25);
+  box-shadow: 0 12px 28px rgba(24, 24, 27, 0.14);
 }
 
 .panel {

--- a/packages/chrome-devtools/src/App.tsx
+++ b/packages/chrome-devtools/src/App.tsx
@@ -11,6 +11,7 @@ import ProxyLayout from './component/Layout';
 import Dependency from './component/DependencyGraph';
 import ModuleInfo from './component/ModuleInfo';
 import SharedDepsExplorer from './component/SharedDepsExplorer';
+import LoadingTrace from './component/LoadingTrace';
 import LanguageSwitch from './component/LanguageSwitch';
 import ThemeToggle from './component/ThemeToggle';
 import {
@@ -99,6 +100,7 @@ const NAV_ITEMS = [
   { key: 'proxy', i18nKey: 'app.nav.proxy' },
   { key: 'dependency', i18nKey: 'app.nav.dependency' },
   { key: 'share', i18nKey: 'app.nav.share' },
+  { key: 'loadingTrace', i18nKey: 'app.nav.loadingTrace' },
   { key: 'performance', i18nKey: 'app.nav.performance' },
 ] as const;
 
@@ -409,6 +411,8 @@ const InnerApp = (props: RootComponentProps) => {
             )}
           />
         );
+      case 'loadingTrace':
+        return <LoadingTrace tabId={inspectedTab?.id} />;
       case 'performance':
         return (
           <div className={styles.placeholder}>

--- a/packages/chrome-devtools/src/component/LoadingTrace/index.module.scss
+++ b/packages/chrome-devtools/src/component/LoadingTrace/index.module.scss
@@ -1,0 +1,558 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 0;
+  color: var(--color-text-1, #1f2937);
+}
+
+.wrapper :global(.arco-btn-primary) {
+  border-color: #18181b;
+  background: #18181b;
+  color: #fff;
+}
+
+.wrapper :global(.arco-btn-primary:not(.arco-btn-disabled):hover) {
+  border-color: #27272a;
+  background: #27272a;
+  color: #fff;
+}
+
+.wrapper :global(.arco-btn-primary:not(.arco-btn-disabled):active) {
+  border-color: #09090b;
+  background: #09090b;
+}
+
+.wrapper :global(.arco-btn-secondary) {
+  border-color: var(--color-border-2, rgba(203, 213, 225, 0.65));
+  background: var(--color-fill-2, rgba(15, 23, 42, 0.04));
+  color: var(--color-text-1, #18181b);
+}
+
+.wrapper :global(.arco-btn-secondary:not(.arco-btn-disabled):hover) {
+  border-color: rgba(24, 24, 27, 0.28);
+  background: rgba(24, 24, 27, 0.08);
+  color: var(--color-text-1, #18181b);
+}
+
+.wrapper :global(.arco-switch-checked) {
+  background-color: #18181b;
+}
+
+.wrapper :global(.arco-switch-checked:hover) {
+  background-color: #27272a;
+}
+
+.wrapper :global(.arco-input-inner-wrapper-focus),
+.wrapper :global(.arco-input-inner-wrapper:focus-within) {
+  border-color: rgba(24, 24, 27, 0.45) !important;
+  box-shadow: 0 0 0 2px rgba(24, 24, 27, 0.08) !important;
+}
+
+.wrapper :global(.arco-tag),
+.wrapper :global(.arco-tag-color-arcoblue) {
+  border-color: rgba(24, 24, 27, 0.12);
+  background: rgba(24, 24, 27, 0.06);
+  color: var(--color-text-1, #18181b);
+}
+
+.toolbar,
+.configGrid,
+.stats,
+.viewer {
+  border: 1px solid var(--color-border-2, rgba(203, 213, 225, 0.5));
+  background: var(--color-bg-2, rgba(255, 255, 255, 0.92));
+  border-radius: 14px;
+  box-sizing: border-box;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  flex-wrap: wrap;
+}
+
+.titleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.subtitle {
+  font-size: 12px;
+  color: var(--color-text-2, rgba(75, 85, 99, 0.82));
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.configButton {
+  border-color: var(--color-border-2, rgba(203, 213, 225, 0.65)) !important;
+  background: var(--color-fill-2, rgba(15, 23, 42, 0.04)) !important;
+  color: var(--color-text-1, #18181b) !important;
+}
+
+.configButton:hover {
+  border-color: rgba(24, 24, 27, 0.28) !important;
+  background: rgba(24, 24, 27, 0.08) !important;
+  color: var(--color-text-1, #18181b) !important;
+}
+
+.configButtonActive,
+.configButtonActive:hover,
+.primaryAction,
+.primaryAction:hover {
+  border-color: #18181b !important;
+  background: #18181b !important;
+  color: #fff !important;
+}
+
+.configButtonActive:active,
+.primaryAction:active {
+  border-color: #09090b !important;
+  background: #09090b !important;
+  color: #fff !important;
+}
+
+.primaryAction:disabled {
+  border-color: rgba(24, 24, 27, 0.14) !important;
+  background: rgba(24, 24, 27, 0.08) !important;
+  color: rgba(24, 24, 27, 0.36) !important;
+}
+
+.configGrid {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 14px 24px;
+  padding: 16px;
+  overflow: visible;
+}
+
+.field,
+.fieldWide,
+.switchField {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--color-text-2, rgba(75, 85, 99, 0.86));
+}
+
+.labelWithHelp {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  position: relative;
+  white-space: nowrap;
+}
+
+.labelText {
+  color: var(--color-text-2, rgba(75, 85, 99, 0.86));
+}
+
+.helpIcon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-text-3, rgba(75, 85, 99, 0.62));
+  cursor: help;
+}
+
+.helpIcon:hover {
+  color: var(--color-text-1, #1f2937);
+}
+
+.helpIcon::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: 0;
+  top: calc(100% + 6px);
+  z-index: 20;
+  width: 260px;
+  max-width: min(260px, calc(100vw - 48px));
+  box-sizing: border-box;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(15, 23, 42, 0.96);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+  color: #fff;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: normal;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(4px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease,
+    visibility 120ms ease;
+}
+
+.helpIcon::before {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: calc(100% + 1px);
+  z-index: 21;
+  border-width: 0 5px 5px;
+  border-style: solid;
+  border-color: transparent transparent rgba(15, 23, 42, 0.96);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(4px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease,
+    visibility 120ms ease;
+}
+
+.helpIcon:hover::after,
+.helpIcon:focus-visible::after,
+.helpIcon:hover::before,
+.helpIcon:focus-visible::before {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.labelColon {
+  color: var(--color-text-2, rgba(75, 85, 99, 0.86));
+}
+
+.switchField {
+  justify-content: space-between;
+}
+
+.segmentedControl {
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  gap: 2px;
+  min-height: 32px;
+  padding: 2px;
+  border: 1px solid var(--color-border-2, rgba(203, 213, 225, 0.65));
+  border-radius: 6px;
+  background: var(--color-fill-2, rgba(15, 23, 42, 0.04));
+  box-sizing: border-box;
+}
+
+.segmentButton {
+  min-width: 48px;
+  height: 26px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text-2, rgba(75, 85, 99, 0.88));
+  font-size: 12px;
+  line-height: 26px;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.remoteInput {
+  width: 240px;
+}
+
+.segmentButton:hover {
+  background: rgba(24, 24, 27, 0.08);
+  color: var(--color-text-1, #1f2937);
+}
+
+.segmentButton:focus-visible {
+  outline: 2px solid rgba(24, 24, 27, 0.42);
+  outline-offset: 1px;
+}
+
+.segmentButtonActive,
+.segmentButtonActive:hover {
+  background: #18181b;
+  color: #fff;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  gap: 12px;
+  padding: 14px 16px;
+}
+
+.stats > div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.statValue {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text-1, #1f2937);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.statLabel {
+  font-size: 11px;
+  color: var(--color-text-2, rgba(75, 85, 99, 0.78));
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.viewer {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  min-height: 420px;
+  overflow: hidden;
+}
+
+.reportList {
+  border-right: 1px solid var(--color-border-2, rgba(203, 213, 225, 0.5));
+  overflow: auto;
+  min-height: 0;
+}
+
+.reportFilter {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 12px;
+  border-bottom: 1px solid var(--color-border-1, rgba(203, 213, 225, 0.35));
+  background: var(--color-bg-2, rgba(255, 255, 255, 0.96));
+}
+
+.reportSearch {
+  width: 100%;
+}
+
+.reportItem {
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid var(--color-border-1, rgba(203, 213, 225, 0.35));
+  background: transparent;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 12px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.reportItem:hover,
+.activeReport {
+  background: rgba(24, 24, 27, 0.08);
+}
+
+.reportTitle {
+  width: 100%;
+  font-size: 13px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reportMeta {
+  width: 100%;
+  font-size: 11px;
+  color: var(--color-text-2, rgba(75, 85, 99, 0.78));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reportTagRow {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.statusTag {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 7px;
+  border: 1px solid rgba(24, 24, 27, 0.12);
+  border-radius: 999px;
+  background: rgba(24, 24, 27, 0.05);
+  color: var(--color-text-2, rgba(75, 85, 99, 0.9));
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 18px;
+  text-transform: uppercase;
+}
+
+.statusTagsuccess {
+  border-color: rgba(24, 24, 27, 0.2);
+  background: rgba(24, 24, 27, 0.08);
+  color: var(--color-text-1, #18181b);
+}
+
+.statusTagfailed {
+  border-color: #18181b;
+  background: #18181b;
+  color: #fff;
+}
+
+.statusTagpending {
+  border-color: rgba(24, 24, 27, 0.12);
+  background: rgba(24, 24, 27, 0.03);
+  color: var(--color-text-2, rgba(75, 85, 99, 0.82));
+}
+
+.timeline {
+  min-width: 0;
+  overflow: auto;
+  padding: 16px;
+}
+
+.reportHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--color-border-1, rgba(203, 213, 225, 0.35));
+}
+
+.reportHeading {
+  display: block;
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.traceId {
+  display: block;
+  font-size: 11px;
+  color: var(--color-text-2, rgba(75, 85, 99, 0.78));
+  word-break: break-all;
+}
+
+.tags {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.diagnosis {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(24, 24, 27, 0.06);
+  color: var(--color-text-1, #1f2937);
+  font-size: 13px;
+}
+
+.eventList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.eventItem {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr);
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--color-border-1, rgba(203, 213, 225, 0.28));
+}
+
+.eventTime {
+  font-size: 11px;
+  color: var(--color-text-2, rgba(75, 85, 99, 0.72));
+  padding-top: 2px;
+}
+
+.eventBody {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.eventMain {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.phase {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.duration,
+.eventMeta {
+  font-size: 12px;
+  color: var(--color-text-2, rgba(75, 85, 99, 0.76));
+}
+
+.eventMeta,
+.error {
+  overflow-wrap: anywhere;
+}
+
+.error {
+  font-size: 12px;
+  color: var(--color-text-1, #18181b);
+}
+
+.emptyPanel {
+  min-height: 260px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+@media (max-width: 980px) {
+  .viewer {
+    grid-template-columns: 1fr;
+  }
+
+  .reportList {
+    border-right: 0;
+    border-bottom: 1px solid var(--color-border-2, rgba(203, 213, 225, 0.5));
+    max-height: 220px;
+  }
+}
+
+@media (max-width: 640px) {
+  .stats {
+    grid-template-columns: 1fr;
+  }
+
+  .eventItem {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/chrome-devtools/src/component/LoadingTrace/index.tsx
+++ b/packages/chrome-devtools/src/component/LoadingTrace/index.tsx
@@ -1,0 +1,706 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Empty,
+  Input,
+  Modal,
+  Switch,
+  Tag,
+} from '@arco-design/web-react';
+import {
+  IconDownload,
+  IconPlayArrow,
+  IconQuestionCircle,
+  IconRefresh,
+  IconSearch,
+  IconSettings,
+} from '@arco-design/web-react/icon';
+import { useTranslation } from 'react-i18next';
+
+import {
+  applyObservabilityConfig,
+  disableObservabilityConfig,
+  mergeObservabilityReports,
+  readObservabilityConfig,
+  readObservabilitySnapshot,
+  reloadInspectedPage,
+  type ObservabilityDevtoolsReport,
+} from '../../utils/chrome/observability';
+import {
+  DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG,
+  normalizeObservabilityDevtoolsConfig,
+  type ObservabilityDevtoolsConfig,
+  type ObservabilityDevtoolsLevel,
+} from '../../utils/chrome/observability-shared';
+import { MESSAGE_OBSERVABILITY_DEVTOOLS_EVENT } from '../../utils/chrome/messages';
+import styles from './index.module.scss';
+
+interface LoadingTraceProps {
+  tabId?: number;
+}
+
+interface SegmentedOption<T extends string> {
+  label: string;
+  value: T;
+}
+
+interface SegmentedControlProps<T extends string> {
+  value: T;
+  options: Array<SegmentedOption<T>>;
+  onChange(value: T): void;
+}
+
+interface FieldLabelProps {
+  label: string;
+  tip: string;
+}
+
+const FieldLabel = ({ label, tip }: FieldLabelProps) => (
+  <span className={styles.labelWithHelp}>
+    <span className={styles.labelText}>{label}</span>
+    <span
+      className={styles.helpIcon}
+      data-tip={tip}
+      tabIndex={0}
+      aria-label={tip}
+    >
+      <IconQuestionCircle />
+    </span>
+    <span className={styles.labelColon}>:</span>
+  </span>
+);
+
+const SegmentedControl = <T extends string>({
+  value,
+  options,
+  onChange,
+}: SegmentedControlProps<T>) => (
+  <div className={styles.segmentedControl} role="group">
+    {options.map((option) => {
+      const isActive = option.value === value;
+      return (
+        <button
+          key={option.value}
+          type="button"
+          className={`${styles.segmentButton} ${
+            isActive ? styles.segmentButtonActive : ''
+          }`}
+          aria-pressed={isActive}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </button>
+      );
+    })}
+  </div>
+);
+
+const formatTime = (timestamp?: number) => {
+  if (!timestamp) {
+    return '-';
+  }
+  try {
+    return new Date(timestamp).toLocaleTimeString();
+  } catch {
+    return '-';
+  }
+};
+
+const getReportTitle = (report: ObservabilityDevtoolsReport) =>
+  report.requestId ||
+  report.remote?.name ||
+  report.shared?.name ||
+  report.traceId ||
+  'unknown';
+
+const getReportOutcome = (report: ObservabilityDevtoolsReport) =>
+  report.summary?.outcome || report.status || 'pending';
+
+const getReportState = (report: ObservabilityDevtoolsReport) => {
+  const outcome = getReportOutcome(report);
+  if (
+    report.status === 'error' ||
+    outcome === 'failed' ||
+    report.failedPhase ||
+    report.errorMessage
+  ) {
+    return 'failed';
+  }
+  if (report.status === 'success') {
+    return 'success';
+  }
+  return 'pending';
+};
+
+const getReportSearchText = (report: ObservabilityDevtoolsReport) =>
+  [
+    getReportTitle(report),
+    report.traceId,
+    report.status,
+    getReportOutcome(report),
+    report.hostName,
+    report.remote?.name,
+    report.remote?.alias,
+    report.remote?.entry,
+    report.shared?.name,
+    report.shared?.provider,
+    report.expose,
+    report.failedPhase,
+    report.errorCode,
+    report.errorName,
+    report.errorMessage,
+    report.ownerHint,
+    report.summary?.lastPhase,
+    report.diagnosis?.title,
+    report.__scope,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+const fuzzyMatchReport = (
+  report: ObservabilityDevtoolsReport,
+  keyword: string,
+) => {
+  const tokens = keyword.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (!tokens.length) {
+    return true;
+  }
+  const haystack = getReportSearchText(report);
+  return tokens.every((token) => haystack.includes(token));
+};
+
+const downloadJson = (name: string, data: unknown) => {
+  const blob = new Blob([`${JSON.stringify(data, null, 2)}\n`], {
+    type: 'application/json;charset=utf-8',
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = name;
+  anchor.click();
+  URL.revokeObjectURL(url);
+};
+
+const getConfigSignature = (config: ObservabilityDevtoolsConfig) =>
+  JSON.stringify(normalizeObservabilityDevtoolsConfig(config));
+
+const LoadingTrace = ({ tabId }: LoadingTraceProps) => {
+  const { t } = useTranslation();
+  const [config, setConfig] = useState<ObservabilityDevtoolsConfig>(
+    DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG,
+  );
+  const [savedConfig, setSavedConfig] = useState<ObservabilityDevtoolsConfig>(
+    DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG,
+  );
+  const [stored, setStored] = useState(false);
+  const [reports, setReports] = useState<ObservabilityDevtoolsReport[]>([]);
+  const [scopes, setScopes] = useState<string[]>([]);
+  const [selectedTraceId, setSelectedTraceId] = useState<string>();
+  const [busy, setBusy] = useState(false);
+  const [statusText, setStatusText] = useState<string>('');
+  const [showConfigPanel, setShowConfigPanel] = useState(false);
+  const [reportKeyword, setReportKeyword] = useState('');
+
+  const filteredReports = useMemo(
+    () => reports.filter((report) => fuzzyMatchReport(report, reportKeyword)),
+    [reports, reportKeyword],
+  );
+
+  const selectedReport = useMemo(
+    () =>
+      filteredReports.find((report) => report.traceId === selectedTraceId) ||
+      filteredReports[0],
+    [filteredReports, selectedTraceId],
+  );
+
+  const latestReport = reports[0];
+  const isObservabilityEnabled = stored && config.enabled !== false;
+  const isConfigDirty = useMemo(
+    () => getConfigSignature(config) !== getConfigSignature(savedConfig),
+    [config, savedConfig],
+  );
+  const levelOptions = useMemo<
+    Array<SegmentedOption<ObservabilityDevtoolsLevel>>
+  >(
+    () => [
+      {
+        label: t('loadingTrace.config.verbose'),
+        value: 'verbose',
+      },
+      {
+        label: t('loadingTrace.config.summary'),
+        value: 'summary',
+      },
+      {
+        label: t('loadingTrace.config.error'),
+        value: 'error',
+      },
+    ],
+    [t],
+  );
+  const shouldShowApplyButton = !isObservabilityEnabled || isConfigDirty;
+  const eventCount = useMemo(
+    () =>
+      reports.reduce(
+        (count, report) => count + (report.events?.length || 0),
+        0,
+      ),
+    [reports],
+  );
+
+  const refreshSnapshot = useCallback(async () => {
+    const snapshot = await readObservabilitySnapshot();
+    setConfig(snapshot.config);
+    setSavedConfig(snapshot.config);
+    setStored(snapshot.stored);
+    setScopes(snapshot.scopes);
+    setReports((current) =>
+      mergeObservabilityReports(current, snapshot.reports),
+    );
+    setSelectedTraceId((current) => current || snapshot.reports[0]?.traceId);
+    return snapshot;
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const pageConfig = await readObservabilityConfig();
+        if (!cancelled) {
+          setConfig(pageConfig);
+          setSavedConfig(pageConfig);
+        }
+        const snapshot = await refreshSnapshot();
+        if (!cancelled) {
+          setStatusText(
+            snapshot.stored
+              ? t('loadingTrace.status.enabled')
+              : t('loadingTrace.status.disabled'),
+          );
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setStatusText(t('loadingTrace.status.unavailable'));
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshSnapshot, t, tabId]);
+
+  useEffect(() => {
+    const onMessage = (
+      message: { type?: string; data?: any },
+      sender: chrome.runtime.MessageSender,
+    ) => {
+      if (message?.type !== MESSAGE_OBSERVABILITY_DEVTOOLS_EVENT) {
+        return;
+      }
+      const senderTabId = sender?.tab?.id;
+      if (tabId && senderTabId && senderTabId !== tabId) {
+        return;
+      }
+
+      const payload = message.data;
+      if (payload?.config) {
+        const nextConfig = normalizeObservabilityDevtoolsConfig(payload.config);
+        setConfig(nextConfig);
+        setSavedConfig(nextConfig);
+        setStored(payload.config.enabled !== false);
+      }
+      if (payload?.kind === 'installed') {
+        setStatusText(t('loadingTrace.status.enabled'));
+      }
+      if (payload?.report?.traceId) {
+        const report = {
+          ...payload.report,
+          __scope: payload.scope || payload.report.__scope,
+        } as ObservabilityDevtoolsReport;
+        setReports((current) => mergeObservabilityReports(current, [report]));
+        setSelectedTraceId((current) => current || report.traceId);
+      }
+    };
+
+    chrome.runtime.onMessage.addListener(onMessage);
+    return () => chrome.runtime.onMessage.removeListener(onMessage);
+  }, [tabId, t]);
+
+  const updateConfig = (patch: Partial<ObservabilityDevtoolsConfig>) => {
+    setConfig((current) =>
+      normalizeObservabilityDevtoolsConfig({
+        ...current,
+        ...patch,
+      }),
+    );
+  };
+
+  const updateReactConfig = (
+    patch: Partial<Omit<ObservabilityDevtoolsConfig['react'], 'remoteIds'>> & {
+      remoteIds?: string[] | string;
+    },
+  ) => {
+    setConfig((current) =>
+      normalizeObservabilityDevtoolsConfig({
+        ...current,
+        react: {
+          ...current.react,
+          ...patch,
+        },
+      }),
+    );
+  };
+
+  const applyAndReload = async () => {
+    setBusy(true);
+    try {
+      const nextConfig = normalizeObservabilityDevtoolsConfig({
+        ...config,
+        enabled: true,
+      });
+      await applyObservabilityConfig(nextConfig);
+      setConfig(nextConfig);
+      setSavedConfig(nextConfig);
+      setStored(true);
+      setReports([]);
+      setSelectedTraceId(undefined);
+      setStatusText(t('loadingTrace.status.reloading'));
+      await reloadInspectedPage();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmApply = () => {
+    Modal.confirm({
+      title: isObservabilityEnabled
+        ? t('loadingTrace.confirm.updateTitle')
+        : t('loadingTrace.confirm.observeTitle'),
+      content: t('loadingTrace.confirm.content'),
+      okText: t('loadingTrace.actions.confirm'),
+      cancelText: t('loadingTrace.actions.cancel'),
+      onOk: () => applyAndReload(),
+    });
+  };
+
+  const disableAndReload = async () => {
+    setBusy(true);
+    try {
+      await disableObservabilityConfig();
+      setStored(false);
+      setReports([]);
+      setSelectedTraceId(undefined);
+      setStatusText(t('loadingTrace.status.disabled'));
+      await reloadInspectedPage();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    setBusy(true);
+    try {
+      const snapshot = await refreshSnapshot();
+      setStatusText(
+        snapshot.reports.length
+          ? t('loadingTrace.status.synced')
+          : t('loadingTrace.status.noReports'),
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleExport = () => {
+    downloadJson(`mf-observability-${Date.now()}.json`, {
+      exportedAt: new Date().toISOString(),
+      config,
+      scopes,
+      reports,
+    });
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <section className={styles.toolbar}>
+        <div className={styles.titleGroup}>
+          <span className={styles.title}>{t('loadingTrace.title')}</span>
+          {isObservabilityEnabled ? (
+            <span className={styles.subtitle}>{statusText}</span>
+          ) : null}
+        </div>
+        <div className={styles.actions}>
+          <Button
+            className={`${styles.configButton} ${
+              showConfigPanel ? styles.configButtonActive : ''
+            }`}
+            shape="circle"
+            icon={<IconSettings />}
+            aria-pressed={showConfigPanel}
+            title={t('loadingTrace.actions.config')}
+            onClick={() => setShowConfigPanel((visible) => !visible)}
+          />
+          {shouldShowApplyButton ? (
+            <Button
+              className={styles.primaryAction}
+              icon={<IconPlayArrow />}
+              loading={busy}
+              onClick={confirmApply}
+            >
+              {isObservabilityEnabled
+                ? t('loadingTrace.actions.updateConfig')
+                : t('loadingTrace.actions.observeNow')}
+            </Button>
+          ) : null}
+          {isObservabilityEnabled ? (
+            <>
+              <Button loading={busy} onClick={disableAndReload}>
+                {t('loadingTrace.actions.disable')}
+              </Button>
+              <Button
+                icon={<IconRefresh />}
+                loading={busy}
+                onClick={handleRefresh}
+              >
+                {t('loadingTrace.actions.refresh')}
+              </Button>
+              <Button
+                icon={<IconDownload />}
+                disabled={!reports.length}
+                onClick={handleExport}
+              >
+                {t('loadingTrace.actions.export')}
+              </Button>
+            </>
+          ) : null}
+        </div>
+      </section>
+
+      {showConfigPanel ? (
+        <>
+          <section className={styles.configGrid}>
+            <label className={styles.field}>
+              <FieldLabel
+                label={t('loadingTrace.config.level')}
+                tip={t('loadingTrace.config.levelTip')}
+              />
+              <SegmentedControl
+                value={config.level}
+                options={levelOptions}
+                onChange={(level) => updateConfig({ level })}
+              />
+            </label>
+            <label className={styles.field}>
+              <FieldLabel
+                label={t('loadingTrace.config.console')}
+                tip={t('loadingTrace.config.consoleTip')}
+              />
+              <Switch
+                checked={config.console}
+                onChange={(checked) => updateConfig({ console: checked })}
+              />
+            </label>
+            <label className={styles.switchField}>
+              <FieldLabel
+                label={t('loadingTrace.config.reactCallback')}
+                tip={t('loadingTrace.config.reactCallbackTip')}
+              />
+              <Switch
+                checked={config.react.injectLoadedCallback}
+                onChange={(checked) =>
+                  updateReactConfig({ injectLoadedCallback: checked })
+                }
+              />
+            </label>
+            <label className={styles.fieldWide}>
+              <FieldLabel
+                label={t('loadingTrace.config.remoteIds')}
+                tip={t('loadingTrace.config.remoteIdsTip')}
+              />
+              <Input
+                className={styles.remoteInput}
+                value={config.react.remoteIds.join(', ')}
+                onChange={(value) => updateReactConfig({ remoteIds: value })}
+                disabled={!config.react.injectLoadedCallback}
+              />
+            </label>
+          </section>
+        </>
+      ) : null}
+
+      {isObservabilityEnabled ? (
+        <>
+          <section className={styles.stats}>
+            <div>
+              <span className={styles.statValue}>ON</span>
+              <span className={styles.statLabel}>
+                {t('loadingTrace.stats.state')}
+              </span>
+            </div>
+            <div>
+              <span className={styles.statValue}>{reports.length}</span>
+              <span className={styles.statLabel}>
+                {t('loadingTrace.stats.reports')}
+              </span>
+            </div>
+            <div>
+              <span className={styles.statValue}>{eventCount}</span>
+              <span className={styles.statLabel}>
+                {t('loadingTrace.stats.events')}
+              </span>
+            </div>
+            <div>
+              <span className={styles.statValue}>
+                {latestReport?.summary?.outcome || '-'}
+              </span>
+              <span className={styles.statLabel}>
+                {t('loadingTrace.stats.latest')}
+              </span>
+            </div>
+          </section>
+
+          <section className={styles.viewer}>
+            <div className={styles.reportList}>
+              {reports.length ? (
+                <>
+                  <div className={styles.reportFilter}>
+                    <Input
+                      className={styles.reportSearch}
+                      prefix={<IconSearch />}
+                      allowClear
+                      placeholder={t('loadingTrace.reports.search')}
+                      value={reportKeyword}
+                      onChange={(value) => setReportKeyword(value)}
+                    />
+                  </div>
+                  {filteredReports.length ? (
+                    filteredReports.map((report) => {
+                      const state = getReportState(report);
+                      return (
+                        <button
+                          key={report.traceId}
+                          type="button"
+                          className={`${styles.reportItem} ${
+                            selectedReport?.traceId === report.traceId
+                              ? styles.activeReport
+                              : ''
+                          }`}
+                          onClick={() => setSelectedTraceId(report.traceId)}
+                        >
+                          <span className={styles.reportTitle}>
+                            {getReportTitle(report)}
+                          </span>
+                          <span className={styles.reportTagRow}>
+                            <span
+                              className={`${styles.statusTag} ${
+                                styles[`statusTag${state}`]
+                              }`}
+                            >
+                              {t(`loadingTrace.reports.${state}`)}
+                            </span>
+                          </span>
+                          <span className={styles.reportMeta}>
+                            {formatTime(report.updatedAt)}
+                          </span>
+                        </button>
+                      );
+                    })
+                  ) : (
+                    <div className={styles.emptyPanel}>
+                      <Empty description={t('loadingTrace.reports.noMatch')} />
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className={styles.emptyPanel}>
+                  <Empty description={t('loadingTrace.empty')} />
+                </div>
+              )}
+            </div>
+
+            <div className={styles.timeline}>
+              {selectedReport ? (
+                <>
+                  <div className={styles.reportHeader}>
+                    <div>
+                      <span className={styles.reportHeading}>
+                        {getReportTitle(selectedReport)}
+                      </span>
+                      <span className={styles.traceId}>
+                        {selectedReport.traceId}
+                      </span>
+                    </div>
+                    <div className={styles.tags}>
+                      <span
+                        className={`${styles.statusTag} ${
+                          styles[`statusTag${getReportState(selectedReport)}`]
+                        }`}
+                      >
+                        {t(
+                          `loadingTrace.reports.${getReportState(selectedReport)}`,
+                        )}
+                      </span>
+                      {selectedReport.__scope ? (
+                        <Tag>{selectedReport.__scope}</Tag>
+                      ) : null}
+                    </div>
+                  </div>
+                  {selectedReport.diagnosis?.title ? (
+                    <div className={styles.diagnosis}>
+                      {selectedReport.diagnosis.title}
+                    </div>
+                  ) : null}
+                  <div className={styles.eventList}>
+                    {(selectedReport.events || []).map((event, index) => (
+                      <div
+                        className={styles.eventItem}
+                        key={`${event.traceId}-${event.phase}-${event.timestamp}-${index}`}
+                      >
+                        <div className={styles.eventTime}>
+                          {formatTime(event.timestamp)}
+                        </div>
+                        <div className={styles.eventBody}>
+                          <div className={styles.eventMain}>
+                            <span className={styles.phase}>{event.phase}</span>
+                            <Tag>{event.status}</Tag>
+                            {event.duration !== undefined ? (
+                              <span className={styles.duration}>
+                                {event.duration}ms
+                              </span>
+                            ) : null}
+                          </div>
+                          <div className={styles.eventMeta}>
+                            {event.message ||
+                              event.lifecycle ||
+                              event.requestId ||
+                              '-'}
+                          </div>
+                          {event.errorMessage ? (
+                            <div className={styles.error}>
+                              {event.errorCode
+                                ? `${event.errorCode}: ${event.errorMessage}`
+                                : event.errorMessage}
+                            </div>
+                          ) : null}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <div className={styles.emptyPanel}>
+                  <Empty description={t('loadingTrace.empty')} />
+                </div>
+              )}
+            </div>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+};
+
+export default LoadingTrace;

--- a/packages/chrome-devtools/src/i18n/index.ts
+++ b/packages/chrome-devtools/src/i18n/index.ts
@@ -13,6 +13,7 @@ const resources = {
           proxy: 'Proxy',
           dependency: 'Dependency graph',
           share: 'Shared',
+          loadingTrace: 'Loading trace',
           performance: 'Performance',
         },
         header: {
@@ -241,6 +242,64 @@ const resources = {
         entry: 'Entry',
         version: 'Version',
       },
+      loadingTrace: {
+        title: 'Loading Trace',
+        empty: 'No loading report yet',
+        status: {
+          enabled: 'Observability is enabled for the current page.',
+          disabled: 'Observability is not enabled for the current page.',
+          unavailable: 'Current page is unavailable.',
+          reloading: 'Configuration saved. Reloading current page.',
+          synced: 'Reports synced.',
+          noReports: 'No report found on the current page.',
+        },
+        confirm: {
+          observeTitle: 'Start observability?',
+          updateTitle: 'Update configuration?',
+          content:
+            'The current tab will reload after the configuration is saved.',
+        },
+        actions: {
+          observeNow: 'Observe now',
+          updateConfig: 'Update config',
+          config: 'Configuration',
+          disable: 'Disable',
+          refresh: 'Sync',
+          export: 'Export',
+          confirm: 'Confirm',
+          cancel: 'Cancel',
+        },
+        config: {
+          level: 'Level',
+          levelTip:
+            'Controls how much event detail is kept. Verbose keeps the full timeline, summary keeps key results, and error focuses on failures.',
+          verbose: 'Verbose',
+          summary: 'Summary',
+          error: 'Error',
+          console: 'Console hints',
+          consoleTip:
+            'Prints lightweight hints in the inspected page console. Turn it off when the page console should stay clean.',
+          reactCallback: 'React callback',
+          reactCallbackTip:
+            'Injects an onMFRemoteLoaded callback prop into matched React remote function components so producers can mark business readiness.',
+          remoteIds: 'Module filter',
+          remoteIdsTip:
+            'Only used when React callback is enabled. Empty means no filter; filled values only inject callbacks for matching loadRemote request ids or exposes.',
+        },
+        stats: {
+          state: 'State',
+          reports: 'Reports',
+          events: 'Events',
+          latest: 'Latest outcome',
+        },
+        reports: {
+          search: 'Filter reports',
+          noMatch: 'No matching report',
+          success: 'Success',
+          failed: 'Failed',
+          pending: 'Pending',
+        },
+      },
     },
   },
   'zh-CN': {
@@ -251,6 +310,7 @@ const resources = {
           proxy: '代理配置',
           dependency: '依赖关系图',
           share: '共享依赖',
+          loadingTrace: '加载链路',
           performance: '性能',
         },
         header: {
@@ -472,6 +532,63 @@ const resources = {
         shared: '共享依赖',
         entry: '入口',
         version: '版本',
+      },
+      loadingTrace: {
+        title: '加载链路',
+        empty: '暂无加载报告',
+        status: {
+          enabled: '当前页面已开启可观测。',
+          disabled: '当前页面未开启可观测。',
+          unavailable: '当前页面暂不可用。',
+          reloading: '配置已保存，正在刷新当前页面。',
+          synced: '报告已同步。',
+          noReports: '当前页面还没有报告。',
+        },
+        confirm: {
+          observeTitle: '开启观测？',
+          updateTitle: '更新配置？',
+          content: '保存配置后会刷新当前标签页。',
+        },
+        actions: {
+          observeNow: '立即观测',
+          updateConfig: '更新配置',
+          config: '配置',
+          disable: '关闭',
+          refresh: '同步',
+          export: '导出',
+          confirm: '确认',
+          cancel: '取消',
+        },
+        config: {
+          level: '记录级别',
+          levelTip:
+            '控制保留多少事件细节。完整会保留完整链路，摘要只保留关键结果，错误只关注失败。',
+          verbose: '完整',
+          summary: '摘要',
+          error: '错误',
+          console: '控制台提示',
+          consoleTip:
+            '在被调试页面的控制台打印轻量提示。如果想保持页面控制台干净，可以关闭。',
+          reactCallback: 'React 回调',
+          reactCallbackTip:
+            '给匹配的 React 远程函数组件注入 onMFRemoteLoaded 回调，让生产者主动标记业务就绪。',
+          remoteIds: '模块过滤',
+          remoteIdsTip:
+            '仅在开启 React 回调时生效。留空表示不过滤；填写后只对匹配的 loadRemote 请求 id 或 expose 注入回调。',
+        },
+        stats: {
+          state: '状态',
+          reports: '报告',
+          events: '事件',
+          latest: '最新结果',
+        },
+        reports: {
+          search: '过滤报告',
+          noMatch: '没有匹配的报告',
+          success: '成功',
+          failed: '失败',
+          pending: '进行中',
+        },
       },
     },
   },

--- a/packages/chrome-devtools/src/utils/chrome/index.ts
+++ b/packages/chrome-devtools/src/utils/chrome/index.ts
@@ -38,10 +38,11 @@ export const syncActiveTab = async (tabId?: number) => {
       setTargetTab(tab);
       return tab;
     }
-    const [activeTab] = await getTabs({
+    const tabs = await getTabs({
       active: true,
       lastFocusedWindow: true,
     });
+    const activeTab = Array.isArray(tabs) ? tabs[0] : undefined;
     setTargetTab(activeTab);
     return activeTab;
   } catch (error) {
@@ -66,9 +67,9 @@ export function getInspectWindowTabId() {
         function (info, error) {
           const { tabId } = chrome.devtools.inspectedWindow;
           getTabs().then((tabs) => {
-            const target = tabs.find(
-              (tab: chrome.tabs.Tab) => tab.id === tabId,
-            );
+            const target = Array.isArray(tabs)
+              ? tabs.find((tab: chrome.tabs.Tab) => tab.id === tabId)
+              : undefined;
             setTargetTab(target as chrome.tabs.Tab);
           });
           console.log(

--- a/packages/chrome-devtools/src/utils/chrome/messages.ts
+++ b/packages/chrome-devtools/src/utils/chrome/messages.ts
@@ -1,2 +1,7 @@
 export const MESSAGE_OPEN_SIDE_PANEL = 'mf-devtools/open-side-panel';
 export const MESSAGE_ACTIVE_TAB_CHANGED = 'mf-devtools/active-tab-changed';
+export const MESSAGE_OBSERVABILITY_DEVTOOLS_EVENT =
+  'mf-devtools/observability-event';
+export const OBSERVABILITY_DEVTOOLS_SOURCE = 'module-federation/observability';
+export const OBSERVABILITY_DEVTOOLS_STORAGE_KEY =
+  '__MF_DEVTOOLS_OBSERVABILITY_CONFIG__';

--- a/packages/chrome-devtools/src/utils/chrome/observability-plugin.ts
+++ b/packages/chrome-devtools/src/utils/chrome/observability-plugin.ts
@@ -1,0 +1,121 @@
+import {
+  createObservability,
+  type ObservabilityPluginOptions,
+} from '@module-federation/observability-plugin';
+
+import {
+  OBSERVABILITY_DEVTOOLS_SOURCE,
+  OBSERVABILITY_DEVTOOLS_STORAGE_KEY,
+} from './messages';
+import {
+  createObservabilityPluginOptions,
+  normalizeObservabilityDevtoolsConfig,
+} from './observability-shared';
+
+const DEVTOOLS_PLUGIN_NAME = 'observability-plugin-devtools';
+
+type FederationGlobal = {
+  __GLOBAL_PLUGIN__?: Array<{ name?: string }>;
+} & Record<string, unknown>;
+
+type FederationWindow = Window & {
+  __FEDERATION__?: FederationGlobal;
+  __VMOK__?: FederationGlobal;
+};
+
+const getFederationWindow = () => window as unknown as FederationWindow;
+
+const safeReadStoredConfig = () => {
+  try {
+    const raw = window.localStorage?.getItem(
+      OBSERVABILITY_DEVTOOLS_STORAGE_KEY,
+    );
+    if (!raw) {
+      return undefined;
+    }
+    return normalizeObservabilityDevtoolsConfig(JSON.parse(raw));
+  } catch {
+    return undefined;
+  }
+};
+
+const defineWritableGlobal = (
+  key: '__FEDERATION__' | '__VMOK__',
+  value: any,
+) => {
+  const targetWindow = getFederationWindow();
+  try {
+    Object.defineProperty(targetWindow, key, {
+      value,
+      configurable: true,
+      writable: true,
+    });
+  } catch {
+    targetWindow[key] = value;
+  }
+};
+
+const ensureFederationGlobal = () => {
+  const targetWindow = getFederationWindow();
+  const federation = targetWindow.__FEDERATION__ || targetWindow.__VMOK__ || {};
+
+  if (!targetWindow.__FEDERATION__) {
+    defineWritableGlobal('__FEDERATION__', federation);
+  }
+  if (!targetWindow.__VMOK__) {
+    defineWritableGlobal('__VMOK__', targetWindow.__FEDERATION__);
+  }
+
+  if (!targetWindow.__FEDERATION__?.__GLOBAL_PLUGIN__) {
+    targetWindow.__FEDERATION__ = targetWindow.__FEDERATION__ || federation;
+    targetWindow.__FEDERATION__.__GLOBAL_PLUGIN__ = [];
+  }
+
+  return targetWindow.__FEDERATION__;
+};
+
+const notifyInstalled = (
+  status: 'installed' | 'skipped',
+  reason?: string,
+  config?: ReturnType<typeof normalizeObservabilityDevtoolsConfig>,
+) => {
+  try {
+    window.postMessage(
+      {
+        schemaVersion: 1,
+        source: OBSERVABILITY_DEVTOOLS_SOURCE,
+        kind: status,
+        reason,
+        config,
+        createdAt: Date.now(),
+      },
+      '*',
+    );
+  } catch {
+    // Devtools status delivery is best effort only.
+  }
+};
+
+const install = () => {
+  const config = safeReadStoredConfig();
+  if (!config?.enabled) {
+    return;
+  }
+
+  const federation = ensureFederationGlobal();
+  const globalPlugins = federation?.__GLOBAL_PLUGIN__ || [];
+  if (globalPlugins.some((plugin) => plugin?.name === DEVTOOLS_PLUGIN_NAME)) {
+    notifyInstalled('skipped', 'already-installed', config);
+    return;
+  }
+
+  const controller = createObservability(
+    createObservabilityPluginOptions(config) as ObservabilityPluginOptions,
+  );
+  controller.plugin.name = DEVTOOLS_PLUGIN_NAME;
+  globalPlugins.push(controller.plugin);
+  federation.__GLOBAL_PLUGIN__ = globalPlugins;
+  notifyInstalled('installed', undefined, config);
+};
+
+install();

--- a/packages/chrome-devtools/src/utils/chrome/observability-shared.ts
+++ b/packages/chrome-devtools/src/utils/chrome/observability-shared.ts
@@ -1,0 +1,166 @@
+import { OBSERVABILITY_DEVTOOLS_SOURCE } from './messages';
+
+export type ObservabilityDevtoolsLevel = 'error' | 'summary' | 'verbose';
+export type ObservabilityDevtoolsMode = 'development' | 'production';
+
+export interface ObservabilityDevtoolsConfig {
+  enabled: boolean;
+  level: ObservabilityDevtoolsLevel;
+  maxEvents: number;
+  console: boolean;
+  browser: {
+    enabled: boolean;
+    scope: string;
+    mode: ObservabilityDevtoolsMode;
+  };
+  trace: {
+    printStart: boolean;
+  };
+  react: {
+    injectLoadedCallback: boolean;
+    remoteIds: string[];
+  };
+}
+
+const DEFAULT_SCOPE = 'mf-devtools';
+const MIN_EVENTS = 10;
+const MAX_EVENTS = 1000;
+
+export const DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG: ObservabilityDevtoolsConfig =
+  {
+    enabled: true,
+    level: 'verbose',
+    maxEvents: 300,
+    console: true,
+    browser: {
+      enabled: true,
+      scope: DEFAULT_SCOPE,
+      mode: 'development',
+    },
+    trace: {
+      printStart: true,
+    },
+    react: {
+      injectLoadedCallback: false,
+      remoteIds: [],
+    },
+  };
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const normalizeBoolean = (value: unknown, fallback: boolean) =>
+  typeof value === 'boolean' ? value : fallback;
+
+const normalizeLevel = (value: unknown): ObservabilityDevtoolsLevel =>
+  value === 'error' || value === 'summary' || value === 'verbose'
+    ? value
+    : DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG.level;
+
+const normalizeMode = (value: unknown): ObservabilityDevtoolsMode =>
+  value === 'production' || value === 'development'
+    ? value
+    : DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG.browser.mode;
+
+const normalizeMaxEvents = (value: unknown) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG.maxEvents;
+  }
+  return Math.max(MIN_EVENTS, Math.min(MAX_EVENTS, Math.floor(parsed)));
+};
+
+const normalizeScope = (value: unknown) => {
+  if (typeof value !== 'string') {
+    return DEFAULT_SCOPE;
+  }
+  const trimmed = value.trim().replace(/[^\w:@.-]+/g, '-');
+  return trimmed || DEFAULT_SCOPE;
+};
+
+const normalizeRemoteIds = (value: unknown) => {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => String(item || '').trim())
+      .filter(Boolean)
+      .slice(0, 50);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .slice(0, 50);
+  }
+  return [];
+};
+
+export const normalizeObservabilityDevtoolsConfig = (
+  value?: Partial<ObservabilityDevtoolsConfig> | Record<string, unknown> | null,
+): ObservabilityDevtoolsConfig => {
+  const source = isObject(value) ? value : {};
+  const browser = isObject(source.browser) ? source.browser : {};
+  const trace = isObject(source.trace) ? source.trace : {};
+  const react = isObject(source.react) ? source.react : {};
+
+  return {
+    enabled: normalizeBoolean(
+      source.enabled,
+      DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG.enabled,
+    ),
+    level: normalizeLevel(source.level),
+    maxEvents: normalizeMaxEvents(source.maxEvents),
+    console: normalizeBoolean(
+      source.console,
+      DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG.console,
+    ),
+    browser: {
+      enabled: normalizeBoolean(
+        browser.enabled,
+        DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG.browser.enabled,
+      ),
+      scope: normalizeScope(browser.scope),
+      mode: normalizeMode(browser.mode),
+    },
+    trace: {
+      printStart: normalizeBoolean(
+        trace.printStart,
+        DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG.trace.printStart,
+      ),
+    },
+    react: {
+      injectLoadedCallback: normalizeBoolean(
+        react.injectLoadedCallback,
+        DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG.react.injectLoadedCallback,
+      ),
+      remoteIds: normalizeRemoteIds(react.remoteIds),
+    },
+  };
+};
+
+export const createObservabilityPluginOptions = (
+  config: ObservabilityDevtoolsConfig,
+) => ({
+  enabled: config.enabled,
+  level: config.level,
+  maxEvents: config.maxEvents,
+  console: config.console,
+  browser: {
+    enabled: config.browser.enabled,
+    scope: config.browser.scope,
+    mode: config.browser.mode,
+  },
+  trace: {
+    printStart: config.trace.printStart,
+  },
+  devtools: {
+    enabled: true,
+    source: OBSERVABILITY_DEVTOOLS_SOURCE,
+  },
+  react: config.react.injectLoadedCallback
+    ? {
+        injectLoadedCallback: true,
+        remoteIds: config.react.remoteIds,
+      }
+    : undefined,
+});

--- a/packages/chrome-devtools/src/utils/chrome/observability.ts
+++ b/packages/chrome-devtools/src/utils/chrome/observability.ts
@@ -1,0 +1,233 @@
+import { injectScript } from './index';
+import { OBSERVABILITY_DEVTOOLS_STORAGE_KEY } from './messages';
+import {
+  DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG,
+  normalizeObservabilityDevtoolsConfig,
+  type ObservabilityDevtoolsConfig,
+} from './observability-shared';
+
+export interface ObservabilityDevtoolsEvent {
+  traceId: string;
+  timestamp: number;
+  phase: string;
+  status: string;
+  requestId?: string;
+  lifecycle?: string;
+  message?: string;
+  remote?: {
+    name?: string;
+    entry?: string;
+    alias?: string;
+  };
+  shared?: {
+    name?: string;
+    selectedVersion?: string;
+    provider?: string;
+    reason?: string;
+  };
+  expose?: string;
+  duration?: number;
+  errorCode?: string;
+  errorName?: string;
+  errorMessage?: string;
+  ownerHint?: string;
+  recovered?: boolean;
+  cached?: boolean;
+}
+
+export interface ObservabilityDevtoolsReport {
+  traceId: string;
+  status: string;
+  requestId?: string;
+  hostName?: string;
+  remote?: {
+    name?: string;
+    entry?: string;
+    alias?: string;
+  };
+  shared?: {
+    name?: string;
+    selectedVersion?: string;
+    provider?: string;
+    reason?: string;
+  };
+  expose?: string;
+  startedAt: number;
+  updatedAt: number;
+  duration: number;
+  failedPhase?: string;
+  errorCode?: string;
+  errorName?: string;
+  errorMessage?: string;
+  ownerHint?: string;
+  events: ObservabilityDevtoolsEvent[];
+  summary?: {
+    outcome?: string;
+    runtimeLoaded?: boolean;
+    componentLoaded?: boolean;
+    loadCompleted?: boolean;
+    recovered?: boolean;
+    lastPhase?: string;
+  };
+  diagnosis?: {
+    title?: string;
+    ownerHint?: string;
+    errorCode?: string;
+    actions?: Array<{ title?: string; detail?: string }>;
+    warnings?: string[];
+  };
+  __scope?: string;
+}
+
+export interface ObservabilityDevtoolsSnapshot {
+  config: ObservabilityDevtoolsConfig;
+  stored: boolean;
+  scopes: string[];
+  reports: ObservabilityDevtoolsReport[];
+}
+
+const readConfigFromPage = (storageKey: string) => {
+  try {
+    const raw = window.localStorage?.getItem(storageKey);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeConfigToPage = (storageKey: string, config: unknown) => {
+  window.localStorage?.setItem(storageKey, JSON.stringify(config));
+  return config;
+};
+
+const removeConfigFromPage = (storageKey: string) => {
+  window.localStorage?.removeItem(storageKey);
+  return true;
+};
+
+const reloadPage = () => {
+  globalThis.location?.reload();
+};
+
+const readSnapshotFromPage = (storageKey: string) => {
+  const safeCopy = (value: unknown) => {
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch {
+      return undefined;
+    }
+  };
+
+  const rawConfig = (() => {
+    try {
+      const raw = window.localStorage?.getItem(storageKey);
+      return raw ? JSON.parse(raw) : null;
+    } catch {
+      return null;
+    }
+  })();
+  const federation = (window as any).__FEDERATION__ || (window as any).__VMOK__;
+  const readers = federation?.__OBSERVABILITY__ || {};
+  const reports: Array<ObservabilityDevtoolsReport> = [];
+  const scopes = Object.keys(readers);
+
+  scopes.forEach((scope) => {
+    const reader = readers[scope];
+    if (!reader || typeof reader.getReports !== 'function') {
+      return;
+    }
+
+    try {
+      const scopeReports = reader.getReports({ limit: 100 });
+      if (!Array.isArray(scopeReports)) {
+        return;
+      }
+      scopeReports.forEach((report) => {
+        const copied = safeCopy(report) as ObservabilityDevtoolsReport;
+        if (copied?.traceId) {
+          copied.__scope = scope;
+          reports.push(copied);
+        }
+      });
+    } catch {
+      // One broken reader should not block other scopes.
+    }
+  });
+
+  return {
+    config: rawConfig,
+    stored: Boolean(rawConfig),
+    scopes,
+    reports,
+  };
+};
+
+export const readObservabilityConfig = async () => {
+  const config = await injectScript(
+    readConfigFromPage,
+    false,
+    OBSERVABILITY_DEVTOOLS_STORAGE_KEY,
+  );
+
+  return normalizeObservabilityDevtoolsConfig(
+    config || DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG,
+  );
+};
+
+export const applyObservabilityConfig = async (
+  config: ObservabilityDevtoolsConfig,
+) =>
+  injectScript(
+    writeConfigToPage,
+    false,
+    OBSERVABILITY_DEVTOOLS_STORAGE_KEY,
+    normalizeObservabilityDevtoolsConfig(config),
+  );
+
+export const disableObservabilityConfig = async () =>
+  injectScript(removeConfigFromPage, false, OBSERVABILITY_DEVTOOLS_STORAGE_KEY);
+
+export const reloadInspectedPage = async () => injectScript(reloadPage, false);
+
+export const readObservabilitySnapshot =
+  async (): Promise<ObservabilityDevtoolsSnapshot> => {
+    const snapshot = await injectScript(
+      readSnapshotFromPage,
+      true,
+      OBSERVABILITY_DEVTOOLS_STORAGE_KEY,
+    );
+
+    return {
+      config: normalizeObservabilityDevtoolsConfig(
+        snapshot?.config || DEFAULT_OBSERVABILITY_DEVTOOLS_CONFIG,
+      ),
+      stored: Boolean(snapshot?.stored),
+      scopes: Array.isArray(snapshot?.scopes) ? snapshot.scopes : [],
+      reports: Array.isArray(snapshot?.reports) ? snapshot.reports : [],
+    };
+  };
+
+export const mergeObservabilityReports = (
+  currentReports: ObservabilityDevtoolsReport[],
+  incomingReports: ObservabilityDevtoolsReport[],
+) => {
+  const merged = new Map<string, ObservabilityDevtoolsReport>();
+
+  currentReports.forEach((report) => {
+    if (report.traceId) {
+      merged.set(report.traceId, report);
+    }
+  });
+  incomingReports.forEach((report) => {
+    if (report.traceId) {
+      merged.set(report.traceId, report);
+    }
+  });
+
+  return Array.from(merged.values()).sort((left, right) => {
+    if ((right.updatedAt || 0) !== (left.updatedAt || 0)) {
+      return (right.updatedAt || 0) - (left.updatedAt || 0);
+    }
+    return (right.startedAt || 0) - (left.startedAt || 0);
+  });
+};

--- a/packages/chrome-devtools/src/utils/chrome/post-message-listener.ts
+++ b/packages/chrome-devtools/src/utils/chrome/post-message-listener.ts
@@ -1,10 +1,27 @@
 import { sanitizePostMessagePayload } from './safe-post-message';
+import {
+  MESSAGE_OBSERVABILITY_DEVTOOLS_EVENT,
+  OBSERVABILITY_DEVTOOLS_SOURCE,
+} from './messages';
 
 if (window.moduleHandler) {
   window.removeEventListener('message', window.moduleHandler);
 } else {
   window.moduleHandler = (event) => {
     const { origin, data } = event;
+    if (data?.source === OBSERVABILITY_DEVTOOLS_SOURCE) {
+      chrome.runtime
+        .sendMessage({
+          type: MESSAGE_OBSERVABILITY_DEVTOOLS_EVENT,
+          origin,
+          data: sanitizePostMessagePayload(data),
+        })
+        .catch(() => {
+          return false;
+        });
+      return;
+    }
+
     if (!data.moduleInfo) {
       return;
     }

--- a/packages/observability-plugin/README.md
+++ b/packages/observability-plugin/README.md
@@ -42,6 +42,9 @@ Enable only the output channels that match the environment:
 
 - Browser dev: use `browser.enabled: true` with a scoped reader such as
   `window.__FEDERATION__.__OBSERVABILITY__.host`.
+- Chrome DevTools integration: use `devtools: true` together with browser
+  output so a browser extension can receive loading events through
+  `window.postMessage`.
 - Agent-led browser dev: use `collector: true` to POST reports to the local
   skill collector on `127.0.0.1:17891`.
 - Browser prod: set `browser.mode: "production"` so console output stays limited
@@ -222,6 +225,27 @@ window.__FEDERATION__.__OBSERVABILITY__.host.getReports({ limit: 5 });
 window.__FEDERATION__.__OBSERVABILITY__.host.findReports({ remote: 'remote1' });
 window.__FEDERATION__.__OBSERVABILITY__.host.exportReport('mf-trace-id');
 ```
+
+Chrome DevTools panels can opt in to event delivery without polling the page:
+
+```ts
+ObservabilityPlugin({
+  level: 'verbose',
+  browser: {
+    enabled: true,
+    scope: 'host',
+    mode: 'development',
+  },
+  trace: {
+    printStart: true,
+  },
+  devtools: true,
+});
+```
+
+This posts structured event/report snapshots to the page with
+`window.postMessage`. Browser extensions can forward those messages from their
+content script to the panel. The channel is disabled by default.
 
 `getReports({ limit })` returns recent reports newest first. `findReports()` can
 filter by `traceId`, `remote`, `expose`, `shared`, `status`, or `outcome`.

--- a/packages/observability-plugin/__tests__/observability.spec.ts
+++ b/packages/observability-plugin/__tests__/observability.spec.ts
@@ -1266,6 +1266,59 @@ describe('ObservabilityPlugin', () => {
     }
   });
 
+  it('posts events to the browser devtools channel when enabled', () => {
+    const originalPostMessage = (globalThis as { postMessage?: unknown })
+      .postMessage;
+    const postMessageMock = vi.fn();
+    Object.defineProperty(globalThis, 'postMessage', {
+      value: postMessageMock,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const observability = createObservability({
+        level: 'verbose',
+        console: false,
+        browser: {
+          enabled: true,
+          scope: 'runtime_host',
+        },
+        devtools: true,
+      });
+
+      emitRemoteStart(observability);
+
+      expect(postMessageMock).toHaveBeenCalledTimes(1);
+      expect(postMessageMock.mock.calls[0]?.[1]).toBe('*');
+      expect(postMessageMock.mock.calls[0]?.[0]).toMatchObject({
+        schemaVersion: 1,
+        source: 'module-federation/observability',
+        kind: 'event',
+        scope: 'host',
+        event: {
+          phase: 'loadRemote',
+          status: 'start',
+          requestId: 'remote/Button',
+        },
+        report: {
+          requestId: 'remote/Button',
+          status: 'pending',
+        },
+      });
+    } finally {
+      if (originalPostMessage) {
+        Object.defineProperty(globalThis, 'postMessage', {
+          value: originalPostMessage,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        Reflect.deleteProperty(globalThis, 'postMessage');
+      }
+    }
+  });
+
   it('omits undefined fields from public snapshots', async () => {
     const observability = createObservability({
       level: 'verbose',

--- a/packages/observability-plugin/src/index.ts
+++ b/packages/observability-plugin/src/index.ts
@@ -237,6 +237,12 @@ export interface ObservabilityPluginOptions {
   trace?: {
     printStart?: boolean;
   };
+  devtools?:
+    | boolean
+    | {
+        enabled?: boolean;
+        source?: string;
+      };
   react?: {
     enabled?: boolean;
     injectLoadedCallback?: boolean;
@@ -533,6 +539,11 @@ interface ObservabilityCollectorOptions {
   port: number;
 }
 
+interface ObservabilityDevtoolsOptions {
+  enabled: true;
+  source: string;
+}
+
 type ObservabilityFetch = (
   input: string,
   init?: {
@@ -549,6 +560,7 @@ const DEFAULT_MAX_EVENTS = 100;
 const HARD_MAX_EVENTS = 1000;
 const DEFAULT_COLLECTOR_PORT = 17891;
 const COLLECTOR_PATH = '/__mf_observability';
+const DEFAULT_DEVTOOLS_SOURCE = 'module-federation/observability';
 const COMPONENT_BUSINESS_LOADED_EVENT = 'component:business-loaded';
 const ON_MF_REMOTE_LOADED_PROP = 'onMFRemoteLoaded';
 const SENSITIVE_PAIR_PATTERN =
@@ -615,6 +627,26 @@ function normalizeCollectorOptions(
   return {
     enabled: true,
     port: normalizeCollectorPort(value.port),
+  };
+}
+
+function normalizeDevtoolsOptions(
+  value: ObservabilityPluginOptions['devtools'],
+): ObservabilityDevtoolsOptions | undefined {
+  if (value === true) {
+    return {
+      enabled: true,
+      source: DEFAULT_DEVTOOLS_SOURCE,
+    };
+  }
+
+  if (!value || value === false || value.enabled === false) {
+    return undefined;
+  }
+
+  return {
+    enabled: true,
+    source: sanitizeText(value.source, 160) || DEFAULT_DEVTOOLS_SOURCE,
   };
 }
 
@@ -1750,6 +1782,7 @@ export function createObservability(
   const traceByRemote = new Map<string, string>();
   const phaseStartTimes = new Map<string, number>();
   const collectorOptions = normalizeCollectorOptions(options.collector);
+  const devtoolsOptions = normalizeDevtoolsOptions(options.devtools);
   const seenManifestUrls = new Set<string>();
   const seenRemoteEntryKeys = new Set<string>();
   const consoleReportedTraceIds = new Set<string>();
@@ -2759,6 +2792,38 @@ export function createObservability(
     }
   };
 
+  const notifyDevtools = (
+    event: ObservabilityEvent,
+    report: ObservabilityReport,
+  ) => {
+    if (!devtoolsOptions) {
+      return;
+    }
+
+    const poster = (globalThis as { postMessage?: unknown }).postMessage;
+    if (typeof poster !== 'function') {
+      return;
+    }
+
+    try {
+      poster.call(
+        globalThis,
+        {
+          schemaVersion: 1,
+          source: devtoolsOptions.source,
+          kind: 'event',
+          createdAt: Date.now(),
+          scope: browserGlobalScope || report.hostName,
+          event: copyEvent(event),
+          report: copyReport(report),
+        },
+        '*',
+      );
+    } catch {
+      // Browser extension delivery is optional and must not affect MF loading.
+    }
+  };
+
   const getEventsSnapshot = () => events.map(copyEvent);
 
   const getTraceIdsSnapshot = () => Array.from(reports.keys());
@@ -3100,6 +3165,7 @@ export function createObservability(
     emitStartConsoleHint(event, report);
     emitConsoleHint(event, report, input.error);
     notifyCollector(event, report);
+    notifyDevtools(event, report);
     notifyRawError(input.error, event, report, origin);
     notifyEvent(event, report, origin);
     notifyReport(report, origin);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3061,6 +3061,9 @@ importers:
       '@modern-js/runtime':
         specifier: 2.70.8
         version: 2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
+      '@module-federation/observability-plugin':
+        specifier: workspace:*
+        version: link:../observability-plugin
       '@module-federation/sdk':
         specifier: workspace:*
         version: link:../sdk


### PR DESCRIPTION
## Summary

- Add a Loading Trace tab to the Chrome DevTools extension for enabling observability, configuring it, viewing live loading reports, filtering reports, and exporting report data.
- Wire the Chrome DevTools extension to inject the observability plugin and receive report updates from the inspected page.
- Extend the observability plugin with DevTools message delivery and React loaded-callback support, plus README and tests.
- Fix active tab syncing so missing tab query results do not produce runtime warnings.

## Validation

- `pnpm --filter @module-federation/devtools test`
- `pnpm --filter @module-federation/devtools build`
- `pnpm --filter @module-federation/devtools build:devtool`
- `pnpm --filter @module-federation/observability-plugin test`
- `pnpm --filter @module-federation/observability-plugin build`
- commit hook ran formatting, lint, and commitlint

Note: local commands reported the existing Node engine warning because this machine is using Node 22 while the repo expects Node 20, but the checks above passed.