### PR TITLE
fix(dts-plugin): define __dirname from import.meta.url for ESM consumers

### DIFF
--- a/.changeset/dts-plugin-esm-dirname.md
+++ b/.changeset/dts-plugin-esm-dirname.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+Fix `__dirname is not defined` ReferenceError when `@module-federation/dts-plugin` is consumed as ESM. `DevWorker`, `DevPlugin`, and `createBroker` now derive `__dirname` from `import.meta.url` (matching the existing `DtsWorker` shim) so the ESM build no longer emits bare `__dirname`.

--- a/packages/dts-plugin/src/dev-worker/DevWorker.ts
+++ b/packages/dts-plugin/src/dev-worker/DevWorker.ts
@@ -1,6 +1,10 @@
+import { fileURLToPath } from 'url';
 import path from 'path';
 import { type DTSManagerOptions, rpc } from '../core/index';
 import { cloneDeepOptions } from '../core/lib/utils';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export interface DevWorkerOptions extends DTSManagerOptions {
   name: string;

--- a/packages/dts-plugin/src/plugins/DevPlugin.ts
+++ b/packages/dts-plugin/src/plugins/DevPlugin.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { fileURLToPath } from 'url';
 import path from 'path';
 import { createDevWorker } from '../dev-worker';
 import {
@@ -17,6 +18,9 @@ import { isTSProject } from '../core/lib/utils';
 
 import type { Compiler, WebpackPluginInstance } from 'webpack';
 import type { DevWorker } from '../dev-worker';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 enum PROCESS_EXIT_CODE {
   SUCCESS = 0,

--- a/packages/dts-plugin/src/server/broker/createBroker.ts
+++ b/packages/dts-plugin/src/server/broker/createBroker.ts
@@ -1,5 +1,9 @@
 import { fork, ChildProcess } from 'child_process';
+import { fileURLToPath } from 'url';
 import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export function createBroker(): ChildProcess {
   const startBrokerPath = path.resolve(__dirname, './start-broker.js');


### PR DESCRIPTION
Fixes #4550

## What changed
`DevWorker`, `DevPlugin`, and `createBroker` in `@module-federation/dts-plugin` referenced a bare `__dirname`. Each now derives it from `import.meta.url`, matching the existing shim already used in `DtsWorker`:

```ts
import { fileURLToPath } from 'url';
import path from 'path';

const __filename = fileURLToPath(import.meta.url);
const __dirname = path.dirname(__filename);
```

## Why
The package publishes an ESM build (`dist/esm/*.mjs`). In ESM modules `__dirname` is not defined, so the emitted `index.mjs` (DevWorker/DevPlugin) and `expose-rpc-*.mjs` (createBroker) used a bare `__dirname` and threw `ReferenceError: __dirname is not defined` at runtime for ESM consumers. Only `DtsWorker` had the shim, so the fix had been applied inconsistently.

## User impact
ESM consumers of `@module-federation/dts-plugin` no longer crash with `__dirname is not defined`; worker/broker forks and the live-reload client asset resolve correctly. CJS output is unchanged.

## Validation
- Built the package (CJS + ESM). Confirmed the ESM chunks now define `__dirname` via `fileURLToPath(import.meta.url)` before use, and verified **no** bare `__dirname` remains in any `dist/esm/*.mjs` chunk.
- `prettier --check`: pass
- dts-plugin tests: 125 passed (14 files)
- changeset: `.changeset/dts-plugin-esm-dirname.md` (patch bump for `@module-federation/dts-plugin`)