### PR TITLE
docs: shared config subpath/prefix matching + bridge-react warnings

### DIFF
--- a/.changeset/docs-shared-config-subpath.md
+++ b/.changeset/docs-shared-config-subpath.md
@@ -1,0 +1,10 @@
+---
+'website-new': patch
+---
+
+docs: document shared config subpath/prefix matching and bridge-react warnings
+
+- Add missing `shareKey` and `request` sections to English `shared.mdx` with prefix-matching explanation and trailing-slash examples.
+- Add `:::warning` callouts to Chinese `shared.mdx` for the common subpath mistake.
+- Add troubleshooting FAQ entries for duplicate subpath imports in both EN and ZH runtime docs.
+- Add `react-dom/client` shared-config warnings to bridge-react docs (`getting-started`, `export-app`, `load-app`) in both EN and ZH.

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ packages/enhanced/generated/**
 apps/rsc-demo/**/build/
 apps/rsc-demo/e2e/test-results/
 .kiro
+
+# Repo-local Cursor litter; tokensave/Cursor config comes from the installed user-level plugin
+.cursor/

--- a/apps/website-new/docs/en/configure/shared.mdx
+++ b/apps/website-new/docs/en/configure/shared.mdx
@@ -20,8 +20,8 @@ interface SharedConfig {
   requiredVersion?: string;
   eager?: boolean;
   shareScope?: string;
-  shareKey?: string;
   import?: string | false;
+  shareKey?: string;
   request?: string;
   allowNodeModulesSuffixMatch?: boolean;
   treeShaking?: TreeShakingConfig;

--- a/apps/website-new/docs/en/configure/shared.mdx
+++ b/apps/website-new/docs/en/configure/shared.mdx
@@ -20,7 +20,9 @@ interface SharedConfig {
   requiredVersion?: string;
   eager?: boolean;
   shareScope?: string;
+  shareKey?: string;
   import?: string | false;
+  request?: string;
   allowNodeModulesSuffixMatch?: boolean;
   treeShaking?: TreeShakingConfig;
 }
@@ -103,6 +105,63 @@ share scope name, default value is `'default'` .
 Control import path of shared dependencies, default value is `undefined` .
 
 If set to `false`, this shared will not be packaged into the product, and only the `shared` provided by the consumer will be used. Therefore, please make sure that the consumer has provided the corresponding `shared` before setting.
+
+## shareKey
+
+- Type: `string`
+- Required: No
+- Default: The property name (`key`) of the `shared` entry
+
+The lookup key used in the shared scope at runtime. Both the provider and the consumer must use the **same** `shareKey` for a shared module to be negotiated successfully; otherwise each side bundles its own copy.
+
+The default is the property name itself, so most of the time you do not need to set it. A typical custom scenario is mapping an alias to a different real package:
+
+```ts
+shared: {
+  'my-alias': {
+    import: 'react',      // actual package to resolve
+    shareKey: 'react',    // negotiate in shared scope as "react"
+  },
+}
+```
+
+:::warning
+If `shareKey` is omitted, the negotiation key is the property name itself (`"my-alias"` in the example above). If the other side registers with `"react"`, the two will never match.
+:::
+
+## request
+
+- Type: `string`
+- Required: No
+- Default: The property name (`key`) of the `shared` entry
+
+The module request path that the bundler intercepts at build time. When the code contains an `import` that matches this value, the bundler replaces it with a shared-scope consumer instead of bundling the dependency into the output.
+
+The default is the property name, which is sufficient for most cases. The difference between `request` and `shareKey`:
+
+| Field | Stage | Question it answers |
+|---|---|---|
+| `request` | Build-time · module graph | Which `import` to intercept |
+| `shareKey` | Runtime · negotiation | Which slot in the shared scope to use |
+
+### Prefix matching with trailing slash
+
+If `request` ends with `/`, the bundler treats it as a **prefix match** and intercepts every subpath import under that namespace. The final `shareKey` is formed by appending the subpath suffix to the configured `shareKey` (or the prefix itself if `shareKey` is omitted).
+
+```ts
+shared: {
+  'react-dom/': {
+    request: 'react-dom/',   // intercepts import 'react-dom/client', 'react-dom/server', etc.
+    shareKey: 'react-dom/',  // final shareKey = "react-dom/" + subpath suffix
+  },
+}
+```
+
+This is essential for packages that expose subpath modules (e.g. `react-dom/client`, `lodash/debounce`, `@scope/package/subpath`). Without the trailing slash, only the exact package name is intercepted; subpath imports will be bundled locally and will not participate in shared scope negotiation.
+
+:::warning Common mistake
+Writing `'react-dom'` (no trailing slash) only intercepts `import 'react-dom'`. Any code that does `import { createRoot } from 'react-dom/client'` will load a second copy of React DOM, which breaks React singleton requirements and causes hydration errors.
+:::
 
 ## allowNodeModulesSuffixMatch
 

--- a/apps/website-new/docs/en/configure/shared.mdx
+++ b/apps/website-new/docs/en/configure/shared.mdx
@@ -160,7 +160,7 @@ shared: {
 This is essential for packages that expose subpath modules (e.g. `react-dom/client`, `lodash/debounce`, `@scope/package/subpath`). Without the trailing slash, only the exact package name is intercepted; subpath imports will be bundled locally and will not participate in shared scope negotiation.
 
 :::warning Common mistake
-Writing `'react-dom'` (no trailing slash) only intercepts `import 'react-dom'`. Any code that does `import { createRoot } from 'react-dom/client'` will load a second copy of React DOM, which breaks React singleton requirements and causes hydration errors.
+Writing `'react-dom'` (no trailing slash) only intercepts `import 'react-dom'`. Any code that does `import { createRoot } from 'react-dom/client'` will load a second copy of React DOM, which breaks React singleton requirements and causes hydration errors. See the [troubleshooting FAQ](../../guide/troubleshooting/runtime#subpath-imports-are-not-shared-duplicate-dependency-loaded) for more details.
 :::
 
 ## allowNodeModulesSuffixMatch

--- a/apps/website-new/docs/en/configure/shared.mdx
+++ b/apps/website-new/docs/en/configure/shared.mdx
@@ -157,6 +157,17 @@ shared: {
 }
 ```
 
+The same pattern works for utility libraries such as `lodash`:
+
+```ts
+shared: {
+  'lodash/': {
+    request: 'lodash/',    // intercepts import 'lodash/debounce', 'lodash/get', etc.
+    shareKey: 'lodash/',   // final shareKey = "lodash/" + subpath suffix
+  },
+}
+```
+
 This is essential for packages that expose subpath modules (e.g. `react-dom/client`, `lodash/debounce`, `@scope/package/subpath`). Without the trailing slash, only the exact package name is intercepted; subpath imports will be bundled locally and will not participate in shared scope negotiation.
 
 :::warning Common mistake

--- a/apps/website-new/docs/en/guide/bridge/react/export-app.mdx
+++ b/apps/website-new/docs/en/guide/bridge/react/export-app.mdx
@@ -104,6 +104,18 @@ export default {
 When enabling Bridge Router, do not configure `react-router-dom` as a shared dependency, otherwise it will cause routing functionality issues.
 :::
 
+:::warning Important
+`@module-federation/bridge-react/18` and `/19` import `createRoot` from `react-dom/client`. If you only configure `"react-dom"` as a shared dependency, `react-dom/client` will not be shared and can cause React version mismatch errors. Make sure to use the trailing-slash prefix form:
+
+```ts
+shared: {
+  'react-dom/': {
+    singleton: true,
+  },
+}
+```
+:::
+
 ## createBridgeComponent API Reference
 
 ### Function Signature

--- a/apps/website-new/docs/en/guide/bridge/react/getting-started.mdx
+++ b/apps/website-new/docs/en/guide/bridge/react/getting-started.mdx
@@ -33,5 +33,17 @@ import { createBridgeComponent } from '@module-federation/bridge-react/18'; // R
 import { createBridgeComponent } from '@module-federation/bridge-react/19'; // React 19
 ```
 
+:::warning Important
+`@module-federation/bridge-react/18` and `/19` import `createRoot` from `react-dom/client`. If you only configure `"react-dom"` as a shared dependency, `react-dom/client` will not be shared and can cause React version mismatch errors. Make sure to use the trailing-slash prefix form:
+
+```ts
+shared: {
+  'react-dom/': {
+    singleton: true,
+  },
+}
+```
+:::
+
 ### 💡 Examples
 [Complete Examples](https://github.com/module-federation/core/tree/main/apps/router-demo) - Complete micro-frontend project containing multiple React applications

--- a/apps/website-new/docs/en/guide/bridge/react/load-app.mdx
+++ b/apps/website-new/docs/en/guide/bridge/react/load-app.mdx
@@ -55,6 +55,10 @@ export default defineConfig({
 });
 ```
 
+:::tip
+If the remote uses React 18/19 bridge, make sure to also configure the `shared` section with the trailing-slash prefix form (`'react-dom/'`) so that `react-dom/client` is correctly shared.
+:::
+
 ### Step 2: Create Remote Components
 
 #### 2.1 Define Loading and Error Components

--- a/apps/website-new/docs/en/guide/troubleshooting/runtime.mdx
+++ b/apps/website-new/docs/en/guide/troubleshooting/runtime.mdx
@@ -468,6 +468,33 @@ This problem can be avoided by setting `shared` and setting `singleton: true` si
 
 ![](@public/guide/chrome-devtools/mf-devtool-hmr.jpg)
 
+### Subpath imports are not shared (duplicate dependency loaded)
+
+#### Symptom
+
+- The browser downloads two copies of the same package (e.g. `react-dom`)
+- React throws "Invalid hook call" or hydration mismatch errors
+- `loadShare` returns `false` for subpath imports like `react-dom/client`
+
+#### Root cause
+
+The `shared` config only lists the exact package name, e.g. `'react-dom'`. Module Federation intercepts imports at build time. An exact name only intercepts `import 'react-dom'`; subpath imports such as `import { createRoot } from 'react-dom/client'` bypass the shared config and are bundled locally.
+
+#### Solution
+
+Use a **trailing slash** to enable prefix matching for any package that exposes subpaths:
+
+```ts title="rspack.config.ts"
+shared: {
+  react: { singleton: true },
+  'react-dom': { singleton: true },      // exact match — only 'react-dom'
+  'react-dom/': { singleton: true },     // prefix match — 'react-dom/client', 'react-dom/server', ...
+  'react/': { singleton: true },         // prefix match — 'react/jsx-runtime', 'react/jsx-dev-runtime', ...
+}
+```
+
+The same applies to scoped packages (`'@scope/package/'`) and utility libraries (`'lodash/'`).
+
 ### A preload for 'http://resource-url' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.
 
 #### Reason

--- a/apps/website-new/docs/zh/configure/shared.mdx
+++ b/apps/website-new/docs/zh/configure/shared.mdx
@@ -155,6 +155,10 @@ shared: {
 }
 ```
 
+:::warning 常见错误
+`'react-dom'`（无尾部斜杠）只会拦截 `import 'react-dom'`。任何执行 `import { createRoot } from 'react-dom/client'` 的代码都会加载第二份 React DOM 副本，破坏 React 单例要求并导致 hydration 错误。
+:::
+
 ## allowNodeModulesSuffixMatch
 
 - 类型：`boolean`

--- a/apps/website-new/docs/zh/configure/shared.mdx
+++ b/apps/website-new/docs/zh/configure/shared.mdx
@@ -20,8 +20,8 @@ interface SharedConfig {
   requiredVersion?: string;
   eager?: boolean;
   shareScope?: string;
-  shareKey?: string;
   import?: string | false;
+  shareKey?: string;
   request?: string;
   allowNodeModulesSuffixMatch?: boolean;
   treeShaking?: TreeShakingConfig;

--- a/apps/website-new/docs/zh/configure/shared.mdx
+++ b/apps/website-new/docs/zh/configure/shared.mdx
@@ -155,6 +155,17 @@ shared: {
 }
 ```
 
+同样的模式也适用于工具库，例如 `lodash`：
+
+```ts
+shared: {
+  'lodash/': {
+    request: 'lodash/',    // 拦截所有 import 'lodash/*'
+    shareKey: 'lodash/',   // 最终协商 key = "lodash/" + 子路径后缀
+  },
+}
+```
+
 :::warning 常见错误
 `'react-dom'`（无尾部斜杠）只会拦截 `import 'react-dom'`。任何执行 `import { createRoot } from 'react-dom/client'` 的代码都会加载第二份 React DOM 副本，破坏 React 单例要求并导致 hydration 错误。
 :::

--- a/apps/website-new/docs/zh/configure/shared.mdx
+++ b/apps/website-new/docs/zh/configure/shared.mdx
@@ -148,9 +148,9 @@ shared: {
 
 ```ts
 shared: {
-  'lodash/': {
-    request: 'lodash/',    // 拦截所有 import 'lodash/*'
-    shareKey: 'lodash/',   // 最终协商 key = "lodash/" + 子路径后缀
+  'react-dom/': {
+    request: 'react-dom/',    // 拦截所有 import 'react-dom/*'
+    shareKey: 'react-dom/',   // 最终协商 key = "react-dom/" + 子路径后缀
   },
 }
 ```

--- a/apps/website-new/docs/zh/guide/bridge/react/export-app.mdx
+++ b/apps/website-new/docs/zh/guide/bridge/react/export-app.mdx
@@ -105,6 +105,18 @@ export default {
 启用 Bridge Router 时，请勿将 `react-router-dom` 配置为 shared 依赖，否则会导致路由功能异常。
 :::
 
+:::warning 重要
+`@module-federation/bridge-react/18` 和 `/19` 从 `react-dom/client` 导入 `createRoot`。如果你只将 `"react-dom"` 配置为 shared 依赖，`react-dom/client` 将不会被共享，可能导致 React 版本不匹配错误。请确保使用尾部斜杠前缀形式：
+
+```ts
+shared: {
+  'react-dom/': {
+    singleton: true,
+  },
+}
+```
+:::
+
 ## createBridgeComponent API 参考
 
 ### 函数签名

--- a/apps/website-new/docs/zh/guide/bridge/react/getting-started.mdx
+++ b/apps/website-new/docs/zh/guide/bridge/react/getting-started.mdx
@@ -31,5 +31,18 @@ import { createBridgeComponent } from '@module-federation/bridge-react'; // Reac
 import { createBridgeComponent } from '@module-federation/bridge-react/18'; // React 18
 import { createBridgeComponent } from '@module-federation/bridge-react/19'; // React 19
 ```
+
+:::warning 重要
+`@module-federation/bridge-react/18` 和 `/19` 从 `react-dom/client` 导入 `createRoot`。如果你只将 `"react-dom"` 配置为 shared 依赖，`react-dom/client` 将不会被共享，可能导致 React 版本不匹配错误。请确保使用尾部斜杠前缀形式：
+
+```ts
+shared: {
+  'react-dom/': {
+    singleton: true,
+  },
+}
+```
+:::
+
 ### 💡 示例
 [完整示例](https://github.com/module-federation/core/tree/main/apps/router-demo) - 包含多个 React 应用的完整微前端项目

--- a/apps/website-new/docs/zh/guide/bridge/react/load-app.mdx
+++ b/apps/website-new/docs/zh/guide/bridge/react/load-app.mdx
@@ -57,6 +57,10 @@ export default defineConfig({
 });
 ```
 
+:::tip
+如果远程应用使用 React 18/19 bridge，请确保也使用尾部斜杠前缀形式 (`'react-dom/'`) 配置 `shared` 部分，以便 `react-dom/client` 被正确共享。
+:::
+
 ### 步骤 2: 创建远程组件
 
 #### 2.1 定义加载和错误组件

--- a/apps/website-new/docs/zh/guide/troubleshooting/runtime.mdx
+++ b/apps/website-new/docs/zh/guide/troubleshooting/runtime.mdx
@@ -465,6 +465,33 @@ Uncaught TypeError: Cannot read properties on null (reading `useState`)
 
 ![](@public/guide/chrome-devtools/mf-devtool-hmr.jpg)
 
+### 子路径导入未被共享（加载了重复依赖）
+
+#### 现象
+
+- 浏览器下载了同一依赖的两份副本（例如 `react-dom`）
+- React 抛出 "Invalid hook call" 或 hydration 不匹配错误
+- 对 `react-dom/client` 等子路径调用 `loadShare` 返回 `false`
+
+#### 原因
+
+`shared` 配置只列出了精确包名，例如 `'react-dom'`。Module Federation 在构建时拦截导入。精确名称只会拦截 `import 'react-dom'`；子路径导入如 `import { createRoot } from 'react-dom/client'` 会绕过 shared 配置，被本地打包。
+
+#### 解决方案
+
+对任何暴露子路径的依赖，使用**尾部斜杠**开启前缀匹配：
+
+```ts title="rspack.config.ts"
+shared: {
+  react: { singleton: true },
+  'react-dom': { singleton: true },      // 精确匹配 — 仅 'react-dom'
+  'react-dom/': { singleton: true },     // 前缀匹配 — 'react-dom/client'、'react-dom/server'、...
+  'react/': { singleton: true },         // 前缀匹配 — 'react/jsx-runtime'、'react/jsx-dev-runtime'、...
+}
+```
+
+此规则同样适用于作用域包（`'@scope/package/'`）和工具库（`'lodash/'`）。
+
 ### A preload for 'http://resource-url' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.
 
 #### 原因


### PR DESCRIPTION
## What changed

This PR documents the trailing-slash / prefix-matching pattern for shared config and adds prominent warnings for bridge-react users about `react-dom/client` subpath imports.

### shared config docs
- **EN**: Added missing `shareKey` and `request` sections to `shared.mdx` (mirrors ZH structure) with prefix-matching explanation and a `:::warning Common mistake` callout about exact-match vs trailing-slash.
- **ZH**: Enhanced existing `request` section with a clearer `:::warning \u5e38\u89c1\u9519\u8bef` callout.

### Runtime troubleshooting
- **EN**: Added "Subpath imports are not shared (duplicate dependency loaded)" FAQ entry under Common Issues.
- **ZH**: Mirrored the FAQ entry.

### bridge-react docs
- **EN**: Added `react-dom/client` warnings to `getting-started.mdx`, `export-app.mdx`, and `load-app.mdx`.
- **ZH**: Mirrored all three warnings.

## Why

Issue #4727 shows users frequently configure `"react-dom"` as a shared singleton without realizing that subpath imports like `react-dom/client` bypass shared module resolution. The correct configuration is a trailing slash: `"react-dom/"`. This is working as intended \u2014 the fix is documentation, not code.

## Validation

- Documentation-only changes; no code changes.
- Both English and Chinese docs updated.
- Changeset added for `website-new`.

## PR conventions

- Conventional commit title: `docs: ...`
- Prose-first body explaining what changed, why, and validation.

Closes #4727