### PR TITLE
test(dts-plugin): add regression test for Windows path quoting (#4133)

### DIFF
--- a/packages/dts-plugin/src/core/lib/typeScriptCompiler.test.ts
+++ b/packages/dts-plugin/src/core/lib/typeScriptCompiler.test.ts
@@ -206,6 +206,37 @@ describe('typeScriptCompiler', () => {
       expect(args[4]).toEqual(expect.any(String));
     });
 
+    it('does not wrap project path in single quotes on Windows (#4133)', async () => {
+      const execPromise = vi.fn().mockRejectedValue(new Error('tsc error'));
+      vi.spyOn(util, 'promisify').mockReturnValue(
+        execPromise as unknown as ReturnType<typeof util.promisify>,
+      );
+      const restorePlatform = withProcessPlatform('win32');
+      const filepath = join(__dirname, './typeScriptCompiler.ts');
+      const mapToExpose = {
+        tsCompiler: filepath,
+      };
+
+      try {
+        await compileTs(
+          mapToExpose,
+          { ...tsConfig, files: [filepath] },
+          remoteOptions,
+        );
+      } catch {
+        // expected to throw because execPromise is rejected
+      } finally {
+        restorePlatform();
+      }
+
+      const args = execPromise.mock.calls[0]?.[1] as string[];
+      const projectIndex = args.indexOf('--project');
+      expect(projectIndex).toBeGreaterThan(-1);
+      const projectPath = args[projectIndex + 1];
+      expect(projectPath).toBeDefined();
+      expect(projectPath).not.toContain("'");
+    });
+
     it('ignores inherited declarationDir', async () => {
       const projectDir = join(tmpDir, 'declarationDirProject');
       const srcDir = join(projectDir, 'src');


### PR DESCRIPTION
## Summary

Adds a regression test that verifies the `--project` argument passed to `tsc` on Windows does not contain single quotes. This prevents the Windows `cmd.exe` path parsing issue reported in #4133.

## Root Cause

The original issue (#4133) was caused by `exec` being used with single quotes around the temp tsconfig path on Windows:

```ts
const cmd = ` ${remoteOptions.compilerInstance} --project '${tempTsConfigJsonPath}'`;
```

Windows `cmd.exe` does not treat single quotes as string delimiters, causing the path to be parsed incorrectly.

## Fix Status

This issue was already fixed in PR #4382 (merged 2026-02-09) by switching to `execFile` with array arguments and enabling `shell: true` on Windows. This PR adds a regression test to ensure the fix is protected.

## Test Plan

- `pnpm exec vitest run src/core/lib/typeScriptCompiler.test.ts --config vite.config.mts`

Closes #4133