### PR TITLE
fix(enhanced): include duplicate shared fallback versions

### DIFF
--- a/.changeset/green-shared-fallbacks.md
+++ b/.changeset/green-shared-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/enhanced": patch
+---
+
+Fix shared tree-shaking fallback generation for duplicate package versions.

--- a/packages/enhanced/src/lib/sharing/tree-shaking/CollectSharedEntryPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/tree-shaking/CollectSharedEntryPlugin.ts
@@ -18,17 +18,74 @@ export type CollectSharedEntryPluginOptions = {
   shareScope?: string;
 };
 
+const NODE_MODULES = 'node_modules';
+const PNPM_STORE = '.pnpm';
+
+const getPackageNameFromRequest = (request: string): string => {
+  const parts = request.split('/').filter(Boolean);
+  if (!parts.length) {
+    return request;
+  }
+  if (parts[0].startsWith('@') && parts.length >= 2) {
+    return `${parts[0]}/${parts[1]}`;
+  }
+  return parts[0];
+};
+
+const getPackagePathParts = (packageName: string): string[] =>
+  packageName.split('/').filter(Boolean);
+
+const findNodeModulesDirs = (startContext: string): string[] => {
+  const dirs: string[] = [];
+  let current = path.resolve(startContext);
+  const root = path.parse(current).root;
+
+  while (true) {
+    const nodeModulesPath = path.join(current, NODE_MODULES);
+    if (fs.existsSync(nodeModulesPath)) {
+      dirs.push(nodeModulesPath);
+    }
+    if (current === root) {
+      break;
+    }
+    current = path.dirname(current);
+  }
+
+  return dirs;
+};
+
+const addShareRequest = (
+  collectedEntries: ShareRequestsMap,
+  sharedName: string,
+  request: string,
+  version: string,
+) => {
+  collectedEntries[sharedName] ||= { requests: [] };
+  const requests = collectedEntries[sharedName].requests;
+  if (
+    requests.some(
+      ([existingRequest, existingVersion]) =>
+        existingRequest === request && existingVersion === version,
+    )
+  ) {
+    return;
+  }
+  requests.push([request, version]);
+};
+
 function inferPkgVersionFromResource(resource: string): string | undefined {
   try {
-    const nmIndex = resource.lastIndexOf('node_modules');
+    const nmIndex = resource.lastIndexOf(NODE_MODULES);
     if (nmIndex === -1) {
       return undefined;
     }
-    const after = resource.substring(nmIndex + 'node_modules'.length + 1);
+    const after = resource.substring(nmIndex + NODE_MODULES.length + 1);
 
     // pnpm layout: node_modules/.pnpm/<encoded@version>/node_modules/<pkg>/...
-    if (after.startsWith('.pnpm/')) {
-      const m = after.match(/\.pnpm\/(?:[^/]+)@([^/]+)\/node_modules\//);
+    if (after.startsWith(`${PNPM_STORE}/`)) {
+      const m = after.match(
+        new RegExp(`\\${PNPM_STORE}/(?:[^/]+)@([^/]+)/${NODE_MODULES}/`),
+      );
       if (m && m[1]) {
         return m[1];
       }
@@ -44,7 +101,7 @@ function inferPkgVersionFromResource(resource: string): string | undefined {
     } else {
       pkgPathParts = [parts[0]];
     }
-    const nmBase = resource.substring(0, nmIndex + 'node_modules'.length + 1);
+    const nmBase = resource.substring(0, nmIndex + NODE_MODULES.length + 1);
     const pkgJsonPath = path.join(nmBase, ...pkgPathParts, 'package.json');
     try {
       const content = fs.readFileSync(pkgJsonPath, 'utf-8');
@@ -60,6 +117,99 @@ function inferPkgVersionFromResource(resource: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+const readPackageVersion = (packageJsonPath: string): string | undefined => {
+  try {
+    const content = fs.readFileSync(packageJsonPath, 'utf-8');
+    const pkg = JSON.parse(content);
+    return typeof pkg?.version === 'string' && pkg.version
+      ? pkg.version
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export function collectInstalledSharedPackageVersions(
+  context: string,
+  sharedOptions: NormalizedSharedOptions,
+): ShareRequestsMap {
+  const collectedEntries: ShareRequestsMap = {};
+
+  for (const [sharedName, sharedConfig] of sharedOptions) {
+    const importRequest =
+      typeof sharedConfig.import === 'string'
+        ? sharedConfig.import
+        : sharedConfig.packageName || sharedName;
+    const packageName = getPackageNameFromRequest(
+      sharedConfig.packageName || importRequest,
+    );
+    const packagePathParts = getPackagePathParts(packageName);
+
+    for (const nodeModulesPath of findNodeModulesDirs(context)) {
+      const directPackageJson = path.join(
+        nodeModulesPath,
+        ...packagePathParts,
+        'package.json',
+      );
+      const directVersion = readPackageVersion(directPackageJson);
+      if (directVersion) {
+        addShareRequest(
+          collectedEntries,
+          sharedName,
+          path.dirname(directPackageJson),
+          directVersion,
+        );
+      }
+
+      const pnpmStorePath = path.join(nodeModulesPath, PNPM_STORE);
+      if (!fs.existsSync(pnpmStorePath)) {
+        continue;
+      }
+
+      let storeEntries: string[];
+      try {
+        storeEntries = fs.readdirSync(pnpmStorePath);
+      } catch {
+        continue;
+      }
+
+      for (const storeEntry of storeEntries) {
+        const packageJsonPath = path.join(
+          pnpmStorePath,
+          storeEntry,
+          NODE_MODULES,
+          ...packagePathParts,
+          'package.json',
+        );
+        const version = readPackageVersion(packageJsonPath);
+        if (!version) {
+          continue;
+        }
+        addShareRequest(
+          collectedEntries,
+          sharedName,
+          path.dirname(packageJsonPath),
+          version,
+        );
+      }
+    }
+  }
+
+  return collectedEntries;
+}
+
+export function mergeShareRequestsMap(
+  target: ShareRequestsMap,
+  source: ShareRequestsMap,
+): ShareRequestsMap {
+  Object.entries(source).forEach(([sharedName, { requests }]) => {
+    requests.forEach(([request, version]) => {
+      addShareRequest(target, sharedName, request, version);
+    });
+  });
+  return target;
 }
 
 class CollectSharedEntryPlugin {
@@ -89,7 +239,7 @@ class CollectSharedEntryPlugin {
       (_compilation, { normalModuleFactory }) => {
         normalModuleFactory.hooks.module.tap(
           'CollectSharedEntryPlugin',
-          (module, { resource }, resolveData) => {
+          (module, { resource }) => {
             if (!resource || !('rawRequest' in module)) {
               return module;
             }
@@ -99,16 +249,17 @@ class CollectSharedEntryPlugin {
             if (!matchedSharedOption) {
               return module;
             }
-            const [sharedName, _] = matchedSharedOption;
+            const [sharedName] = matchedSharedOption;
             const sharedVersion = inferPkgVersionFromResource(resource);
             if (!sharedVersion) {
               return module;
             }
-            collectedEntries[sharedName] ||= { requests: [] };
-            collectedEntries[sharedName].requests.push([
+            addShareRequest(
+              collectedEntries,
+              sharedName,
               resource,
               sharedVersion,
-            ]);
+            );
             return module;
           },
         );

--- a/packages/enhanced/src/lib/sharing/tree-shaking/IndependentSharedPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/tree-shaking/IndependentSharedPlugin.ts
@@ -13,6 +13,8 @@ import {
   StatsFileName,
 } from '@module-federation/sdk';
 import CollectSharedEntryPlugin, {
+  collectInstalledSharedPackageVersions,
+  mergeShareRequestsMap,
   type ShareRequestsMap,
 } from './CollectSharedEntryPlugin';
 import SharedUsedExportsOptimizerPlugin from './SharedUsedExportsOptimizerPlugin';
@@ -240,13 +242,26 @@ export default class IndependentSharedPlugin {
 
     const shareRequestsMap: ShareRequestsMap =
       await this.createIndependentCompiler(parentCompiler);
+    mergeShareRequestsMap(
+      shareRequestsMap,
+      collectInstalledSharedPackageVersions(
+        parentCompiler.context,
+        sharedOptions,
+      ),
+    );
 
     await Promise.all(
       sharedOptions.map(async ([shareName, shareConfig]) => {
         if (!shareConfig.treeShaking) {
           return;
         }
-        const shareRequests = shareRequestsMap[shareName].requests;
+        const shareRequests = Array.from(
+          new Map(
+            (shareRequestsMap[shareName]?.requests || []).map(
+              ([request, version]) => [version, [request, version] as const],
+            ),
+          ).values(),
+        );
         await Promise.all(
           shareRequests.map(async ([request, version]) => {
             const sharedConfig = sharedOptions.find(
@@ -455,8 +470,9 @@ export default class IndependentSharedPlugin {
           return;
         }
 
-        shareRequestsMap &&
+        if (shareRequestsMap) {
           console.log(`Shared "${shareName}" compilation succeeded`);
+        }
 
         resolve(extraPlugin.getData());
       });

--- a/packages/enhanced/test/unit/sharing/tree-shaking/CollectSharedEntryPlugin.test.ts
+++ b/packages/enhanced/test/unit/sharing/tree-shaking/CollectSharedEntryPlugin.test.ts
@@ -1,0 +1,91 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  collectInstalledSharedPackageVersions,
+  mergeShareRequestsMap,
+} from '../../../../src/lib/sharing/tree-shaking/CollectSharedEntryPlugin';
+import type { NormalizedSharedOptions } from '../../../../src/lib/sharing/SharePlugin';
+
+const writePackageJson = (packageDir: string, version: string) => {
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageDir, 'package.json'),
+    JSON.stringify({ name: path.basename(packageDir), version }),
+  );
+};
+
+describe('CollectSharedEntryPlugin tree-shaking helpers', () => {
+  it('collects duplicate pnpm package versions for shared fallback generation', () => {
+    const context = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'mf-shared-versions-'),
+    );
+    try {
+      writePackageJson(
+        path.join(
+          context,
+          'node_modules',
+          '.pnpm',
+          'nanoid@3.3.11',
+          'node_modules',
+          'nanoid',
+        ),
+        '3.3.11',
+      );
+      writePackageJson(
+        path.join(
+          context,
+          'node_modules',
+          '.pnpm',
+          'nanoid@5.1.6',
+          'node_modules',
+          'nanoid',
+        ),
+        '5.1.6',
+      );
+
+      const sharedOptions: NormalizedSharedOptions = [
+        [
+          'nanoid',
+          { import: 'nanoid', treeShaking: { mode: 'runtime-infer' } },
+        ],
+      ];
+
+      const collected = collectInstalledSharedPackageVersions(
+        context,
+        sharedOptions,
+      );
+
+      expect(collected.nanoid.requests).toEqual(
+        expect.arrayContaining([
+          [expect.stringContaining('nanoid@3.3.11'), '3.3.11'],
+          [expect.stringContaining('nanoid@5.1.6'), '5.1.6'],
+        ]),
+      );
+    } finally {
+      fs.rmSync(context, { recursive: true, force: true });
+    }
+  });
+
+  it('deduplicates merged shared requests by request and version', () => {
+    const target = {
+      nanoid: {
+        requests: [['/node_modules/nanoid', '5.1.6'] as [string, string]],
+      },
+    };
+
+    mergeShareRequestsMap(target, {
+      nanoid: {
+        requests: [
+          ['/node_modules/nanoid', '5.1.6'],
+          ['/node_modules/.pnpm/nanoid@3.3.11/node_modules/nanoid', '3.3.11'],
+        ],
+      },
+    });
+
+    expect(target.nanoid.requests).toEqual([
+      ['/node_modules/nanoid', '5.1.6'],
+      ['/node_modules/.pnpm/nanoid@3.3.11/node_modules/nanoid', '3.3.11'],
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed

Fixes #4748.

Shared tree-shaking fallback generation now supplements the collected root shared package with all installed versions of that same package from `node_modules`, including pnpm's `.pnpm` store layout. Fallback generation then de-duplicates by version so duplicate installed versions can each get a matching fallback artifact.

## Why

When a remote used `nanoid@3.3.11` through a nested package while the root app had `nanoid@5.1.6`, the manifest could point to `3.3.11` but only a `5.1.6` fallback was emitted. Runtime then failed because the matching fallback was missing.

## Validation

- `pnpm exec prettier --check packages/enhanced/src/lib/sharing/tree-shaking/CollectSharedEntryPlugin.ts packages/enhanced/src/lib/sharing/tree-shaking/IndependentSharedPlugin.ts packages/enhanced/test/unit/sharing/tree-shaking/CollectSharedEntryPlugin.test.ts .changeset/green-shared-fallbacks.md`
- `pnpm --dir packages/enhanced exec rstest test/unit/sharing/tree-shaking/CollectSharedEntryPlugin.test.ts -c rstest.config.ts`
- `pnpm --filter @module-federation/enhanced run build`
- `python3.12 .codex/skills/changeset-pr/scripts/run_changeset_status.py --verbose`
- `git diff --check`

I also ran the package lint path through the commit hook. It passed with existing package warnings.