### PR TITLE
chore(dts-plugin): drop `isomorphic-ws` and use `ws` directly

### DIFF
--- a/.changeset/drop-isomorphic-ws-dts-plugin.md
+++ b/.changeset/drop-isomorphic-ws-dts-plugin.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+chore(dts-plugin): drop `isomorphic-ws` and use `ws` directly. All call sites are Node-only (broker server, dev WebSocket client), so the cross-environment wrapper added no value. `Publisher.ts` only used `WebSocket` as a type, so its `ws` import is now `import type`.

--- a/packages/dts-plugin/package.json
+++ b/packages/dts-plugin/package.json
@@ -71,7 +71,6 @@
     "@module-federation/third-party-dts-extractor": "workspace:*",
     "adm-zip": "0.5.10",
     "ansi-colors": "4.1.3",
-    "isomorphic-ws": "5.0.0",
     "undici": "7.24.7",
     "node-schedule": "2.1.1",
     "ws": "8.21.0"

--- a/packages/dts-plugin/src/server/DevServer.ts
+++ b/packages/dts-plugin/src/server/DevServer.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'isomorphic-ws';
+import WebSocket from 'ws';
 import { UpdateMode } from './constant';
 import { Broker } from './broker/Broker';
 import { fib, getIdentifier, getIPV4, fileLog } from './utils';

--- a/packages/dts-plugin/src/server/Publisher.ts
+++ b/packages/dts-plugin/src/server/Publisher.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'ws';
+import type WebSocket from 'ws';
 import {
   FetchTypesAPI,
   FetchTypesAPIPayload,

--- a/packages/dts-plugin/src/server/WebClient.ts
+++ b/packages/dts-plugin/src/server/WebClient.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'isomorphic-ws';
+import type WebSocket from 'ws';
 import { DEFAULT_WEB_SOCKET_PORT } from './constant';
 import { Message } from './message/Message';
 import { AddWebClientAction } from './message/Action';

--- a/packages/dts-plugin/src/server/broker/Broker.ts
+++ b/packages/dts-plugin/src/server/broker/Broker.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, createServer } from 'http';
 import { UpdateMode } from '../constant';
-import WebSocket from 'isomorphic-ws';
+import WebSocket from 'ws';
 import schedule from 'node-schedule';
 import { parse } from 'url';
 import { Publisher } from '../Publisher';

--- a/packages/dts-plugin/src/server/createWebsocket.ts
+++ b/packages/dts-plugin/src/server/createWebsocket.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'isomorphic-ws';
+import WebSocket from 'ws';
 import {
   DEFAULT_WEB_SOCKET_PORT,
   WEB_SOCKET_CONNECT_MAGIC_ID,

--- a/packages/dts-plugin/src/server/types/broker.ts
+++ b/packages/dts-plugin/src/server/types/broker.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'isomorphic-ws';
+import type WebSocket from 'ws';
 import { Subscriber } from './message';
 
 type SubscriberIdentifier = string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3237,9 +3237,6 @@ importers:
       ansi-colors:
         specifier: 4.1.3
         version: 4.1.3
-      isomorphic-ws:
-        specifier: 5.0.0
-        version: 5.0.0(ws@8.21.0)
       node-schedule:
         specifier: 2.1.1
         version: 2.1.1
@@ -48409,10 +48406,6 @@ snapshots:
   isomorphic-ws@5.0.0(ws@8.18.0):
     dependencies:
       ws: 8.18.0
-
-  isomorphic-ws@5.0.0(ws@8.21.0):
-    dependencies:
-      ws: 8.21.0
 
   isstream@0.1.2: {}
 


### PR DESCRIPTION
Every `isomorphic-ws` import sits in a Node-only code path — the broker server (which uses `WebSocket.Server`, a `ws`-specific construct that has no browser equivalent) and the dev WebSocket client. The wrapper was abstracting over a browser case that never existed here.

`Publisher.ts` only touched `WebSocket` as a type, so its `ws` import is now `import type` and contributes no runtime require.

`isomorphic-ws@5.0.0(ws@8.21.0)` was the only snapshot variant orphaned by the importer change, so it's removed from the lockfile too. The `ws@8.18.0` variant stays because other workspace packages still pin it.

All 125 dts-plugin tests pass.