### PR TITLE
fix(observability-plugin): gate dev channels outside production

### DIFF
--- a/.changeset/quiet-collector-debug.md
+++ b/.changeset/quiet-collector-debug.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/observability-plugin": patch
+---
+
+Only notify local observability development channels outside production mode.

--- a/packages/observability-plugin/__tests__/observability.spec.ts
+++ b/packages/observability-plugin/__tests__/observability.spec.ts
@@ -1569,14 +1569,55 @@ describe('ObservabilityPlugin', () => {
     expect(report?.events).toHaveLength(2);
   });
 
-  it('posts events to the local collector when enabled', () => {
+  it('skips the local collector outside debug mode', () => {
     const originalFetch = globalThis.fetch;
+    const originalDebug = process.env['FEDERATION_DEBUG'];
     const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
     Object.defineProperty(globalThis, 'fetch', {
       value: fetchMock,
       configurable: true,
       writable: true,
     });
+    delete process.env['FEDERATION_DEBUG'];
+
+    try {
+      const observability = createObservability({
+        level: 'verbose',
+        collector: true,
+      });
+
+      emitRemoteStart(observability);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      if (originalDebug === undefined) {
+        delete process.env['FEDERATION_DEBUG'];
+      } else {
+        process.env['FEDERATION_DEBUG'] = originalDebug;
+      }
+
+      if (originalFetch) {
+        Object.defineProperty(globalThis, 'fetch', {
+          value: originalFetch,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        Reflect.deleteProperty(globalThis, 'fetch');
+      }
+    }
+  });
+
+  it('posts events to the local collector in debug mode', () => {
+    const originalFetch = globalThis.fetch;
+    const originalDebug = process.env['FEDERATION_DEBUG'];
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    Object.defineProperty(globalThis, 'fetch', {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    });
+    process.env['FEDERATION_DEBUG'] = 'true';
 
     try {
       const observability = createObservability({
@@ -1617,6 +1658,63 @@ describe('ObservabilityPlugin', () => {
         },
       });
     } finally {
+      if (originalDebug === undefined) {
+        delete process.env['FEDERATION_DEBUG'];
+      } else {
+        process.env['FEDERATION_DEBUG'] = originalDebug;
+      }
+
+      if (originalFetch) {
+        Object.defineProperty(globalThis, 'fetch', {
+          value: originalFetch,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        Reflect.deleteProperty(globalThis, 'fetch');
+      }
+    }
+  });
+
+  it('logs local collector connection failures in debug mode', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalDebug = process.env['FEDERATION_DEBUG'];
+    const consoleDebug = vi
+      .spyOn(console, 'debug')
+      .mockImplementation(() => undefined);
+    const fetchError = new Error('collector unavailable');
+    const fetchMock = vi.fn(() => Promise.reject(fetchError));
+    Object.defineProperty(globalThis, 'fetch', {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    });
+    process.env['FEDERATION_DEBUG'] = 'true';
+
+    try {
+      const observability = createObservability({
+        level: 'verbose',
+        collector: true,
+      });
+
+      emitRemoteStart(observability);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(consoleDebug).toHaveBeenCalledWith(
+        '[ Module Federation Observability Plugin ]',
+        'Failed to notify local observability collector.',
+        fetchError,
+        expect.stringContaining('Stack trace:'),
+      );
+    } finally {
+      consoleDebug.mockRestore();
+
+      if (originalDebug === undefined) {
+        delete process.env['FEDERATION_DEBUG'];
+      } else {
+        process.env['FEDERATION_DEBUG'] = originalDebug;
+      }
+
       if (originalFetch) {
         Object.defineProperty(globalThis, 'fetch', {
           value: originalFetch,
@@ -1670,6 +1768,77 @@ describe('ObservabilityPlugin', () => {
         },
       });
     } finally {
+      if (originalPostMessage) {
+        Object.defineProperty(globalThis, 'postMessage', {
+          value: originalPostMessage,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        Reflect.deleteProperty(globalThis, 'postMessage');
+      }
+    }
+  });
+
+  it('skips collector and devtools channels in production mode', () => {
+    const originalFetch = globalThis.fetch;
+    const originalDebug = process.env['FEDERATION_DEBUG'];
+    const originalNodeEnv = process.env['NODE_ENV'];
+    const originalPostMessage = (globalThis as { postMessage?: unknown })
+      .postMessage;
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    const postMessageMock = vi.fn();
+
+    Object.defineProperty(globalThis, 'fetch', {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, 'postMessage', {
+      value: postMessageMock,
+      configurable: true,
+      writable: true,
+    });
+    process.env['FEDERATION_DEBUG'] = 'true';
+    process.env['NODE_ENV'] = 'production';
+
+    try {
+      const observability = createObservability({
+        level: 'verbose',
+        console: false,
+        browser: {
+          enabled: true,
+          scope: 'runtime_host',
+        },
+        collector: true,
+        devtools: true,
+      });
+
+      emitRemoteStart(observability);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(postMessageMock).not.toHaveBeenCalled();
+    } finally {
+      if (originalDebug === undefined) {
+        delete process.env['FEDERATION_DEBUG'];
+      } else {
+        process.env['FEDERATION_DEBUG'] = originalDebug;
+      }
+      if (originalNodeEnv === undefined) {
+        delete process.env['NODE_ENV'];
+      } else {
+        process.env['NODE_ENV'] = originalNodeEnv;
+      }
+
+      if (originalFetch) {
+        Object.defineProperty(globalThis, 'fetch', {
+          value: originalFetch,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        Reflect.deleteProperty(globalThis, 'fetch');
+      }
       if (originalPostMessage) {
         Object.defineProperty(globalThis, 'postMessage', {
           value: originalPostMessage,

--- a/packages/observability-plugin/src/core.ts
+++ b/packages/observability-plugin/src/core.ts
@@ -2,6 +2,7 @@ import type {
   ModuleFederation,
   ModuleFederationRuntimePlugin,
 } from '@module-federation/runtime';
+import { createLogger, isDebugMode } from '@module-federation/sdk';
 
 export type ObservabilityLevel = 'error' | 'summary' | 'verbose';
 export type ObservabilityEventStatus =
@@ -649,6 +650,7 @@ const DEFAULT_MAX_EVENTS = 100;
 const HARD_MAX_EVENTS = 1000;
 const DEFAULT_COLLECTOR_PORT = 17891;
 const COLLECTOR_PATH = '/__mf_observability';
+const logger = createLogger('[ Module Federation Observability Plugin ]');
 const DEFAULT_DEVTOOLS_SOURCE = 'module-federation/observability';
 const COMPONENT_BUSINESS_LOADED_EVENT = 'component:business-loaded';
 const ON_MF_REMOTE_LOADED_PROP = 'onMFRemoteLoaded';
@@ -3172,7 +3174,7 @@ export function createObservability(
     event: ObservabilityEvent,
     report: ObservabilityReport,
   ) => {
-    if (!collectorOptions) {
+    if (!collectorOptions || !isDebugMode()) {
       return;
     }
 
@@ -3200,11 +3202,13 @@ export function createObservability(
         keepalive: body.length <= 64 * 1024,
         credentials: 'omit',
         mode: 'cors',
-      }).catch(() => {
+      }).catch((error) => {
         // The local collector is optional and must not affect MF loading.
+        logger.debug('Failed to notify local observability collector.', error);
       });
-    } catch {
+    } catch (error) {
       // The local collector is optional and must not affect MF loading.
+      logger.debug('Failed to notify local observability collector.', error);
     }
   };
 
@@ -3394,6 +3398,18 @@ export function createObservability(
   };
 
   const shouldUseConsole = () => options.console !== false;
+
+  const shouldUseDevelopmentChannels = () => {
+    if (
+      typeof process === 'undefined' ||
+      !process.env ||
+      typeof process.env.NODE_ENV === 'undefined'
+    ) {
+      return false;
+    }
+
+    return process.env.NODE_ENV !== 'production';
+  };
 
   const shouldUseMinimalBrowserConsole = () =>
     options.browser?.mode === 'production';
@@ -3591,8 +3607,10 @@ export function createObservability(
     const report = updateReport(event);
     emitStartConsoleHint(event, report);
     emitConsoleHint(event, report, input.error);
-    notifyCollector(event, report);
-    notifyDevtools(event, report);
+    if (shouldUseDevelopmentChannels()) {
+      notifyCollector(event, report);
+      notifyDevtools(event, report);
+    }
     notifyRawError(input.error, event, report, origin);
     notifyEvent(event, report, origin);
     notifyReport(report, origin);

--- a/packages/observability-plugin/src/core.ts
+++ b/packages/observability-plugin/src/core.ts
@@ -3174,7 +3174,7 @@ export function createObservability(
     event: ObservabilityEvent,
     report: ObservabilityReport,
   ) => {
-    if (!collectorOptions || !isDebugMode()) {
+    if (!collectorOptions) {
       return;
     }
 


### PR DESCRIPTION
## What changed

This updates the observability plugin so the local collector and devtools notification channels only run outside production mode.

## Why

The local collector is a development-only path. In production, it should not attempt to notify the local collector or browser devtools channel.

## Impact

Production pages will skip those development notification channels. Debug/local collector behavior remains available outside production mode.

## Validation

- `pnpm --filter @module-federation/observability-plugin run test -- --runInBand`
- `pnpm exec prettier --check packages/observability-plugin/src/core.ts packages/observability-plugin/__tests__/observability.spec.ts .changeset/quiet-collector-debug.md`
- `pnpm --filter @module-federation/observability-plugin run lint`
- `pnpm --filter @module-federation/observability-plugin run build`
- `python .codex/skills/changeset-pr/scripts/run_changeset_status.py --verbose`