### PR TITLE
fix: modern.js ssr static asset public path

### DIFF
--- a/.changeset/modern-ssr-static-assets.md
+++ b/.changeset/modern-ssr-static-assets.md
@@ -1,0 +1,6 @@
+---
+"@module-federation/modern-js": patch
+"@module-federation/modern-js-v3": patch
+---
+
+Keep Modern.js SSR static asset imports on the app public path while preserving bundled SSR JavaScript paths.

--- a/packages/modernjs-v3/package.json
+++ b/packages/modernjs-v3/package.json
@@ -156,7 +156,7 @@
     "@module-federation/manifest": "workspace:*",
     "@rslib/core": "0.18.5",
     "@rsbuild/core": "2.0.0-beta.2",
-    "@rspack/core": "2.0.0-beta.0",
+    "@rspack/core": "2.0.6",
     "@modern-js/app-tools": "3.0.1",
     "@modern-js/server-runtime": "3.0.1",
     "@modern-js/module-tools": "2.70.5",

--- a/packages/modernjs-v3/package.json
+++ b/packages/modernjs-v3/package.json
@@ -156,6 +156,7 @@
     "@module-federation/manifest": "workspace:*",
     "@rslib/core": "0.18.5",
     "@rsbuild/core": "2.0.0-beta.2",
+    "@rspack/core": "2.0.0-beta.0",
     "@modern-js/app-tools": "3.0.1",
     "@modern-js/server-runtime": "3.0.1",
     "@modern-js/module-tools": "2.70.5",

