### PR TITLE
fix(bridge-vue3): handle RemoteApp keepalive lifecycle

### DIFF
--- a/.changeset/sweet-vue-keepalive.md
+++ b/.changeset/sweet-vue-keepalive.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/bridge-vue3": patch
+---
+
+Fix RemoteApp lifecycle handling when it is wrapped by Vue KeepAlive.

--- a/packages/bridge/vue3-bridge/__tests__/remoteApp.test.ts
+++ b/packages/bridge/vue3-bridge/__tests__/remoteApp.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp, defineComponent, h, KeepAlive, nextTick } from 'vue';
+import { createMemoryHistory, createRouter, RouterView } from 'vue-router';
+import RemoteApp from '../src/remoteApp';
+
+const { dispatchPopstateEnv } = vi.hoisted(() => ({
+  dispatchPopstateEnv: vi.fn(),
+}));
+
+vi.mock('@module-federation/bridge-shared', () => ({
+  dispatchPopstateEnv,
+}));
+
+vi.mock('@module-federation/runtime', () => ({
+  getInstance: () => ({
+    bridgeHook: {
+      lifecycle: {
+        beforeBridgeRender: { emit: vi.fn(async () => ({})) },
+        afterBridgeRender: { emit: vi.fn() },
+        beforeBridgeDestroy: { emit: vi.fn() },
+        afterBridgeDestroy: { emit: vi.fn() },
+      },
+    },
+  }),
+}));
+
+const flushBridgeRender = async () => {
+  await nextTick();
+  await Promise.resolve();
+  await nextTick();
+};
+
+describe('RemoteApp', () => {
+  let root: HTMLDivElement;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    document.body.appendChild(root);
+    dispatchPopstateEnv.mockClear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('destroys and re-renders the remote app when used under KeepAlive', async () => {
+    const providerReturn = {
+      render: vi.fn(),
+      destroy: vi.fn(),
+    };
+    const RemoteRoute = defineComponent({
+      setup() {
+        return () =>
+          h(RemoteApp, {
+            moduleName: 'ecApp',
+            basename: '/ec',
+            providerInfo: () => providerReturn,
+          });
+      },
+    });
+
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', component: { template: '<div>home</div>' } },
+        { path: '/ec/:pathMatch(.*)*', component: RemoteRoute },
+      ],
+    });
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(RouterView, null, {
+            default: ({ Component }) =>
+              h(KeepAlive, null, () => (Component ? h(Component) : null)),
+          });
+      },
+    });
+
+    const app = createApp(App);
+    app.use(router);
+
+    await router.push('/ec');
+    await router.isReady();
+    app.mount(root);
+    await flushBridgeRender();
+    expect(providerReturn.render).toHaveBeenCalledTimes(1);
+
+    await router.push('/');
+    await flushBridgeRender();
+    expect(providerReturn.destroy).toHaveBeenCalledTimes(1);
+
+    await router.push('/ec');
+    await flushBridgeRender();
+    expect(providerReturn.render).toHaveBeenCalledTimes(2);
+
+    app.unmount();
+  });
+});

--- a/packages/bridge/vue3-bridge/src/remoteApp.tsx
+++ b/packages/bridge/vue3-bridge/src/remoteApp.tsx
@@ -2,9 +2,12 @@ import {
   ref,
   onMounted,
   onBeforeUnmount,
+  onActivated,
+  onDeactivated,
   watch,
   defineComponent,
   useAttrs,
+  nextTick,
 } from 'vue';
 import { dispatchPopstateEnv } from '@module-federation/bridge-shared';
 import { useRoute } from 'vue-router';
