### PR TITLE
fix(dts-plugin): update ws for CVE-2026-45736

### DIFF
--- a/.changeset/clean-ws-security.md
+++ b/.changeset/clean-ws-security.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+Update the dts plugin websocket dependency to a version that includes the CVE-2026-45736 fix.

--- a/packages/dts-plugin/package.json
+++ b/packages/dts-plugin/package.json
@@ -74,7 +74,7 @@
     "isomorphic-ws": "5.0.0",
     "undici": "7.24.7",
     "node-schedule": "2.1.1",
-    "ws": "8.18.0"
+    "ws": "8.20.1"
   },
   "devDependencies": {
     "@module-federation/runtime": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3237,7 +3237,7 @@ importers:
         version: 4.1.3
       isomorphic-ws:
         specifier: 5.0.0
-        version: 5.0.0(ws@8.18.0)
+        version: 5.0.0(ws@8.20.1)
       node-schedule:
         specifier: 2.1.1
         version: 2.1.1
@@ -3248,8 +3248,8 @@ importers:
         specifier: 7.24.7
         version: 7.24.7
       ws:
-        specifier: 8.18.0
-        version: 8.18.0
+        specifier: 8.20.1
+        version: 8.20.1
     devDependencies:
       '@module-federation/runtime':
         specifier: workspace:*
@@ -26377,8 +26377,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -26389,8 +26389,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -31442,7 +31442,7 @@ snapshots:
       http-compression: 1.0.6
       minimatch: 3.1.5
       path-to-regexp: 6.3.0
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@25.6.0)(typescript@5.9.3)
       tsconfig-paths: 4.2.0
@@ -31471,7 +31471,7 @@ snapshots:
       http-compression: 1.0.6
       minimatch: 3.1.5
       path-to-regexp: 6.3.0
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3)
       tsconfig-paths: 4.2.0
@@ -32063,14 +32063,14 @@ snapshots:
       axios: 1.15.0
       chalk: 3.0.0
       fs-extra: 9.1.0
-      isomorphic-ws: 5.0.0(ws@8.18.0)
+      isomorphic-ws: 5.0.0(ws@8.20.1)
       koa: 3.0.3
       lodash.clonedeepwith: 4.5.0
       log4js: 6.9.1
       node-schedule: 2.1.1
       rambda: 9.2.1
       typescript: 5.9.3
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       vue-tsc: 2.2.12(typescript@5.9.3)
     transitivePeerDependencies:
@@ -32090,13 +32090,13 @@ snapshots:
       axios: 1.15.0
       chalk: 3.0.0
       fs-extra: 9.1.0
-      isomorphic-ws: 5.0.0(ws@8.18.0)
+      isomorphic-ws: 5.0.0(ws@8.20.1)
       lodash.clonedeepwith: 4.5.0
       log4js: 6.9.1
       node-schedule: 2.1.1
       rambda: 9.2.1
       typescript: 5.9.3
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       vue-tsc: 2.2.12(typescript@5.9.3)
     transitivePeerDependencies:
@@ -37401,7 +37401,7 @@ snapshots:
       p-retry: 6.2.1
       webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.27.3)(webpack-cli@5.1.4))
       webpack-dev-server: 5.2.0(webpack-cli@5.1.4)(webpack@5.104.1)
-      ws: 8.18.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@types/express'
       - bufferutil
@@ -38019,7 +38019,7 @@ snapshots:
       util: 0.12.5
       util-deprecate: 1.0.2
       watchpack: 2.5.1
-      ws: 8.18.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -38048,7 +38048,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.6.3
       util: 0.12.5
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       prettier: 3.8.1
     transitivePeerDependencies:
@@ -38069,7 +38069,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.6.3
       util: 0.12.5
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       prettier: 3.8.1
     transitivePeerDependencies:
@@ -47600,9 +47600,9 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isomorphic-ws@5.0.0(ws@8.18.0):
+  isomorphic-ws@5.0.0(ws@8.20.1):
     dependencies:
-      ws: 8.18.0
+      ws: 8.20.1
 
   isstream@0.1.2: {}
 
@@ -48278,7 +48278,7 @@ snapshots:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
-      ws: 8.18.0
+      ws: 8.20.1
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -58157,7 +58157,7 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.27.3)(webpack-cli@5.1.4))
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.27.3)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
@@ -58196,7 +58196,7 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
@@ -58236,7 +58236,7 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
@@ -58276,7 +58276,7 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.0)(webpack-cli@5.1.4))
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
@@ -58315,7 +58315,7 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.27.3)(webpack-cli@5.1.4))
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.27.3)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
@@ -58830,9 +58830,9 @@ snapshots:
 
   ws@7.5.10: {}
 
-  ws@8.18.0: {}
-
   ws@8.20.0: {}
+
+  ws@8.20.1: {}
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Updates the direct dts-plugin ws dependency from 8.18.0 to 8.20.1.
- Refreshes pnpm-lock.yaml entries that resolved ws 8.18.0 to the patched 8.20.1 release.

Closes #4753

## Validation
- corepack pnpm install --frozen-lockfile --lockfile-only --ignore-scripts
- corepack pnpm audit --prod --json checked for ws advisory visibility
- corepack pnpm --filter @module-federation/dts-plugin run test -- --runInBand attempted, but failed because workspace packages such as @module-federation/sdk and @module-federation/error-codes were not built and packages/dts-plugin/dist/core was absent in this fresh worktree.

## Skipped checks
- Full package build/test/lint were not run to keep this dependency-only security PR scoped. The targeted dts-plugin test requires built workspace artifacts in this worktree.