--- a/packages/modernjs-v3/src/cli/ssrPlugin.spec.ts
+++ b/packages/modernjs-v3/src/cli/ssrPlugin.spec.ts
@@ -1,0 +1,191 @@
+import path from 'path';
+import { createRequire } from 'node:module';
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { describe, expect, it, vi } from 'vitest';
+
+const nodeRequire = createRequire(__filename);
+
+const rspack = nodeRequire('@rspack/core') as typeof import('@rspack/core');
+const { ModuleFederationPlugin } = nodeRequire(
+  '@module-federation/enhanced/rspack',
+) as typeof import('@module-federation/enhanced/rspack');
+
+const createPluginHarness = async () => {
+  const { moduleFederationSSRPlugin } = await import('./ssrPlugin');
+  const pluginOptions = {
+    assetFileNames: {},
+    assetResources: {},
+    csrConfig: {},
+    distOutputDir: '/project/dist',
+    fetchServerQuery: undefined,
+    secondarySharedTreeShaking: false,
+    ssrConfig: {},
+    userConfig: {
+      ssr: {
+        distOutputDir: '/project/dist/bundles',
+      },
+    },
+  } as any;
+
+  let rsbuildPlugin: any;
+  const api = {
+    _internalRuntimePlugins: vi.fn(),
+    _internalServerPlugins: vi.fn(),
+    config: vi.fn((callback) => {
+      const config = callback();
+      rsbuildPlugin = config.builderPlugins[0];
+    }),
+    getAppContext: vi.fn(() => ({ bundlerType: 'rspack' })),
+    getConfig: vi.fn(() => ({ server: { ssr: true } })),
+    modifyBundlerChain: vi.fn(),
+    onAfterBuild: vi.fn(),
+    onDevCompileDone: vi.fn(),
+  };
+
+  await moduleFederationSSRPlugin(pluginOptions).setup!(api as any);
+
+  const rsbuildApi = {
+    modifyEnvironmentConfig: vi.fn(),
+    modifyRspackConfig: vi.fn(),
+    processAssets: vi.fn(),
+  };
+
+  rsbuildPlugin.setup(rsbuildApi);
+
+  const modifyEnvironmentConfig =
+    rsbuildApi.modifyEnvironmentConfig.mock.calls[0][0];
+  modifyEnvironmentConfig(
+    {
+      output: {
+        distPath: { root: '/project/dist' },
+        target: 'web',
+      },
+    },
+    { name: 'web' },
+  );
+  modifyEnvironmentConfig(
+    {
+      output: {
+        distPath: { root: '/project/dist/bundles' },
+        target: 'node',
+      },
+    },
+    { name: 'node' },
+  );
+
+  return { rsbuildApi };
+};
+
+const runCompiler = (config: import('@rspack/core').Configuration) =>
+  new Promise<void>((resolve, reject) => {
+    const compiler = rspack.rspack(config);
+    compiler.run((err, stats) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      if (stats?.hasErrors()) {
+        reject(new Error(stats.toString({ all: false, errors: true })));
+        return;
+      }
+      compiler.close((closeErr) => {
+        if (closeErr) {
+          reject(closeErr);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+
+describe('moduleFederationSSRPlugin', () => {
+  it('keeps SSR JavaScript under bundles while asset/resource URLs use the browser static path', async () => {
+    const outputDir = await mkdtemp(
+      path.join(tmpdir(), 'modern-js-v3-ssr-public-path-'),
+    );
+    const sourceDir = path.join(outputDir, 'src');
+    const browserPublicPath = 'https://cdn.example.com/app/';
+    const ssrPublicPath = `${browserPublicPath}bundles/`;
+
+    try {
+      await mkdir(sourceDir, { recursive: true });
+      await writeFile(
+        path.join(sourceDir, 'asset.svg'),
+        '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" /></svg>',
+      );
+      await writeFile(
+        path.join(sourceDir, 'asset.ts'),
+        "import assetUrl from './asset.svg';\nexport default assetUrl;\n",
+      );
+
+      const { rsbuildApi } = await createPluginHarness();
+      const config: import('@rspack/core').Configuration = {
+        mode: 'production',
+        context: outputDir,
+        target: 'async-node',
+        entry: {},
+        output: {
+          path: path.join(outputDir, 'dist', 'bundles'),
+          filename: '[name].js',
+          chunkFilename: '[name].js',
+          chunkFormat: 'commonjs',
+          chunkLoading: 'async-node',
+          library: { type: 'commonjs-module' },
+          publicPath: browserPublicPath,
+          uniqueName: 'remote',
+        },
+        module: {
+          rules: [
+            {
+              test: /\.svg$/,
+              type: 'asset/resource',
+              generator: {
+                filename: 'static/svg/[name].[contenthash][ext]',
+              },
+            },
+          ],
+        },
+        plugins: [
+          new ModuleFederationPlugin({
+            name: 'remote',
+            filename: 'remote.js',
+            exposes: {
+              './Asset': './src/asset.ts',
+            },
+            library: { type: 'commonjs-module' },
+            manifest: false,
+          }),
+        ],
+      };
+
+      const modifyRspackConfig = rsbuildApi.modifyRspackConfig.mock.calls[0][0];
+      modifyRspackConfig(config, { environment: { name: 'node' } });
+
+      expect(config.output?.publicPath).toBe(ssrPublicPath);
+      expect(config.module?.generator?.asset?.publicPath).toBe(
+        browserPublicPath,
+      );
+      expect(config.module?.generator?.['asset/resource']?.publicPath).toBe(
+        browserPublicPath,
+      );
+
+      await runCompiler(config);
+
+      const remote = nodeRequire(
+        path.join(outputDir, 'dist', 'bundles', 'remote.js'),
+      ) as {
+        get: (expose: string) => Promise<() => { default: string }>;
+      };
+      const factory = await remote.get('./Asset');
+      const exposedModule = factory();
+
+      expect(exposedModule.default).toMatch(
+        /^https:\/\/cdn\.example\.com\/app\/static\/svg\/asset\.[^.]+\.svg$/,
+      );
+      expect(exposedModule.default).not.toContain('/bundles/static/');
+    } finally {
+      await rm(outputDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/modernjs-v3/src/cli/ssrPlugin.ts
+++ b/packages/modernjs-v3/src/cli/ssrPlugin.ts
@@ -64,6 +64,31 @@ function getManifestAssetFileNames(
 type ModifyBundlerConfiguration = Parameters<ModifyRspackConfigFn>[0];
 type ModifyBundlerUtils = Parameters<ModifyRspackConfigFn>[1];
 
+const STATIC_ASSET_MODULE_TYPES = ['asset', 'asset/resource'] as const;
+
+const preserveStaticAssetPublicPath = (
+  config: ModifyBundlerConfiguration,
+  publicPath: unknown,
+) => {
+  if (
+    typeof publicPath !== 'string' ||
+    publicPath === '' ||
+    publicPath === 'auto'
+  ) {
+    return;
+  }
+  config.module ||= {};
+  const moduleConfig = config.module as {
+    generator?: Record<string, Record<string, unknown> | undefined>;
+  };
+  moduleConfig.generator ||= {};
+
+  for (const moduleType of STATIC_ASSET_MODULE_TYPES) {
+    moduleConfig.generator[moduleType] ||= {};
+    moduleConfig.generator[moduleType]!.publicPath ??= publicPath;
+  }
+};
+
 const mfSSRRsbuildPlugin = (
   pluginOptions: Required<InternalModernPluginOptions>,
 ): RsbuildPlugin => {
@@ -155,7 +180,9 @@ const mfSSRRsbuildPlugin = (
         if (!userSSRConfig.distOutputDir) {
           return;
         }
-        config.output!.publicPath = `${config.output!.publicPath}${path.relative(csrOutputPath, ssrOutputPath)}/`;
+        const publicPath = config.output!.publicPath;
+        preserveStaticAssetPublicPath(config, publicPath);
+        config.output!.publicPath = `${publicPath}${path.relative(csrOutputPath, ssrOutputPath)}/`;
         return config;
       };
       api.modifyRspackConfig((config, utils) => {

--- a/packages/modernjs/src/cli/ssrPlugin.spec.ts
+++ b/packages/modernjs/src/cli/ssrPlugin.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const createPluginHarness = async () => {
+  const { moduleFederationSSRPlugin } = await import('./ssrPlugin');
+  const pluginOptions = {
+    assetFileNames: {},
+    assetResources: {},
+    csrConfig: {},
+    distOutputDir: '/project/dist',
+    fetchServerQuery: undefined,
+    secondarySharedTreeShaking: false,
+    ssrConfig: {},
+    userConfig: {
+      ssr: {
+        distOutputDir: '/project/dist/bundles',
+      },
+    },
+  } as any;
+
+  let rsbuildPlugin: any;
+  const api = {
+    _internalRuntimePlugins: vi.fn(),
+    _internalServerPlugins: vi.fn(),
+    config: vi.fn((callback) => {
+      const config = callback();
+      rsbuildPlugin = config.builderPlugins[0];
+    }),
+    getAppContext: vi.fn(() => ({ bundlerType: 'rspack' })),
+    getConfig: vi.fn(() => ({ server: { ssr: true } })),
+    modifyBundlerChain: vi.fn(),
+    onAfterBuild: vi.fn(),
+    onDevCompileDone: vi.fn(),
+  };
+
+  await moduleFederationSSRPlugin(pluginOptions).setup!(api as any);
+
+  const rsbuildApi = {
+    modifyEnvironmentConfig: vi.fn(),
+    modifyRspackConfig: vi.fn(),
+    modifyWebpackConfig: vi.fn(),
+    processAssets: vi.fn(),
+  };
+
+  rsbuildPlugin.setup(rsbuildApi);
+
+  const modifyEnvironmentConfig =
+    rsbuildApi.modifyEnvironmentConfig.mock.calls[0][0];
+  modifyEnvironmentConfig(
+    {
+      output: {
+        distPath: { root: '/project/dist' },
+        target: 'web',
+      },
+    },
+    { name: 'web' },
+  );
+  modifyEnvironmentConfig(
+    {
+      output: {
+        distPath: { root: '/project/dist/bundles' },
+        target: 'node',
+      },
+    },
+    { name: 'node' },
+  );
+
+  return { rsbuildApi };
+};
+
+describe('moduleFederationSSRPlugin', () => {
+  it('preserves the browser publicPath for static asset generators when bundling SSR output', async () => {
+    const browserPublicPath = 'https://cdn.example.com/app/';
+    const ssrPublicPath = `${browserPublicPath}bundles/`;
+    const { rsbuildApi } = await createPluginHarness();
+
+    for (const hookName of ['modifyWebpackConfig', 'modifyRspackConfig']) {
+      const config: any = {
+        output: {
+          publicPath: browserPublicPath,
+        },
+        module: {},
+      };
+      const hook = rsbuildApi[hookName].mock.calls[0][0];
+
+      hook(config, { environment: { name: 'node' } });
+
+      expect(config.output.publicPath).toBe(ssrPublicPath);
+      expect(config.module.generator.asset.publicPath).toBe(browserPublicPath);
+      expect(config.module.generator['asset/resource'].publicPath).toBe(
+        browserPublicPath,
+      );
+    }
+  });
+});

--- a/packages/modernjs/src/cli/ssrPlugin.ts
+++ b/packages/modernjs/src/cli/ssrPlugin.ts
@@ -81,6 +81,31 @@ type ModifyBundlerUtils =
   | Parameters<ModifyWebpackConfigFn>[1]
   | Parameters<ModifyRspackConfigFn>[1];
 
+const STATIC_ASSET_MODULE_TYPES = ['asset', 'asset/resource'] as const;
+
+const preserveStaticAssetPublicPath = (
+  config: ModifyBundlerConfiguration,
+  publicPath: unknown,
+) => {
+  if (
+    typeof publicPath !== 'string' ||
+    publicPath === '' ||
+    publicPath === 'auto'
+  ) {
+    return;
+  }
+  config.module ||= {};
+  const moduleConfig = config.module as {
+    generator?: Record<string, Record<string, unknown> | undefined>;
+  };
+  moduleConfig.generator ||= {};
+
+  for (const moduleType of STATIC_ASSET_MODULE_TYPES) {
+    moduleConfig.generator[moduleType] ||= {};
+    moduleConfig.generator[moduleType]!.publicPath ??= publicPath;
+  }
+};
+
 const mfSSRRsbuildPlugin = (
   pluginOptions: Required<InternalModernPluginOptions>,
 ): RsbuildPlugin => {
@@ -172,7 +197,9 @@ const mfSSRRsbuildPlugin = (
         if (!userSSRConfig.distOutputDir) {
           return;
         }
-        config.output!.publicPath = `${config.output!.publicPath}${path.relative(csrOutputPath, ssrOutputPath)}/`;
+        const publicPath = config.output!.publicPath;
+        preserveStaticAssetPublicPath(config, publicPath);
+        config.output!.publicPath = `${publicPath}${path.relative(csrOutputPath, ssrOutputPath)}/`;
         return config;
       };
       api.modifyWebpackConfig((config, utils) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3734,8 +3734,8 @@ importers:
         specifier: 0.18.5
         version: 0.18.5(@microsoft/api-extractor@7.57.7(@types/node@25.9.1))(typescript@5.9.3)
       '@rspack/core':
-        specifier: 2.0.0-beta.0
-        version: 2.0.0-beta.0(@module-federation/runtime-tools@2.5.0(node-fetch@3.3.0))(@swc/helpers@0.5.17)
+        specifier: 2.0.6
+        version: 2.0.6(@module-federation/runtime-tools@2.5.0(node-fetch@3.3.0))(@swc/helpers@0.5.17)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.28
@@ -5885,14 +5885,23 @@ packages:
     resolution: {integrity: sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==}
     engines: {node: '>=16'}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.9.0':
     resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -8605,6 +8614,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@ndelangen/get-tarball@3.0.9':
     resolution: {integrity: sha512-9JKTEik4vq+yGosHYhZ1tiH/3WpUS0Nh0kej4Agndhox8pAdWhEx5knFVRcb/ya9knCRCs1rPxNrSXTDdfVqpA==}
@@ -11491,6 +11506,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.0.6':
+    resolution: {integrity: sha512-0giCKiWlBfcM4i2scv1j2k9HlSecO9Ybhaa5wsMUyvcFeKr9HbNHh7C2eDFlC6zaI85IUdY71TXF/g/Tcxr9MA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@0.7.5':
     resolution: {integrity: sha512-teLK0TB1x0CsvaaiCopsFx4EvJe+/Hljwii6R7C9qOZs5zSOfbT/LQ202eA0sAGodCncARCGaXVrsekbrRYqeA==}
     cpu: [x64]
@@ -11543,6 +11563,11 @@ packages:
 
   '@rspack/binding-darwin-x64@2.0.0-beta.0':
     resolution: {integrity: sha512-GucsfjrSKBZ9cuOTXmHWxeY2wPmaNyvGNxTyzttjRcfwqOWz8r+ku6PCsMSXUqxZRYWW1L9mvtTdlDrzTYJZ0w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.0.6':
+    resolution: {integrity: sha512-/mMo2IpI02aOKMlHbVbZue3TJxFqHGX+ibVTdEO+6bzRSuHs7+R9KM5U3XH2YxcWJy5Sid1X1T1pJAjsXcE3rA==}
     cpu: [x64]
     os: [darwin]
 
@@ -11601,6 +11626,11 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-gnu@2.0.6':
+    resolution: {integrity: sha512-H6ACzeM1KBxYDEF8YAim3501Jb1aCsSG79Gjm1M4pwJ5OJPK2ydiJEa438ugXmh0962eKYMHI2yZY0sQq8txaw==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-arm64-musl@0.7.5':
     resolution: {integrity: sha512-6RcxG42mLM01Pa6UYycACu/Nu9qusghAPUJumb8b8x5TRIDEtklYC5Ck6Rmagm+8E0ucMude2E/D4rMdIFcS3A==}
     cpu: [arm64]
@@ -11653,6 +11683,11 @@ packages:
 
   '@rspack/binding-linux-arm64-musl@2.0.0-beta.0':
     resolution: {integrity: sha512-S2fshx0Rf7/XYwoMLaqFsVg4y+VAfHzubrczy8AW5xIs6UNC3eRLVTgShLerUPtF6SG+v6NQxQ9JI3vOo2qPOA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@2.0.6':
+    resolution: {integrity: sha512-QTFmBg0n+L397Wi8CIjbd5pe/hxpHnqCDaG1A7e2NWX8Fj9zulAoKLiKflQa1ELEhAY4Foq88aX75+Ilt2tHcw==}
     cpu: [arm64]
     os: [linux]
 
@@ -11711,6 +11746,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-gnu@2.0.6':
+    resolution: {integrity: sha512-rerCAz022zf0ewxI+7n3SrqLEaxCL+MXRxKjK5FLUGFa8UkIrivq+VUP/1OB6JLh2Bucebc7Y9WoWHvtk22mLA==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-musl@0.7.5':
     resolution: {integrity: sha512-dDgi/ThikMy1m4llxPeEXDCA2I8F8ezFS/eCPLZGU2/J1b4ALwDjuRsMmo+VXSlFCKgIt98V6h1woeg7nu96yg==}
     cpu: [x64]
@@ -11766,6 +11806,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-musl@2.0.6':
+    resolution: {integrity: sha512-96IgOFXQjX6Wbxd+DCYJFy2r/VMu1OoHifW4Cr3kGTYDKoQOIMLwb0ieu/ILp2dGWFMZo5S8odiByAmNICAOIA==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-wasm32-wasi@1.4.11':
     resolution: {integrity: sha512-hiYxHZjaZ17wQtXyLCK0IdtOvMWreGVTiGsaHCxyeT+SldDG+r16bXNjmlqfZsjlfl1mkAqKz1dg+mMX28OTqw==}
     cpu: [wasm32]
@@ -11788,6 +11833,10 @@ packages:
 
   '@rspack/binding-wasm32-wasi@2.0.0-beta.0':
     resolution: {integrity: sha512-o6OatnNvb4kCzXbCaomhENGaCsO3naIyAqqErew90HeAwa1lfY3NhRfDLeIyuANQ+xqFl34/R7n8q3ZDx3nd4Q==}
+    cpu: [wasm32]
+
+  '@rspack/binding-wasm32-wasi@2.0.6':
+    resolution: {integrity: sha512-0aWiF+qmdb0csp1x+MaR2o1pscoquLaEbLTVdKjmoTRs6sguMemtB1ObnVTahAUL73P66WePuNpFAJ81zNdqzQ==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@0.7.5':
@@ -11842,6 +11891,11 @@ packages:
 
   '@rspack/binding-win32-arm64-msvc@2.0.0-beta.0':
     resolution: {integrity: sha512-neCzVllXzIqM8p8qKb89qV7wyk233gC/V9VrHIKbGeQjAEzpBsk5GOWlFbq5DDL6tivQ+uzYaTrZWm9tb2qxXg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.6':
+    resolution: {integrity: sha512-BX638A1MXsjc2E3tUskVh3X/WBIHjLKK+lo395v7MmEL9u2BA6l3F6RyW+YaJOt5aEOOv83iA7iCZsviVZ49Uw==}
     cpu: [arm64]
     os: [win32]
 
@@ -11900,6 +11954,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.0.6':
+    resolution: {integrity: sha512-DCK/+MlN35uvH7tp4j0hbg8wIs9MHArMIrNZXtiD8xP6DNw2wrXcGC1VaxxR5apyWpqXAfIL/KsXBiWS3ygCvg==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@0.7.5':
     resolution: {integrity: sha512-PpVpP6J5/2b4T10hzSUwjLvmdpAOj3ozARl1Nrf/lsbYwhiXivoB8Gvoy/xe/Xpgr732Dk9VCeeW8rreWOOUVQ==}
     cpu: [x64]
@@ -11955,6 +12014,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.0.6':
+    resolution: {integrity: sha512-TxutgzdEX9BkAU/5liKxdQmggJ23INz7EZDWtzSJO6C2SiSYzTJdyPQDIJi1ddkM5TX/drzH184gAJMVOQefng==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@0.7.5':
     resolution: {integrity: sha512-XcdOvaCz1mWWwr5vmEY9zncdInrjINEh60EWkYdqtCA67v7X7rB1fe6n4BeAI1+YLS2Eacj+lytlr+n7I+DYVg==}
 
@@ -11987,6 +12051,9 @@ packages:
 
   '@rspack/binding@2.0.0-beta.0':
     resolution: {integrity: sha512-L6PPqhwZWC2vzwdhBItNPXw+7V4sq+MBDRXLdd8NMqaJSCB5iKdJIbpbEQucST9Nn7V28IYoQTXs6+ol5vWUBA==}
+
+  '@rspack/binding@2.0.6':
+    resolution: {integrity: sha512-z5EO9mPlmYNpHAlRGub0Chr6D+Klgy+tX36n7tCm7VRGRlwTmTU9wSENrYbHcCpFbegtrE0s30rDeTBeOu+JiQ==}
 
   '@rspack/cli@1.3.9':
     resolution: {integrity: sha512-jGsde6kP1S7QntU4TYNv8KAHRwe5lb21rRVVj6qGFOQ7pckxWadyYyowo6Qg43OYlPAc9ZlDlba3Zg3gQoD73g==}
@@ -12090,6 +12157,18 @@ packages:
     peerDependencies:
       '@module-federation/runtime-tools': '>=0.22.0'
       '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.0.6':
+    resolution: {integrity: sha512-ronRqH1T2dYdMFVOQbGvDNxYaLugQK8qhNYYtS2DbOvPKQYvdIYWDenL9k/WV+hLoknnPWMn2ME2cKJcK3Po+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
     peerDependenciesMeta:
       '@module-federation/runtime-tools':
         optional: true
@@ -29210,10 +29289,21 @@ snapshots:
     dependencies:
       '@edge-runtime/primitives': 4.1.0
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
       tslib: 2.8.1
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emnapi/runtime@1.9.0':
     dependencies:
@@ -29222,6 +29312,11 @@ snapshots:
   '@emnapi/wasi-threads@1.2.0':
     dependencies:
       tslib: 2.8.1
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -33552,6 +33647,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@ndelangen/get-tarball@3.0.9':
     dependencies:
       gunzip-maybe: 1.4.2
@@ -37630,6 +37732,9 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.0-beta.0':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.0.6':
+    optional: true
+
   '@rspack/binding-darwin-x64@0.7.5':
     optional: true
 
@@ -37661,6 +37766,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.0-beta.0':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.6':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@0.7.5':
@@ -37696,6 +37804,9 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@2.0.0-beta.0':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.0.6':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@0.7.5':
     optional: true
 
@@ -37727,6 +37838,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.0-beta.0':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.6':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@0.7.5':
@@ -37762,6 +37876,9 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@2.0.0-beta.0':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.0.6':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@0.7.5':
     optional: true
 
@@ -37795,6 +37912,9 @@ snapshots:
   '@rspack/binding-linux-x64-musl@2.0.0-beta.0':
     optional: true
 
+  '@rspack/binding-linux-x64-musl@2.0.6':
+    optional: true
+
   '@rspack/binding-wasm32-wasi@1.4.11':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.1
@@ -37823,6 +37943,13 @@ snapshots:
   '@rspack/binding-wasm32-wasi@2.0.0-beta.0':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.0.6':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@0.7.5':
@@ -37858,6 +37985,9 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@2.0.0-beta.0':
     optional: true
 
+  '@rspack/binding-win32-arm64-msvc@2.0.6':
+    optional: true
+
   '@rspack/binding-win32-ia32-msvc@0.7.5':
     optional: true
 
@@ -37891,6 +38021,9 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@2.0.0-beta.0':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.0.6':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@0.7.5':
     optional: true
 
@@ -37922,6 +38055,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.0-beta.0':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.6':
     optional: true
 
   '@rspack/binding@0.7.5':
@@ -38061,6 +38197,19 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 2.0.0-beta.0
       '@rspack/binding-win32-ia32-msvc': 2.0.0-beta.0
       '@rspack/binding-win32-x64-msvc': 2.0.0-beta.0
+
+  '@rspack/binding@2.0.6':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.6
+      '@rspack/binding-darwin-x64': 2.0.6
+      '@rspack/binding-linux-arm64-gnu': 2.0.6
+      '@rspack/binding-linux-arm64-musl': 2.0.6
+      '@rspack/binding-linux-x64-gnu': 2.0.6
+      '@rspack/binding-linux-x64-musl': 2.0.6
+      '@rspack/binding-wasm32-wasi': 2.0.6
+      '@rspack/binding-win32-arm64-msvc': 2.0.6
+      '@rspack/binding-win32-ia32-msvc': 2.0.6
+      '@rspack/binding-win32-x64-msvc': 2.0.6
 
   '@rspack/cli@1.3.9(@rspack/core@1.3.9(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)':
     dependencies:
@@ -38217,6 +38366,13 @@ snapshots:
     optionalDependencies:
       '@module-federation/runtime-tools': 2.5.0(node-fetch@3.3.2)
       '@swc/helpers': 0.5.19
+
+  '@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.0(node-fetch@3.3.0))(@swc/helpers@0.5.17)':
+    dependencies:
+      '@rspack/binding': 2.0.6
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.0(node-fetch@3.3.0)
+      '@swc/helpers': 0.5.17
 
   '@rspack/dev-server@1.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3733,6 +3733,9 @@ importers:
       '@rslib/core':
         specifier: 0.18.5
         version: 0.18.5(@microsoft/api-extractor@7.57.7(@types/node@25.9.1))(typescript@5.9.3)
+      '@rspack/core':
+        specifier: 2.0.0-beta.0
+        version: 2.0.0-beta.0(@module-federation/runtime-tools@2.5.0(node-fetch@3.3.0))(@swc/helpers@0.5.17)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.28


### PR DESCRIPTION
## Description

Fix Modern.js SSR remote asset public paths so JavaScript entry files continue to resolve from the bundles directory while static assets referenced by the manifest resolve from their static asset path.

This also adds regression coverage for both Modern.js plugin variants and declares the Rspack dependency needed by the Modern.js v3 tests.

Validation run locally:

- `pnpm install --frozen-lockfile --lockfile-only --ignore-scripts`
- `node scripts/check-ghost-deps.mjs`
- `pnpm exec vitest run packages/modernjs-v3/src/cli/ssrPlugin.spec.ts packages/modernjs/src/cli/ssrPlugin.spec.ts`
- `pnpm exec prettier --check packages/modernjs-v3/package.json pnpm-lock.yaml`
- `pnpm exec turbo run build --filter=@module-federation/modern-js-v3`

## Related Issue

No linked issue. This fixes the SSR asset path regression reproduced while validating Modern.js remotes after publishing assets to a CDN-like layout.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.