### PR TITLE
fix(storybook-addon): expand peer dep to support Storybook v10

### DIFF
--- a/.changeset/storybook-peer-v10.md
+++ b/.changeset/storybook-peer-v10.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/storybook-addon': patch
+---
+
+Expand `@storybook/node-logger` peer dependency range to include Storybook v9 and v10.

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -69,7 +69,7 @@
     "@nx/webpack": ">= 16.0.0",
     "@nx/module-federation": ">= 16.0.0",
     "@storybook/core": ">= 8.2.0",
-    "@storybook/node-logger": "^6.5.16 || ^7.0.0 || ^8.0.0",
+    "@storybook/node-logger": "^6.5.16 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "storybook": ">= 8.2.0",
     "webpack": "^5.75.0",
     "webpack-virtual-modules": "0.6.2"


### PR DESCRIPTION
Fixes #4758.

## What changed
- Updated `@storybook/node-logger` peer dependency range from `^6.5.16 || ^7.0.0 || ^8.0.0` to `^6.5.16 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0` so users on Storybook 10.x no longer get peer dependency warnings.
- Added a patch-level changeset for `@module-federation/storybook-addon`.

## Validation run
- prettier --check: passed
- git diff --check: passed
- pnpm --filter @module-federation/storybook-addon run build: passed
- No other peer dep ranges were modified.