### PR TITLE
fix(dts-plugin): restore manifest types fallback

### DIFF
--- a/.changeset/green-manifest-types.md
+++ b/.changeset/green-manifest-types.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+Restore convention-based `@mf-types` fallback URLs for manifest remotes when manifest metadata omits type locations or the manifest fetch fails.

--- a/packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts
@@ -190,6 +190,35 @@ describe('DTSManager General Tests', () => {
       expect(result.apiTypeUrl).toBe('');
     });
 
+    it('should fall back to convention-based type URLs when manifest metadata lacks types', async () => {
+      vi.spyOn(utils, 'nativeFetch').mockResolvedValueOnce({
+        data: {
+          metaData: {
+            publicPath: 'http://example.com/static/',
+          },
+        },
+        status: 200,
+        headers: {},
+      } as any);
+
+      const remoteInfo: RemoteInfo = {
+        name: 'test',
+        url: 'http://example.com/static/mf-manifest.json',
+        alias: 'test-alias',
+      };
+
+      const result = await dtsManager.requestRemoteManifest(remoteInfo, {
+        remoteTypesFolder: '@mf-types',
+        timeout: 60000,
+        family: 4,
+      } as any);
+
+      expect(result.zipUrl).toBe('http://example.com/static/@mf-types.zip');
+      expect(result.apiTypeUrl).toBe(
+        'http://example.com/static/@mf-types.d.ts',
+      );
+    });
+
     it('should handle manifest fetch errors', async () => {
       vi.spyOn(utils, 'nativeFetch').mockRejectedValueOnce(
         new Error('Network error'),
@@ -201,9 +230,13 @@ describe('DTSManager General Tests', () => {
         alias: 'test-alias',
       };
 
-      // @ts-expect-error only need timeout, which is not required
-      const result = await dtsManager.requestRemoteManifest(remoteInfo, {});
-      expect(result).toEqual(remoteInfo);
+      const result = await dtsManager.requestRemoteManifest(remoteInfo, {
+        remoteTypesFolder: '@mf-types',
+        timeout: 60000,
+        family: 4,
+      } as any);
+      expect(result.zipUrl).toBe('http://example.com/@mf-types.zip');
+      expect(result.apiTypeUrl).toBe('http://example.com/@mf-types.d.ts');
     });
 
     it('should handle manifest with getPublicPath function', async () => {

--- a/packages/dts-plugin/src/core/lib/DTSManager.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.ts
@@ -40,6 +40,31 @@ interface UpdateTypesOptions {
   once?: boolean;
 }
 
+const buildManifestConventionZipUrl = (
+  remoteUrl: string,
+  remoteTypesFolder = '@mf-types',
+) => {
+  const parsedRemoteUrl = new URL(remoteUrl, 'file:');
+
+  const pathnameWithoutEntry = parsedRemoteUrl.pathname
+    .split('/')
+    .slice(0, -1)
+    .join('/');
+  parsedRemoteUrl.pathname = `${pathnameWithoutEntry}/${remoteTypesFolder}.zip`;
+
+  return parsedRemoteUrl.protocol === 'file:'
+    ? parsedRemoteUrl.pathname
+    : parsedRemoteUrl.href;
+};
+
+const buildManifestConventionApiTypeUrl = (zipUrl?: string) => {
+  if (!zipUrl) {
+    return '';
+  }
+
+  return zipUrl.replace('.zip', '.d.ts');
+};
+
 class DTSManager {
   options: DTSManagerOptions;
   runtimePkgs: string[];
@@ -221,6 +246,17 @@ class DTSManager {
       if (remoteInfo.zipUrl) {
         return remoteInfo as Required<RemoteInfo>;
       }
+
+      const fallbackZipUrl = buildManifestConventionZipUrl(
+        remoteInfo.url,
+        hostOptions.remoteTypesFolder,
+      );
+      const fallbackRemoteInfo = {
+        ...remoteInfo,
+        zipUrl: fallbackZipUrl,
+        apiTypeUrl: buildManifestConventionApiTypeUrl(fallbackZipUrl),
+      } as Required<RemoteInfo>;
+
       const url = remoteInfo.url;
       const res = await nativeFetch(url, {
         timeout: hostOptions.timeout,
@@ -228,7 +264,7 @@ class DTSManager {
       });
       const manifestJson = res.data as unknown as Manifest;
       if (!manifestJson.metaData.types.zip) {
-        throw new Error(`Can not get ${remoteInfo.name}'s types archive url!`);
+        return fallbackRemoteInfo;
       }
       const addProtocol = (u: string): string => {
         if (u.startsWith('//')) {
@@ -268,12 +304,20 @@ class DTSManager {
       ).href;
       return remoteInfo as Required<RemoteInfo>;
     } catch (_err) {
+      const fallbackZipUrl = buildManifestConventionZipUrl(
+        remoteInfo.url,
+        hostOptions.remoteTypesFolder,
+      );
       fileLog(
         `fetch manifest failed, ${_err}, ${remoteInfo.name} will be ignored`,
         'requestRemoteManifest',
         'error',
       );
-      return remoteInfo as Required<RemoteInfo>;
+      return {
+        ...remoteInfo,
+        zipUrl: fallbackZipUrl,
+        apiTypeUrl: buildManifestConventionApiTypeUrl(fallbackZipUrl),
+      } as Required<RemoteInfo>;
     }
   }
 


### PR DESCRIPTION
## Summary
- restore convention-based `@mf-types.zip` / `@mf-types.d.ts` fallback URLs for manifest remotes in `@module-federation/dts-plugin`
- keep manifest-provided `metaData.types` URLs preferred when they are present
- add regression coverage plus a patch changeset for `@module-federation/dts-plugin`

## Root cause
Commit `13dce52eb` removed the convention-based `@mf-types` URL construction that manifest remotes previously inherited from `hostPlugin.ts`. After that change, manifest remotes depended entirely on `DTSManager.requestRemoteManifest()` fetching the manifest and reading `metaData.types.zip` / `api`. When the manifest fetch failed or the manifest omitted `metaData.types`, `zipUrl` stayed empty and `@mf-types` consumption broke.

## Changed files
- `packages/dts-plugin/src/core/lib/DTSManager.ts`
- `packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts`
- `.changeset/green-manifest-types.md`

## Validation already run
- `pnpm --filter @module-federation/dts-plugin exec vitest run src/core/lib/DTSManager.general.spec.ts -t "fall back to convention-based type URLs when manifest metadata lacks types" --config vite.config.mts` (failed as expected before the fix: `zipUrl` was undefined)
- `pnpm --filter @module-federation/dts-plugin exec vitest run src/core/lib/DTSManager.general.spec.ts --config vite.config.mts`
- `pnpm --filter @module-federation/dts-plugin run test`
- `pnpm --filter @module-federation/dts-plugin run build`
- `pnpm exec prettier --check packages/dts-plugin/src/core/lib/DTSManager.ts packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts .changeset/green-manifest-types.md`
- `pnpm exec prettier --check .`
- `git diff --check`
- `git commit` hook ran `node tools/scripts/lint-fix.mjs`, which reformatted changed files if needed and ran Turbo lint for `@module-federation/dts-plugin`

## Skipped checks
- No Storybook-addon validation: no Storybook-addon files or config changed, and the fix is scoped to `@module-federation/dts-plugin`.
- No full monorepo package pipeline beyond `@module-federation/dts-plugin`: AGENTS.md says to run the smallest deterministic set for package-only changes; targeted dts-plugin test/build plus repo-wide Prettier covered this diff.
- No release/publish execution: AGENTS.md forbids publish/release execution unless explicitly requested.

## Notes
- pnpm warned that the current shell is Node `v22.22.3` while the repo expects Node `^20`; all validation commands still exited successfully.
- The dts-plugin build emitted pre-existing tsdown/webpack warning noise but exited `0`.
- The full dts-plugin test run emitted an existing IPC-channel error message during `DTSManager.spec.ts` but the suite still exited `0`.

Closes #4759
