### PR TITLE
docs(bridge-react): fix loading option example

### DIFF
--- a/apps/website-new/docs/en/guide/bridge/react/load-app.mdx
+++ b/apps/website-new/docs/en/guide/bridge/react/load-app.mdx
@@ -88,7 +88,7 @@ import { LoadingComponent, ErrorFallback } from '../components/RemoteComponents'
 
 export const Remote1App = createRemoteAppComponent({
   loader: () => loadRemote('remote1/export-app'),
-  loading: LoadingComponent,
+  loading: <LoadingComponent />,
   fallback: ErrorFallback,
 });
 ```

--- a/apps/website-new/docs/zh/guide/bridge/react/load-app.mdx
+++ b/apps/website-new/docs/zh/guide/bridge/react/load-app.mdx
@@ -98,7 +98,7 @@ import { LoadingComponent, ErrorFallback } from '../components/RemoteComponents'
 
 export const Remote1App = createRemoteAppComponent({
   loader: () => loadRemote('remote1/export-app'),
-  loading: LoadingComponent,
+  loading: <LoadingComponent />,
   fallback: ErrorFallback,
 });
 ```


### PR DESCRIPTION
## What changed

Fixes #4599.

The React bridge docs now pass the `loading` option as a rendered element instead of a component function in both English and Chinese docs.

## Why

The documented API expects a React node, so the previous example could lead users to copy an invalid shape.

## Validation

- `pnpm exec prettier --check apps/website-new/docs/en/guide/bridge/react/load-app.mdx apps/website-new/docs/zh/guide/bridge/react/load-app.mdx`
- `git diff --check`

No package build was run because this PR only changes docs examples.