### PR TITLE
fix(deps): update axios security release

### DIFF
--- a/.changeset/bright-axios-security.md
+++ b/.changeset/bright-axios-security.md
@@ -1,0 +1,7 @@
+---
+'@module-federation/typescript': patch
+'@module-federation/native-federation-tests': patch
+'@module-federation/native-federation-typescript': patch
+---
+
+Update direct axios dependencies to the current security release.

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "adm-zip": "0.5.16",
     "ansi-colors": "4.1.3",
     "antd": "5.19.1",
-    "axios": "1.15.0",
+    "axios": "1.16.1",
     "core-js": "3.36.1",
     "encoding": "^0.1.13",
     "express": "5.2.1",

--- a/packages/native-federation-tests/package.json
+++ b/packages/native-federation-tests/package.json
@@ -89,7 +89,7 @@
   "dependencies": {
     "adm-zip": "^0.5.14",
     "ansi-colors": "^4.1.3",
-    "axios": "1.15.0",
+    "axios": "1.16.1",
     "rambda": "^9.2.1",
     "tsdown": "0.20.3",
     "unplugin": "^1.10.1"

--- a/packages/native-federation-typescript/package.json
+++ b/packages/native-federation-typescript/package.json
@@ -89,7 +89,7 @@
   "dependencies": {
     "adm-zip": "^0.5.14",
     "ansi-colors": "^4.1.3",
-    "axios": "1.15.0",
+    "axios": "1.16.1",
     "rambda": "^9.2.1",
     "unplugin": "^1.10.1"
   },

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -43,7 +43,7 @@
     "react-dom": "*"
   },
   "dependencies": {
-    "axios": "1.15.0",
+    "axios": "1.16.1",
     "lodash.get": "4.4.2",
     "node-fetch": "2.7.0",
     "tapable": "2.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14842,7 +14842,7 @@ packages:
     engines: {node: '>=4'}
 
   axios@1.16.1:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 5.19.1
         version: 5.19.1(date-fns@4.1.0)(luxon@3.7.2)(moment@2.30.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.1
+        version: 1.16.1
       core-js:
         specifier: 3.36.1
         version: 3.36.1
@@ -3756,8 +3756,8 @@ importers:
         specifier: ^4.1.3
         version: 4.1.3
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.1
+        version: 1.16.1
       rambda:
         specifier: ^9.2.1
         version: 9.2.1
@@ -3784,8 +3784,8 @@ importers:
         specifier: ^4.1.3
         version: 4.1.3
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.1
+        version: 1.16.1
       rambda:
         specifier: ^9.2.1
         version: 9.2.1
@@ -4405,8 +4405,8 @@ importers:
   packages/typescript:
     dependencies:
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.1
+        version: 1.16.1
       lodash.get:
         specifier: 4.4.2
         version: 4.4.2
@@ -14841,7 +14841,7 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.15.0:
+  axios@1.16.1:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   axobject-query@4.1.0:
@@ -30827,7 +30827,7 @@ snapshots:
       '@modern-js/plugin-i18n': 2.70.5
       '@modern-js/utils': 2.70.5
       '@swc/helpers': 0.5.17
-      axios: 1.15.0
+      axios: 1.16.1
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - '@types/node'
@@ -30841,7 +30841,7 @@ snapshots:
       '@modern-js/plugin-i18n': 2.70.8
       '@modern-js/utils': 2.70.8
       '@swc/helpers': 0.5.17
-      axios: 1.15.0
+      axios: 1.16.1
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - '@types/node'
@@ -31437,7 +31437,7 @@ snapshots:
       '@modern-js/types': 2.70.5
       '@modern-js/utils': 2.70.5
       '@swc/helpers': 0.5.17
-      axios: 1.15.0
+      axios: 1.16.1
       connect-history-api-fallback: 2.0.0
       http-compression: 1.0.6
       minimatch: 3.1.5
@@ -31466,7 +31466,7 @@ snapshots:
       '@modern-js/types': 2.70.8
       '@modern-js/utils': 2.70.8
       '@swc/helpers': 0.5.17
-      axios: 1.15.0
+      axios: 1.16.1
       connect-history-api-fallback: 2.0.0
       http-compression: 1.0.6
       minimatch: 3.1.5
@@ -31493,7 +31493,7 @@ snapshots:
       '@modern-js/types': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.17
-      axios: 1.15.0
+      axios: 1.16.1
       connect-history-api-fallback: 2.0.0
       http-compression: 1.0.6
       minimatch: 3.1.5
@@ -31519,7 +31519,7 @@ snapshots:
       '@modern-js/types': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.17
-      axios: 1.15.0
+      axios: 1.16.1
       connect-history-api-fallback: 2.0.0
       http-compression: 1.0.6
       minimatch: 3.1.5
@@ -31545,7 +31545,7 @@ snapshots:
       '@modern-js/types': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.17
-      axios: 1.15.0
+      axios: 1.16.1
       connect-history-api-fallback: 2.0.0
       http-compression: 1.0.6
       minimatch: 3.1.5
@@ -32060,7 +32060,7 @@ snapshots:
       '@module-federation/third-party-dts-extractor': 0.21.6
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
-      axios: 1.15.0
+      axios: 1.16.1
       chalk: 3.0.0
       fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
@@ -32087,7 +32087,7 @@ snapshots:
       '@module-federation/third-party-dts-extractor': 2.2.2
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
-      axios: 1.15.0
+      axios: 1.16.1
       chalk: 3.0.0
       fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
@@ -41832,7 +41832,7 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.15.0:
+  axios@1.16.1:
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
@@ -50359,7 +50359,7 @@ snapshots:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       '@zkochan/js-yaml': 0.0.7
-      axios: 1.15.0
+      axios: 1.16.1
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
       cliui: 8.0.1
@@ -57991,7 +57991,7 @@ snapshots:
 
   wait-on@7.2.0:
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.1
       joi: 17.13.3
       lodash: 4.17.23
       minimist: 1.2.8


### PR DESCRIPTION
## Summary
- Updates direct axios dependencies from 1.15.0 to 1.16.1.
- Refreshes pnpm-lock.yaml axios resolutions to the patched release.

Closes #4653

## Validation
- corepack pnpm install --frozen-lockfile --lockfile-only --ignore-scripts
- corepack pnpm audit --prod --json checked axios advisories after the lock update.

## Skipped checks
- Full package build/test/lint were not run because this PR only updates a direct dependency and lockfile entries for the security advisory.