### PR TITLE
fix(dts-plugin): normalize manifest type URLs on Windows

### DIFF
--- a/.changeset/warm-dts-windows-paths.md
+++ b/.changeset/warm-dts-windows-paths.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/dts-plugin': patch
+'@module-federation/sdk': patch
+---
+
+Fix Windows manifest type URL resolution in dts-plugin consumeTypes and allow the default IP family option to auto-select with `0`.

--- a/apps/website-new/docs/en/configure/dts.mdx
+++ b/apps/website-new/docs/en/configure/dts.mdx
@@ -223,7 +223,7 @@ interface DtsHostOptions {
   deleteTypesFolder?: boolean;
   maxRetries?: number;
   consumeAPITypes?: boolean;
-  family?: 4 | 6;
+  family?: 0 | 4 | 6;
 }
 ```
 
@@ -356,9 +356,9 @@ export default createModuleFederationConfig({
 
 #### family
 
-- Type: `4 | 6`
+- Type: `0 | 4 | 6`
 - Required: No
-- Default value: 4
+- Default value: 0
 
 Configure the IP version family that will be used for network operations.
 

--- a/apps/website-new/docs/zh/configure/dts.mdx
+++ b/apps/website-new/docs/zh/configure/dts.mdx
@@ -353,9 +353,9 @@ export default createModuleFederationConfig({
 ```
 #### family
 
-- Type: `4 | 6`
+- Type: `0 | 4 | 6`
 - Required: No
-- Default value: 4
+- Default value: 0
 
 配置 ip 版本，用于加载生产者类型文件。
 

--- a/packages/dts-plugin/src/core/configurations/hostPlugin.test.ts
+++ b/packages/dts-plugin/src/core/configurations/hostPlugin.test.ts
@@ -43,7 +43,7 @@ describe('hostPlugin', () => {
           runtimePkgs: [],
           remoteTypeUrls: {},
           timeout: 60000,
-          family: 4,
+          family: 0,
           typesOnBuild: false,
         });
 
@@ -102,6 +102,17 @@ describe('hostPlugin', () => {
             'moduleFederationTypescript',
           ),
         ).toStrictEqual(destinationPath);
+      });
+
+      it('preserves an explicit IPv6 family override', () => {
+        const options = {
+          moduleFederationConfig,
+          family: 6 as const,
+        };
+
+        const { hostOptions } = retrieveHostConfig(options);
+
+        expect(hostOptions.family).toBe(6);
       });
     });
 

