### PR TITLE
feat(rspress-plugin): rebuild llms output from html

### DIFF
--- a/.changeset/gentle-rspress-llms.md
+++ b/.changeset/gentle-rspress-llms.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rspress-plugin': patch
+---
+
+Rebuild llms output from generated HTML for federated Rspress builds.

--- a/apps/website-new/docs/en/integrations/documentation/rspress.mdx
+++ b/apps/website-new/docs/en/integrations/documentation/rspress.mdx
@@ -121,6 +121,19 @@ If you are using remoteSearch or other search functions, you can set `rebuildSea
 
 > Note: This feature is only effective in ssg mode.
 
+#### rebuildLlms
+
+* Type: `boolean`
+* Default: `true`
+
+When Rspress generates `llms.txt` and `llms-full.txt`, federated document fragments may not have title, description, or page content available yet.
+
+To avoid empty llms output, the MF Rspress Plugin rebuilds the llms output from the rendered `html` after SSG is complete.
+
+You can set `rebuildLlms: false` to disable this behavior.
+
+> Note: This feature is only effective in ssg mode and only runs when Rspress `llms` is enabled.
+
 ## FAQ
 
 ### Does it support local search?

--- a/apps/website-new/docs/zh/integrations/documentation/rspress.mdx
+++ b/apps/website-new/docs/zh/integrations/documentation/rspress.mdx
@@ -121,6 +121,19 @@ Rspress 构建时会自动生成搜索索引，但是生成过程仅支持 `.mdx
 
 > 注意：该功能仅在 ssg 模式下生效。
 
+#### rebuildLlms
+
+* 类型：`boolean`
+* 默认值：`true`
+
+当 Rspress 生成 `llms.txt` 和 `llms-full.txt` 时，模块联邦文档片段可能还没有可用的标题、描述或页面内容。
+
+为了避免生成空的 llms 输出，MF Rspress Plugin 会在 SSG 完成后根据渲染完成的 `html` 重新构建 llms 输出。
+
+你可以设置 `rebuildLlms: false` 来禁用此行为。
+
+> 注意：该功能仅在 ssg 模式下生效，并且只会在启用 Rspress `llms` 时运行。
+
 ## FAQ
 
 ### 是否支持 local search ？

