### PR TITLE
fix(examples): avoid direct antd package imports

### DIFF
--- a/apps/manifest-demo/3010-rspack-provider/src/components/ButtonOldAnt.tsx
+++ b/apps/manifest-demo/3010-rspack-provider/src/components/ButtonOldAnt.tsx
@@ -1,8 +1,6 @@
 import Button from 'antd/lib/button';
-import antdPackage from 'antd/package.json';
+import { version } from 'antd';
 import * as stuff from './stuff.module.css';
-
-const { version } = antdPackage;
 
 export default function ButtonOldAnt() {
   return (

--- a/apps/manifest-demo/webpack-host/src/components/ButtonOldAnt.tsx
+++ b/apps/manifest-demo/webpack-host/src/components/ButtonOldAnt.tsx
@@ -1,8 +1,6 @@
 import Button from 'antd/lib/button';
-import antdPackage from 'antd/package.json';
+import { version } from 'antd';
 import stuff from './stuff.module.css';
-
-const { version } = antdPackage;
 
 export default function ButtonOldAnt() {
   return <Button className={stuff.test}>Button from antd@{version}</Button>;

--- a/apps/runtime-demo/3007-runtime-remote/src/components/ButtonOldAnt.tsx
+++ b/apps/runtime-demo/3007-runtime-remote/src/components/ButtonOldAnt.tsx
@@ -1,8 +1,6 @@
 import Button from 'antd/lib/button';
-import antdPackage from 'antd/package.json';
+import { version } from 'antd';
 import stuff from './stuff.module.css';
-
-const { version } = antdPackage;
 
 export default function ButtonOldAnt() {
   return (


### PR DESCRIPTION
## Summary
- Replace direct `antd/package.json` imports in runtime and manifest demo components with Ant Design's public `version` export.
- Keeps the examples compatible with the repo's restricted-import lint rule for package JSON imports.

## Test plan
- `ESLINT_USE_FLAT_CONFIG=false pnpm exec eslint --no-error-on-unmatched-pattern --ignore-pattern node_modules apps/runtime-demo/3007-runtime-remote/src/components/ButtonOldAnt.tsx apps/manifest-demo/webpack-host/src/components/ButtonOldAnt.tsx apps/manifest-demo/3010-rspack-provider/src/components/ButtonOldAnt.tsx`
- `pnpm --filter runtime-remote2 run lint`
- `pnpm exec turbo run lint --filter=runtime-remote2 --filter=3008-webpack-host --filter=3010-rspack-provider`
- Pre-commit hook (`lint-fix` and `commitlint`) passed during commit

## Notes
- The local shell uses Node 22, so pnpm emitted the repo's expected Node `^20` engine warning.
- `apps/3002-checkout/components/ButtonOldAnt.tsx` still has the same import pattern, but that app's lint command currently fails before file linting because of an existing ESLint config circular-structure error; this PR avoids mixing that config issue into the focused demo lint fix.