### PR TITLE
feat(runtime): observe preload resource results

### DIFF
--- a/.changeset/preload-resource-observability.md
+++ b/.changeset/preload-resource-observability.md
@@ -1,0 +1,7 @@
+---
+"@module-federation/runtime-core": patch
+"@module-federation/observability-plugin": patch
+"@module-federation/sdk": patch
+---
+
+Track preload resource results and expose resource context to loader hooks.

--- a/apps/runtime-demo/3005-runtime-host/cypress/e2e/app.cy.ts
+++ b/apps/runtime-demo/3005-runtime-host/cypress/e2e/app.cy.ts
@@ -226,7 +226,7 @@ describe('3005-runtime-host/', () => {
         expect(latestReport.summary.preloaded).to.equal(true);
         expect(latestReport.summary.outcome).to.equal('preloaded');
         expect(latestReport.diagnosis.title).to.equal(
-          'Remote preload prepared',
+          'Remote preloaded successfully',
         );
       });
     });

--- a/apps/website-new/docs/en/guide/runtime/runtime-api.mdx
+++ b/apps/website-new/docs/en/guide/runtime/runtime-api.mdx
@@ -796,6 +796,81 @@ Through `preloadRemote`, you can start preloading module resources at an earlier
 * `remote`'s synchronous or asynchronous resources
 * `remote`'s dependent `remote` resources
 
+`preloadRemote` waits for the resources involved in the current preload call to
+finish. The Promise resolves when every resource succeeds or is already cached.
+If any resource fails or times out, the Promise rejects and the error object
+contains the preload resource results.
+
+If you only need the final result, use `await` or `.then/.catch`:
+
+```ts
+import { preloadRemote } from '@module-federation/enhanced/runtime';
+
+try {
+  await preloadRemote([
+    {
+      nameOrAlias: 'sub1',
+      exposes: ['add'],
+      resourceCategory: 'all',
+    },
+  ]);
+
+  console.log('sub1/add preload success');
+} catch (error) {
+  console.error('sub1/add preload failed', error);
+}
+```
+
+If you need to count which resources succeeded, failed, timed out, or came from
+cache, read `results` from the error object:
+
+```ts
+type PreloadRemoteError = Error & {
+  results?: Array<{
+    id: string;
+    results: Array<{
+      url: string;
+      status: 'success' | 'error' | 'timeout' | 'cached';
+      resourceType: 'manifest' | 'remoteEntry' | 'js' | 'css';
+      error?: unknown;
+    }>;
+  }>;
+};
+
+preloadRemote([
+  {
+    nameOrAlias: 'sub1',
+    exposes: ['add'],
+    resourceCategory: 'all',
+  },
+]).catch((error: PreloadRemoteError) => {
+  const failedResources =
+    error.results
+      ?.flatMap((remoteResult) =>
+        remoteResult.results.map((resource) => ({
+          id: remoteResult.id,
+          ...resource,
+        })),
+      )
+      .filter(
+        (resource) =>
+          resource.status === 'error' || resource.status === 'timeout',
+      ) ?? [];
+
+  failedResources.forEach((resource) => {
+    console.error(
+      `[preloadRemote] ${resource.id} ${resource.resourceType} failed`,
+      resource.url,
+      resource.error,
+    );
+  });
+});
+```
+
+When `exposes` is not specified, the resource id is `remoteName/*`. When
+`exposes` is specified, the runtime generates resources per expose and the
+resource id is `remoteName/expose`.
+
 <Tabs>
   <Tab label="Build Plugin(Use build plugin)">
   ```tsx

--- a/apps/website-new/docs/en/guide/runtime/runtime-hooks.mdx
+++ b/apps/website-new/docs/en/guide/runtime/runtime-hooks.mdx
@@ -727,6 +727,8 @@ type ResourceLoadContext = {
 `timeout` is measured in milliseconds and controls the script loading timeout. The default value is `20000`.
 `resourceContext` tells whether this resource load came from `loadRemote` or
 `preloadRemote`, plus the resource type and id.
+You can combine `timeout` and `resourceContext` to set different timeouts for
+remoteEntry loads and preload loads.
 
 * example
 
@@ -811,10 +813,45 @@ type CreateLinkOptions ={
   remoteInfo?: RemoteInfo;
   resourceContext?: ResourceLoadContext;
 }
+
+type CreateLinkHookReturn =
+  | HTMLLinkElement
+  | { link?: HTMLLinkElement; timeout?: number }
+  | void;
 ```
 
 `resourceContext` has the same shape as in `createScript`. It can distinguish
 preloaded JS/CSS, actual remoteEntry loading, and the related resource id.
+`timeout` is measured in milliseconds and controls the link loading timeout. The
+default value is `20000`.
+
+Example: use a shorter timeout for low-priority preload resources, while keeping
+normal remote loading more tolerant.
+
+```ts
+import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
+
+const resourceTimeoutPlugin = (): ModuleFederationRuntimePlugin => ({
+  name: 'resource-timeout-plugin',
+  createScript({ resourceContext }) {
+    if (
+      resourceContext?.initiator === 'loadRemote' &&
+      resourceContext.resourceType === 'remoteEntry'
+    ) {
+      return {
+        timeout: 30000,
+      };
+    }
+  },
+  createLink({ resourceContext }) {
+    if (resourceContext?.initiator === 'preloadRemote') {
+      return {
+        timeout: 5000,
+      };
+    }
+  },
+});
+```
 
 ## loadEntryError
 

--- a/apps/website-new/docs/en/guide/runtime/runtime-hooks.mdx
+++ b/apps/website-new/docs/en/guide/runtime/runtime-hooks.mdx
@@ -708,15 +708,25 @@ type CreateScriptOptions ={
   url: string;
   attrs?: Record<string, any>;
   remoteInfo?: RemoteInfo;
+  resourceContext?: ResourceLoadContext;
 }
 
 type CreateScriptHookReturn =
   | HTMLScriptElement
   | { script?: HTMLScriptElement; timeout?: number }
   | void;
+
+type ResourceLoadContext = {
+  initiator: 'loadRemote' | 'preloadRemote';
+  id: string;
+  resourceType: 'manifest' | 'remoteEntry' | 'js' | 'css';
+  url?: string;
+}
 ```
 
 `timeout` is measured in milliseconds and controls the script loading timeout. The default value is `20000`.
+`resourceContext` tells whether this resource load came from `loadRemote` or
+`preloadRemote`, plus the resource type and id.
 
 * example
 
@@ -752,8 +762,16 @@ The `fetch` function allows customizing the request that fetches the manifest JS
 - **Type**
 
 ```typescript
-function fetch(manifestUrl: string, requestInit: RequestInit, remoteInfo?: RemoteInfo): Promise<Response> | void | false;
+function fetch(
+  manifestUrl: string,
+  requestInit: RequestInit,
+  remoteInfo?: RemoteInfo,
+  resourceContext?: ResourceLoadContext,
+): Promise<Response> | void | false;
 ```
+
+`resourceContext` can tell whether this manifest request came from `loadRemote`
+or `preloadRemote`.
 
 - Example for including the credentials when fetching the manifest JSON:
 
@@ -791,8 +809,12 @@ type CreateLinkOptions ={
   url: string;
   attrs?: Record<string, any>;
   remoteInfo?: RemoteInfo;
+  resourceContext?: ResourceLoadContext;
 }
 ```
+
+`resourceContext` has the same shape as in `createScript`. It can distinguish
+preloaded JS/CSS, actual remoteEntry loading, and the related resource id.
 
 ## loadEntryError
 

--- a/apps/website-new/docs/en/plugin/plugins/observability-plugin.mdx
+++ b/apps/website-new/docs/en/plugin/plugins/observability-plugin.mdx
@@ -21,6 +21,7 @@ Use it when you want to answer questions such as:
 - Which phase failed: manifest, remoteEntry, init, expose, factory, or shared?
 - Did the load recover through a runtime fallback or recovery path?
 - Which shared dependency provider and version were selected?
+- Did `preloadRemote` actually finish loading its resources?
 - What report should I give to a human or AI coding agent?
 
 Shared observability is scoped to the MF instance. It tells you which MF
@@ -38,6 +39,14 @@ handled path as `summary.outcome: "recovered"`,
 `shared.reason: "custom-share-info-unmatched"`. It means the runtime continued
 through a recoverable path. Inspect shared configuration only if you expected a
 specific provider/version to be selected.
+
+Preload observability answers whether `preloadRemote` actually finished loading
+its resources. After `preloadRemote` completes, reports include
+`phase: "preload"` resource results with the resource URL, resource type,
+status, and preload `id`. Status can be `success`, `error`, `timeout`, or
+`cached`. When the call does not specify `exposes`, the `id` is `remoteName/*`.
+When `exposes` are provided, each expose is recorded separately as
+`remoteName/expose`.
 
 If you want to try the report workflow first, or inspect and export reports
 directly from the page, install the latest
@@ -178,6 +187,9 @@ Common strategies:
 - Shared dependency auditing: also upload
   `report.summary.outcome === "shared-resolved"` so you can see which provider
   and version were selected.
+- Preload result auditing: also upload
+  `report.summary.outcome === "preloaded"` or failed `phase: "preload"` events
+  to count successful, failed, timed out, and cached preload resources.
 - Full loading observability: sample successful `runtime-loaded`,
   `component-loaded`, and `shared-resolved` reports.
 
@@ -186,8 +198,9 @@ After you have a report, read it in this order:
 1. `diagnosis`: owner hint, key facts, and suggested next actions.
 2. `summary`: final result. `runtime-loaded` means the remote loaded,
    `component-loaded` means business code reported readiness, `shared-resolved`
-   means a shared provider/version was selected, `failed` means loading failed,
-   and `recovered` means the runtime continued through a recoverable path.
+   means a shared provider/version was selected, `preloaded` means preload
+   resources completed, `failed` means loading failed, and `recovered` means the
+   runtime continued through a recoverable path.
 3. `remote` / `shared`: the current load target. For shared reports, inspect
    `provider`, `requiredVersion`, `selectedVersion`, and `availableVersions`.
 4. `moduleInfo`: deployment-provided module information, useful for snapshot
