### PR TITLE
fix(dts-plugin): handle Windows localhost type URLs

### DIFF
--- a/.changeset/silver-dts-urls.md
+++ b/.changeset/silver-dts-urls.md
@@ -1,0 +1,6 @@
+---
+"@module-federation/dts-plugin": patch
+"@module-federation/sdk": patch
+---
+
+Fix manifest type URL resolution on Windows.

--- a/apps/website-new/docs/en/configure/dts.mdx
+++ b/apps/website-new/docs/en/configure/dts.mdx
@@ -223,7 +223,7 @@ interface DtsHostOptions {
   deleteTypesFolder?: boolean;
   maxRetries?: number;
   consumeAPITypes?: boolean;
-  family?: 4 | 6;
+  family?: 0 | 4 | 6;
 }
 ```
 
@@ -356,9 +356,9 @@ export default createModuleFederationConfig({
 
 #### family
 
-- Type: `4 | 6`
+- Type: `0 | 4 | 6`
 - Required: No
-- Default value: 4
+- Default value: 0
 
 Configure the IP version family that will be used for network operations.
 

--- a/apps/website-new/docs/zh/configure/dts.mdx
+++ b/apps/website-new/docs/zh/configure/dts.mdx
@@ -353,9 +353,9 @@ export default createModuleFederationConfig({
 ```
 #### family
 
-- Type: `4 | 6`
+- Type: `0 | 4 | 6`
 - Required: No
-- Default value: 4
+- Default value: 0
 
 配置 ip 版本，用于加载生产者类型文件。
 

--- a/packages/dts-plugin/src/core/configurations/hostPlugin.test.ts
+++ b/packages/dts-plugin/src/core/configurations/hostPlugin.test.ts
@@ -43,7 +43,7 @@ describe('hostPlugin', () => {
           runtimePkgs: [],
           remoteTypeUrls: {},
           timeout: 60000,
-          family: 4,
+          family: 0,
           typesOnBuild: false,
         });
 
