### PR TITLE
fix(node): report HTTP failures before evaluating remote scripts

### DIFF
--- a/.changeset/quiet-node-loader-status.md
+++ b/.changeset/quiet-node-loader-status.md
@@ -1,0 +1,6 @@
+---
+"@module-federation/sdk": patch
+"@module-federation/node": patch
+---
+
+Report non-ok HTTP responses from Node remote entry and chunk loaders before evaluating response bodies as JavaScript.

--- a/packages/node/src/__tests__/runtimePlugin.test.ts
+++ b/packages/node/src/__tests__/runtimePlugin.test.ts
@@ -425,6 +425,98 @@ describe('runtimePlugin', () => {
       expect(callback).toHaveBeenCalledWith(expect.any(Error), null);
     });
 
+    it('should report HTTP status before evaluating a non-ok loader hook response', async () => {
+      const url = Object.assign(new URL('http://example.com/chunk.js'), {
+        mfMetadata: {
+          resolvedFrom: 'public-path',
+          remoteName: 'chunk.js',
+          publicPath: 'http://localhost:3000/',
+        },
+      });
+      const callback = jest.fn();
+      const args = {
+        origin: {
+          options: {
+            name: 'test-host',
+          },
+          loaderHook: {
+            lifecycle: {
+              fetch: {
+                emit: jest.fn().mockResolvedValue(
+                  new Response('Injected missing chunk', {
+                    status: 404,
+                    statusText: 'Not Found',
+                    headers: {
+                      'content-type': 'text/plain',
+                    },
+                  }),
+                ),
+              },
+            },
+          },
+        },
+      };
+
+      fetchAndRun(url, 'chunk.js', callback, args);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const error = callback.mock.calls[0][0] as Error;
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('HTTP 404');
+      expect(error.message).toContain(url.href);
+      expect(error.message).not.toContain('Unexpected identifier');
+      expect(error.message).not.toContain('Federated chunk execution failed.');
+      expect(callback).toHaveBeenCalledWith(error, null);
+    });
+
+    it('should report HTTP status before evaluating a non-ok fallback fetch response', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        new Response('Service unavailable chunk', {
+          status: 503,
+          statusText: 'Service Unavailable',
+          headers: {
+            'content-type': 'text/plain',
+          },
+        }),
+      );
+
+      const url = Object.assign(new URL('http://example.com/chunk.js'), {
+        mfMetadata: {
+          resolvedFrom: 'public-path',
+          remoteName: 'chunk.js',
+          publicPath: 'http://localhost:3000/',
+        },
+      });
+      const callback = jest.fn();
+      const args = {
+        origin: {
+          options: {
+            name: 'test-host',
+          },
+          loaderHook: {
+            lifecycle: {
+              fetch: {
+                emit: jest.fn().mockResolvedValue(null),
+              },
+            },
+          },
+        },
+      };
+
+      fetchAndRun(url, 'chunk.js', callback, args);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const error = callback.mock.calls[0][0] as Error;
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('HTTP 503');
+      expect(error.message).toContain(url.href);
+      expect(error.message).not.toContain('Unexpected identifier');
+      expect(error.message).not.toContain('Federated chunk execution failed.');
+      expect(callback).toHaveBeenCalledWith(error, null);
+    });
+
     it('should attach remote chunk context when execution fails', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({
         text: jest.fn().mockResolvedValue('const broken = { foo: };'),

--- a/packages/node/src/runtimePlugin.ts
+++ b/packages/node/src/runtimePlugin.ts
@@ -43,7 +43,7 @@ export const nodeRuntimeImportCache = new Map<string, Promise<any>>();
 const CHUNK_PREVIEW_LENGTH = 240;
 type ChunkResolutionSource = 'public-path' | 'remote-entry-fallback';
 type ChunkLocationSource = 'filesystem' | 'remote-url';
-type ChunkUrlMetadata = {
+type ChunkResolutionMetadata = {
   chunkName: string;
   publicPath?: string;
   remoteName?: string;
@@ -51,68 +51,190 @@ type ChunkUrlMetadata = {
   resolvedFrom: ChunkResolutionSource;
   remoteEntryUrl?: string;
 };
+type ChunkFetchContext = {
+  chunkName: string;
+  location: string;
+  hostName?: string;
+  chunkResolution?: ChunkResolutionMetadata;
+};
+type FetchResponseLike = {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  text: () => Promise<string>;
+};
 
-const getChunkPreview = (content: string): string =>
-  content.slice(0, CHUNK_PREVIEW_LENGTH).replace(/\s+/g, ' ').trim();
+const getChunkPreview = (chunkText: string): string =>
+  chunkText.slice(0, CHUNK_PREVIEW_LENGTH).replace(/\s+/g, ' ').trim();
 
-const enrichChunkExecutionError = (
-  error: unknown,
-  options: {
-    chunkName: string;
-    location: string;
-    source: ChunkLocationSource;
-    content: string;
-    hostName?: string;
-    resolution?: ChunkUrlMetadata;
-  },
-): Error => {
-  const normalizedError =
-    error instanceof Error ? error : new Error(String(error));
-  const preview = getChunkPreview(options.content);
-  const details = [
-    `Federated chunk execution failed.`,
-    `chunk: ${options.chunkName}`,
-    `source: ${options.source}`,
-    `location: ${options.location}`,
-  ];
-
-  if (options.hostName) {
-    details.push(`host: ${options.hostName}`);
+const isSuccessfulHttpResponse = (response: FetchResponseLike): boolean => {
+  if (typeof response.ok === 'boolean') {
+    return response.ok;
   }
 
-  if (options.resolution) {
-    details.push(`resolved-from: ${options.resolution.resolvedFrom}`);
+  const status = Number(response.status);
+  return (
+    !Number.isFinite(status) || status === 0 || (status >= 200 && status < 300)
+  );
+};
 
-    if (options.resolution.remoteName) {
-      details.push(`remote: ${options.resolution.remoteName}`);
+const formatHttpStatus = (response: FetchResponseLike): string => {
+  const status = Number(response.status);
+  const statusText =
+    typeof response.statusText === 'string' ? response.statusText.trim() : '';
+
+  if (!Number.isFinite(status) || status === 0) {
+    return 'non-ok HTTP response';
+  }
+
+  return `HTTP ${status}${statusText ? ` ${statusText}` : ''}`;
+};
+
+const createChunkFetchError = (
+  response: FetchResponseLike,
+  context: ChunkFetchContext & { responseText: string },
+): Error => {
+  const preview = getChunkPreview(context.responseText);
+  const messageLines = [
+    `Federated chunk fetch failed.`,
+    `chunk: ${context.chunkName}`,
+    `location: ${context.location}`,
+    `status: ${formatHttpStatus(response)}`,
+  ];
+
+  if (context.hostName) {
+    messageLines.push(`host: ${context.hostName}`);
+  }
+
+  if (context.chunkResolution) {
+    messageLines.push(`resolved-from: ${context.chunkResolution.resolvedFrom}`);
+
+    if (context.chunkResolution.remoteName) {
+      messageLines.push(`remote: ${context.chunkResolution.remoteName}`);
     }
 
-    if (options.resolution.publicPath) {
-      details.push(`public-path: ${options.resolution.publicPath}`);
+    if (context.chunkResolution.publicPath) {
+      messageLines.push(`public-path: ${context.chunkResolution.publicPath}`);
     }
 
-    if (options.resolution.rootOutputDir) {
-      details.push(`root-output-dir: ${options.resolution.rootOutputDir}`);
+    if (context.chunkResolution.rootOutputDir) {
+      messageLines.push(
+        `root-output-dir: ${context.chunkResolution.rootOutputDir}`,
+      );
     }
 
-    if (options.resolution.remoteEntryUrl) {
-      details.push(`remote-entry: ${options.resolution.remoteEntryUrl}`);
+    if (context.chunkResolution.remoteEntryUrl) {
+      messageLines.push(
+        `remote-entry: ${context.chunkResolution.remoteEntryUrl}`,
+      );
     }
   }
 
   if (preview) {
-    details.push(`preview: ${preview}`);
+    messageLines.push(`preview: ${preview}`);
   }
 
-  normalizedError.message = `${normalizedError.message}\n${details.join('\n')}`;
+  const error = new Error(messageLines.join('\n'));
+  Object.assign(error, {
+    chunkName: context.chunkName,
+    chunkLocation: context.location,
+    chunkSource: 'remote-url',
+    chunkPreview: preview,
+    chunkHostName: context.hostName,
+    chunkResolution: context.chunkResolution,
+    status: response.status,
+    statusText: response.statusText,
+  });
+
+  return error;
+};
+
+const readValidatedChunkResponseText = async (
+  response: FetchResponseLike,
+  chunkFetchContext: ChunkFetchContext,
+): Promise<string> => {
+  const responseText = await response.text();
+
+  if (!isSuccessfulHttpResponse(response)) {
+    throw createChunkFetchError(response, {
+      ...chunkFetchContext,
+      responseText,
+    });
+  }
+
+  return responseText;
+};
+
+const enrichChunkExecutionError = (
+  error: unknown,
+  executionContext: {
+    chunkName: string;
+    location: string;
+    source: ChunkLocationSource;
+    chunkCode: string;
+    hostName?: string;
+    chunkResolution?: ChunkResolutionMetadata;
+  },
+): Error => {
+  const normalizedError =
+    error instanceof Error ? error : new Error(String(error));
+  const preview = getChunkPreview(executionContext.chunkCode);
+  const messageLines = [
+    `Federated chunk execution failed.`,
+    `chunk: ${executionContext.chunkName}`,
+    `source: ${executionContext.source}`,
+    `location: ${executionContext.location}`,
+  ];
+
+  if (executionContext.hostName) {
+    messageLines.push(`host: ${executionContext.hostName}`);
+  }
+
+  if (executionContext.chunkResolution) {
+    messageLines.push(
+      `resolved-from: ${executionContext.chunkResolution.resolvedFrom}`,
+    );
+
+    if (executionContext.chunkResolution.remoteName) {
+      messageLines.push(
+        `remote: ${executionContext.chunkResolution.remoteName}`,
+      );
+    }
+
+    if (executionContext.chunkResolution.publicPath) {
+      messageLines.push(
+        `public-path: ${executionContext.chunkResolution.publicPath}`,
+      );
+    }
+
+    if (executionContext.chunkResolution.rootOutputDir) {
+      messageLines.push(
+        `root-output-dir: ${executionContext.chunkResolution.rootOutputDir}`,
+      );
+    }
+
+    if (executionContext.chunkResolution.remoteEntryUrl) {
+      messageLines.push(
+        `remote-entry: ${executionContext.chunkResolution.remoteEntryUrl}`,
+      );
+    }
+  }
+
+  if (preview) {
+    messageLines.push(`preview: ${preview}`);
+  }
+
+  normalizedError.message = `${normalizedError.message}\n${messageLines.join(
+    '\n',
+  )}`;
 
   Object.assign(normalizedError, {
-    chunkName: options.chunkName,
-    chunkLocation: options.location,
-    chunkSource: options.source,
+    chunkName: executionContext.chunkName,
+    chunkLocation: executionContext.location,
+    chunkSource: executionContext.source,
     chunkPreview: preview,
-    chunkHostName: options.hostName,
-    chunkResolution: options.resolution,
+    chunkHostName: executionContext.hostName,
+    chunkResolution: executionContext.chunkResolution,
   });
 
   return normalizedError;
@@ -187,12 +309,12 @@ export const loadFromFs = (
   const vm = __non_webpack_require__('vm') as typeof import('vm');
 
   if (fs.existsSync(filename)) {
-    fs.readFile(filename, 'utf-8', (err, content) => {
+    fs.readFile(filename, 'utf-8', (err, chunkCode) => {
       if (err) return callback(err, null);
       const chunk = {};
       try {
         const script = new vm.Script(
-          `(function(exports, require, __dirname, __filename) {${content}\n})`,
+          `(function(exports, require, __dirname, __filename) {${chunkCode}\n})`,
           {
             filename,
             importModuleDynamically:
@@ -213,7 +335,7 @@ export const loadFromFs = (
             chunkName: path.basename(filename),
             location: filename,
             source: 'filesystem',
-            content,
+            chunkCode,
           }),
           null,
         );
@@ -231,6 +353,17 @@ export const fetchAndRun = (
   callback: (err: Error | null, chunk: any) => void,
   args: any,
 ): void => {
+  const hostName = args?.origin?.options?.name || args?.origin?.name;
+  const chunkResolution = (
+    url as URL & { mfMetadata?: ChunkResolutionMetadata }
+  ).mfMetadata;
+  const chunkFetchContext = {
+    chunkName,
+    location: url.href,
+    hostName,
+    chunkResolution,
+  };
+
   (typeof fetch === 'undefined'
     ? importNodeModule<typeof import('node-fetch')>('node-fetch').then(
         (mod) => mod.default,
@@ -242,18 +375,19 @@ export const fetchAndRun = (
         .emit(url.href, {})
         .then((res: Response | null) => {
           if (!res || !(res instanceof Response)) {
-            return fetchFunction(url.href).then((response) => response.text());
+            return fetchFunction(url.href).then((response) =>
+              readValidatedChunkResponseText(response, chunkFetchContext),
+            );
           }
-          return res.text();
+          return readValidatedChunkResponseText(res, chunkFetchContext);
         });
     })
-    .then((data) => {
+    .then((chunkCode) => {
       const chunk = {};
-      const hostName = args?.origin?.options?.name || args?.origin?.name;
-      const resolution = (url as URL & { mfMetadata?: ChunkUrlMetadata })
-        .mfMetadata;
       try {
-        eval(`(function(exports, require, __dirname, __filename) {${data}\n})`)(
+        eval(
+          `(function(exports, require, __dirname, __filename) {${chunkCode}\n})`,
+        )(
           chunk,
           __non_webpack_require__,
           url.pathname.split('/').slice(0, -1).join('/'),
@@ -266,9 +400,9 @@ export const fetchAndRun = (
             chunkName,
             location: url.href,
             source: 'remote-url',
-            content: data,
+            chunkCode,
             hostName,
-            resolution,
+            chunkResolution,
           }),
           null,
         );

--- a/packages/sdk/__tests__/node-http-status.spec.ts
+++ b/packages/sdk/__tests__/node-http-status.spec.ts
@@ -1,0 +1,60 @@
+import { createScriptNode } from '../src/node';
+
+const createResponse = (
+  body: string,
+  init: { status: number; statusText?: string },
+): Response =>
+  ({
+    ok: init.status >= 200 && init.status < 300,
+    status: init.status,
+    statusText: init.statusText ?? '',
+    text: jest.fn().mockResolvedValue(body),
+  }) as unknown as Response;
+
+const loadNodeScript = (attrs: Record<string, unknown> = {}) =>
+  new Promise((resolve, reject) => {
+    createScriptNode(
+      'http://example.com/remoteEntry.js',
+      (error, scriptContext) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(scriptContext);
+      },
+      attrs,
+    );
+  });
+
+describe('Node script HTTP status handling', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('rejects non-ok CommonJS responses before evaluating the body', async () => {
+    const fetchMock = jest.fn().mockImplementation(() =>
+      Promise.resolve(
+        createResponse('Injected missing remoteEntry', {
+          status: 404,
+          statusText: 'Not Found',
+        }),
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let error: Error | undefined;
+    try {
+      await loadNodeScript();
+    } catch (caughtError) {
+      error = caughtError as Error;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.name).toBe('ScriptNetworkError');
+    expect(error?.message).toContain('HTTP 404');
+    expect(error?.message).not.toContain('Unexpected identifier');
+  });
+});

--- a/packages/sdk/src/node.ts
+++ b/packages/sdk/src/node.ts
@@ -30,6 +30,67 @@ function importNodeModule<T>(name: string): Promise<T> {
   return promise;
 }
 
+const SCRIPT_RESPONSE_PREVIEW_LENGTH = 240;
+
+const getScriptResponsePreview = (responseText: string): string =>
+  responseText
+    .slice(0, SCRIPT_RESPONSE_PREVIEW_LENGTH)
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const isSuccessfulHttpResponse = (response: Response): boolean => {
+  if (typeof response.ok === 'boolean') {
+    return response.ok;
+  }
+
+  const status = Number(response.status);
+  return (
+    !Number.isFinite(status) || status === 0 || (status >= 200 && status < 300)
+  );
+};
+
+const formatHttpStatus = (response: Response): string => {
+  const status = Number(response.status);
+  const statusText =
+    typeof response.statusText === 'string' ? response.statusText.trim() : '';
+
+  if (!Number.isFinite(status) || status === 0) {
+    return 'non-ok HTTP response';
+  }
+
+  return `HTTP ${status}${statusText ? ` ${statusText}` : ''}`;
+};
+
+const createScriptNetworkError = (
+  response: Response,
+  url: string,
+  responseText: string,
+): Error => {
+  const preview = getScriptResponsePreview(responseText);
+  const previewSuffix = preview ? `; preview: ${preview}` : '';
+  const error = new Error(
+    `ScriptNetworkError: Failed to load Node.js script "${url}" - ${formatHttpStatus(
+      response,
+    )}${previewSuffix}`,
+  );
+
+  error.name = 'ScriptNetworkError';
+  return error;
+};
+
+const readValidatedScriptResponseText = async (
+  response: Response,
+  url: string,
+): Promise<string> => {
+  const responseText = await response.text();
+
+  if (!isSuccessfulHttpResponse(response)) {
+    throw createScriptNetworkError(response, url, responseText);
+  }
+
+  return responseText;
+};
+
 const lazyLoaderHookFetch = async (
   input: RequestInfo | URL,
   init?: RequestInit,
@@ -90,7 +151,10 @@ export const createScriptNode =
         const handleScriptFetch = async (f: typeof fetch, urlObj: URL) => {
           try {
             const res = await f(urlObj.href);
-            const data = await res.text();
+            const data = await readValidatedScriptResponseText(
+              res,
+              urlObj.href,
+            );
             const [path, vm] = await Promise.all([
               importNodeModule<typeof import('path')>('path'),
               importNodeModule<typeof import('vm')>('vm'),
@@ -419,7 +483,7 @@ async function loadModule(url: string, options: LoadModuleOptions) {
   }
 
   const response = await fetch(url);
-  const code = await response.text();
+  const code = await readValidatedScriptResponseText(response, url);
   const nodeUrl = await importNodeModule<typeof import('node:url')>('node:url');
   const cwdFileUrl = nodeUrl.pathToFileURL(process.cwd()).href;
 


### PR DESCRIPTION
## Description

This fixes Node.js remote script loading paths so non-ok HTTP responses are reported before their response bodies are evaluated as JavaScript.

Previously, when a Node remote entry or federated runtime chunk returned an HTTP error response such as 404 or 503, the loader could read the response body and attempt to evaluate it as JavaScript. That could surface a confusing syntax error such as `Unexpected identifier` instead of the actual HTTP failure.

This change:

- Adds HTTP status validation before evaluating Node remote entry responses in `@module-federation/sdk`.
- Adds HTTP status validation before evaluating fetched federated chunks in `@module-federation/node`.
- Preserves diagnostic context for chunk loading failures, including chunk name, URL, host, resolution metadata, HTTP status, and response preview.
- Adds regression tests for non-ok remote entry and chunk responses.
- Adds a patch changeset for `@module-federation/sdk` and `@module-federation/node`.

Tested with Node.js `v20.19.5`:

- `corepack pnpm --filter @module-federation/sdk run test`
- `corepack pnpm --filter @module-federation/node run test`
- `corepack pnpm --filter @module-federation/sdk run build`
- `corepack pnpm --filter @module-federation/node run build`
- `corepack pnpm --filter @module-federation/sdk run lint`
- `corepack pnpm --filter @module-federation/node run lint`
- `corepack pnpm exec prettier --check packages/sdk/src/node.ts packages/sdk/__tests__/node-http-status.spec.ts packages/node/src/runtimePlugin.ts packages/node/src/__tests__/runtimePlugin.test.ts .changeset/quiet-node-loader-status.md`

## Related Issue

Fixes #4810

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