@@ -207,7 +220,8 @@ ObservabilityPlugin({
     const shouldUpload =
       report.status === 'error' ||
       outcome === 'recovered' ||
-      outcome === 'shared-resolved';
+      outcome === 'shared-resolved' ||
+      outcome === 'preloaded';
 
     if (!shouldUpload) {
       return;

--- a/apps/website-new/docs/zh/guide/runtime/runtime-api.mdx
+++ b/apps/website-new/docs/zh/guide/runtime/runtime-api.mdx
@@ -834,6 +834,75 @@ type PreloadRemoteArgs = {
 * `remote` 的同步资源还是异步资源
 * `remote` 依赖的 `remote` 资源
 
+`preloadRemote` 会等待本次预加载涉及的资源完成。如果资源全部成功加载或命中缓存，Promise 会 resolve；如果有资源加载失败或超时，Promise 会 reject，并在错误对象上携带本次预加载的资源结果。
+
+如果只关心最终结果，可以直接用 `await` 或 `.then/.catch` 判断：
+
+```ts
+import { preloadRemote } from '@module-federation/enhanced/runtime';
+
+try {
+  await preloadRemote([
+    {
+      nameOrAlias: 'sub1',
+      exposes: ['add'],
+      resourceCategory: 'all',
+    },
+  ]);
+
+  console.log('sub1/add preload success');
+} catch (error) {
+  console.error('sub1/add preload failed', error);
+}
+```
+
+如果需要统计具体哪些资源成功、失败、超时或命中缓存，可以读取错误对象上的 `results`：
+
+```ts
+type PreloadRemoteError = Error & {
+  results?: Array<{
+    id: string;
+    results: Array<{
+      url: string;
+      status: 'success' | 'error' | 'timeout' | 'cached';
+      resourceType: 'manifest' | 'remoteEntry' | 'js' | 'css';
+      error?: unknown;
+    }>;
+  }>;
+};
+
+preloadRemote([
+  {
+    nameOrAlias: 'sub1',
+    exposes: ['add'],
+    resourceCategory: 'all',
+  },
+]).catch((error: PreloadRemoteError) => {
+  const failedResources =
+    error.results
+      ?.flatMap((remoteResult) =>
+        remoteResult.results.map((resource) => ({
+          id: remoteResult.id,
+          ...resource,
+        })),
+      )
+      .filter(
+        (resource) =>
+          resource.status === 'error' || resource.status === 'timeout',
+      ) ?? [];
+
+  failedResources.forEach((resource) => {
+    console.error(
+      `[preloadRemote] ${resource.id} ${resource.resourceType} failed`,
+      resource.url,
+      resource.error,
+    );
+  });
+});
+```
+
+如果没有指定 `exposes`，本次预加载的资源 id 是 `remoteName/*`。如果指定了 `exposes`，运行时会按 expose 单独生成资源，资源 id 是 `remoteName/expose`。
+
 <Tabs>
   <Tab label="Build Plugin（使用构建插件）">
   ```tsx

--- a/apps/website-new/docs/zh/guide/runtime/runtime-hooks.mdx
+++ b/apps/website-new/docs/zh/guide/runtime/runtime-hooks.mdx
@@ -675,15 +675,24 @@ type CreateScriptOptions ={
   url: string;
   attrs?: Record<string, any>;
   remoteInfo?: RemoteInfo;
+  resourceContext?: ResourceLoadContext;
 }
 
 type CreateScriptHookReturn =
   | HTMLScriptElement
   | { script?: HTMLScriptElement; timeout?: number }
   | void;
+
+type ResourceLoadContext = {
+  initiator: 'loadRemote' | 'preloadRemote';
+  id: string;
+  resourceType: 'manifest' | 'remoteEntry' | 'js' | 'css';
+  url?: string;
+}
 ```
 
 `timeout` 单位为毫秒，用于设置脚本加载超时时间。默认值为 `20000`。
+`resourceContext` 用于判断这次资源加载来自 `loadRemote` 还是 `preloadRemote`，以及对应的资源类型和 id。
 
 * example
 
@@ -719,8 +728,15 @@ const changeScriptAttributePlugin: () => ModuleFederationRuntimePlugin =
 - **Type**
 
 ```typescript
-function fetch(manifestUrl: string, requestInit: RequestInit, remoteInfo?: RemoteInfo): Promise<Response> | void | false;
+function fetch(
+  manifestUrl: string,
+  requestInit: RequestInit,
+  remoteInfo?: RemoteInfo,
+  resourceContext?: ResourceLoadContext,
+): Promise<Response> | void | false;
 ```
+
+`resourceContext` 可用于判断这次 manifest 请求来自 `loadRemote` 还是 `preloadRemote`。
 
 - 示例：在获取清单（manifest）JSON 时包含凭证：
 
@@ -758,8 +774,11 @@ type CreateLinkOptions ={
   url: string;
   attrs?: Record<string, any>;
   remoteInfo?: RemoteInfo;
+  resourceContext?: ResourceLoadContext;
 }
 ```
+
+`resourceContext` 的结构和 `createScript` 一致，可用于区分预加载的 JS/CSS、实际加载的 remoteEntry，以及它们对应的资源 id。
 
 ## loadEntryError
 

--- a/apps/website-new/docs/zh/guide/runtime/runtime-hooks.mdx
+++ b/apps/website-new/docs/zh/guide/runtime/runtime-hooks.mdx
@@ -693,6 +693,7 @@ type ResourceLoadContext = {
 
 `timeout` 单位为毫秒，用于设置脚本加载超时时间。默认值为 `20000`。
 `resourceContext` 用于判断这次资源加载来自 `loadRemote` 还是 `preloadRemote`，以及对应的资源类型和 id。
+可以结合 `timeout` 和 `resourceContext`，为实际远程加载和预加载设置不同的超时时间。
 
 * example
 
@@ -776,9 +777,42 @@ type CreateLinkOptions ={
   remoteInfo?: RemoteInfo;
   resourceContext?: ResourceLoadContext;
 }
+
+type CreateLinkHookReturn =
+  | HTMLLinkElement
+  | { link?: HTMLLinkElement; timeout?: number }
+  | void;
 ```
 
 `resourceContext` 的结构和 `createScript` 一致，可用于区分预加载的 JS/CSS、实际加载的 remoteEntry，以及它们对应的资源 id。
+`timeout` 单位为毫秒，用于设置 link 加载超时时间。默认值为 `20000`。
+
+示例：让实际加载 remoteEntry 时等待更久，让低优先级预加载资源更快结束。
+
+```ts
+import type { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
+
+const resourceTimeoutPlugin = (): ModuleFederationRuntimePlugin => ({
+  name: 'resource-timeout-plugin',
+  createScript({ resourceContext }) {
+    if (
+      resourceContext?.initiator === 'loadRemote' &&
+      resourceContext.resourceType === 'remoteEntry'
+    ) {
+      return {
+        timeout: 30000,
+      };
+    }
+  },
+  createLink({ resourceContext }) {
+    if (resourceContext?.initiator === 'preloadRemote') {
+      return {
+        timeout: 5000,
+      };
+    }
+  },
+});
+```
 
 ## loadEntryError
 

--- a/apps/website-new/docs/zh/plugin/plugins/observability-plugin.mdx
+++ b/apps/website-new/docs/zh/plugin/plugins/observability-plugin.mdx
@@ -17,11 +17,14 @@ description: 观测 Module Federation 加载过程，收集运行时和构建侧
 - 失败发生在 manifest、remoteEntry、init、expose、factory 还是 shared？
 - 这次加载是否通过运行时 fallback 或恢复路径完成了？
 - 这次命中了哪个 shared provider 和版本？
+- `preloadRemote` 的资源是否真正预加载成功？
 - 应该把哪份报告交给人或 AI coding agent 排查？
 
 shared 观测的边界是实例级别：它用于说明哪个 MF 实例加载了哪个共享依赖、最终使用了哪个已注册的 provider/version，以及对应的 scope、版本、eager 等基础信息。它不保证还原该 shared 是由哪个 remote/expose 间接触发的。一次链路涉及多个 shared 时，请查看 `events` 中所有 `phase: "shared"` 的事件；`summary.shared` 只是最后一次观测到的 shared 摘要。
 
 如果构建插件传入了 `customShareInfo`，但运行时没有匹配到已注册的 shared provider，这不是普通的 fatal error。报告会把它描述为 `summary.outcome: "recovered"`、`summary.phases.shared.status: "complete"`，并在 `shared.reason` 中标记 `"custom-share-info-unmatched"`。它表示运行时走了可继续执行的处理路径；只有当你预期它必须命中某个 provider/version 时，才需要继续检查 shared 配置。
+
+预加载观测用于回答 `preloadRemote` 是否真的把资源加载完。`preloadRemote` 完成后，报告会记录 `phase: "preload"` 的资源结果，包含资源地址、资源类型、状态和这次预加载的 `id`。状态可能是 `success`、`error`、`timeout` 或 `cached`。如果调用时没有指定 `exposes`，`id` 会是 `remoteName/*`；如果指定了 `exposes`，每个 expose 会单独记录成 `remoteName/expose`。
 
 如果你想先体验报告效果，或者希望在页面里直接查看和导出报告，可以安装最新的 [Module Federation Chrome 插件](https://chromewebstore.google.com/detail/module-federation/aeoilchhomapofiopejjlecddfldpeom?hl=zh-CN&utm_source=ext_sidebar)。插件的「加载追踪」Tab 会读取页面已有的观测插件报告；如果页面还没有接入观测插件，也可以在当前 Tab 临时开启采集。更多使用方式见 [Chrome Devtool 加载追踪](../../guide/debug/chrome-devtool#加载追踪)。
 
@@ -201,12 +204,13 @@ export const observabilityPlugin = ObservabilityPlugin({
 
 - 只排查故障：上报 `report.status === "error"` 和 `report.summary.outcome === "recovered"`。
 - 观测 shared 选择结果：额外上报 `report.summary.outcome === "shared-resolved"`，用于查看 shared 使用了哪个 provider 和版本。
+- 观测预加载结果：额外上报 `report.summary.outcome === "preloaded"` 或 `phase: "preload"` 的失败事件，用于统计哪些资源预加载成功、失败、超时或命中缓存。
 - 观测完整加载链路：按比例采样 `runtime-loaded`、`component-loaded`、`shared-resolved` 等成功报告。
 
 拿到报告后，优先按这个顺序分析：
 
 1. `diagnosis`：直接给出问题归属、关键证据和下一步建议。
-2. `summary`：判断最终结果。`runtime-loaded` 表示 remote 已加载，`component-loaded` 表示业务组件主动确认成功，`shared-resolved` 表示 shared 已选出 provider 和版本，`failed` 表示失败，`recovered` 表示走了可继续执行的恢复路径。
+2. `summary`：判断最终结果。`runtime-loaded` 表示 remote 已加载，`component-loaded` 表示业务组件主动确认成功，`shared-resolved` 表示 shared 已选出 provider 和版本，`preloaded` 表示预加载资源已完成，`failed` 表示失败，`recovered` 表示走了可继续执行的恢复路径。
 3. `remote` / `shared`：确认当前加载对象。shared 报告重点看 `provider`、`requiredVersion`、`selectedVersion`、`availableVersions`。
 4. `moduleInfo`：排查依赖部署平台下发的模块信息是否匹配。
 5. `events`：按时间线查看卡在哪个阶段。
@@ -224,7 +228,8 @@ ObservabilityPlugin({
     const shouldUpload =
       report.status === 'error' ||
       outcome === 'recovered' ||
-      outcome === 'shared-resolved';
+      outcome === 'shared-resolved' ||
+      outcome === 'preloaded';
 
     if (!shouldUpload) {
       return;

--- a/packages/observability-plugin/README.md
+++ b/packages/observability-plugin/README.md
@@ -87,6 +87,7 @@ and exposes the final loading state through a small `summary` object:
 - `runtime-loaded`: Module Federation finished loading the remote module.
 - `component-loaded`: business code called `markComponentLoaded`, or a producer
   called the injected `onMFRemoteLoaded` callback.
+- `preloaded`: `preloadRemote` finished loading the selected resources.
 - `failed`: the load failed and `failedPhase` points to the first specific
   failing phase.
 - `recovered`: loading hit an error but a fallback/recovery path returned a
@@ -113,6 +114,20 @@ Successful verbose reports include the key runtime stages: remote match,
 manifest, remoteEntry load, remoteEntry init, expose resolution, module factory
 execution, and final load completion. When a stage has matching start and end
 events, the end event includes a bounded `duration` value.
+
+Preload reports include resource-level results from `preloadRemote`. Each
+result records the resource URL, `resourceType`, `initiator`, preload `id`, and
+status: `success`, `error`, `timeout`, or `cached`. Calls without `exposes` use
+`remoteName/*` as the preload `id`. Calls with `exposes` are recorded per
+expose as `remoteName/expose`. The plugin does not change the existing
+`generatePreloadAssets` return shape; preload resources are still plain URL
+arrays.
+
+Runtime resource hooks also receive a `resourceContext` object on manifest,
+remoteEntry, preload JS, and preload CSS resource loads. It contains
+`initiator`, `id`, `resourceType`, and `url`, so custom loaders can tell whether
+the resource was requested by `loadRemote` or `preloadRemote` without parsing
+the URL.
 
 The report also keeps compact loading state under `summary`. It contains the
 final outcome, per-phase status and duration under `summary.phases`, safe

--- a/packages/observability-plugin/__tests__/observability.spec.ts
+++ b/packages/observability-plugin/__tests__/observability.spec.ts
@@ -2010,13 +2010,13 @@ describe('ObservabilityPlugin', () => {
     });
   });
 
-  it('records preloadRemote asset preparation as a successful preload outcome', async () => {
+  it('records preloadRemote resource results as a successful preload outcome', async () => {
     const observability = createObservability({
       level: 'verbose',
       console: false,
     });
 
-    await observability.plugin.generatePreloadAssets?.({
+    const preloadArgs = {
       origin: enabledOrigin,
       preloadOptions: {
         remote: {
@@ -2042,6 +2042,29 @@ describe('ObservabilityPlugin', () => {
         alias: 'dynamic-remote',
         entry: 'http://localhost:3007/mf-manifest.json',
       },
+    } as any;
+
+    await observability.plugin.generatePreloadAssets?.(preloadArgs);
+    await observability.plugin.afterPreloadRemote?.({
+      origin: enabledOrigin,
+      preloadOps: [preloadArgs.preloadOptions.preloadConfig],
+      results: [
+        {
+          remote: preloadArgs.remote,
+          remoteInfo: preloadArgs.remoteInfo,
+          preloadConfig: preloadArgs.preloadOptions.preloadConfig,
+          id: 'runtime_remote2/ButtonOldAnt',
+          results: [
+            {
+              url: 'http://localhost:3007/static/ButtonOldAnt.js',
+              status: 'success',
+              resourceType: 'js',
+              initiator: 'preloadRemote',
+              id: 'runtime_remote2/ButtonOldAnt',
+            },
+          ],
+        },
+      ],
     } as any);
 
     const report = observability.getLatestReport();
@@ -2057,7 +2080,7 @@ describe('ObservabilityPlugin', () => {
         outcome: 'preloaded',
       },
       diagnosis: {
-        title: 'Remote preload prepared',
+        title: 'Remote preloaded successfully',
         outcome: 'preloaded',
       },
     });
@@ -2066,11 +2089,74 @@ describe('ObservabilityPlugin', () => {
         expect.objectContaining({
           phase: 'preload',
           status: 'success',
-          lifecycle: 'generatePreloadAssets',
-          message: 'preload:assets-ready',
+          lifecycle: 'afterPreloadRemote',
+          message: 'preload:js:success',
         }),
       ]),
     );
+  });
+
+  it('records failed preloadRemote resources with resource details', async () => {
+    const observability = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+
+    await observability.plugin.afterPreloadRemote?.({
+      origin: enabledOrigin,
+      results: [
+        {
+          remote: {
+            name: 'runtime_remote2',
+            alias: 'dynamic-remote',
+            entry: 'http://localhost:3007/mf-manifest.json',
+          },
+          remoteInfo: {
+            name: 'runtime_remote2',
+            alias: 'dynamic-remote',
+            entry: 'http://localhost:3007/mf-manifest.json',
+          },
+          preloadConfig: {
+            nameOrAlias: 'dynamic-remote',
+            exposes: ['ButtonOldAnt'],
+          },
+          id: 'runtime_remote2/ButtonOldAnt',
+          results: [
+            {
+              url: 'http://localhost:3007/static/missing.js',
+              status: 'error',
+              resourceType: 'js',
+              initiator: 'preloadRemote',
+              id: 'runtime_remote2/ButtonOldAnt',
+              error: new Error('LinkNetworkError: Failed to load link'),
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    const report = observability.getLatestReport();
+
+    expect(report).toMatchObject({
+      status: 'error',
+      requestId: 'runtime_remote2/ButtonOldAnt',
+      summary: {
+        outcome: 'failed',
+      },
+      errorContext: {
+        resourceType: 'js',
+        initiator: 'preloadRemote',
+        status: 'error',
+        id: 'runtime_remote2/ButtonOldAnt',
+      },
+    });
+    expect(report?.events[0]).toMatchObject({
+      phase: 'preload',
+      status: 'error',
+      lifecycle: 'afterPreloadRemote',
+      message: 'preload:js:error',
+      sanitizedUrl: 'http://localhost:3007/static/missing.js',
+    });
   });
 
   it('keeps manifest, remoteEntry, and runtime load events in the same remote trace', async () => {

--- a/packages/observability-plugin/src/chrome-devtool.ts
+++ b/packages/observability-plugin/src/chrome-devtool.ts
@@ -14,6 +14,7 @@ export function ChromeObservabilityPlugin(
     guardRuntimeHooksByRuntimeVersion: true,
     disablePreloadHooks: true,
     returnHookArgs: true,
+    forceDevelopmentChannels: true,
   }).plugin;
 }
 

--- a/packages/observability-plugin/src/core.ts
+++ b/packages/observability-plugin/src/core.ts
@@ -342,6 +342,7 @@ export interface ObservabilityRuntimeAdapterOptions {
   guardRuntimeHooksByRuntimeVersion?: boolean;
   disablePreloadHooks?: boolean;
   returnHookArgs?: boolean;
+  forceDevelopmentChannels?: boolean;
 }
 
 declare module '@module-federation/runtime-core' {
@@ -2143,6 +2144,8 @@ export function createObservability(
     adapterOptions.guardRuntimeHooksByRuntimeVersion === true;
   const shouldDisablePreloadHooks = adapterOptions.disablePreloadHooks === true;
   const shouldReturnHookArgs = adapterOptions.returnHookArgs === true;
+  const shouldForceDevelopmentChannels =
+    adapterOptions.forceDevelopmentChannels === true;
   const returnHookArgs = <T>(args: T): T | undefined =>
     shouldReturnHookArgs ? args : undefined;
   const level = options.level || 'summary';
@@ -3424,16 +3427,25 @@ export function createObservability(
   const shouldUseConsole = () => options.console !== false;
 
   const shouldUseDevelopmentChannels = () => {
-    if (
-      typeof process === 'undefined' ||
-      !process.env ||
-      typeof process.env.NODE_ENV === 'undefined'
-    ) {
+    if (shouldUseMinimalBrowserConsole()) {
       return false;
+    }
+
+    if (shouldForceDevelopmentChannels) {
+      return true;
+    }
+
+    if (typeof process === 'undefined' || !process.env) {
+      return true;
     }
 
     return process.env.NODE_ENV !== 'production';
   };
+
+  const shouldNotifyCollector = () =>
+    shouldUseDevelopmentChannels() && isDebugMode();
+
+  const shouldNotifyDevtools = () => shouldUseDevelopmentChannels();
 
   const shouldUseMinimalBrowserConsole = () =>
     options.browser?.mode === 'production';
@@ -3631,8 +3643,10 @@ export function createObservability(
     const report = updateReport(event);
     emitStartConsoleHint(event, report);
     emitConsoleHint(event, report, input.error);
-    if (shouldUseDevelopmentChannels()) {
+    if (shouldNotifyCollector()) {
       notifyCollector(event, report);
+    }
+    if (shouldNotifyDevtools()) {
       notifyDevtools(event, report);
     }
     notifyRawError(input.error, event, report, origin);

--- a/packages/observability-plugin/src/core.ts
+++ b/packages/observability-plugin/src/core.ts
@@ -488,6 +488,30 @@ interface ObservabilityPreloadAssetsArgs {
   remoteInfo?: ObservabilityRuntimeRemoteSource;
 }
 
+interface ObservabilityPreloadAssetResult {
+  url?: string;
+  status?: 'success' | 'error' | 'timeout' | 'cached';
+  resourceType?: string;
+  initiator?: string;
+  id?: string;
+  error?: unknown;
+}
+
+interface ObservabilityPreloadRemoteResult {
+  remote?: ObservabilityRuntimeRemoteSource;
+  remoteInfo?: ObservabilityRuntimeRemoteSource;
+  preloadConfig?: ObservabilityPreloadConfig;
+  id?: string;
+  results?: ObservabilityPreloadAssetResult[];
+}
+
+interface ObservabilityAfterPreloadRemoteArgs {
+  origin: ObservabilityRuntimeOrigin;
+  preloadOps?: ObservabilityPreloadConfig[];
+  results?: ObservabilityPreloadRemoteResult[];
+  error?: unknown;
+}
+
 type ObservabilitySnapshotRemoteSource = ObservabilityRuntimeRemoteSource & {
   remoteEntry?: string;
   ssrRemoteEntry?: string;
@@ -2586,7 +2610,7 @@ export function createObservability(
         return 'Remote loaded successfully';
       }
       if (report.summary.preloaded) {
-        return 'Remote preload prepared';
+        return 'Remote preloaded successfully';
       }
       return 'Remote loading is pending';
     }
@@ -4460,7 +4484,7 @@ export function createObservability(
     plugin.generatePreloadAssets = (args) => {
       const preloadArgs = args as ObservabilityPreloadAssetsArgs;
       if (!prepareRuntimeOrigin(preloadArgs.origin)) {
-        return;
+        return returnHookArgs(args);
       }
 
       const remote = createRemoteInfo(
@@ -4470,7 +4494,7 @@ export function createObservability(
       recordEvent(
         {
           phase: 'preload',
-          status: 'success',
+          status: 'start',
           requestId:
             remote?.name || sanitizeText(preloadConfig?.nameOrAlias, 160),
           remote,
@@ -4488,6 +4512,77 @@ export function createObservability(
         },
         preloadArgs.origin,
       );
+
+      return returnHookArgs(args);
+    };
+
+    plugin.afterPreloadRemote = (args) => {
+      const preloadArgs = args as ObservabilityAfterPreloadRemoteArgs;
+      if (!prepareRuntimeOrigin(preloadArgs.origin)) {
+        return returnHookArgs(args);
+      }
+
+      const results = preloadArgs.results || [];
+      if (results.length === 0 && preloadArgs.error) {
+        recordEvent(
+          {
+            phase: 'preload',
+            status: 'error',
+            requestId: 'preloadRemote',
+            lifecycle: 'afterPreloadRemote',
+            message: 'preload:failed',
+            error: preloadArgs.error,
+          },
+          preloadArgs.origin,
+        );
+        return returnHookArgs(args);
+      }
+
+      results.forEach((preloadResult) => {
+        const remote = createRemoteInfo(
+          preloadResult.remoteInfo || preloadResult.remote,
+        );
+        const requestId =
+          sanitizeRequestId(preloadResult.id) ||
+          remote?.name ||
+          sanitizeText(preloadResult.preloadConfig?.nameOrAlias, 160);
+
+        preloadResult.results?.forEach((assetResult) => {
+          const isError =
+            assetResult.status === 'error' || assetResult.status === 'timeout';
+          recordEvent(
+            {
+              phase: 'preload',
+              status: isError ? 'error' : 'success',
+              requestId,
+              remote,
+              url: assetResult.url,
+              cached: assetResult.status === 'cached',
+              lifecycle: 'afterPreloadRemote',
+              message: `preload:${assetResult.resourceType || 'resource'}:${assetResult.status || 'complete'}`,
+              error: isError ? assetResult.error : undefined,
+              errorContext: isError
+                ? {
+                    resourceType: assetResult.resourceType,
+                    initiator: assetResult.initiator,
+                    status: assetResult.status,
+                    id: assetResult.id,
+                  }
+                : undefined,
+              metadata: clipObservabilityMetadata({
+                resourceType: assetResult.resourceType,
+                initiator: assetResult.initiator,
+                status: assetResult.status,
+                id: assetResult.id,
+                preloadNameOrAlias: preloadResult.preloadConfig?.nameOrAlias,
+              }),
+            },
+            preloadArgs.origin,
+          );
+        });
+      });
+
+      return returnHookArgs(args);
     };
   }
 

--- a/packages/runtime-core/__tests__/hooks.spec.ts
+++ b/packages/runtime-core/__tests__/hooks.spec.ts
@@ -404,6 +404,95 @@ describe('hooks', () => {
     reset();
   });
 
+  it('preloadRemote reports timeout from createLink hook timeout', async () => {
+    const remotePublicPath = 'http://localhost:1111/';
+    const reset = addGlobalSnapshot({
+      '@loader-hooks/globalinfo': {
+        globalName: '',
+        buildVersion: '',
+        publicPath: '',
+        remoteTypes: '',
+        shared: [],
+        remoteEntry: '',
+        remoteEntryType: 'global',
+        modules: [],
+        version: '0.0.1',
+        remotesInfo: {
+          '@loader-hooks/app3': {
+            matchedVersion: '0.0.1',
+          },
+        },
+      },
+      '@loader-hooks/app3:0.0.1': {
+        globalName: '@loader-hooks/app3',
+        publicPath: remotePublicPath,
+        remoteTypes: '',
+        shared: [],
+        buildVersion: 'custom',
+        remotesInfo: {},
+        remoteEntryType: 'global',
+        modules: [],
+        version: '0.0.1',
+        remoteEntry: 'resources/hooks/app3/federation-remote-entry.js',
+      },
+    });
+
+    let afterPreloadArgs: any;
+    const INSTANCE = new ModuleFederation({
+      name: '@loader-hooks/globalinfo',
+      remotes: [
+        {
+          name: '@loader-hooks/app3',
+          version: '*',
+        },
+      ],
+      plugins: [
+        {
+          name: 'timeout-preload-assets',
+          async generatePreloadAssets() {
+            return {
+              cssAssets: [],
+              jsAssetsWithoutEntry: [
+                'http://localhost:1111/__virtual__/timeout-chunk.js',
+              ],
+              entryAssets: [],
+            } as any;
+          },
+          createLink({ url, resourceContext }) {
+            expect(resourceContext).toMatchObject({
+              initiator: 'preloadRemote',
+              resourceType: 'js',
+              id: '@loader-hooks/app3/*',
+            });
+            const link = document.createElement('link');
+            link.href = url;
+            return {
+              link,
+              timeout: 1,
+            };
+          },
+          afterPreloadRemote(args) {
+            afterPreloadArgs = args;
+          },
+        },
+      ],
+    });
+
+    await expect(
+      INSTANCE.preloadRemote([{ nameOrAlias: '@loader-hooks/app3' }]),
+    ).rejects.toThrow('preloadRemote failed to load 1 resource');
+
+    expect(afterPreloadArgs.results[0].results[0]).toMatchObject({
+      url: 'http://localhost:1111/__virtual__/timeout-chunk.js',
+      status: 'timeout',
+      resourceType: 'js',
+      initiator: 'preloadRemote',
+      id: '@loader-hooks/app3/*',
+    });
+
+    reset();
+  });
+
   it('uses exact expose ids when preloadRemote is configured with exposes', async () => {
     const remotePublicPath = 'http://localhost:1111/';
     const reset = addGlobalSnapshot({

--- a/packages/runtime-core/__tests__/hooks.spec.ts
+++ b/packages/runtime-core/__tests__/hooks.spec.ts
@@ -170,18 +170,28 @@ describe('hooks', () => {
       plugins: [
         {
           name: 'change-script-attribute',
-          createScript({ url, remoteInfo }) {
+          createScript({ url, remoteInfo, resourceContext }) {
             // Assert remote context is exposed for remoteEntry loads
             if (url === testRemoteEntry) {
               expect(remoteInfo).toMatchObject({
                 name: '@loader-hooks/app2',
                 entry: testRemoteEntry,
               });
+              expect(resourceContext).toMatchObject({
+                initiator: 'loadRemote',
+                resourceType: 'remoteEntry',
+              });
+              expect(resourceContext?.id).toBe('@loader-hooks/app2/say');
             }
             if (url === preloadRemoteEntry) {
               expect(remoteInfo).toMatchObject({
                 name: '@loader-hooks/app3',
                 entry: preloadRemoteEntry,
+              });
+              expect(resourceContext).toMatchObject({
+                initiator: 'preloadRemote',
+                id: '@loader-hooks/app3/*',
+                resourceType: 'remoteEntry',
               });
             }
             const script = document.createElement('script');
@@ -261,6 +271,7 @@ describe('hooks', () => {
       remotes: [
         {
           name: '@loader-hooks/app3',
+          alias: 'app3-alias',
           version: '*',
         },
       ],
@@ -279,8 +290,12 @@ describe('hooks', () => {
         },
         {
           name: 'capture-link-remote-info',
-          createLink({ url, attrs, remoteInfo }) {
+          createLink({ url, attrs, remoteInfo, resourceContext }) {
             lastLinkRemoteInfo = remoteInfo;
+            expect(resourceContext).toMatchObject({
+              initiator: 'preloadRemote',
+              id: '@loader-hooks/app3/*',
+            });
             const link = document.createElement('link');
             link.href = url;
             if (attrs) {
@@ -288,16 +303,186 @@ describe('hooks', () => {
                 link.setAttribute(k, String(v));
               });
             }
+            setTimeout(() => {
+              link.onload?.(new Event('load'));
+            });
             return link;
           },
         },
       ],
     });
 
-    await INSTANCE.preloadRemote([{ nameOrAlias: '@loader-hooks/app3' }]);
+    await INSTANCE.preloadRemote([{ nameOrAlias: 'app3-alias' }]);
     expect(lastLinkRemoteInfo).toMatchObject({
       name: '@loader-hooks/app3',
     });
+
+    reset();
+  });
+
+  it('preloadRemote rejects when a preload resource fails', async () => {
+    const remotePublicPath = 'http://localhost:1111/';
+    const reset = addGlobalSnapshot({
+      '@loader-hooks/globalinfo': {
+        globalName: '',
+        buildVersion: '',
+        publicPath: '',
+        remoteTypes: '',
+        shared: [],
+        remoteEntry: '',
+        remoteEntryType: 'global',
+        modules: [],
+        version: '0.0.1',
+        remotesInfo: {
+          '@loader-hooks/app3': {
+            matchedVersion: '0.0.1',
+          },
+        },
+      },
+      '@loader-hooks/app3:0.0.1': {
+        globalName: '@loader-hooks/app3',
+        publicPath: remotePublicPath,
+        remoteTypes: '',
+        shared: [],
+        buildVersion: 'custom',
+        remotesInfo: {},
+        remoteEntryType: 'global',
+        modules: [],
+        version: '0.0.1',
+        remoteEntry: 'resources/hooks/app3/federation-remote-entry.js',
+      },
+    });
+
+    let afterPreloadArgs: any;
+    const INSTANCE = new ModuleFederation({
+      name: '@loader-hooks/globalinfo',
+      remotes: [
+        {
+          name: '@loader-hooks/app3',
+          version: '*',
+        },
+      ],
+      plugins: [
+        {
+          name: 'force-preload-assets',
+          async generatePreloadAssets() {
+            return {
+              cssAssets: [],
+              jsAssetsWithoutEntry: [
+                'http://localhost:1111/__virtual__/missing-chunk.js',
+              ],
+              entryAssets: [],
+            } as any;
+          },
+          createLink({ url }) {
+            const link = document.createElement('link');
+            link.href = url;
+            setTimeout(() => {
+              link.onerror?.(new Event('error'));
+            });
+            return link;
+          },
+          afterPreloadRemote(args) {
+            afterPreloadArgs = args;
+          },
+        },
+      ],
+    });
+
+    await expect(
+      INSTANCE.preloadRemote([{ nameOrAlias: '@loader-hooks/app3' }]),
+    ).rejects.toThrow('preloadRemote failed to load 1 resource');
+
+    expect(afterPreloadArgs.results[0].results[0]).toMatchObject({
+      url: 'http://localhost:1111/__virtual__/missing-chunk.js',
+      status: 'error',
+      resourceType: 'js',
+      initiator: 'preloadRemote',
+      id: '@loader-hooks/app3/*',
+    });
+
+    reset();
+  });
+
+  it('uses exact expose ids when preloadRemote is configured with exposes', async () => {
+    const remotePublicPath = 'http://localhost:1111/';
+    const reset = addGlobalSnapshot({
+      '@loader-hooks/globalinfo': {
+        globalName: '',
+        buildVersion: '',
+        publicPath: '',
+        remoteTypes: '',
+        shared: [],
+        remoteEntry: '',
+        remoteEntryType: 'global',
+        modules: [],
+        version: '0.0.1',
+        remotesInfo: {
+          '@loader-hooks/app3': {
+            matchedVersion: '0.0.1',
+          },
+        },
+      },
+      '@loader-hooks/app3:0.0.1': {
+        globalName: '@loader-hooks/app3',
+        publicPath: remotePublicPath,
+        remoteTypes: '',
+        shared: [],
+        buildVersion: 'custom',
+        remotesInfo: {},
+        remoteEntryType: 'global',
+        modules: [],
+        version: '0.0.1',
+        remoteEntry: 'resources/hooks/app3/federation-remote-entry.js',
+      },
+    });
+
+    const generatedExposes: Array<string[] | undefined> = [];
+    const resourceIds: string[] = [];
+    const INSTANCE = new ModuleFederation({
+      name: '@loader-hooks/globalinfo',
+      remotes: [
+        {
+          name: '@loader-hooks/app3',
+          version: '*',
+        },
+      ],
+      plugins: [
+        {
+          name: 'force-expose-preload-assets',
+          async generatePreloadAssets(args) {
+            generatedExposes.push(args.preloadOptions.preloadConfig.exposes);
+            const expose = args.preloadOptions.preloadConfig.exposes?.[0];
+            return {
+              cssAssets: [],
+              jsAssetsWithoutEntry: [
+                `http://localhost:1111/__virtual__/${expose}.js`,
+              ],
+              entryAssets: [],
+            } as any;
+          },
+          createLink({ url, resourceContext }) {
+            resourceIds.push(resourceContext?.id || '');
+            const link = document.createElement('link');
+            link.href = url;
+            setTimeout(() => {
+              link.onload?.(new Event('load'));
+            });
+            return link;
+          },
+        },
+      ],
+    });
+
+    await INSTANCE.preloadRemote([
+      { nameOrAlias: '@loader-hooks/app3', exposes: ['Button', 'Card'] },
+    ]);
+
+    expect(generatedExposes).toEqual([['Button'], ['Card']]);
+    expect(resourceIds).toEqual([
+      '@loader-hooks/app3/Button',
+      '@loader-hooks/app3/Card',
+    ]);
 
     reset();
   });
@@ -336,8 +521,13 @@ describe('hooks', () => {
     let lastFetchRemoteInfo: any;
     const fetchPlugin: () => ModuleFederationRuntimePlugin = () => ({
       name: 'fetch-plugin',
-      fetch(url, options, remoteInfo) {
+      fetch(url, options, remoteInfo, resourceContext) {
         lastFetchRemoteInfo = remoteInfo;
+        expect(resourceContext).toMatchObject({
+          initiator: 'loadRemote',
+          id: '@loader-hooks/app2/say',
+          resourceType: 'manifest',
+        });
         if (url === 'http://mockxxx.com/loader-fetch-hooks-mf-manifest.json') {
           return Promise.resolve(responseBody);
         }

--- a/packages/runtime-core/src/core.ts
+++ b/packages/runtime-core/src/core.ts
@@ -1,5 +1,6 @@
 import { isBrowserEnvValue } from '@module-federation/sdk';
 import type {
+  CreateLinkHookReturnDom,
   CreateScriptHookReturn,
   GlobalModuleInfo,
   ModuleInfo,
@@ -17,6 +18,7 @@ import {
   InitScope,
   RemoteEntryInitOptions,
   CallFrom,
+  ResourceLoadContext,
 } from './type';
 import { getBuilderId, registerPlugins, getRemoteEntry, error } from './utils';
 import {
@@ -120,6 +122,7 @@ export class ModuleFederation {
            * (e.g. preloadRemote / loading remoteEntry).
            */
           remoteInfo?: RemoteInfo;
+          resourceContext?: ResourceLoadContext;
         },
       ],
       CreateScriptHookReturn
@@ -135,12 +138,13 @@ export class ModuleFederation {
            * (e.g. preloadRemote / loading remoteEntry).
            */
           remoteInfo?: RemoteInfo;
+          resourceContext?: ResourceLoadContext;
         },
       ],
-      HTMLLinkElement | void
+      CreateLinkHookReturnDom
     >(),
     fetch: new AsyncHook<
-      [string, RequestInit, RemoteInfo?],
+      [string, RequestInit, RemoteInfo?, ResourceLoadContext?],
       Promise<Response> | void | false
     >(),
     loadEntryError: new AsyncHook<

--- a/packages/runtime-core/src/module/index.ts
+++ b/packages/runtime-core/src/module/index.ts
@@ -3,6 +3,7 @@ import {
   error,
   processModuleAlias,
   optionsToMFContext,
+  composeRemoteRequestId,
 } from '../utils';
 import { safeToString, ModuleInfo } from '@module-federation/sdk';
 import {
@@ -106,7 +107,7 @@ class Module {
     this.host = host;
   }
 
-  async getEntry(): Promise<RemoteEntryExports> {
+  async getEntry(expose?: string): Promise<RemoteEntryExports> {
     if (this.remoteEntryExports) {
       return this.remoteEntryExports;
     }
@@ -115,6 +116,11 @@ class Module {
       origin: this.host,
       remoteInfo: this.remoteInfo,
       remoteEntryExports: this.remoteEntryExports,
+      resourceContext: {
+        initiator: 'loadRemote',
+        id: composeRemoteRequestId(this.remoteInfo.name, expose),
+        resourceType: 'remoteEntry',
+      },
     });
 
     assert(
@@ -132,9 +138,10 @@ class Module {
     id?: string,
     remoteSnapshot?: ModuleInfo,
     rawInitScope?: InitScope,
+    expose?: string,
   ) {
     // Get remoteEntry.js
-    const remoteEntryExports = await this.getEntry();
+    const remoteEntryExports = await this.getEntry(expose);
 
     if (this.inited) {
       await this.host.loaderHook.lifecycle.afterInitRemote.emit({
@@ -282,7 +289,12 @@ class Module {
   ) {
     const { loadFactory = true } = options || { loadFactory: true };
 
-    const remoteEntryExports = await this.init(id, remoteSnapshot);
+    const remoteEntryExports = await this.init(
+      id,
+      remoteSnapshot,
+      undefined,
+      expose,
+    );
     this.lib = remoteEntryExports;
 
     await this.host.loaderHook.lifecycle.beforeGetExpose.emit({

--- a/packages/runtime-core/src/plugins/snapshot/SnapshotHandler.ts
+++ b/packages/runtime-core/src/plugins/snapshot/SnapshotHandler.ts
@@ -12,7 +12,7 @@ import {
   RUNTIME_013,
   runtimeDescMap,
 } from '@module-federation/error-codes';
-import { Options, Remote } from '../../type';
+import { Options, Remote, ResourceLoadInitiator } from '../../type';
 import {
   isRemoteInfoWithEntry,
   error,
@@ -122,11 +122,11 @@ export class SnapshotHandler {
   async loadRemoteSnapshotInfo({
     moduleInfo,
     id,
-    expose,
+    initiator = 'loadRemote',
   }: {
     moduleInfo: Remote;
     id?: string;
-    expose?: string;
+    initiator?: ResourceLoadInitiator;
   }):
     | Promise<{
         remoteSnapshot: ModuleInfo;
@@ -202,6 +202,10 @@ export class SnapshotHandler {
           remoteEntry,
           moduleInfo,
           {},
+          {
+            initiator,
+            id: id || moduleInfo.name,
+          },
         );
         // eslint-disable-next-line @typescript-eslint/no-shadow
         const globalSnapshotRes = setGlobalSnapshotInfoByModuleInfo(
@@ -233,6 +237,10 @@ export class SnapshotHandler {
           moduleInfo.entry,
           moduleInfo,
           {},
+          {
+            initiator,
+            id: id || moduleInfo.name,
+          },
         );
         // eslint-disable-next-line @typescript-eslint/no-shadow
         const globalSnapshotRes = setGlobalSnapshotInfoByModuleInfo(
@@ -283,6 +291,10 @@ export class SnapshotHandler {
     manifestUrl: string,
     moduleInfo: Remote,
     extraOptions: Record<string, any>,
+    resourceOptions?: {
+      initiator: ResourceLoadInitiator;
+      id: string;
+    },
   ): Promise<Manifest> {
     const getManifest = async (): Promise<Manifest> => {
       const remoteInfo = getRemoteInfo(moduleInfo);
@@ -296,6 +308,13 @@ export class SnapshotHandler {
           manifestUrl,
           {},
           remoteInfo,
+          resourceOptions
+            ? {
+                ...resourceOptions,
+                url: manifestUrl,
+                resourceType: 'manifest',
+              }
+            : undefined,
         );
         if (!res || !(res instanceof Response)) {
           res = await fetch(manifestUrl, {});
@@ -375,12 +394,17 @@ export class SnapshotHandler {
     manifestUrl: string,
     moduleInfo: Remote,
     extraOptions: Record<string, any>,
+    resourceOptions?: {
+      initiator: ResourceLoadInitiator;
+      id: string;
+    },
   ): Promise<ModuleInfo> {
     const asyncLoadProcess = async () => {
       const manifestJson = await this.getManifestJson(
         manifestUrl,
         moduleInfo,
         extraOptions,
+        resourceOptions,
       );
       const remoteSnapshot = generateSnapshotFromManifest(manifestJson, {
         version: manifestUrl,

--- a/packages/runtime-core/src/plugins/snapshot/index.ts
+++ b/packages/runtime-core/src/plugins/snapshot/index.ts
@@ -7,6 +7,7 @@ import { ModuleFederationRuntimePlugin } from '../../type/plugin';
 import { RUNTIME_011, runtimeDescMap } from '@module-federation/error-codes';
 import {
   error,
+  composeRemoteRequestId,
   isPureRemoteEntry,
   isRemoteInfoWithEntry,
   getRemoteEntryInfoFromSnapshot,
@@ -46,7 +47,7 @@ export function snapshotPlugin(): ModuleFederationRuntimePlugin {
         const { remoteSnapshot, globalSnapshot } =
           await origin.snapshotHandler.loadRemoteSnapshotInfo({
             moduleInfo: remote,
-            id,
+            id: composeRemoteRequestId(remote.name, expose),
           });
 
         assignRemoteInfo(remoteInfo, remoteSnapshot);
@@ -75,7 +76,10 @@ export function snapshotPlugin(): ModuleFederationRuntimePlugin {
           );
 
         if (assets) {
-          preloadAssets(remoteInfo, origin, assets, false);
+          preloadAssets(remoteInfo, origin, assets, false, {
+            initiator: 'loadRemote',
+            id,
+          }).catch(() => undefined);
         }
 
         return {

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -18,6 +18,7 @@ import {
   PreloadAssets,
   PreloadOptions,
   PreloadRemoteArgs,
+  PreloadRemoteResult,
   Remote,
   RemoteInfo,
   RemoteEntryExports,
@@ -36,6 +37,7 @@ import {
   error,
   getRemoteInfo,
   getRemoteEntryUniqueKey,
+  composeRemoteRequestId,
   matchRemoteWithNameAndExpose,
   optionsToMFContext,
   logger,
@@ -176,12 +178,17 @@ export class RemoteHandler {
       ],
       Promise<PreloadAssets>
     >('generatePreloadAssets'),
-    // not used yet
-    afterPreloadRemote: new AsyncHook<{
-      preloadOps: Array<PreloadRemoteArgs>;
-      options: Options;
-      origin: ModuleFederation;
-    }>(),
+    afterPreloadRemote: new AsyncHook<
+      [
+        {
+          preloadOps: Array<PreloadRemoteArgs>;
+          options: Options;
+          origin: ModuleFederation;
+          results: PreloadRemoteResult[];
+          error?: unknown;
+        },
+      ]
+    >('afterPreloadRemote'),
     // TODO: Move to loaderHook
     loadEntry: new AsyncHook<
       [
@@ -366,6 +373,7 @@ export class RemoteHandler {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   async preloadRemote(preloadOptions: Array<PreloadRemoteArgs>): Promise<void> {
     const { host } = this;
+    const preloadResults: PreloadRemoteResult[] = [];
 
     await this.hooks.lifecycle.beforePreloadRemote.emit({
       preloadOps: preloadOptions,
@@ -378,29 +386,117 @@ export class RemoteHandler {
       preloadOptions,
     );
 
-    await Promise.all(
-      preloadOps.map(async (ops) => {
-        const { remote } = ops;
-        const remoteInfo = getRemoteInfo(remote);
-        const { globalSnapshot, remoteSnapshot } =
-          await host.snapshotHandler.loadRemoteSnapshotInfo({
-            moduleInfo: remote,
-          });
+    const createPreloadAssetOps = (ops: PreloadOptions[number]) => {
+      const { preloadConfig, remote } = ops;
+      const exposes = preloadConfig.exposes || [];
 
-        const assets = await this.hooks.lifecycle.generatePreloadAssets.emit({
-          origin: host,
-          preloadOptions: ops,
-          remote,
-          remoteInfo,
-          globalSnapshot,
-          remoteSnapshot,
-        });
-        if (!assets) {
-          return;
+      if (!exposes.length) {
+        return [
+          {
+            ops,
+            id: `${remote.name}/*`,
+          },
+        ];
+      }
+
+      return exposes.map((expose) => ({
+        ops: {
+          ...ops,
+          preloadConfig: {
+            ...preloadConfig,
+            exposes: [expose],
+          },
+        },
+        id: composeRemoteRequestId(remote.name, expose),
+      }));
+    };
+
+    let preloadError: Error | undefined;
+
+    await Promise.all(
+      preloadOps.flatMap(createPreloadAssetOps).map(async (assetOps) => {
+        const { ops, id: preloadId } = assetOps;
+        const { remote, preloadConfig } = ops;
+        const remoteInfo = getRemoteInfo(remote);
+        try {
+          const { globalSnapshot, remoteSnapshot } =
+            await host.snapshotHandler.loadRemoteSnapshotInfo({
+              moduleInfo: remote,
+              id: preloadId,
+              initiator: 'preloadRemote',
+            });
+
+          const assets = await this.hooks.lifecycle.generatePreloadAssets.emit({
+            origin: host,
+            preloadOptions: ops,
+            remote,
+            remoteInfo,
+            globalSnapshot,
+            remoteSnapshot,
+          });
+          if (!assets) {
+            return;
+          }
+          const results = await preloadAssets(remoteInfo, host, assets, true, {
+            initiator: 'preloadRemote',
+            id: preloadId,
+          });
+          preloadResults.push({
+            remote,
+            remoteInfo,
+            preloadConfig,
+            id: preloadId,
+            results,
+          });
+        } catch (error) {
+          preloadResults.push({
+            remote,
+            remoteInfo,
+            preloadConfig,
+            id: preloadId,
+            results: [
+              {
+                url: remoteInfo.entry,
+                status: 'error',
+                resourceType: /\.json(?:$|[?#])/i.test(remoteInfo.entry)
+                  ? 'manifest'
+                  : 'remoteEntry',
+                initiator: 'preloadRemote',
+                id: preloadId,
+                error,
+              },
+            ],
+          });
         }
-        preloadAssets(remoteInfo, host, assets);
       }),
     );
+
+    const failedResults = preloadResults.flatMap((preloadResult) =>
+      preloadResult.results.filter(
+        (result) => result.status === 'error' || result.status === 'timeout',
+      ),
+    );
+    if (failedResults.length > 0) {
+      preloadError = new Error(
+        `preloadRemote failed to load ${failedResults.length} resource(s).`,
+      );
+      Object.assign(preloadError, {
+        results: preloadResults,
+        failedResults,
+      });
+    }
+
+    await this.hooks.lifecycle.afterPreloadRemote.emit({
+      preloadOps: preloadOptions,
+      options: host.options,
+      origin: host,
+      results: preloadResults,
+      error: preloadError,
+    });
+
+    if (preloadError) {
+      throw preloadError;
+    }
   }
 
   registerRemotes(remotes: Remote[], options?: { force?: boolean }): void {

--- a/packages/runtime-core/src/type/preload.ts
+++ b/packages/runtime-core/src/type/preload.ts
@@ -18,6 +18,36 @@ export type PreloadOptions = Array<{
   preloadConfig: PreloadConfig;
 }>;
 
+export type ResourceLoadInitiator = 'loadRemote' | 'preloadRemote';
+
+export type ResourceLoadType = 'manifest' | 'remoteEntry' | 'js' | 'css';
+
+export interface ResourceLoadContext {
+  initiator: ResourceLoadInitiator;
+  id: string;
+  resourceType: ResourceLoadType;
+  url?: string;
+}
+
+export type PreloadAssetStatus = 'success' | 'error' | 'timeout' | 'cached';
+
+export interface PreloadAssetResult {
+  url: string;
+  status: PreloadAssetStatus;
+  resourceType: ResourceLoadType;
+  initiator: ResourceLoadInitiator;
+  id: string;
+  error?: unknown;
+}
+
+export interface PreloadRemoteResult {
+  remote: Remote;
+  remoteInfo: RemoteInfo;
+  preloadConfig: PreloadConfig;
+  id: string;
+  results: PreloadAssetResult[];
+}
+
 export type EntryAssets = {
   name: string;
   url: string;

--- a/packages/runtime-core/src/utils/load.ts
+++ b/packages/runtime-core/src/utils/load.ts
@@ -7,7 +7,12 @@ import {
 import { DEFAULT_REMOTE_TYPE, DEFAULT_SCOPE } from '../constant';
 import { ModuleFederation } from '../core';
 import { globalLoading, getRemoteEntryExports } from '../global';
-import { Remote, RemoteEntryExports, RemoteInfo } from '../type';
+import {
+  Remote,
+  RemoteEntryExports,
+  RemoteInfo,
+  ResourceLoadContext,
+} from '../type';
 import { assert, error } from './logger';
 import {
   RUNTIME_001,
@@ -107,6 +112,7 @@ async function loadEntryScript({
   remoteInfo,
   loaderHook,
   getEntryUrl,
+  resourceContext,
 }: {
   name: string;
   globalName: string;
@@ -114,6 +120,7 @@ async function loadEntryScript({
   remoteInfo: RemoteInfo;
   loaderHook: ModuleFederation['loaderHook'];
   getEntryUrl?: (url: string) => string;
+  resourceContext?: ResourceLoadContext;
 }): Promise<RemoteEntryExports> {
   const { entryExports: remoteEntryExports } = getRemoteEntryExports(
     name,
@@ -133,6 +140,12 @@ async function loadEntryScript({
         url,
         attrs,
         remoteInfo,
+        resourceContext: resourceContext
+          ? {
+              ...resourceContext,
+              url,
+            }
+          : undefined,
       });
 
       if (!res) return;
@@ -178,11 +191,13 @@ async function loadEntryDom({
   remoteEntryExports,
   loaderHook,
   getEntryUrl,
+  resourceContext,
 }: {
   remoteInfo: RemoteInfo;
   remoteEntryExports?: RemoteEntryExports;
   loaderHook: ModuleFederation['loaderHook'];
   getEntryUrl?: (url: string) => string;
+  resourceContext?: ResourceLoadContext;
 }) {
   const { entry, entryGlobalName: globalName, name, type } = remoteInfo;
   switch (type) {
@@ -199,6 +214,7 @@ async function loadEntryDom({
         remoteInfo,
         loaderHook,
         getEntryUrl,
+        resourceContext,
       });
   }
 }
@@ -206,9 +222,11 @@ async function loadEntryDom({
 async function loadEntryNode({
   remoteInfo,
   loaderHook,
+  resourceContext,
 }: {
   remoteInfo: RemoteInfo;
   loaderHook: ModuleFederation['loaderHook'];
+  resourceContext?: ResourceLoadContext;
 }) {
   const { entry, entryGlobalName: globalName, name, type } = remoteInfo;
   const { entryExports: remoteEntryExports } = getRemoteEntryExports(
@@ -228,6 +246,12 @@ async function loadEntryNode({
           url,
           attrs,
           remoteInfo,
+          resourceContext: resourceContext
+            ? {
+                ...resourceContext,
+                url,
+              }
+            : undefined,
         });
 
         if (!res) return;
@@ -262,12 +286,14 @@ export async function getRemoteEntry(params: {
   remoteEntryExports?: RemoteEntryExports | undefined;
   getEntryUrl?: (url: string) => string;
   _inErrorHandling?: boolean; // Add flag to prevent recursion
+  resourceContext?: ResourceLoadContext;
 }): Promise<RemoteEntryExports | false | void> {
   const {
     origin,
     remoteEntryExports,
     remoteInfo,
     getEntryUrl,
+    resourceContext,
     _inErrorHandling = false,
   } = params;
   const uniqueKey = getRemoteEntryUniqueKey(remoteInfo);
@@ -302,8 +328,9 @@ export async function getRemoteEntry(params: {
               remoteEntryExports,
               loaderHook,
               getEntryUrl,
+              resourceContext,
             })
-          : loadEntryNode({ remoteInfo, loaderHook });
+          : loadEntryNode({ remoteInfo, loaderHook, resourceContext });
       })
       .then(async (res) => {
         await origin.loaderHook.lifecycle.afterLoadEntry.emit({

--- a/packages/runtime-core/src/utils/manifest.ts
+++ b/packages/runtime-core/src/utils/manifest.ts
@@ -1,5 +1,16 @@
 import { Remote } from '../type';
 
+export function composeRemoteRequestId(
+  remoteName: string,
+  expose?: string,
+): string {
+  if (!expose || expose === '.') {
+    return remoteName;
+  }
+
+  return `${remoteName}/${expose.replace(/^\.\//, '')}`;
+}
+
 // Function to match a remote with its name and expose
 // id: pkgName(@federation/app1) + expose(button) = @federation/app1/button
 // id: alias(app1) + expose(button) = app1/button

--- a/packages/runtime-core/src/utils/preload.ts
+++ b/packages/runtime-core/src/utils/preload.ts
@@ -1,11 +1,14 @@
 import { createLink, createScript, safeToString } from '@module-federation/sdk';
 import {
   PreloadAssets,
+  PreloadAssetResult,
   PreloadConfig,
   PreloadOptions,
   PreloadRemoteArgs,
   Remote,
   RemoteInfo,
+  ResourceLoadContext,
+  ResourceLoadType,
   depsPreloadArg,
 } from '../type';
 import { matchRemote } from './manifest';
@@ -63,32 +66,210 @@ export function normalizePreloadExposes(exposes?: string[]): string[] {
   });
 }
 
+function isTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.message.includes('timed out') || error.name.includes('Timeout');
+}
+
+function createAssetResult(
+  context: ResourceLoadContext,
+  url: string,
+  status: PreloadAssetResult['status'],
+  error?: unknown,
+): PreloadAssetResult {
+  return {
+    url,
+    status,
+    resourceType: context.resourceType,
+    initiator: context.initiator,
+    id: context.id,
+    error,
+  };
+}
+
+async function waitForRemoteEntryPreload(
+  host: ModuleFederation,
+  remoteInfo: RemoteInfo,
+  entryRemoteInfo: RemoteInfo,
+  context: ResourceLoadContext,
+): Promise<PreloadAssetResult> {
+  const cachedRemote = host.moduleCache.get(entryRemoteInfo.name);
+  const url = entryRemoteInfo.entry;
+  if (cachedRemote?.remoteEntryExports) {
+    return createAssetResult(context, url, 'cached');
+  }
+
+  try {
+    const remoteEntryExports = await getRemoteEntry({
+      origin: host,
+      remoteInfo: entryRemoteInfo,
+      remoteEntryExports: cachedRemote?.remoteEntryExports,
+      resourceContext: {
+        ...context,
+        url,
+      },
+    });
+    if (!remoteEntryExports) {
+      throw new Error(`Failed to load remoteEntry "${url}".`);
+    }
+    return createAssetResult(context, url, 'success');
+  } catch (error) {
+    return createAssetResult(
+      context,
+      url,
+      isTimeoutError(error) ? 'timeout' : 'error',
+      error,
+    );
+  }
+}
+
+function waitForLinkPreload({
+  host,
+  remoteInfo,
+  url,
+  attrs,
+  context,
+  needDeleteLink,
+}: {
+  host: ModuleFederation;
+  remoteInfo: RemoteInfo;
+  url: string;
+  attrs: Record<string, string>;
+  context: ResourceLoadContext;
+  needDeleteLink?: boolean;
+}): Promise<PreloadAssetResult> {
+  return new Promise((resolve) => {
+    const { link, needAttach } = createLink({
+      url,
+      cb: () => {
+        resolve(
+          createAssetResult(context, url, needAttach ? 'success' : 'cached'),
+        );
+      },
+      onErrorCallback: (error) => {
+        resolve(
+          createAssetResult(
+            context,
+            url,
+            isTimeoutError(error) ? 'timeout' : 'error',
+            error,
+          ),
+        );
+      },
+      attrs,
+      createLinkHook: (hookUrl, hookAttrs) => {
+        const res = host.loaderHook.lifecycle.createLink.emit({
+          url: hookUrl,
+          attrs: hookAttrs,
+          remoteInfo,
+          resourceContext: {
+            ...context,
+            url: hookUrl,
+          },
+        });
+        if (res instanceof HTMLLinkElement) {
+          return res;
+        }
+        return res;
+      },
+      needDeleteLink,
+    });
+
+    needAttach && document.head.appendChild(link);
+  });
+}
+
+function waitForScriptPreload({
+  host,
+  remoteInfo,
+  url,
+  attrs,
+  context,
+}: {
+  host: ModuleFederation;
+  remoteInfo: RemoteInfo;
+  url: string;
+  attrs: Record<string, string>;
+  context: ResourceLoadContext;
+}): Promise<PreloadAssetResult> {
+  return new Promise((resolve) => {
+    const { script, needAttach } = createScript({
+      url,
+      cb: () => {
+        resolve(
+          createAssetResult(context, url, needAttach ? 'success' : 'cached'),
+        );
+      },
+      onErrorCallback: (error) => {
+        resolve(
+          createAssetResult(
+            context,
+            url,
+            isTimeoutError(error) ? 'timeout' : 'error',
+            error,
+          ),
+        );
+      },
+      attrs,
+      createScriptHook: (hookUrl: string, hookAttrs: any) => {
+        const res = host.loaderHook.lifecycle.createScript.emit({
+          url: hookUrl,
+          attrs: hookAttrs,
+          remoteInfo,
+          resourceContext: {
+            ...context,
+            url: hookUrl,
+          },
+        });
+        if (res instanceof HTMLScriptElement) {
+          return res;
+        }
+        return res;
+      },
+      needDeleteScript: true,
+    });
+
+    needAttach && document.head.appendChild(script);
+  });
+}
+
+function createResourceContext(
+  baseContext: Omit<ResourceLoadContext, 'resourceType'>,
+  resourceType: ResourceLoadType,
+): ResourceLoadContext {
+  return {
+    ...baseContext,
+    resourceType,
+  };
+}
+
 export function preloadAssets(
   remoteInfo: RemoteInfo,
   host: ModuleFederation,
   assets: PreloadAssets,
   // It is used to distinguish preload from load remote parallel loading
   useLinkPreload = true,
-): void {
+  baseContext: Omit<ResourceLoadContext, 'resourceType'> = {
+    initiator: 'preloadRemote',
+    id: remoteInfo.name,
+  },
+): Promise<PreloadAssetResult[]> {
   const { cssAssets, jsAssetsWithoutEntry, entryAssets } = assets;
+  const results: Array<Promise<PreloadAssetResult>> = [];
 
   if (host.options.inBrowser) {
     entryAssets.forEach((asset) => {
-      const { moduleInfo } = asset;
-      const module = host.moduleCache.get(remoteInfo.name);
-      if (module) {
-        getRemoteEntry({
-          origin: host,
-          remoteInfo: moduleInfo,
-          remoteEntryExports: module.remoteEntryExports,
-        });
-      } else {
-        getRemoteEntry({
-          origin: host,
-          remoteInfo: moduleInfo,
-          remoteEntryExports: undefined,
-        });
-      }
+      const { moduleInfo: entryRemoteInfo } = asset;
+      results.push(
+        waitForRemoteEntryPreload(
+          host,
+          remoteInfo,
+          entryRemoteInfo,
+          createResourceContext(baseContext, 'remoteEntry'),
+        ),
+      );
     });
 
     if (useLinkPreload) {
@@ -97,26 +278,15 @@ export function preloadAssets(
         as: 'style',
       };
       cssAssets.forEach((cssUrl) => {
-        const { link: cssEl, needAttach } = createLink({
-          url: cssUrl,
-          cb: () => {
-            // noop
-          },
-          attrs: defaultAttrs,
-          createLinkHook: (url, attrs) => {
-            const res = host.loaderHook.lifecycle.createLink.emit({
-              url,
-              attrs,
-              remoteInfo,
-            });
-            if (res instanceof HTMLLinkElement) {
-              return res;
-            }
-            return;
-          },
-        });
-
-        needAttach && document.head.appendChild(cssEl);
+        results.push(
+          waitForLinkPreload({
+            host,
+            remoteInfo,
+            url: cssUrl,
+            attrs: defaultAttrs,
+            context: createResourceContext(baseContext, 'css'),
+          }),
+        );
       });
     } else {
       const defaultAttrs = {
@@ -124,27 +294,16 @@ export function preloadAssets(
         type: 'text/css',
       };
       cssAssets.forEach((cssUrl) => {
-        const { link: cssEl, needAttach } = createLink({
-          url: cssUrl,
-          cb: () => {
-            // noop
-          },
-          attrs: defaultAttrs,
-          createLinkHook: (url, attrs) => {
-            const res = host.loaderHook.lifecycle.createLink.emit({
-              url,
-              attrs,
-              remoteInfo,
-            });
-            if (res instanceof HTMLLinkElement) {
-              return res;
-            }
-            return;
-          },
-          needDeleteLink: false,
-        });
-
-        needAttach && document.head.appendChild(cssEl);
+        results.push(
+          waitForLinkPreload({
+            host,
+            remoteInfo,
+            url: cssUrl,
+            attrs: defaultAttrs,
+            needDeleteLink: false,
+            context: createResourceContext(baseContext, 'css'),
+          }),
+        );
       });
     }
 
@@ -154,25 +313,15 @@ export function preloadAssets(
         as: 'script',
       };
       jsAssetsWithoutEntry.forEach((jsUrl) => {
-        const { link: linkEl, needAttach } = createLink({
-          url: jsUrl,
-          cb: () => {
-            // noop
-          },
-          attrs: defaultAttrs,
-          createLinkHook: (url: string, attrs) => {
-            const res = host.loaderHook.lifecycle.createLink.emit({
-              url,
-              attrs,
-              remoteInfo,
-            });
-            if (res instanceof HTMLLinkElement) {
-              return res;
-            }
-            return;
-          },
-        });
-        needAttach && document.head.appendChild(linkEl);
+        results.push(
+          waitForLinkPreload({
+            host,
+            remoteInfo,
+            url: jsUrl,
+            attrs: defaultAttrs,
+            context: createResourceContext(baseContext, 'js'),
+          }),
+        );
       });
     } else {
       const defaultAttrs = {
@@ -180,27 +329,18 @@ export function preloadAssets(
         type: remoteInfo?.type === 'module' ? 'module' : 'text/javascript',
       };
       jsAssetsWithoutEntry.forEach((jsUrl) => {
-        const { script: scriptEl, needAttach } = createScript({
-          url: jsUrl,
-          cb: () => {
-            // noop
-          },
-          attrs: defaultAttrs,
-          createScriptHook: (url: string, attrs: any) => {
-            const res = host.loaderHook.lifecycle.createScript.emit({
-              url,
-              attrs,
-              remoteInfo,
-            });
-            if (res instanceof HTMLScriptElement) {
-              return res;
-            }
-            return;
-          },
-          needDeleteScript: true,
-        });
-        needAttach && document.head.appendChild(scriptEl);
+        results.push(
+          waitForScriptPreload({
+            host,
+            remoteInfo,
+            url: jsUrl,
+            attrs: defaultAttrs,
+            context: createResourceContext(baseContext, 'js'),
+          }),
+        );
       });
     }
   }
+
+  return Promise.all(results);
 }

--- a/packages/runtime/__tests__/preload-remote.spec.ts
+++ b/packages/runtime/__tests__/preload-remote.spec.ts
@@ -13,20 +13,29 @@ interface ScriptInfo {
   crossorigin: string;
 }
 
+const createdLinkInfos: LinkInfo[] = [];
+const createdScriptInfos: ScriptInfo[] = [];
+
 function getLinkInfos(): Array<LinkInfo> {
   const links = document.querySelectorAll('link');
-  return Array.from(links).map((link) => ({
-    type: link.getAttribute('as') || '',
-    href: link.getAttribute('href') || '',
-    rel: link.getAttribute('rel') || '',
-  }));
+  return [
+    ...Array.from(links).map((link) => ({
+      type: link.getAttribute('as') || '',
+      href: link.getAttribute('href') || '',
+      rel: link.getAttribute('rel') || '',
+    })),
+    ...createdLinkInfos,
+  ];
 }
 function getScriptInfos(): Array<ScriptInfo> {
   const scripts = document.querySelectorAll('script');
-  return Array.from(scripts).map((script) => ({
-    src: script.getAttribute('src') || '',
-    crossorigin: script.getAttribute('crossorigin') || '',
-  }));
+  return [
+    ...Array.from(scripts).map((script) => ({
+      src: script.getAttribute('src') || '',
+      crossorigin: script.getAttribute('crossorigin') || '',
+    })),
+    ...createdScriptInfos,
+  ];
 }
 function getPreloadElInfos() {
   return {
@@ -34,6 +43,37 @@ function getPreloadElInfos() {
     scripts: getScriptInfos(),
   };
 }
+
+function applyAttrs(
+  element: HTMLElement,
+  attrs?: Record<string, string>,
+): void {
+  Object.entries(attrs || {}).forEach(([name, value]) => {
+    element.setAttribute(name, String(value));
+  });
+}
+
+function completeLoadWhenHandlerIsAttached(
+  element: HTMLElement,
+  event: Event,
+): void {
+  let onload: GlobalEventHandlers['onload'] | null = null;
+  Object.defineProperty(element, 'onload', {
+    configurable: true,
+    get() {
+      return onload;
+    },
+    set(handler: GlobalEventHandlers['onload'] | null) {
+      onload = handler;
+      if (handler) {
+        setTimeout(() => {
+          handler.call(element, event);
+        });
+      }
+    },
+  });
+}
+
 describe('preload-remote inBrowser', () => {
   mockStaticServer({
     baseDir: __dirname,
@@ -192,6 +232,8 @@ describe('preload-remote inBrowser', () => {
   beforeEach(() => {
     document.head.innerHTML = '';
     document.body.innerHTML = '';
+    createdLinkInfos.length = 0;
+    createdScriptInfos.length = 0;
     Global.__FEDERATION__.__PRELOADED_MAP__.clear();
   });
   const FMInstance = init({
@@ -207,6 +249,39 @@ describe('preload-remote inBrowser', () => {
         beforeInit(args) {
           args.options.inBrowser = true;
           return args;
+        },
+        loadEntry({ remoteInfo }) {
+          if (
+            remoteInfo?.entry &&
+            !createdScriptInfos.some((info) => info.src === remoteInfo.entry)
+          ) {
+            createdScriptInfos.push({
+              src: remoteInfo.entry,
+              crossorigin: '',
+            });
+          }
+          return {
+            get() {
+              return () => Promise.resolve({});
+            },
+            init() {
+              // noop
+            },
+          };
+        },
+        createLink({ url, attrs }) {
+          const link = document.createElement('link');
+          link.setAttribute('href', url);
+          applyAttrs(link, attrs);
+          if (!createdLinkInfos.some((info) => info.href === url)) {
+            createdLinkInfos.push({
+              type: attrs?.as || '',
+              href: url,
+              rel: attrs?.rel || '',
+            });
+          }
+          completeLoadWhenHandlerIsAttached(link, new Event('load'));
+          return link;
         },
       },
     ],

--- a/packages/sdk/__tests__/dom.spec.ts
+++ b/packages/sdk/__tests__/dom.spec.ts
@@ -348,6 +348,8 @@ describe('createScript - error handling', () => {
 describe('createLink', () => {
   afterEach(() => {
     document.getElementsByTagName('html')[0].innerHTML = '';
+    jest.useRealTimers();
+    jest.restoreAllMocks();
   });
 
   it('should create a new link element if one does not exist', () => {
@@ -455,6 +457,50 @@ describe('createLink', () => {
     }
     link?.onerror?.(new Event('error'));
     expect(onErrorCallback).toHaveBeenCalled();
+  });
+
+  it('should use the timeout specified in the createLinkHook', () => {
+    jest.spyOn(global, 'setTimeout');
+    const url = 'https://example.com/script.js';
+    const cb = jest.fn();
+    const customTimeout = 5000;
+    const { link } = createLink({
+      url,
+      cb,
+      attrs: { rel: 'preload', as: 'script' },
+      createLinkHook: () => ({ timeout: customTimeout }),
+    });
+
+    expect(setTimeout).toHaveBeenCalledWith(
+      expect.any(Function),
+      customTimeout,
+    );
+
+    link?.onload?.(new Event('load'));
+  });
+
+  it('timeout calls onErrorCallback with LinkNetworkError', () => {
+    jest.useFakeTimers();
+    const url = 'https://example.com/timeout.css';
+    const cb = jest.fn();
+    const onErrorCallback = jest.fn();
+
+    createLink({
+      url,
+      cb,
+      onErrorCallback,
+      attrs: { rel: 'preload', as: 'style' },
+      createLinkHook: () => ({ timeout: 100 }),
+    });
+
+    jest.advanceTimersByTime(100);
+
+    expect(onErrorCallback).toHaveBeenCalledTimes(1);
+    expect(onErrorCallback.mock.calls[0][0]).toMatchObject({
+      name: 'LinkNetworkError',
+      message: expect.stringContaining('timed out'),
+    });
+    expect(cb).not.toHaveBeenCalled();
   });
 
   it('should use the link element returned by createLinkHook', () => {

--- a/packages/sdk/src/dom.ts
+++ b/packages/sdk/src/dom.ts
@@ -1,4 +1,9 @@
-import type { CreateScriptHookDom, CreateScriptHookReturnDom } from './types';
+import type {
+  CreateLinkHookDom,
+  CreateLinkHookReturnDom,
+  CreateScriptHookDom,
+  CreateScriptHookReturnDom,
+} from './types';
 import { warn } from './utils';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function safeWrapper<T extends (...args: Array<any>) => any>(
@@ -170,16 +175,15 @@ export function createLink(info: {
   onErrorCallback?: (error: Error) => void;
   attrs: Record<string, string>;
   needDeleteLink?: boolean;
-  createLinkHook?: (
-    url: string,
-    attrs?: Record<string, any>,
-  ) => HTMLLinkElement | void;
+  createLinkHook?: CreateLinkHookDom;
 }) {
   // <link rel="preload" href="script.js" as="script">
 
   // Retrieve the existing script element by its src attribute
   let link: HTMLLinkElement | null = null;
   let needAttach = true;
+  let timeout = 20000;
+  let timeoutId: NodeJS.Timeout | undefined;
   const links = document.getElementsByTagName('link');
   for (let i = 0; i < links.length; i++) {
     const l = links[i];
@@ -200,17 +204,27 @@ export function createLink(info: {
     link = document.createElement('link');
     link.setAttribute('href', info.url);
 
-    let createLinkRes: void | HTMLLinkElement = undefined;
+    let createLinkRes: CreateLinkHookReturnDom = undefined;
+    let shouldApplyAttrs = true;
     const attrs = info.attrs;
 
     if (info.createLinkHook) {
       createLinkRes = info.createLinkHook(info.url, attrs);
       if (createLinkRes instanceof HTMLLinkElement) {
         link = createLinkRes;
+        shouldApplyAttrs = false;
+      } else if (typeof createLinkRes === 'object') {
+        if ('link' in createLinkRes && createLinkRes.link) {
+          link = createLinkRes.link;
+          shouldApplyAttrs = false;
+        }
+        if ('timeout' in createLinkRes && createLinkRes.timeout) {
+          timeout = createLinkRes.timeout;
+        }
       }
     }
 
-    if (attrs && !createLinkRes) {
+    if (attrs && shouldApplyAttrs) {
       Object.keys(attrs).forEach((name) => {
         if (link && !link.getAttribute(name)) {
           link.setAttribute(name, attrs[name]);
@@ -219,14 +233,30 @@ export function createLink(info: {
     }
   }
 
+  if (!needAttach) {
+    Promise.resolve().then(() => {
+      info?.cb && info?.cb();
+    });
+    return { link, needAttach };
+  }
+
   const onLinkComplete = (
     prev: OnErrorEventHandler | GlobalEventHandlers['onload'] | null,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     event: any,
   ): void => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
     const onLinkCompleteCallback = () => {
       if (event?.type === 'error') {
-        info?.onErrorCallback && info?.onErrorCallback(event);
+        const linkError = new Error(
+          event?.isTimeout
+            ? `LinkNetworkError: Link "${info.url}" timed out.`
+            : `LinkNetworkError: Failed to load link "${info.url}" - the URL is unreachable or the server returned an error.`,
+        );
+        linkError.name = 'LinkNetworkError';
+        info?.onErrorCallback && info?.onErrorCallback(linkError);
       } else {
         info?.cb && info?.cb();
       }
@@ -253,6 +283,9 @@ export function createLink(info: {
 
   link.onerror = onLinkComplete.bind(null, link.onerror);
   link.onload = onLinkComplete.bind(null, link.onload);
+  timeoutId = setTimeout(() => {
+    onLinkComplete(null, { type: 'error', isTimeout: true });
+  }, timeout);
 
   return { link, needAttach };
 }

--- a/packages/sdk/src/types/hooks.ts
+++ b/packages/sdk/src/types/hooks.ts
@@ -5,6 +5,11 @@ export type CreateScriptHookReturnDom =
   | { script?: HTMLScriptElement; timeout?: number }
   | void;
 
+export type CreateLinkHookReturnDom =
+  | HTMLLinkElement
+  | { link?: HTMLLinkElement; timeout?: number }
+  | void;
+
 export type CreateScriptHookReturn =
   | CreateScriptHookReturnNode
   | CreateScriptHookReturnDom;
@@ -18,6 +23,11 @@ export type CreateScriptHookDom = (
   url: string,
   attrs?: Record<string, any> | undefined,
 ) => CreateScriptHookReturnDom;
+
+export type CreateLinkHookDom = (
+  url: string,
+  attrs?: Record<string, any> | undefined,
+) => CreateLinkHookReturnDom;
 
 export type CreateScriptHook = (
   url: string,

--- a/skills/mf/assets/observability-chrome-devtool.iife.js
+++ b/skills/mf/assets/observability-chrome-devtool.iife.js
@@ -1230,7 +1230,7 @@
         }
         if (report.summary.componentLoaded) return 'Business component loaded';
         if (report.summary.runtimeLoaded) return 'Remote loaded successfully';
-        if (report.summary.preloaded) return 'Remote preload prepared';
+        if (report.summary.preloaded) return 'Remote preloaded successfully';
         return 'Remote loading is pending';
       }
       switch (report.errorCode) {


### PR DESCRIPTION
## Description

Add resource-level observability for `preloadRemote` and document how to consume the result.

This change makes preload flows easier to inspect:

- `preloadRemote` now waits for the resource results of the current preload call.
- Resource results include success, error, timeout, and cached states.
- Resource loading hooks receive context that identifies whether the request came from `loadRemote` or `preloadRemote`.
- The observability plugin records preload results in reports.
- Runtime API docs include examples for checking preload success/failure and reading failed resources.

## Usage Example

Reviewers can use the new behavior directly from the `preloadRemote` Promise:

```ts
import { preloadRemote } from '@module-federation/enhanced/runtime';

preloadRemote([
  {
    nameOrAlias: 'provider',
    exposes: ['Button'],
    resourceCategory: 'all',
  },
])
  .then(() => {
    console.log('provider/Button preload completed');
  })
  .catch((error) => {
    const failedResources =
      error.failedResults ??
      error.results
        ?.flatMap((remoteResult) => remoteResult.results)
        .filter(
          (resource) =>
            resource.status === 'error' || resource.status === 'timeout',
        );

    console.error('provider/Button preload failed', failedResources);
  });
```

Runtime plugins can also use `resourceContext` to apply different resource policies:

```ts
const resourcePolicyPlugin = () => ({
  name: 'resource-policy-plugin',
  createScript({ resourceContext }) {
    if (resourceContext?.initiator === 'loadRemote') {
      return { timeout: 30000 };
    }
  },
  createLink({ resourceContext }) {
    if (resourceContext?.initiator === 'preloadRemote') {
      return { timeout: 5000 };
    }
  },
});
```

## Related Issue

N/A

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.

Validation:

- `pnpm --filter @module-federation/runtime-core exec tsc --noEmit --pretty false`
- `pnpm --filter @module-federation/observability-plugin exec tsc --noEmit --pretty false`
- `pnpm --filter @module-federation/sdk exec tsc --noEmit --pretty false`
- `pnpm --filter @module-federation/runtime-core test -- hooks.spec.ts`
- `pnpm --filter @module-federation/observability-plugin test -- observability.spec.ts`
- `pnpm exec prettier --check <changed files>`
- `git diff --check`

The commit hook also ran Prettier and package lint for the changed runtime, SDK, and observability packages.