### PR TITLE
fix(dts-plugin): resolve manifest type URLs for .json remote manifests

### DIFF
--- a/.changeset/fix-dts-plugin-4744-manifest-urls.md
+++ b/.changeset/fix-dts-plugin-4744-manifest-urls.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+Fix manifest `.json` remotes so zip/api type URLs are resolved correctly instead of being skipped when the remote entry already has a convention-based zip URL.

--- a/packages/dts-plugin/src/core/configurations/hostPlugin.test.ts
+++ b/packages/dts-plugin/src/core/configurations/hostPlugin.test.ts
@@ -54,6 +54,7 @@ describe('hostPlugin', () => {
             name: 'http://localhost:3000/remoteEntry.js',
             url: 'http://localhost:3000/remoteEntry.js',
             zipUrl: 'http://localhost:3000/@mf-types.zip',
+            hasExplicitTypeUrls: false,
           },
         });
       });
@@ -88,6 +89,7 @@ describe('hostPlugin', () => {
             name: 'http://localhost:3000/remoteEntry.js',
             url: 'http://localhost:3000/remoteEntry.js',
             zipUrl: 'http://localhost:3000/@remote-mf-types.zip',
+            hasExplicitTypeUrls: false,
           },
         });
 
@@ -125,6 +127,7 @@ describe('hostPlugin', () => {
           name: 'http://localhost:3000/subpatha/subpathb/remoteEntry.js',
           url: 'http://localhost:3000/subpatha/subpathb/remoteEntry.js',
           zipUrl: 'http://localhost:3000/subpatha/subpathb/@mf-types.zip',
+          hasExplicitTypeUrls: false,
         },
       });
     });
@@ -148,6 +151,7 @@ describe('hostPlugin', () => {
           name: '/subpatha/mf-manifest.json',
           url: '/subpatha/mf-manifest.json',
           zipUrl: '',
+          hasExplicitTypeUrls: false,
         },
       });
     });
@@ -179,6 +183,7 @@ describe('hostPlugin', () => {
           url: 'http://localhost:3001/remoteEntry.js',
           zipUrl: 'http://localhost:3001/custom-dir/@mf-types.zip',
           apiTypeUrl: 'http://localhost:3001/custom-dir/@mf-types.d.ts',
+          hasExplicitTypeUrls: true,
         },
         'remote2-alias': {
           name: 'remote2',
@@ -186,6 +191,7 @@ describe('hostPlugin', () => {
           url: 'http://localhost:3002/remoteEntry.js',
           zipUrl: 'http://localhost:3002/@mf-types.zip',
           apiTypeUrl: 'http://localhost:3002/@mf-types.d.ts',
+          hasExplicitTypeUrls: false,
         },
       });
     });
@@ -217,6 +223,7 @@ describe('hostPlugin', () => {
           url: 'http://localhost:3001/static/mf-manifest.json',
           zipUrl: 'http://localhost:3001/custom-dir/@mf-types.zip',
           apiTypeUrl: 'http://localhost:3001/custom-dir/@mf-types.d.ts',
+          hasExplicitTypeUrls: true,
         },
       });
     });

--- a/packages/dts-plugin/src/core/configurations/hostPlugin.ts
+++ b/packages/dts-plugin/src/core/configurations/hostPlugin.ts
@@ -98,6 +98,7 @@ export const retrieveRemoteInfo = (options: {
     zipUrl,
     apiTypeUrl,
     alias: remoteAlias,
+    hasExplicitTypeUrls: Boolean(remoteTypeUrl),
   };
 };
 
@@ -127,6 +128,7 @@ const resolveRemotes = (hostOptions: Required<HostOptions>) => {
         zipUrl: zip,
         apiTypeUrl: api,
         alias: alias || remoteName,
+        hasExplicitTypeUrls: true,
       };
       return sum;
     },
@@ -146,6 +148,8 @@ const resolveRemotes = (hostOptions: Required<HostOptions>) => {
         ...accumulator[key],
         url: res.url,
         apiTypeUrl: accumulator[key].apiTypeUrl || res.apiTypeUrl,
+        hasExplicitTypeUrls:
+          accumulator[key].hasExplicitTypeUrls || res.hasExplicitTypeUrls,
       };
       return accumulator;
     }

--- a/packages/dts-plugin/src/core/interfaces/HostOptions.ts
+++ b/packages/dts-plugin/src/core/interfaces/HostOptions.ts
@@ -13,4 +13,5 @@ export interface RemoteInfo {
   alias: string;
   zipUrl?: string;
   apiTypeUrl?: string;
+  hasExplicitTypeUrls?: boolean;
 }

--- a/packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.general.spec.ts
@@ -236,6 +236,57 @@ describe('DTSManager General Tests', () => {
       expect(result.zipUrl).toContain('http://example.com/custom/types.zip');
       expect(result.apiTypeUrl).toContain('http://example.com/custom/api.d.ts');
     });
