### PR TITLE
fix(rsbuild-plugin): avoid configuring chunkLoading

### DIFF
--- a/.changeset/tender-eels-dress.md
+++ b/.changeset/tender-eels-dress.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rsbuild-plugin': patch
+---
+
+fix(rsbuild-plugin): The Rsbuild plugin no longer requires chunkLoading to be configured.

--- a/packages/rsbuild-plugin/src/cli/index.ts
+++ b/packages/rsbuild-plugin/src/cli/index.ts
@@ -519,7 +519,6 @@ export const pluginModuleFederation = (
             !isActiveRspressSSGEnvironmentConfig &&
             target !== 'node'
           ) {
-            bundlerConfig.output!.chunkLoading = 'jsonp';
             bundlerConfig.output!.chunkLoadingGlobal = `chunk_${moduleFederationOptions.name} `;
           }
 


### PR DESCRIPTION
## What changed

Removed the Rsbuild plugin's automatic `chunkLoading` assignment and added a patch changeset for the package.

## Why

Rsbuild plugin users should not need to configure or inherit `chunkLoading` from this plugin.

## Validation

- `pnpm exec prettier --check packages/rsbuild-plugin/src/cli/index.ts .changeset/tender-eels-dress.md`
- `pnpm --filter @module-federation/rsbuild-plugin run test`
- `pnpm --filter @module-federation/rsbuild-plugin run build`
- `pnpm --filter @module-federation/rsbuild-plugin run lint`
