### PR TITLE
fix(rsbuild-plugin): remove whitespace from chunk global

### DIFF
--- a/.changeset/quiet-rsbuild-chunks.md
+++ b/.changeset/quiet-rsbuild-chunks.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/rsbuild-plugin": patch
+---
+
+Fix the default Rsbuild chunk loading global name so it does not include whitespace.

--- a/packages/rsbuild-plugin/src/cli/index.ts
+++ b/packages/rsbuild-plugin/src/cli/index.ts
@@ -519,7 +519,7 @@ export const pluginModuleFederation = (
             !isActiveRspressSSGEnvironmentConfig &&
             target !== 'node'
           ) {
-            bundlerConfig.output!.chunkLoadingGlobal = `chunk_${moduleFederationOptions.name} `;
+            bundlerConfig.output!.chunkLoadingGlobal = `chunk_${moduleFederationOptions.name}`;
           }
 
           if (isNodeTargetEnvironmentConfig) {

--- a/packages/rsbuild-plugin/src/cli/node-target.spec.ts
+++ b/packages/rsbuild-plugin/src/cli/node-target.spec.ts
@@ -239,6 +239,33 @@ describe('pluginModuleFederation node target environment behavior', () => {
     expect(mfOptions.remoteType).toBeUndefined();
   });
 
+  it('sets a chunk loading global without whitespace for web targets', () => {
+    const plugin = pluginModuleFederation(createMfOptions());
+    const { api, state } = createMockApi({
+      environments: {
+        web: {},
+      },
+    });
+    const webBundlerConfig: Rspack.Configuration = {
+      name: 'web',
+      output: {
+        path: '/tmp/web',
+      },
+      optimization: {},
+      plugins: [],
+    };
+
+    plugin.setup(api as any);
+    expect(state.beforeCreateCompiler).toBeDefined();
+
+    state.beforeCreateCompiler!({
+      bundlerConfigs: [webBundlerConfig],
+    });
+
+    expect(webBundlerConfig.output?.chunkLoadingGlobal).toBe('chunk_host');
+    expect(webBundlerConfig.output?.chunkLoadingGlobal).not.toMatch(/\s/);
+  });
+
   it('keeps target=dual restriction for non-rslib/non-rspress callers', () => {
     const plugin = pluginModuleFederation(createMfOptions(), {
       target: 'dual',


### PR DESCRIPTION
## What changed

Fixes the default Rsbuild chunk loading global name so it no longer includes a trailing space.

## Why

The previous default generated a name that looked normal but contained hidden whitespace, which could cause mismatches with tools or code expecting the clean name.

## Impact

Projects that rely on the plugin default now get a clean chunk loading global name. Projects that set their own value are unchanged.

## Validation

- `pnpm --filter @module-federation/rsbuild-plugin run test`
- `pnpm --filter @module-federation/rsbuild-plugin run build`
- `pnpm --filter @module-federation/rsbuild-plugin run lint`
- `pnpm exec prettier --check packages/rsbuild-plugin/src/cli/index.ts packages/rsbuild-plugin/src/cli/node-target.spec.ts .changeset/quiet-rsbuild-chunks.md`
- `/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 .codex/skills/changeset-pr/scripts/run_changeset_status.py --verbose`

## Notes

`pnpm exec prettier --check .` was also run, but it failed on existing generated files under `apps/website-new/doc_build`; the files changed in this PR pass formatting.