@@ -72,7 +72,7 @@ describe('hostPlugin', () => {
           runtimePkgs: [],
           remoteTypeUrls: {},
           timeout: 60000,
-          family: 4,
+          family: 0,
           typesOnBuild: false,
         };
 

--- a/packages/dts-plugin/src/core/configurations/hostPlugin.ts
+++ b/packages/dts-plugin/src/core/configurations/hostPlugin.ts
@@ -21,7 +21,7 @@ const defaultOptions = {
   remoteTypeUrls: {},
   timeout: 60000,
   typesOnBuild: false,
-  family: 4,
+  family: 0,
 } satisfies Partial<HostOptions>;
 
 const buildZipUrl = (hostOptions: Required<HostOptions>, url: string) => {

--- a/packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts
@@ -236,6 +236,37 @@ describe('DTSManager General Tests', () => {
       expect(result.zipUrl).toContain('http://example.com/custom/types.zip');
       expect(result.apiTypeUrl).toContain('http://example.com/custom/api.d.ts');
     });
+
+    it('should join manifest type URLs without using platform paths', async () => {
+      const manifestResponse = {
+        data: {
+          metaData: {
+            types: {
+              zip: '@mf-types.zip',
+              api: '@mf-types.d.ts',
+            },
+            publicPath: 'http://localhost:8090/',
+          },
+        },
+      };
+
+      vi.spyOn(utils, 'nativeFetch').mockResolvedValueOnce({
+        data: manifestResponse.data,
+        status: 200,
+        headers: {},
+      } as any);
+
+      const remoteInfo: RemoteInfo = {
+        name: 'test',
+        url: 'http://localhost:8090/mf-manifest.json',
+        alias: 'test-alias',
+      };
+
+      // @ts-expect-error only need timeout, which is not required
+      const result = await dtsManager.requestRemoteManifest(remoteInfo, {});
+      expect(result.zipUrl).toBe('http://localhost:8090/@mf-types.zip');
+      expect(result.apiTypeUrl).toBe('http://localhost:8090/@mf-types.d.ts');
+    });
   });
 
   describe('consumeTargetRemotes', () => {

--- a/packages/dts-plugin/src/core/lib/DTSManager.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.ts
@@ -40,6 +40,24 @@ interface UpdateTypesOptions {
   once?: boolean;
 }
 
+const addProtocol = (url: string): string => {
+  if (url.startsWith('//')) {
+    return `https:${url}`;
+  }
+  return url;
+};
+
+const joinUrl = (baseUrl: string, filePath: string): string => {
+  const normalizedFilePath = addProtocol(filePath);
+  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(normalizedFilePath)) {
+    return new URL(normalizedFilePath).href;
+  }
+
+  const normalizedBaseUrl = addProtocol(baseUrl).replace(/\/?$/, '/');
+  return new URL(normalizedFilePath.replace(/^\/+/, ''), normalizedBaseUrl)
+    .href;
+};
+
 class DTSManager {
   options: DTSManagerOptions;
   runtimePkgs: string[];
@@ -230,13 +248,6 @@ class DTSManager {
       if (!manifestJson.metaData.types.zip) {
         throw new Error(`Can not get ${remoteInfo.name}'s types archive url!`);
       }
-      const addProtocol = (u: string): string => {
-        if (u.startsWith('//')) {
-          return `https:${u}`;
-        }
-        return u;
-      };
-
       let publicPath;
 
       if ('publicPath' in manifestJson.metaData) {
@@ -255,17 +266,16 @@ class DTSManager {
         publicPath = inferAutoPublicPath(remoteInfo.url);
       }
 
-      remoteInfo.zipUrl = new URL(
-        path.join(addProtocol(publicPath), manifestJson.metaData.types.zip),
-      ).href;
+      remoteInfo.zipUrl = joinUrl(publicPath, manifestJson.metaData.types.zip);
       if (!manifestJson.metaData.types.api) {
         console.warn(`Can not get ${remoteInfo.name}'s api types url!`);
         remoteInfo.apiTypeUrl = '';
         return remoteInfo as Required<RemoteInfo>;
       }
-      remoteInfo.apiTypeUrl = new URL(
-        path.join(addProtocol(publicPath), manifestJson.metaData.types.api),
-      ).href;
+      remoteInfo.apiTypeUrl = joinUrl(
+        publicPath,
+        manifestJson.metaData.types.api,
+      );
       return remoteInfo as Required<RemoteInfo>;
     } catch (_err) {
       fileLog(

--- a/packages/dts-plugin/src/core/lib/utils.ts
+++ b/packages/dts-plugin/src/core/lib/utils.ts
@@ -166,7 +166,7 @@ const getEnvHeaders = (): Record<string, string> => {
 
 export type FetchRequestConfig = {
   timeout?: number;
-  family?: 4 | 6;
+  family?: 0 | 4 | 6;
   headers?: Record<string, string>;
   responseType?: 'arraybuffer';
   /**
@@ -181,7 +181,7 @@ export type FetchRequestConfig = {
   agent?: unknown;
 };
 
-const createDispatcherFromFamily = (family?: 4 | 6): DispatcherLike => {
+const createDispatcherFromFamily = (family?: 0 | 4 | 6): DispatcherLike => {
   if (!family) return undefined;
   if (dispatcherCache.has(family)) return dispatcherCache.get(family);
   try {

--- a/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
+++ b/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
@@ -382,7 +382,7 @@ export interface DtsHostOptions {
   remoteTypeUrls?: (() => Promise<RemoteTypeUrls>) | RemoteTypeUrls;
   timeout?: number;
   /** The family of IP, used for network requests */
-  family?: 4 | 6;
+  family?: 0 | 4 | 6;
   typesOnBuild?: boolean;
 }
 


### PR DESCRIPTION
## What changed

Fixes #4415.

This updates the DTS plugin so localhost type requests are no longer forced to IPv4 by default, and manifest-provided type URLs are joined as URLs instead of filesystem paths. The docs and public option type were updated to match.

## Why

On Windows, path-style joining could turn manifest type URLs into invalid backslash paths. The default IP family also made localhost resolution more brittle than necessary.

## Validation

- `pnpm exec prettier --check packages/dts-plugin/src/core/lib/DTSManager.ts packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts packages/dts-plugin/src/core/configurations/hostPlugin.ts packages/dts-plugin/src/core/configurations/hostPlugin.test.ts packages/dts-plugin/src/core/lib/utils.ts packages/sdk/src/types/plugins/ModuleFederationPlugin.ts apps/website-new/docs/en/configure/dts.mdx apps/website-new/docs/zh/configure/dts.mdx .changeset/silver-dts-urls.md`
- `pnpm --filter @module-federation/dts-plugin exec vitest run src/core/lib/DTSManager.general.spec.ts src/core/configurations/hostPlugin.test.ts --config vite.config.mts`
- `pnpm --filter @module-federation/dts-plugin run build`
- `pnpm --filter @module-federation/sdk run build`
- `python3.12 .codex/skills/changeset-pr/scripts/run_changeset_status.py --verbose`
- `git diff --check`

Builds completed successfully. The package builds still print existing warning output from dependency declaration files, but exit successfully.