### PR TITLE
fix(storybook-addon): pass through Rsbuild federation options

### DIFF
--- a/.changeset/tough-storybook-options.md
+++ b/.changeset/tough-storybook-options.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/storybook-addon': patch
+---
+
+Pass all Rsbuild Module Federation options through the Storybook addon preset so advanced options such as `dts.consumeTypes.remoteTypeUrls`, `manifest`, and `runtimePlugins` are preserved.

--- a/packages/storybook-addon/preset.ts
+++ b/packages/storybook-addon/preset.ts
@@ -8,14 +8,7 @@ export default {
     config: RsbuildConfig,
     options: moduleFederationPlugin.ModuleFederationPluginOptions,
   ) => {
-    const { remotes, shared, name, shareStrategy } = options;
-
-    return withModuleFederation(config, {
-      name,
-      remotes,
-      shared,
-      shareStrategy,
-    });
+    return withModuleFederation(config, options);
   },
 };
 export { PLUGIN_NAME } from './src/utils/with-module-federation-enhanced-rsbuild.js';

--- a/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.spec.ts
+++ b/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.spec.ts
@@ -85,33 +85,33 @@ describe(`${withModuleFederation.name}()`, () => {
     });
   });
 
-  it('does not forward Storybook preset metadata into the Rsbuild plugin options', async () => {
-    const futureFederationOption = {
-      enabled: true,
+  it('does not forward Storybook metadata into the Rsbuild plugin options', async () => {
+    // Keys Storybook injects into the `Options` object passed to `rsbuildFinal`.
+    // The enhanced ModuleFederationPlugin schema is strict
+    // (`additionalProperties: false`), so any of these leaking through would
+    // fail validation and break Storybook startup.
+    const storybookMetadata = {
+      cacheKey: 'storybook-cache-key',
+      configDir: '.storybook',
+      configType: 'DEVELOPMENT',
+      presets: { apply: () => undefined },
+      presetsList: [],
+      cache: {},
+      features: {},
+      packageJson: { name: 'host' },
+      port: 6006,
+      outputDir: 'storybook-static',
+      // An unknown/unrecognized key must also be dropped, since the schema
+      // rejects additional properties.
+      futureStorybookOption: { enabled: true },
     };
-    const storybookOptions: moduleFederationPlugin.ModuleFederationPluginOptions & {
-      cacheKey: string;
-      configDir: string;
-      configType: string;
-      futureFederationOption: {
-        enabled: boolean;
-      };
-      presets: {
-        apply: () => void;
-      };
-    } = {
+    const storybookOptions = {
       name: 'storybook-host',
       remotes: {
         remote: 'remote@http://localhost:3001/mf-manifest.json',
       },
-      cacheKey: 'storybook-cache-key',
-      configDir: '.storybook',
-      configType: 'DEVELOPMENT',
-      futureFederationOption,
-      presets: {
-        apply: () => undefined,
-      },
-    };
+      ...storybookMetadata,
+    } as unknown as moduleFederationPlugin.ModuleFederationPluginOptions;
 
     const pluginOptions =
       await getModuleFederationPluginOptions(storybookOptions);
@@ -121,11 +121,10 @@ describe(`${withModuleFederation.name}()`, () => {
       remotes: {
         remote: 'remote@http://localhost:3001/mf-manifest.json',
       },
-      futureFederationOption,
     });
-    expect(pluginOptions).not.toHaveProperty('cacheKey');
-    expect(pluginOptions).not.toHaveProperty('configDir');
-    expect(pluginOptions).not.toHaveProperty('configType');
-    expect(pluginOptions).not.toHaveProperty('presets');
+
+    for (const key of Object.keys(storybookMetadata)) {
+      expect(pluginOptions).not.toHaveProperty(key);
+    }
   });
 });

--- a/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.spec.ts
+++ b/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.spec.ts
@@ -86,10 +86,16 @@ describe(`${withModuleFederation.name}()`, () => {
   });
 
   it('does not forward Storybook preset metadata into the Rsbuild plugin options', async () => {
+    const futureFederationOption = {
+      enabled: true,
+    };
     const storybookOptions: moduleFederationPlugin.ModuleFederationPluginOptions & {
       cacheKey: string;
       configDir: string;
       configType: string;
+      futureFederationOption: {
+        enabled: boolean;
+      };
       presets: {
         apply: () => void;
       };
@@ -101,6 +107,7 @@ describe(`${withModuleFederation.name}()`, () => {
       cacheKey: 'storybook-cache-key',
       configDir: '.storybook',
       configType: 'DEVELOPMENT',
+      futureFederationOption,
       presets: {
         apply: () => undefined,
       },
@@ -114,6 +121,7 @@ describe(`${withModuleFederation.name}()`, () => {
       remotes: {
         remote: 'remote@http://localhost:3001/mf-manifest.json',
       },
+      futureFederationOption,
     });
     expect(pluginOptions).not.toHaveProperty('cacheKey');
     expect(pluginOptions).not.toHaveProperty('configDir');

--- a/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.spec.ts
+++ b/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.spec.ts
@@ -1,0 +1,87 @@
+import { moduleFederationPlugin } from '@module-federation/sdk';
+
+class MockModuleFederationPlugin {}
+
+jest.mock('@module-federation/enhanced/rspack', () => ({
+  ModuleFederationPlugin: MockModuleFederationPlugin,
+}));
+
+import {
+  PLUGIN_NAME,
+  withModuleFederation,
+} from './with-module-federation-enhanced-rsbuild.js';
+
+const getModuleFederationPluginOptions = async (
+  options: moduleFederationPlugin.ModuleFederationPluginOptions,
+) => {
+  const rsbuildConfig = withModuleFederation({}, options);
+  const [plugin] = rsbuildConfig.plugins || [];
+  const rsbuildPlugin = plugin as { setup: (api: unknown) => void };
+
+  const use = jest.fn();
+  const chain = {
+    plugin: jest.fn(() => ({ use })),
+  };
+  const api = {
+    modifyRsbuildConfig: jest.fn(),
+    modifyBundlerChain: jest.fn((callback) => callback(chain)),
+  };
+
+  rsbuildPlugin.setup(api as never);
+
+  expect(chain.plugin).toHaveBeenCalledWith(PLUGIN_NAME);
+  expect(use).toHaveBeenCalledWith(MockModuleFederationPlugin, [
+    expect.any(Object),
+  ]);
+
+  return use.mock.calls[0][1][0];
+};
+
+describe(`${withModuleFederation.name}()`, () => {
+  it('passes through advanced Module Federation options for the Rsbuild plugin', async () => {
+    const remoteTypeUrls = {
+      remote: {
+        alias: 'remote',
+        api: 'http://localhost:3001/@mf-types.d.ts',
+        zip: 'http://localhost:3001/@mf-types.zip',
+      },
+    };
+    const runtimePlugin = './runtime-plugin.js';
+
+    const pluginOptions = await getModuleFederationPluginOptions({
+      name: 'storybook-host',
+      remotes: {
+        remote: 'remote@http://localhost:3001/mf-manifest.json',
+      },
+      shared: {
+        lodash: { singleton: true },
+      },
+      dts: {
+        consumeTypes: {
+          remoteTypeUrls,
+        },
+      },
+      manifest: false,
+      runtimePlugins: [runtimePlugin],
+    });
+
+    expect(pluginOptions).toMatchObject({
+      name: 'storybook-host',
+      remotes: {
+        remote: 'remote@http://localhost:3001/mf-manifest.json',
+      },
+      dts: {
+        consumeTypes: {
+          remoteTypeUrls,
+        },
+      },
+      manifest: false,
+      runtimePlugins: [runtimePlugin],
+    });
+    expect(pluginOptions.shared).toMatchObject({
+      react: { singleton: true },
+      'react-dom': { singleton: true },
+      lodash: { singleton: true },
+    });
+  });
+});

--- a/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.spec.ts
+++ b/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.spec.ts
@@ -84,4 +84,40 @@ describe(`${withModuleFederation.name}()`, () => {
       lodash: { singleton: true },
     });
   });
+
+  it('does not forward Storybook preset metadata into the Rsbuild plugin options', async () => {
+    const storybookOptions: moduleFederationPlugin.ModuleFederationPluginOptions & {
+      cacheKey: string;
+      configDir: string;
+      configType: string;
+      presets: {
+        apply: () => void;
+      };
+    } = {
+      name: 'storybook-host',
+      remotes: {
+        remote: 'remote@http://localhost:3001/mf-manifest.json',
+      },
+      cacheKey: 'storybook-cache-key',
+      configDir: '.storybook',
+      configType: 'DEVELOPMENT',
+      presets: {
+        apply: () => undefined,
+      },
+    };
+
+    const pluginOptions =
+      await getModuleFederationPluginOptions(storybookOptions);
+
+    expect(pluginOptions).toMatchObject({
+      name: 'storybook-host',
+      remotes: {
+        remote: 'remote@http://localhost:3001/mf-manifest.json',
+      },
+    });
+    expect(pluginOptions).not.toHaveProperty('cacheKey');
+    expect(pluginOptions).not.toHaveProperty('configDir');
+    expect(pluginOptions).not.toHaveProperty('configType');
+    expect(pluginOptions).not.toHaveProperty('presets');
+  });
 });

--- a/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
+++ b/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
@@ -60,6 +60,7 @@ export const withModuleFederation = (
       api.modifyBundlerChain(async (chain) => {
         chain.plugin(PLUGIN_NAME).use(ModuleFederationPlugin, [
           {
+            ...options,
             name: options.name || PLUGIN_NAME,
             shared: {
               react: {

--- a/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
+++ b/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
@@ -9,20 +9,57 @@ import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core';
 import type { moduleFederationPlugin } from '@module-federation/sdk';
 
 type StorybookRsbuildOptions =
-  moduleFederationPlugin.ModuleFederationPluginOptions & {
-    cacheKey?: string;
-    configDir?: string;
-    configType?: string;
-    presets?: unknown;
-  } & Record<string, unknown>;
+  moduleFederationPlugin.ModuleFederationPluginOptions &
+    Record<string, unknown>;
 
-const getModuleFederationOptions = ({
-  cacheKey,
-  configDir,
-  configType,
-  presets,
-  ...moduleFederationOptions
-}: StorybookRsbuildOptions): moduleFederationPlugin.ModuleFederationPluginOptions => {
+// Storybook passes its full `Options` object (configDir, configType, presets,
+// presetsList, cache, features, packageJson, port, ...) as the second argument
+// to the `rsbuildFinal` hook. The enhanced `ModuleFederationPlugin` schema is
+// strict (`additionalProperties: false`) and rejects any unknown key, so we
+// must keep only valid Module Federation options and drop Storybook metadata.
+// An allowlist is used (rather than stripping known Storybook keys) so the
+// addon stays robust as Storybook adds new metadata fields.
+const MODULE_FEDERATION_OPTION_KEYS = [
+  'async',
+  'bridge',
+  'dev',
+  'dts',
+  'experiments',
+  'exposes',
+  'filename',
+  'getPublicPath',
+  'implementation',
+  'injectTreeShakingUsedExports',
+  'library',
+  'manifest',
+  'name',
+  'remoteType',
+  'remotes',
+  'runtime',
+  'runtimePlugins',
+  'shareScope',
+  'shareStrategy',
+  'shared',
+  'treeShakingDir',
+  'treeShakingSharedExcludePlugins',
+  'treeShakingSharedPlugins',
+  'virtualRuntimeEntry',
+] as const satisfies ReadonlyArray<
+  keyof moduleFederationPlugin.ModuleFederationPluginOptions
+>;
+
+const getModuleFederationOptions = (
+  options: StorybookRsbuildOptions,
+): moduleFederationPlugin.ModuleFederationPluginOptions => {
+  const moduleFederationOptions: moduleFederationPlugin.ModuleFederationPluginOptions =
+    {};
+
+  for (const key of MODULE_FEDERATION_OPTION_KEYS) {
+    if (options[key] !== undefined) {
+      (moduleFederationOptions as Record<string, unknown>)[key] = options[key];
+    }
+  }
+
   return moduleFederationOptions;
 };
 

--- a/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
+++ b/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
@@ -8,47 +8,22 @@ import { correctImportPath } from './correctImportPath.js';
 import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core';
 import type { moduleFederationPlugin } from '@module-federation/sdk';
 
-const moduleFederationOptionKeys = [
-  'async',
-  'bridge',
-  'dev',
-  'dts',
-  'experiments',
-  'exposes',
-  'filename',
-  'getPublicPath',
-  'implementation',
-  'injectTreeShakingUsedExports',
-  'library',
-  'manifest',
-  'name',
-  'remoteType',
-  'remotes',
-  'runtime',
-  'runtimePlugins',
-  'shareScope',
-  'shareStrategy',
-  'shared',
-  'treeShakingDir',
-  'treeShakingSharedExcludePlugins',
-  'treeShakingSharedPlugins',
-  'virtualRuntimeEntry',
-] as const satisfies readonly (keyof moduleFederationPlugin.ModuleFederationPluginOptions)[];
-
 type StorybookRsbuildOptions =
-  moduleFederationPlugin.ModuleFederationPluginOptions &
-    Record<string, unknown>;
+  moduleFederationPlugin.ModuleFederationPluginOptions & {
+    cacheKey?: string;
+    configDir?: string;
+    configType?: string;
+    presets?: unknown;
+  } & Record<string, unknown>;
 
-const getModuleFederationOptions = (
-  options: StorybookRsbuildOptions,
-): moduleFederationPlugin.ModuleFederationPluginOptions => {
-  return Object.fromEntries(
-    moduleFederationOptionKeys.flatMap((key) => {
-      const value = options[key];
-
-      return value === undefined ? [] : [[key, value]];
-    }),
-  ) as moduleFederationPlugin.ModuleFederationPluginOptions;
+const getModuleFederationOptions = ({
+  cacheKey,
+  configDir,
+  configType,
+  presets,
+  ...moduleFederationOptions
+}: StorybookRsbuildOptions): moduleFederationPlugin.ModuleFederationPluginOptions => {
+  return moduleFederationOptions;
 };
 
 const tempDirPath = path.resolve(process.cwd(), `node_modules/${TEMP_DIR}`);

--- a/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
+++ b/packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts
@@ -8,6 +8,49 @@ import { correctImportPath } from './correctImportPath.js';
 import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core';
 import type { moduleFederationPlugin } from '@module-federation/sdk';
 
+const moduleFederationOptionKeys = [
+  'async',
+  'bridge',
+  'dev',
+  'dts',
+  'experiments',
+  'exposes',
+  'filename',
+  'getPublicPath',
+  'implementation',
+  'injectTreeShakingUsedExports',
+  'library',
+  'manifest',
+  'name',
+  'remoteType',
+  'remotes',
+  'runtime',
+  'runtimePlugins',
+  'shareScope',
+  'shareStrategy',
+  'shared',
+  'treeShakingDir',
+  'treeShakingSharedExcludePlugins',
+  'treeShakingSharedPlugins',
+  'virtualRuntimeEntry',
+] as const satisfies readonly (keyof moduleFederationPlugin.ModuleFederationPluginOptions)[];
+
+type StorybookRsbuildOptions =
+  moduleFederationPlugin.ModuleFederationPluginOptions &
+    Record<string, unknown>;
+
+const getModuleFederationOptions = (
+  options: StorybookRsbuildOptions,
+): moduleFederationPlugin.ModuleFederationPluginOptions => {
+  return Object.fromEntries(
+    moduleFederationOptionKeys.flatMap((key) => {
+      const value = options[key];
+
+      return value === undefined ? [] : [[key, value]];
+    }),
+  ) as moduleFederationPlugin.ModuleFederationPluginOptions;
+};
+
 const tempDirPath = path.resolve(process.cwd(), `node_modules/${TEMP_DIR}`);
 export const PLUGIN_NAME = 'module-federation-storybook-addon';
 // add bootstrap for host project
@@ -32,6 +75,10 @@ export const withModuleFederation = (
   rsbuildConfig: RsbuildConfig,
   options: moduleFederationPlugin.ModuleFederationPluginOptions,
 ) => {
+  const moduleFederationOptions = getModuleFederationOptions(
+    options as StorybookRsbuildOptions,
+  );
+
   rsbuildConfig.plugins ??= [];
   rsbuildConfig.source ??= {};
   rsbuildConfig.source.entry ??= {};
@@ -60,8 +107,8 @@ export const withModuleFederation = (
       api.modifyBundlerChain(async (chain) => {
         chain.plugin(PLUGIN_NAME).use(ModuleFederationPlugin, [
           {
-            ...options,
-            name: options.name || PLUGIN_NAME,
+            ...moduleFederationOptions,
+            name: moduleFederationOptions.name || PLUGIN_NAME,
             shared: {
               react: {
                 singleton: true,
@@ -69,12 +116,12 @@ export const withModuleFederation = (
               'react-dom': {
                 singleton: true,
               },
-              ...options.shared,
+              ...moduleFederationOptions.shared,
             },
             remotes: {
-              ...options.remotes,
+              ...moduleFederationOptions.remotes,
             },
-            shareStrategy: options.shareStrategy,
+            shareStrategy: moduleFederationOptions.shareStrategy,
           },
         ]);
       });


### PR DESCRIPTION
## Summary
- Pass the full Rsbuild Module Federation options object through the Storybook addon preset instead of selecting only name/remotes/shared/shareStrategy.
- Preserve addon React singleton defaults while allowing advanced options such as dts.consumeTypes.remoteTypeUrls, manifest, and runtimePlugins to reach @module-federation/enhanced/rspack.
- Add a regression test for dts/manifest/runtimePlugins pass-through and a changeset for @module-federation/storybook-addon.

## Why
The previous #4767 fallback fix was too broad: manifest remotes should not automatically guess convention type URLs on manifest failures. The immediate Storybook addon bug is that its Rsbuild adapter discards the exact dts options users need to configure explicit type URLs.

Refs #4759.

## Validation
- pnpm --filter @module-federation/storybook-addon exec jest src/utils/with-module-federation-enhanced-rsbuild.spec.ts --config jest.config.ts --runInBand
- pnpm --filter @module-federation/storybook-addon run test
- pnpm --filter @module-federation/storybook-addon run build
- pnpm exec prettier --check packages/storybook-addon/preset.ts packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.ts packages/storybook-addon/src/utils/with-module-federation-enhanced-rsbuild.spec.ts .changeset/tough-storybook-options.md
- git diff --check

## Skipped checks
- Full workspace package build/test/lint: skipped because this PR only touches @module-federation/storybook-addon and its changeset; targeted package test/build plus pre-commit lint covered the changed package.
- dts-plugin tests: skipped because this PR intentionally does not change dts-plugin fallback behavior.