### PR TITLE
fix(bridge-react): keep host fallback outside remote root

### DIFF
--- a/.changeset/clean-react-fallback.md
+++ b/.changeset/clean-react-fallback.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/bridge-react": patch
+---
+
+Keep host fallback components out of the remote React root.

--- a/packages/bridge/bridge-react/__tests__/bridge.spec.tsx
+++ b/packages/bridge/bridge-react/__tests__/bridge.spec.tsx
@@ -55,6 +55,41 @@ describe('bridge', () => {
     );
   });
 
+  it('does not render host fallback inside the remote root', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const HostFallback = jest.fn(() => <div>host fallback</div>);
+    function BrokenComponent() {
+      throw new Error('remote render failed');
+    }
+    const lifeCycle = createBridgeComponent({
+      rootComponent: BrokenComponent,
+    })();
+
+    lifeCycle.render({
+      dom: containerInfo?.container,
+      fallback: HostFallback,
+    });
+
+    await waitFor(
+      () => {
+        expect(getHtml(containerInfo.container)).toMatch(
+          'Something went wrong',
+        );
+        expect(getHtml(containerInfo.container)).not.toMatch('host fallback');
+      },
+      { timeout: 2000 },
+    );
+    expect(HostFallback).not.toHaveBeenCalled();
+
+    lifeCycle.destroy({
+      dom: containerInfo?.container,
+      moduleName: 'test',
+    });
+    consoleError.mockRestore();
+  });
+
   it('createRemoteAppComponent', async () => {
     function Component({ props }: { props?: Record<string, any> }) {
       return <div>life cycle render {props?.msg}</div>;

--- a/packages/bridge/bridge-react/src/provider/versions/bridge-base.tsx
+++ b/packages/bridge/bridge-react/src/provider/versions/bridge-base.tsx
@@ -53,20 +53,24 @@ export function createBaseBridgeComponent<T>({
     const ErrorBoundaryComponent =
       ErrorBoundary as unknown as React.ComponentType<any>;
 
+    const omitHostFallback = <P extends Record<string, unknown>>(props: P) => {
+      const nextProps = { ...props };
+      delete nextProps.fallback;
+      return nextProps;
+    };
+
     const BridgeWrapper = ({
       basename,
       moduleName,
       memoryRoute,
       propsInfo,
-      fallback,
     }: {
       basename?: string;
       moduleName?: string;
       memoryRoute?: any;
       propsInfo: T;
-      fallback?: React.ComponentType<FallbackProps>;
     }) => (
-      <ErrorBoundaryComponent FallbackComponent={fallback || DefaultFallback}>
+      <ErrorBoundaryComponent FallbackComponent={DefaultFallback}>
         <RawComponent
           appInfo={{
             moduleName,
@@ -86,7 +90,6 @@ export function createBaseBridgeComponent<T>({
           dom,
           basename,
           memoryRoute,
-          fallback,
           rootOptions,
           ...propsInfo
         } = info;
@@ -104,10 +107,9 @@ export function createBaseBridgeComponent<T>({
             basename={basename}
             moduleName={moduleName}
             memoryRoute={memoryRoute}
-            fallback={fallback as React.ComponentType<FallbackProps>}
             propsInfo={
               {
-                ...propsInfo,
+                ...omitHostFallback(propsInfo as Record<string, unknown>),
                 basename,
                 ...(beforeBridgeRenderRes as any)?.extraProps,
               } as T


### PR DESCRIPTION
## What changed

Fixes #4588.

The remote React bridge no longer renders the host-provided fallback component inside the remote React root. The remote root now uses its own default fallback boundary, while the host fallback remains available on the host-side boundary created by `createRemoteAppComponent`.

## Why

When host and remote use different React versions, rendering a host fallback component with hooks inside the remote React root can trigger invalid hook calls. Keeping the host fallback on the host side avoids crossing React instances.

## Validation

- `pnpm exec prettier --check packages/bridge/bridge-react/src/provider/versions/bridge-base.tsx packages/bridge/bridge-react/__tests__/bridge.spec.tsx .changeset/clean-react-fallback.md`
- `pnpm --filter @module-federation/bridge-react exec jest --config jest.config.ts __tests__/bridge.spec.tsx --runInBand`
- `pnpm --dir packages/bridge/bridge-react exec jest --config jest.config.ts --runInBand`
- `pnpm --filter @module-federation/bridge-react run build`
- `python3.12 .codex/skills/changeset-pr/scripts/run_changeset_status.py --verbose`
- `git diff --check`

The first full package test command was malformed and found no tests; I reran Jest directly from the package directory and all tests passed.