+
+    it('should respect remoteTypeUrls and skip manifest fetch for manifest URLs', async () => {
+      const remoteInfo: RemoteInfo = {
+        name: 'test',
+        url: 'http://example.com/remote.manifest.json',
+        alias: 'test-alias',
+        zipUrl: 'http://example.com/explicit/types.zip',
+        apiTypeUrl: 'http://example.com/explicit/api.d.ts',
+        hasExplicitTypeUrls: true,
+      };
+
+      const nativeFetchSpy = vi.spyOn(utils, 'nativeFetch');
+
+      // @ts-expect-error only need timeout, which is not required
+      const result = await dtsManager.requestRemoteManifest(remoteInfo, {});
+      expect(result.zipUrl).toBe('http://example.com/explicit/types.zip');
+      expect(result.apiTypeUrl).toBe('http://example.com/explicit/api.d.ts');
+      expect(nativeFetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('should fetch manifest and override pre-populated zipUrl when not from remoteTypeUrls', async () => {
+      const manifestResponse = {
+        data: {
+          metaData: {
+            types: {
+              zip: 'types.zip',
+              api: 'api.d.ts',
+            },
+            publicPath: 'http://example.com/custom/',
+          },
+        },
+      };
+
+      vi.spyOn(utils, 'nativeFetch').mockResolvedValueOnce({
+        data: manifestResponse.data,
+        status: 200,
+        headers: {},
+      } as any);
+
+      const remoteInfo: RemoteInfo = {
+        name: 'test',
+        url: 'http://example.com/remote.manifest.json',
+        alias: 'test-alias',
+        zipUrl: 'http://example.com/wrong.zip',
+      };
+
+      // @ts-expect-error only need timeout, which is not required
+      const result = await dtsManager.requestRemoteManifest(remoteInfo, {});
+      expect(result.zipUrl).toContain('http://example.com/custom/types.zip');
+      expect(result.apiTypeUrl).toContain('http://example.com/custom/api.d.ts');
+    });
   });
 
   describe('consumeTargetRemotes', () => {

--- a/packages/dts-plugin/src/core/lib/DTSManager.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.ts
@@ -218,7 +218,7 @@ class DTSManager {
       if (!remoteInfo.url.includes(MANIFEST_EXT)) {
         return remoteInfo as Required<RemoteInfo>;
       }
-      if (remoteInfo.zipUrl) {
+      if (remoteInfo.hasExplicitTypeUrls) {
         return remoteInfo as Required<RemoteInfo>;
       }
       const url = remoteInfo.url;


### PR DESCRIPTION
Fixes #4744

## What changed
- Added an optional `hasExplicitTypeUrls` flag to `RemoteInfo` so `requestRemoteManifest` can distinguish type URLs the user supplied explicitly (via `dts.consumeTypes.remoteTypeUrls`) from URLs derived by convention.
- Changed the early-return guard in `requestRemoteManifest` to short-circuit only when the type URLs were provided explicitly, instead of whenever `zipUrl` happens to be set.
- Added a regression test for a `.json` manifest remote whose `zipUrl` is pre-populated from a non-explicit source: the manifest is fetched and the zip/api URLs are recomputed from `metaData.publicPath`.

## Context / why
Issue #4744 reported that, for a remote configured with a stable `mf-manifest.json` whose `metaData.publicPath` points at a versioned subdir, `requestRemoteManifest` was a no-op because `buildZipUrl` pre-populated `zipUrl` from the wrong base and the early `if (zipUrl) return` skipped manifest resolution.

That exact scenario was already addressed on `main` by #4730, which stops `buildZipUrl` from running for `.json` manifest URLs (`shouldResolveTypeUrlsByConvention`). #4774 separately hardens the manifest URL computation (`new URL(...)` instead of `path.join(...)`) so it is correct on Windows.

This PR closes the remaining robustness gap: it makes the `requestRemoteManifest` early-return intent-explicit so a convention-derived `zipUrl` can never again shadow manifest-based resolution, and locks the behavior in with a regression test. It is behavior-neutral for current code paths and guards against future regressions of #4744.

## User impact
No behavior change for existing valid configs. Hardens `.json` manifest remote type resolution so the manifest `metaData.publicPath` is always honored unless the user explicitly pinned `remoteTypeUrls`.

## Validation
- `prettier --check`: pass
- dts-plugin tests: 127 passed (incl. new regression tests)
- changeset: `.changeset/fix-dts-plugin-4744-manifest-urls.md` (patch bump for `@module-federation/dts-plugin`)

## Related
- #4730 — convention guard for `.json` URLs (fixed the original no-op)
- #4774 — Windows manifest URL normalization