--- a/packages/rspress-plugin/src/plugin.ts
+++ b/packages/rspress-plugin/src/plugin.ts
@@ -143,7 +143,12 @@ export function pluginModuleFederation(
       routes = routeMetaArr;
     },
     async afterBuild(config) {
-      if (!mfConfig.remotes || isDev()) {
+      const shouldRebuildLlms = Boolean(config.llms && rebuildLlms);
+      if (
+        !mfConfig.remotes ||
+        isDev() ||
+        (!rebuildSearchIndex && !shouldRebuildLlms)
+      ) {
         return;
       }
       if (!enableSSG) {
@@ -174,7 +179,7 @@ export function pluginModuleFederation(
         logger.info('rebuildSearchIndex success!');
       }
 
-      if (config.llms && rebuildLlms) {
+      if (shouldRebuildLlms) {
         await rebuildLlmsByHtml(routes, {
           outputDir,
           defaultLang,

--- a/packages/rspress-plugin/src/plugin.ts
+++ b/packages/rspress-plugin/src/plugin.ts
@@ -6,11 +6,13 @@ import logger from './logger';
 
 import type { moduleFederationPlugin } from '@module-federation/sdk';
 import type { RspressPlugin, RouteMeta } from '@rspress/core';
+import { rebuildLlmsByHtml } from './rebuildLlmsByHtml';
 import { rebuildSearchIndexByHtml } from './rebuildSearchIndexByHtml';
 
 type RspressPluginOptions = {
   autoShared?: boolean;
   rebuildSearchIndex?: boolean;
+  rebuildLlms?: boolean;
 };
 
 const isDev = () => process.env.NODE_ENV === 'development';
@@ -19,7 +21,11 @@ export function pluginModuleFederation(
   mfConfig: moduleFederationPlugin.ModuleFederationPluginOptions,
   rspressOptions?: RspressPluginOptions,
 ): RspressPlugin {
-  const { autoShared = true, rebuildSearchIndex = true } = rspressOptions || {};
+  const {
+    autoShared = true,
+    rebuildSearchIndex = true,
+    rebuildLlms = true,
+  } = rspressOptions || {};
 
   if (autoShared) {
     mfConfig.shared = {
@@ -137,28 +143,46 @@ export function pluginModuleFederation(
       routes = routeMetaArr;
     },
     async afterBuild(config) {
-      if (!mfConfig.remotes || isDev() || !rebuildSearchIndex) {
+      if (!mfConfig.remotes || isDev()) {
         return;
       }
       if (!enableSSG) {
-        logger.error('rebuildSearchIndex is only supported for ssg');
+        logger.error(
+          'rebuildSearchIndex and rebuildLlms are only supported for ssg',
+        );
         process.exit(1);
       }
-      const searchConfig = config?.search || {};
-      const replaceRules = config?.replaceRules || [];
-      const domain = '';
-      const versioned = searchConfig && searchConfig.versioned;
-      const searchCodeBlocks =
-        'codeBlocks' in searchConfig ? Boolean(searchConfig.codeBlocks) : true;
-      await rebuildSearchIndexByHtml(routes, {
-        outputDir,
-        versioned,
-        replaceRules,
-        domain,
-        searchCodeBlocks,
-        defaultLang: config.lang || 'en',
-      });
-      logger.info('rebuildSearchIndex success!');
+      const defaultLang = config.lang || 'en';
+
+      if (rebuildSearchIndex) {
+        const searchConfig = config?.search || {};
+        const replaceRules = config?.replaceRules || [];
+        const domain = '';
+        const versioned = searchConfig && searchConfig.versioned;
+        const searchCodeBlocks =
+          'codeBlocks' in searchConfig
+            ? Boolean(searchConfig.codeBlocks)
+            : true;
+        await rebuildSearchIndexByHtml(routes, {
+          outputDir,
+          versioned,
+          replaceRules,
+          domain,
+          searchCodeBlocks,
+          defaultLang,
+        });
+        logger.info('rebuildSearchIndex success!');
+      }
+
+      if (config.llms && rebuildLlms) {
+        await rebuildLlmsByHtml(routes, {
+          outputDir,
+          defaultLang,
+          base: config.base,
+          defaultVersion: config.multiVersion?.default,
+        });
+        logger.info('rebuildLlms success!');
+      }
     },
   };
 }

--- a/packages/rspress-plugin/src/rebuildLlmsByHtml.ts
+++ b/packages/rspress-plugin/src/rebuildLlmsByHtml.ts
@@ -1,0 +1,356 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as cheerio from 'cheerio';
+import { htmlToText } from 'html-to-text';
+
+import type { RouteMeta } from '@rspress/shared';
+
+export type RebuildLlmsByHtmlOptions = {
+  outputDir: string;
+  defaultLang: string;
+  base?: string;
+  defaultVersion?: string;
+};
+
+type RouteMarkdown = {
+  route: RouteMeta;
+  markdown: string;
+  title: string;
+  description?: string;
+};
+
+const replaceHtmlExt = (filepath: string) => {
+  return filepath.replace(path.extname(filepath), '.html');
+};
+
+const routePageToMdFilename = (routePath: string) => {
+  const fileName = routePath.endsWith('/')
+    ? `${routePath}index.md`
+    : `${routePath}.md`;
+  return fileName.replace(/^\/+/, '');
+};
+
+const addBase = (url: string, base?: string) => {
+  if (!base || base === '/') {
+    return url;
+  }
+  return `${base.replace(/\/$/, '')}/${url.replace(/^\//, '')}`;
+};
+
+const routePathToMdPath = (routePath: string, base?: string) => {
+  const normalizedRoutePath = routePath.replace(/\.html$/, '');
+  const mdPath = normalizedRoutePath.endsWith('/')
+    ? `${normalizedRoutePath}index.md`
+    : `${normalizedRoutePath}.md`;
+  return addBase(mdPath, base);
+};
+
+const getRouteHtmlPath = (
+  route: RouteMeta,
+  { outputDir, defaultLang }: RebuildLlmsByHtmlOptions,
+) => {
+  return replaceHtmlExt(
+    path.join(
+      outputDir,
+      route.lang === defaultLang
+        ? route.relativePath.replace(route.lang, '')
+        : route.relativePath,
+    ),
+  );
+};
+
+function normalizeText(text: string) {
+  return text
+    .replace(/\s+/g, ' ')
+    .replace(/^#+\s*/, '')
+    .trim();
+}
+
+function htmlToMarkdown(html: string) {
+  const $ = cheerio.load(html);
+
+  $('script, style, noscript, template').remove();
+  $('header, nav, aside, footer').remove();
+  $(
+    [
+      '.rp-nav',
+      '.rp-sidebar',
+      '.rp-aside',
+      '.rp-footer',
+      '.rp-doc-footer',
+      '.rp-not-doc',
+    ].join(','),
+  ).remove();
+
+  const docHtml =
+    $('main').first().html() ||
+    $('article').first().html() ||
+    $('.rp-doc').first().html() ||
+    $('body').html() ||
+    html;
+
+  return htmlToText(docHtml, {
+    wordwrap: 80,
+    selectors: [
+      {
+        selector: 'a',
+        options: {
+          ignoreHref: false,
+        },
+      },
+      {
+        selector: 'img',
+        format: 'skip',
+      },
+      ...['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].map((tag) => ({
+        selector: tag,
+        options: {
+          uppercase: false,
+        },
+      })),
+    ],
+    tables: true,
+    longWordSplit: {
+      forceWrapOnLimit: true,
+    },
+  }).trim();
+}
+
+function extractPageInfoFromHtml(html: string) {
+  const $ = cheerio.load(html);
+  const $doc = $('main').first().length
+    ? $('main').first()
+    : $('article').first().length
+      ? $('article').first()
+      : $('.rp-doc').first().length
+        ? $('.rp-doc').first()
+        : $('body');
+
+  $doc
+    .find('a.header-anchor, .header-anchor, .rp-copy, .rp-llms-button')
+    .remove();
+
+  const title =
+    normalizeText($doc.find('h1').first().text()) ||
+    normalizeText($('h1').first().text()) ||
+    normalizeText($('title').first().text());
+  const description = $doc
+    .find('p')
+    .toArray()
+    .map((paragraph) => normalizeText($(paragraph).text()))
+    .find(Boolean);
+
+  return {
+    title,
+    description,
+  };
+}
+
+async function extractRouteMarkdown(
+  routes: RouteMeta[],
+  options: RebuildLlmsByHtmlOptions,
+) {
+  return Promise.all(
+    routes.map(async (route) => {
+      const htmlPath = getRouteHtmlPath(route, options);
+      const html = await fs.readFile(htmlPath, 'utf-8');
+      const { title, description } = extractPageInfoFromHtml(html);
+      return {
+        route,
+        markdown: htmlToMarkdown(html),
+        title,
+        description,
+      };
+    }),
+  );
+}
+
+function getDefaultVersion(routeMarkdownList: RouteMarkdown[]) {
+  return routeMarkdownList.find(({ route }) => route.version)?.route.version;
+}
+
+function getLlmsOutputPrefix(
+  route: RouteMeta,
+  defaultLang: string,
+  defaultVersion?: string,
+) {
+  const langPrefix = route.lang === defaultLang ? '' : `${route.lang}/`;
+  const versionPrefix =
+    defaultVersion && route.version && route.version !== defaultVersion
+      ? `${route.version}/`
+      : '';
+  return `${versionPrefix}${langPrefix}`;
+}
+
+function generateLlmsFullTxt(
+  routeMarkdownList: RouteMarkdown[],
+  options: RebuildLlmsByHtmlOptions,
+) {
+  return routeMarkdownList
+    .map(({ route, markdown }) =>
+      [
+        '---',
+        `url: ${routePathToMdPath(route.routePath, options.base)}`,
+        '---',
+        '',
+        markdown,
+        '',
+      ].join('\n'),
+    )
+    .join('\n');
+}
+
+async function writeRouteMarkdownIfEmpty(
+  routeMarkdownList: RouteMarkdown[],
+  options: RebuildLlmsByHtmlOptions,
+) {
+  await Promise.all(
+    routeMarkdownList.map(async ({ route, markdown }) => {
+      const mdFilename = routePageToMdFilename(route.routePath);
+      const mdPath = path.join(options.outputDir, mdFilename);
+      await fs.mkdir(path.dirname(mdPath), { recursive: true });
+
+      let existingContent = '';
+      try {
+        existingContent = await fs.readFile(mdPath, 'utf-8');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error;
+        }
+      }
+
+      if (!existingContent.trim()) {
+        await fs.writeFile(mdPath, markdown);
+      }
+    }),
+  );
+}
+
+async function patchLlmsFullTxtIfEmpty(
+  routeMarkdownList: RouteMarkdown[],
+  options: RebuildLlmsByHtmlOptions,
+  outputPrefix: string,
+) {
+  const llmsFullPath = path.join(
+    options.outputDir,
+    outputPrefix,
+    'llms-full.txt',
+  );
+  await fs.mkdir(path.dirname(llmsFullPath), { recursive: true });
+
+  const markdownMap = new Map(
+    routeMarkdownList.map(({ route, markdown }) => [
+      routePathToMdPath(route.routePath, options.base),
+      markdown,
+    ]),
+  );
+
+  let original = '';
+  try {
+    original = await fs.readFile(llmsFullPath, 'utf-8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  if (!original) {
+    await fs.writeFile(
+      llmsFullPath,
+      generateLlmsFullTxt(routeMarkdownList, options),
+    );
+    return;
+  }
+
+  const patched = original.replace(
+    /(---\nurl:\s*([^\n]+)\n---\n)([\s\S]*?)(?=\n---\nurl:|$)/g,
+    (section, header: string, url: string, body: string) => {
+      if (body.trim()) {
+        return section;
+      }
+      const markdown = markdownMap.get(url.trim());
+      if (!markdown) {
+        return section;
+      }
+      return `${header}${markdown}\n`;
+    },
+  );
+
+  await fs.writeFile(llmsFullPath, patched);
+}
+
+async function patchLlmsTxtIfEmpty(
+  routeMarkdownList: RouteMarkdown[],
+  options: RebuildLlmsByHtmlOptions,
+  outputPrefix: string,
+) {
+  const llmsPath = path.join(options.outputDir, outputPrefix, 'llms.txt');
+  let original = '';
+
+  try {
+    original = await fs.readFile(llmsPath, 'utf-8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+    return;
+  }
+
+  const pageInfoMap = new Map(
+    routeMarkdownList.map(({ route, title, description }) => [
+      routePathToMdPath(route.routePath, options.base),
+      {
+        title,
+        description,
+      },
+    ]),
+  );
+
+  const patched = original.replace(
+    /^- \[\]\(([^)]+)\)(?::\s*)?$/gm,
+    (line, url: string) => {
+      const pageInfo = pageInfoMap.get(url.trim());
+      if (!pageInfo?.title) {
+        return line;
+      }
+      const suffix = pageInfo.description ? `: ${pageInfo.description}` : '';
+      return `- [${pageInfo.title}](${url})${suffix}`;
+    },
+  );
+
+  if (patched !== original) {
+    await fs.writeFile(llmsPath, patched);
+  }
+}
+
+export async function rebuildLlmsByHtml(
+  routes: RouteMeta[],
+  options: RebuildLlmsByHtmlOptions,
+) {
+  const routeMarkdownList = await extractRouteMarkdown(routes, options);
+  const defaultVersion =
+    options.defaultVersion || getDefaultVersion(routeMarkdownList);
+  const groupedRouteMarkdown = new Map<string, RouteMarkdown[]>();
+
+  await writeRouteMarkdownIfEmpty(routeMarkdownList, options);
+
+  for (const routeMarkdown of routeMarkdownList) {
+    const outputPrefix = getLlmsOutputPrefix(
+      routeMarkdown.route,
+      options.defaultLang,
+      defaultVersion,
+    );
+    const group = groupedRouteMarkdown.get(outputPrefix) || [];
+    group.push(routeMarkdown);
+    groupedRouteMarkdown.set(outputPrefix, group);
+  }
+
+  await Promise.all(
+    Array.from(groupedRouteMarkdown.entries()).map(
+      async ([outputPrefix, group]) => {
+        await patchLlmsTxtIfEmpty(group, options, outputPrefix);
+        await patchLlmsFullTxtIfEmpty(group, options, outputPrefix);
+      },
+    ),
+  );
+}

--- a/packages/rspress-plugin/src/rebuildLlmsByHtml.ts
+++ b/packages/rspress-plugin/src/rebuildLlmsByHtml.ts
@@ -69,6 +69,8 @@ function normalizeText(text: string) {
 function htmlToMarkdown(html: string) {
   const $ = cheerio.load(html);
 
+  // Strip chrome and runtime-only nodes before converting the page body into
+  // Markdown, so llms output contains document content instead of navigation UI.
   $('script, style, noscript, template').remove();
   $('header, nav, aside, footer').remove();
   $(
@@ -204,6 +206,8 @@ async function writeRouteMarkdownIfEmpty(
   routeMarkdownList: RouteMarkdown[],
   options: RebuildLlmsByHtmlOptions,
 ) {
+  // Rspress may already emit route-level Markdown files. Only fill missing or
+  // empty files from HTML so user-authored content is never overwritten.
   await Promise.all(
     routeMarkdownList.map(async ({ route, markdown }) => {
       const mdFilename = routePageToMdFilename(route.routePath);
@@ -254,6 +258,8 @@ async function patchLlmsFullTxtIfEmpty(
     }
   }
 
+  // If llms-full.txt was not generated, create the whole file from the HTML
+  // conversion. Otherwise only patch sections whose body is still empty.
   if (!original) {
     await fs.writeFile(
       llmsFullPath,
@@ -296,6 +302,8 @@ async function patchLlmsTxtIfEmpty(
     return;
   }
 
+  // Rspress can emit placeholder entries like "- [](url)" when route metadata
+  // is unavailable at compile time. Backfill those labels from built HTML.
   const pageInfoMap = new Map(
     routeMarkdownList.map(({ route, title, description }) => [
       routePathToMdPath(route.routePath, options.base),
@@ -327,6 +335,8 @@ export async function rebuildLlmsByHtml(
   routes: RouteMeta[],
   options: RebuildLlmsByHtmlOptions,
 ) {
+  // Treat the generated HTML as the source of truth after federation has
+  // rendered remote content into the static output.
   const routeMarkdownList = await extractRouteMarkdown(routes, options);
   const defaultVersion =
     options.defaultVersion || getDefaultVersion(routeMarkdownList);
@@ -334,6 +344,8 @@ export async function rebuildLlmsByHtml(
 
   await writeRouteMarkdownIfEmpty(routeMarkdownList, options);
 
+  // llms.txt and llms-full.txt are emitted per version/language prefix, so
+  // patch each output group independently.
   for (const routeMarkdown of routeMarkdownList) {
     const outputPrefix = getLlmsOutputPrefix(
       routeMarkdown.route,


### PR DESCRIPTION
## Description

Add llms output rebuilding for federated Rspress builds. When Rspress llms config is enabled, the plugin now reads the generated HTML output after SSG and uses it to fill empty Markdown pages, patch `llms.txt` entries with titles/descriptions, and populate empty `llms-full.txt` sections.

The new `rebuildLlms` plugin option defaults to `true`, matching the existing search index rebuild behavior, and can be disabled independently.

## Related Issue

Not linked.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.

## Validation

- `pnpm exec prettier --check .`
- `pnpm --filter @module-federation/rspress-plugin run build`
- `python3 .codex/skills/changeset-pr/scripts/run_changeset_status.py --verbose`
- `git diff --check`

Skipped checks:

- Package tests were not run because `@module-federation/rspress-plugin` does not define a `test` script.
- Changeset scope helper was attempted, but the local `python3` is 3.9.6 and the helper uses Python 3.10 union type syntax.
