### PR TITLE
fix(dts-plugin): infer extensions for multi-dot exposes

### DIFF
--- a/.changeset/fix-dts-plugin-4789-multi-dot-expose.md
+++ b/.changeset/fix-dts-plugin-4789-multi-dot-expose.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+Fix dts-plugin expose resolution for extensionless multi-dot paths like `foo.generated` so they correctly infer supported source files such as `.ts`, `.tsx`, `.vue`, `.js`, and `.jsx`, while preserving explicit extensions and directory `index` fallback behavior.

--- a/packages/dts-plugin/src/core/configurations/remotePlugin.test.ts
+++ b/packages/dts-plugin/src/core/configurations/remotePlugin.test.ts
@@ -1,9 +1,53 @@
-import { join, resolve } from 'path';
-import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import os from 'os';
+import { dirname, join, resolve } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { retrieveRemoteConfig } from './remotePlugin';
 
 describe('hostPlugin', () => {
+  const tempDirs: string[] = [];
+
+  const createTemporaryProject = (files: Record<string, string>) => {
+    const context = mkdtempSync(join(os.tmpdir(), 'mf-dts-plugin-remote-'));
+    tempDirs.push(context);
+
+    writeFileSync(
+      join(context, 'tsconfig.json'),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            target: 'es2017',
+            module: 'esnext',
+            lib: ['esnext'],
+            moduleResolution: 'node',
+            esModuleInterop: true,
+            strict: true,
+            strictNullChecks: true,
+            resolveJsonModule: true,
+            rootDir: '.',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    for (const [relativePath, contents] of Object.entries(files)) {
+      const absolutePath = join(context, relativePath);
+      mkdirSync(dirname(absolutePath), { recursive: true });
+      writeFileSync(absolutePath, contents);
+    }
+
+    return context;
+  };
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   const moduleFederationConfig = {
     name: 'remotePluginTestHost',
     filename: 'remoteEntry.js',
@@ -208,6 +252,135 @@ describe('hostPlugin', () => {
             'my-types',
             'compiled',
           ),
+        );
+      });
+    });
+    describe('resolves expose paths with supported extensions', () => {
+      const resolveExpose = (
+        exposePath: string,
+        files: Record<string, string>,
+      ) => {
+        const context = createTemporaryProject(files);
+        const { mapComponentsToExpose } = retrieveRemoteConfig({
+          context,
+          tsConfigPath: './tsconfig.json',
+          moduleFederationConfig: {
+            name: 'remotePluginTestHost',
+            filename: 'remoteEntry.js',
+            exposes: {
+              './component': exposePath,
+            },
+          },
+        });
+
+        return {
+          context,
+          resolvedPath: mapComponentsToExpose['./component'],
+        };
+      };
+
+      it('keeps existing single-segment inference for ts files', () => {
+        const { context, resolvedPath } = resolveExpose(
+          './src/components/foo',
+          {
+            'src/components/foo.ts': 'export const foo = 1;\n',
+          },
+        );
+
+        expect(resolvedPath).toBe(resolve(context, 'src/components/foo.ts'));
+      });
+
+      it('infers ts files for multi-dot expose paths', () => {
+        const { context, resolvedPath } = resolveExpose(
+          './src/components/foo.generated',
+          {
+            'src/components/foo.generated.ts': 'export const foo = 1;\n',
+          },
+        );
+
+        expect(resolvedPath).toBe(
+          resolve(context, 'src/components/foo.generated.ts'),
+        );
+      });
+
+      it('preserves explicit multi-dot ts paths', () => {
+        const { context, resolvedPath } = resolveExpose(
+          './src/components/foo.generated.ts',
+          {
+            'src/components/foo.generated.ts': 'export const foo = 1;\n',
+          },
+        );
+
+        expect(resolvedPath).toBe(
+          resolve(context, 'src/components/foo.generated.ts'),
+        );
+      });
+
+      it('infers tsx files for multi-dot expose paths', () => {
+        const { context, resolvedPath } = resolveExpose(
+          './src/components/foo.generated',
+          {
+            'src/components/foo.generated.tsx':
+              'export const Foo = () => null;\n',
+          },
+        );
+
+        expect(resolvedPath).toBe(
+          resolve(context, 'src/components/foo.generated.tsx'),
+        );
+      });
+
+      it('infers vue files for multi-dot expose paths', () => {
+        const { context, resolvedPath } = resolveExpose(
+          './src/components/foo.generated',
+          {
+            'src/components/foo.generated.vue':
+              '<script setup lang="ts">const foo = 1;</script>\n',
+          },
+        );
+
+        expect(resolvedPath).toBe(
+          resolve(context, 'src/components/foo.generated.vue'),
+        );
+      });
+
+      it('infers jsx files for multi-dot expose paths', () => {
+        const { context, resolvedPath } = resolveExpose(
+          './src/components/foo.generated',
+          {
+            'src/components/foo.generated.jsx':
+              'export const Foo = () => null;\n',
+          },
+        );
+
+        expect(resolvedPath).toBe(
+          resolve(context, 'src/components/foo.generated.jsx'),
+        );
+      });
+
+      it('falls back to dotted directory index files', () => {
+        const { context, resolvedPath } = resolveExpose(
+          './src/components/foo.bar',
+          {
+            'src/components/foo.bar/index.ts': 'export const foo = 1;\n',
+          },
+        );
+
+        expect(resolvedPath).toBe(
+          resolve(context, 'src/components/foo.bar/index.ts'),
+        );
+      });
+
+      it('falls back to normal directory index files', () => {
+        const { context, resolvedPath } = resolveExpose(
+          './src/components/foo',
+          {
+            'src/components/foo/index.ts': 'export const foo = 1;\n',
+          },
+        );
+
+        expect(resolvedPath).toBe(
+          resolve(context, 'src/components/foo/index.ts'),
         );
       });
     });

