### PR TITLE
fix(bridge-react): fail build on dts diagnostics

### DIFF
--- a/.changeset/fail-dts-diagnostics.md
+++ b/.changeset/fail-dts-diagnostics.md
@@ -1,0 +1,4 @@
+---
+---
+
+Make bridge-react declaration diagnostics fail the package build instead of being cached as successful Turbo output.

--- a/packages/bridge/bridge-react/vite.config.ts
+++ b/packages/bridge/bridge-react/vite.config.ts
@@ -14,6 +14,13 @@ export default defineConfig({
         '@module-federation/bridge-shared',
         'react-error-boundary',
       ],
+      afterDiagnostic(diagnostics) {
+        if (diagnostics.length > 0) {
+          throw new Error(
+            `Declaration generation failed with ${diagnostics.length} TypeScript diagnostic(s).`,
+          );
+        }
+      },
     }),
   ],
   build: {


### PR DESCRIPTION
## Summary
- make bridge-react's existing vite-plugin-dts build path throw when TypeScript diagnostics are emitted
- prevent Turbo from caching a successful build result that only logged declaration/type errors
- add an empty changeset because this is build tooling behavior, not a published runtime/API change

## Validation
- `pnpm --filter @module-federation/bridge-react run build` on current main now fails with TS2353 and `Declaration generation failed with 1 TypeScript diagnostic(s).`
- temporarily applied the #4764 source fix locally and verified the same build exits 0
- `pnpm exec prettier --check packages/bridge/bridge-react/vite.config.ts .changeset/fail-dts-diagnostics.md`

## Notes
- This PR intentionally exposes the latent bridge-react type error on main, so it should be merged after #4764 or rebased once #4764 lands.