--- a/packages/dts-plugin/src/core/configurations/hostPlugin.ts
+++ b/packages/dts-plugin/src/core/configurations/hostPlugin.ts
@@ -21,7 +21,7 @@ const defaultOptions = {
   remoteTypeUrls: {},
   timeout: 60000,
   typesOnBuild: false,
-  family: 4,
+  family: 0,
 } satisfies Partial<HostOptions>;
 
 const buildZipUrl = (hostOptions: Required<HostOptions>, url: string) => {

--- a/packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts
@@ -160,6 +160,46 @@ describe('DTSManager General Tests', () => {
       expect(result.zipUrl).toContain('http://example.com/types.zip');
     });
 
+    it('should preserve manifest type URLs under Windows path semantics', async () => {
+      const manifestResponse = {
+        data: {
+          metaData: {
+            types: {
+              zip: '@mf-types.zip',
+              api: '@mf-types.d.ts',
+            },
+            publicPath: 'http://localhost:8090',
+          },
+        },
+      };
+
+      vi.spyOn(utils, 'nativeFetch').mockResolvedValueOnce({
+        data: manifestResponse.data,
+        status: 200,
+        headers: {},
+      } as any);
+
+      const remoteInfo: RemoteInfo = {
+        name: 'test',
+        url: 'http://localhost:8090/mf-manifest.json',
+        alias: 'test-alias',
+      };
+
+      const joinSpy = vi
+        .spyOn(path, 'join')
+        .mockImplementation(path.win32.join as typeof path.join);
+
+      try {
+        // @ts-expect-error only need timeout, which is not required
+        const result = await dtsManager.requestRemoteManifest(remoteInfo, {});
+
+        expect(result.zipUrl).toBe('http://localhost:8090/@mf-types.zip');
+        expect(result.apiTypeUrl).toBe('http://localhost:8090/@mf-types.d.ts');
+      } finally {
+        joinSpy.mockRestore();
+      }
+    });
+
     it('should handle manifest URLs without API types', async () => {
       const manifestResponse = {
         data: {

--- a/packages/dts-plugin/src/core/lib/DTSManager.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.ts
@@ -255,8 +255,13 @@ class DTSManager {
         publicPath = inferAutoPublicPath(remoteInfo.url);
       }
 
+      const normalizedPublicPath = addProtocol(publicPath).endsWith('/')
+        ? addProtocol(publicPath)
+        : `${addProtocol(publicPath)}/`;
+
       remoteInfo.zipUrl = new URL(
-        path.join(addProtocol(publicPath), manifestJson.metaData.types.zip),
+        manifestJson.metaData.types.zip,
+        normalizedPublicPath,
       ).href;
       if (!manifestJson.metaData.types.api) {
         console.warn(`Can not get ${remoteInfo.name}'s api types url!`);
@@ -264,7 +269,8 @@ class DTSManager {
         return remoteInfo as Required<RemoteInfo>;
       }
       remoteInfo.apiTypeUrl = new URL(
-        path.join(addProtocol(publicPath), manifestJson.metaData.types.api),
+        manifestJson.metaData.types.api,
+        normalizedPublicPath,
       ).href;
       return remoteInfo as Required<RemoteInfo>;
     } catch (_err) {

--- a/packages/dts-plugin/src/core/lib/utils.ts
+++ b/packages/dts-plugin/src/core/lib/utils.ts
@@ -166,7 +166,7 @@ const getEnvHeaders = (): Record<string, string> => {
 
 export type FetchRequestConfig = {
   timeout?: number;
-  family?: 4 | 6;
+  family?: 0 | 4 | 6;
   headers?: Record<string, string>;
   responseType?: 'arraybuffer';
   /**
@@ -181,7 +181,7 @@ export type FetchRequestConfig = {
   agent?: unknown;
 };
 
-const createDispatcherFromFamily = (family?: 4 | 6): DispatcherLike => {
+const createDispatcherFromFamily = (family?: 0 | 4 | 6): DispatcherLike => {
   if (!family) return undefined;
   if (dispatcherCache.has(family)) return dispatcherCache.get(family);
   try {

--- a/packages/enhanced/src/schemas/container/ModuleFederationPlugin.check.ts
+++ b/packages/enhanced/src/schemas/container/ModuleFederationPlugin.check.ts
@@ -444,7 +444,7 @@ const t = {
                         ],
                       },
                       timeout: { type: 'number' },
-                      family: { enum: [4, 6] },
+                      family: { enum: [0, 4, 6] },
                       typesOnBuild: { type: 'boolean' },
                     },
                   },
@@ -4361,6 +4361,8 @@ function D(
                                                                             const n =
                                                                               c;
                                                                             if (
+                                                                              0 !==
+                                                                                e &&
                                                                               4 !==
                                                                                 e &&
                                                                               6 !==

--- a/packages/enhanced/src/schemas/container/ModuleFederationPlugin.ts
+++ b/packages/enhanced/src/schemas/container/ModuleFederationPlugin.ts
@@ -936,7 +936,7 @@ export default {
                       type: 'number',
                     },
                     family: {
-                      enum: [4, 6],
+                      enum: [0, 4, 6],
                     },
                     typesOnBuild: {
                       type: 'boolean',

--- a/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
+++ b/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
@@ -382,7 +382,7 @@ export interface DtsHostOptions {
   remoteTypeUrls?: (() => Promise<RemoteTypeUrls>) | RemoteTypeUrls;
   timeout?: number;
   /** The family of IP, used for network requests */
-  family?: 4 | 6;
+  family?: 0 | 4 | 6;
   typesOnBuild?: boolean;
 }
 


### PR DESCRIPTION
## Summary

This PR fixes two independent Windows bugs that together caused `dts-plugin` to fail downloading type archives from `localhost`:

### Bug 1: Windows backslashes corrupting HTTP URLs

`DTSManager.requestRemoteManifest()` used `path.join(publicPath, manifestJson.metaData.types.zip)` to construct the ZIP/API download URLs. On Windows, `path.join` uses backslashes (`\`), which corrupts HTTP URLs:

```
path.win32.join('http://localhost:4173/', '@mf-types.zip')
// => 'http:\localhost:4173\@mf-types.zip'
```

Passing this to `new URL()` throws `Invalid URL`.

**Fix:** Use `new URL(relativePath, normalizedBaseUrl).href` instead. This correctly preserves forward slashes in URLs regardless of the host OS.

### Bug 2: IPv4-only forcing breaks Windows localhost connections

The `dts-plugin` defaulted `family: 4`, which forces undici's `fetch()` to use IPv4 only. On Windows, `localhost` resolves to `::1` (IPv6) by default, while Vite's dev server binds to `::1:4173`. The client then tries to connect to `127.0.0.1:4173` (IPv4) and gets `ECONNREFUSED` because the server is not listening on the IPv4 loopback.

**Fix:** Change the default `family` from `4` to `0` (auto-select). With `family: 0`, `createDispatcherFromFamily()` returns `undefined` (no custom Agent), so `fetch()` uses the OS resolver's default behavior — connecting to whichever address the hostname actually resolves to (IPv4, IPv6, or both).

This matches Node.js's own DNS default (`family: 0`) and the behavior of most HTTP clients.

### Type/schema alignment

- SDK types: `family?: 4 | 6` → `family?: 0 | 4 | 6`
- Enhanced runtime schema: `enum: [4, 6]` → `enum: [0, 4, 6]`
- English and Chinese docs updated to document `0` as the default

## Test Plan

- `pnpm --filter @module-federation/dts-plugin exec vitest run src/core/lib/DTSManager.general.spec.ts src/core/configurations/hostPlugin.test.ts --config vite.config.mts`
- `pnpm --filter @module-federation/dts-plugin run build`
- `pnpm --filter @module-federation/sdk run build`
- `pnpm --filter @module-federation/enhanced run build`
- `pnpm exec prettier --check apps/website-new/docs/en/configure/dts.mdx apps/website-new/docs/zh/configure/dts.mdx packages/dts-plugin/src/core/configurations/hostPlugin.test.ts packages/dts-plugin/src/core/configurations/hostPlugin.ts packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts packages/dts-plugin/src/core/lib/DTSManager.ts packages/dts-plugin/src/core/lib/utils.ts packages/sdk/src/types/plugins/ModuleFederationPlugin.ts .changeset/warm-dts-windows-paths.md`
- `git diff --check`

## Known Validation Gap

- `pnpm --filter @module-federation/dts-plugin run test` still fails in pre-existing unrelated `typeScriptCompiler.test.ts` / `DtsWorker.spec.ts` TYPE-001 cases (118 passed, 9 failed locally)

Closes #4415