@@ -26,11 +29,25 @@ export default defineComponent({
     const rootRef = ref(null);
     const providerInfoRef = ref(null);
     const pathname = ref('');
+    const isRendered = ref(false);
+    const isActive = ref(false);
+    const wasDeactivated = ref(false);
     const route = useRoute();
     const hostInstance = getInstance();
     const componentAttrs = useAttrs();
 
+    const getBridgeRenderProps = () => ({
+      name: props.moduleName,
+      dom: rootRef.value,
+      basename: props.basename,
+      memoryRoute: props.memoryRoute,
+      hashRoute: props.hashRoute,
+    });
+
     const renderComponent = async () => {
+      if (!rootRef.value || isRendered.value) {
+        return;
+      }
       const providerReturn = props.providerInfo?.();
       providerInfoRef.value = providerReturn;
 
@@ -54,18 +71,45 @@ export default defineComponent({
 
       renderProps = { ...renderProps, ...beforeBridgeRenderRes.extraProps };
       providerReturn.render(renderProps);
+      isRendered.value = true;
       hostInstance?.bridgeHook?.lifecycle?.afterBridgeRender?.emit(renderProps);
+    };
+
+    const destroyComponent = () => {
+      const providerReturn = providerInfoRef.value as any;
+      if (!providerReturn || !isRendered.value) {
+        return;
+      }
+      LoggerInstance.debug(
+        `createRemoteAppComponent LazyComponent destroy >>>`,
+        {
+          ...props,
+        },
+      );
+
+      const bridgeRenderProps = getBridgeRenderProps();
+      hostInstance?.bridgeHook?.lifecycle?.beforeBridgeDestroy?.emit(
+        bridgeRenderProps,
+      );
+
+      providerReturn.destroy({ dom: rootRef.value });
+      providerInfoRef.value = null;
+      isRendered.value = false;
+
+      hostInstance?.bridgeHook?.lifecycle?.afterBridgeDestroy?.emit(
+        bridgeRenderProps,
+      );
     };
 
     const watchStopHandle = watch(
       () => route?.path,
       (newPath) => {
-        if (newPath !== route.path) {
-          renderComponent();
-        }
-
         // dispatchPopstateEnv
-        if (pathname.value !== '' && pathname.value !== newPath) {
+        if (
+          isActive.value &&
+          pathname.value !== '' &&
+          pathname.value !== newPath
+        ) {
           LoggerInstance.debug(
             `createRemoteAppComponent dispatchPopstateEnv >>>`,
             {
@@ -80,34 +124,29 @@ export default defineComponent({
     );
 
     onMounted(() => {
+      isActive.value = true;
       renderComponent();
     });
 
+    onActivated(async () => {
+      isActive.value = true;
+      if (!wasDeactivated.value) {
+        return;
+      }
+      wasDeactivated.value = false;
+      await nextTick();
+      renderComponent();
+    });
+
+    onDeactivated(() => {
+      isActive.value = false;
+      wasDeactivated.value = true;
+      destroyComponent();
+    });
+
     onBeforeUnmount(() => {
-      LoggerInstance.debug(
-        `createRemoteAppComponent LazyComponent destroy >>>`,
-        {
-          ...props,
-        },
-      );
       watchStopHandle();
-
-      hostInstance?.bridgeHook?.lifecycle?.beforeBridgeDestroy?.emit({
-        name: props.moduleName,
-        dom: rootRef.value,
-        basename: props.basename,
-        memoryRoute: props.memoryRoute,
-        hashRoute: props.hashRoute,
-      });
-
-      (providerInfoRef.value as any)?.destroy({ dom: rootRef.value });
-      hostInstance?.bridgeHook?.lifecycle?.afterBridgeDestroy?.emit({
-        name: props.moduleName,
-        dom: rootRef.value,
-        basename: props.basename,
-        memoryRoute: props.memoryRoute,
-        hashRoute: props.hashRoute,
-      });
+      destroyComponent();
     });
 
     return () => <div {...(props.rootAttrs || {})} ref={rootRef}></div>;

--- a/packages/bridge/vue3-bridge/vitest.config.ts
+++ b/packages/bridge/vue3-bridge/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vitest/config';
 import { resolve } from 'path';
+import vueJsx from '@vitejs/plugin-vue-jsx';
 
 export default defineConfig({
+  plugins: [vueJsx()],
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## What changed

Fixes #4574.

`RemoteApp` now handles Vue `KeepAlive` activation and deactivation. When the host route deactivates the remote app, the bridge destroys the remote instance; when Vue activates it again, the bridge renders a fresh remote instance into the restored DOM.

## Why

With `KeepAlive`, Vue does not unmount and remount the component during route switches. The previous bridge only handled mount and unmount, leaving the remote router instance alive across host route deactivation and allowing stale route state to corrupt later browser-back navigation.

## Validation

- `pnpm exec prettier --check packages/bridge/vue3-bridge/src/remoteApp.tsx packages/bridge/vue3-bridge/__tests__/remoteApp.test.ts packages/bridge/vue3-bridge/vitest.config.ts .changeset/sweet-vue-keepalive.md`
- `pnpm --filter @module-federation/bridge-vue3 exec vitest run __tests__/remoteApp.test.ts --config vitest.config.ts`
- `pnpm --filter @module-federation/bridge-vue3 exec vitest run --config vitest.config.ts`
- `pnpm --filter @module-federation/bridge-vue3 run build`
- `python3.12 .codex/skills/changeset-pr/scripts/run_changeset_status.py --verbose`
- `git diff --check`