### PR TITLE
fix(bridge-react): align prefetch snapshot args

### DIFF
--- a/.changeset/quiet-bridge-prefetch.md
+++ b/.changeset/quiet-bridge-prefetch.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/bridge-react': patch
+---
+
+Align bridge-react prefetch snapshot arguments with the runtime-core snapshot handler type.

--- a/packages/bridge/bridge-react/src/lazy/data-fetch/prefetch.ts
+++ b/packages/bridge/bridge-react/src/lazy/data-fetch/prefetch.ts
@@ -38,7 +38,6 @@ export async function prefetch(options: PrefetchOptions) {
     await instance.snapshotHandler.loadRemoteSnapshotInfo({
       moduleInfo: remote,
       id,
-      expose,
     });
 
   if (preloadComponentResource) {


### PR DESCRIPTION
## Summary
- Remove the unsupported `expose` field from `bridge-react`'s `loadRemoteSnapshotInfo` call.
- Keeps `expose` available for preload asset config while aligning the snapshot call with the runtime-core method signature.

## Why
`@module-federation/bridge-react` declaration generation reports TS2353 because `loadRemoteSnapshotInfo` accepts `{ moduleInfo, id, initiator }`, not `expose`. The mismatch already exists on main and was surfaced by the react-router security PR's affected build path.

## Validation
- `corepack pnpm --filter @module-federation/bridge-react exec tsc -p tsconfig.json --noEmit`
- `corepack pnpm --filter @module-federation/bridge-react run build`
- `corepack pnpm --filter @module-federation/bridge-react run test`
- `corepack pnpm exec prettier --check packages/bridge/bridge-react/src/lazy/data-fetch/prefetch.ts`

Notes:
- Local shell is Node v22.22.3 while the repo declares Node ^20; pnpm emitted the existing engine warning.