### PR TITLE
chore(actions): remove issues-helper usage

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-permissions:
-  contents: read
-
 jobs:
   issue-close-require:
     permissions:
@@ -15,12 +12,27 @@ jobs:
     if: github.repository == 'module-federation/core'
     steps:
       - name: need reproduction
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issues'
-          labels: 'need reproduction'
-          inactive-day: 5
-          body: |
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BODY: |
             As the issue was labelled with `need reproduction`, but no response in 5 days. This issue will be closed. Feel free to comment and reopen it if you have any further questions. For background, see [Why reproductions are required](https://antfu.me/posts/why-reproductions-are-required).
 
             由于该 issue 被标记为 "需要重现"，但在 5 天内没有回应，因此该 issue 将被关闭。如果你有任何进一步的问题，请随时发表评论并重新打开该 issue。背景请参考 [为什么需要最小重现](https://antfu.me/posts/why-reproductions-are-required-zh)。
+        run: |
+          cutoff="$(date -u -d '5 days ago' +%F)"
+          query="repo:${REPO} is:issue is:open label:\"need reproduction\" updated:<${cutoff}"
+          issue_numbers="$(gh api --method GET --paginate search/issues -f q="$query" --jq '.items[].number')"
+
+          if [ -z "$issue_numbers" ]; then
+            echo "No stale issues found."
+            exit 0
+          fi
+
+          while IFS= read -r issue_number; do
+            if [ -z "$issue_number" ]; then
+              continue
+            fi
+
+            gh issue close "${issue_number}" --repo "${REPO}" --comment "$BODY"
+          done <<< "$issue_numbers"

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -5,7 +5,6 @@ on:
     types: [labeled]
 
 permissions:
-  contents: read
   issues: write
 
 jobs:
@@ -15,20 +14,22 @@ jobs:
     steps:
       - name: contribution welcome
         if: github.event.label.name == 'contribution welcome' || github.event.label.name == 'help wanted'
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          labels: 'pending triage, need reproduction'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --remove-label "pending triage" || true
+          gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --remove-label "need reproduction" || true
 
       - name: need reproduction
         if: github.event.label.name == 'need reproduction'
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment, remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          BODY: |
             Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://stackblitz.com/). Issues marked with `need reproduction` will be closed if they have no activity within 5 days.
-          labels: 'pending triage'
+        run: |
+          gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body "$BODY"
+          gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --remove-label "pending triage" || true


### PR DESCRIPTION
## Description

Removes the disabled `actions-cool/issues-helper` action from issue automation workflows and replaces it with GitHub CLI commands on the hosted runner.

This keeps the existing issue behavior:

- contribution/help-wanted labels still clear stale triage labels
- need-reproduction labels still add the reproduction request comment
- stale need-reproduction issues are still closed after five inactive days

It also tightens the workflow token permissions so these jobs only have issue access.

## Related Issue

Security hardening after `actions-cool/issues-helper` was disabled by GitHub.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.

Validation run locally:

- `pnpm exec prettier --check .github/workflows/issue-labeled.yml .github/workflows/issue-close-require.yml`
- `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f); puts \"ok #{f}\" }" .github/workflows/issue-labeled.yml .github/workflows/issue-close-require.yml`
- `git diff --check -- .github/workflows/issue-labeled.yml .github/workflows/issue-close-require.yml`

Skipped full package build/tests because this only changes issue automation workflows.