### PR TITLE
chore: Re-Export UserOptions type along with ModuleFederation

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -21,7 +21,7 @@ export {
   type Federation,
 } from '@module-federation/runtime-core';
 
-export { ModuleFederation, UserOptions };
+export { ModuleFederation, type UserOptions };
 
 export function createInstance(options: UserOptions) {
   // Retrieve debug constructor

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -21,7 +21,7 @@ export {
   type Federation,
 } from '@module-federation/runtime-core';
 
-export { ModuleFederation };
+export { ModuleFederation, UserOptions };
 
 export function createInstance(options: UserOptions) {
   // Retrieve debug constructor


### PR DESCRIPTION
## Description

It is an inconvenience that for end user who only uses the @module-federation/enhanced package. When they want to invoke the createInstance function, suddenly found out the UserOptions type is not exported on top level of @module-federation/enhanced/runtime.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Then user will search where these are defined and dig few levels deep and found out it is proxied through multiple layers of package.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

It is better to export the type of argument for the function that is mentioned in the docs https://module-federation.io/guide/runtime/runtime-api.html#createinstance

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