--- a/packages/dts-plugin/src/core/configurations/remotePlugin.ts
+++ b/packages/dts-plugin/src/core/configurations/remotePlugin.ts
@@ -184,16 +184,19 @@ const readTsConfig = (
   return rawTsConfigJson;
 };
 
-const TS_EXTENSIONS = ['ts', 'tsx', 'vue', 'svelte'];
+const TS_EXTENSIONS = ['.ts', '.tsx', '.vue', '.svelte', '.js', '.jsx'];
 
 const resolveWithExtension = (exposedPath: string, context: string) => {
-  if (extname(exposedPath)) {
+  const explicitExtension = extname(exposedPath);
+
+  if (TS_EXTENSIONS.includes(explicitExtension)) {
     return resolve(context, exposedPath);
   }
+
   for (const extension of TS_EXTENSIONS) {
     const exposedPathWithExtension = resolve(
       context,
-      `${exposedPath}.${extension}`,
+      `${exposedPath}${extension}`,
     );
     if (existsSync(exposedPathWithExtension)) {
       return exposedPathWithExtension;

--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.test.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.test.ts
@@ -340,6 +340,89 @@ describe('typeScriptCompiler', () => {
       expect(directoryStructure).toMatchObject(expectedStructure);
     });
 
+    it('emits wrapper files for multi-dot expose entries', async () => {
+      const projectDir = join(tmpDir, 'multiDotExposeProject');
+      const srcDir = join(projectDir, 'src', 'components');
+      mkdirSync(srcDir, { recursive: true });
+
+      const entryFile = join(srcDir, 'foo.generated.ts');
+      writeFileSync(entryFile, 'export const foo = 1;\n');
+
+      const baseTsConfigPath = join(projectDir, 'tsconfig.json');
+      writeFileSync(
+        baseTsConfigPath,
+        JSON.stringify(
+          {
+            compilerOptions: {
+              target: 'es2017',
+              module: 'esnext',
+              moduleResolution: 'node',
+              strict: true,
+              esModuleInterop: true,
+              declaration: true,
+              emitDeclarationOnly: true,
+              rootDir: projectDir,
+            },
+            include: ['src'],
+          },
+          null,
+          2,
+        ),
+      );
+
+      const outDir = join(
+        projectDir,
+        'typesRemoteFolder',
+        'compiledTypesFolder',
+      );
+
+      await compileTs(
+        { './foo.generated': entryFile },
+        {
+          extends: baseTsConfigPath,
+          compilerOptions: {
+            target: 'es2017',
+            module: 'esnext',
+            moduleResolution: 'node',
+            strict: true,
+            esModuleInterop: true,
+            emitDeclarationOnly: true,
+            noEmit: false,
+            declaration: true,
+            outDir,
+            declarationDir: outDir,
+            rootDir: projectDir,
+          },
+          files: [entryFile],
+          include: [],
+          exclude: [],
+        },
+        {
+          ...remoteOptions,
+          context: projectDir,
+          tsConfigPath: baseTsConfigPath,
+        },
+      );
+
+      const wrapperPath = join(
+        projectDir,
+        'typesRemoteFolder',
+        'foo.generated.d.ts',
+      );
+      const emittedDefinitionPath = join(
+        outDir,
+        'src',
+        'components',
+        'foo.generated.d.ts',
+      );
+
+      expect(existsSync(emittedDefinitionPath)).toBe(true);
+      expect(existsSync(wrapperPath)).toBe(true);
+      expect(readFileSync(wrapperPath, 'utf-8')).toContain(
+        './compiledTypesFolder/src/components/foo.generated',
+      );
+    });
+
     it('with additionalFilesToCompile', async () => {
       const filepath = join(__dirname, './typeScriptCompiler.ts');
 


### PR DESCRIPTION
## Summary
- treat only supported source suffixes as explicit expose extensions in dts-plugin (`.ts`, `.tsx`, `.vue`, `.svelte`, `.js`, `.jsx`)
- probe supported extensions for extensionless multi-dot expose paths like `foo.generated`
- add regression coverage for multi-dot expose inference and wrapper emission in `compileTs`

## Root cause
`resolveWithExtension()` treated any truthy `path.extname()` result as an explicit extension. For `./src/components/foo.generated`, that meant `.generated` short-circuited resolution before `foo.generated.ts` / `.tsx` / `.vue` / `.jsx` could be probed.

## Reproduction
Before this change:
```js
exposes: {
  './foo': './src/components/foo.generated'
}
```
failed to resolve `foo.generated.ts` and the generated declaration wrapper was skipped downstream.

## Test plan
- `pnpm exec vitest run src/core/configurations/remotePlugin.test.ts --config vite.config.mts`
- `pnpm exec vitest run src/core/lib/typeScriptCompiler.test.ts --config vite.config.mts`
- `pnpm --filter @module-federation/dts-plugin test`
- `pnpm --filter @module-federation/dts-plugin build`

Closes #4789
