### PR TITLE
docs(website-new): normalize links in _components mdx

### DIFF
--- a/apps/website-new/docs/en/_components/data-fetch/consumer.mdx
+++ b/apps/website-new/docs/en/_components/data-fetch/consumer.mdx
@@ -1,5 +1,5 @@
 ::: info Note
-Currently, only [Modern.js](/integrations/framework/modernjs) supports data fetching in SSR environments.
+Currently, only [Modern.js](/integrations/framework/modernjs/index.html) supports data fetching in SSR environments.
 :::
 
 In the consumer, we need to use the [createLazyComponent](/guide/bridge/react/load-component.html#what-is-createlazycomponent) API to load the remote component and fetch its data.

--- a/apps/website-new/docs/en/_components/data-fetch/provider-tip.mdx
+++ b/apps/website-new/docs/en/_components/data-fetch/provider-tip.mdx
@@ -1,3 +1,3 @@
 ::: tip
-Producers can use [Rslib](/integrations/build-tool/rslib#ssr) and [Modern.js](/integrations/framework/modernjs).
+Producers can use [Rslib](/integrations/build-tool/rslib.html#ssr) and [Modern.js](/integrations/framework/modernjs/index.html).
 :::

--- a/apps/website-new/docs/en/_components/secondary-build.mdx
+++ b/apps/website-new/docs/en/_components/secondary-build.mdx
@@ -1,7 +1,7 @@
 ## Producing a secondary tree-shaken shared artifact
 
 :::warning Note
-If your goal is “tree-shake a shared dependency for a single application”, [usedExports](../../../docs/configure/shared#usedexports) is usually enough.
+If your goal is “tree-shake a shared dependency for a single application”, [usedExports](/configure/shared.html#usedexports) is usually enough.
 
 This section is about generating a standalone secondary artifact that can be loaded at runtime on demand, and can be distributed or reused from the deployment side.
 :::

--- a/apps/website-new/docs/zh/_components/data-fetch/consumer.mdx
+++ b/apps/website-new/docs/zh/_components/data-fetch/consumer.mdx
@@ -1,5 +1,5 @@
 ::: info 注意
-目前仅 [Modern.js](/integrations/framework/modernjs) 支持在 SSR 环境下使用数据获取能力。
+目前仅 [Modern.js](/integrations/framework/modernjs/index.html) 支持在 SSR 环境下使用数据获取能力。
 :::
 
 在消费者中，我们需要通过 [createLazyComponent](/guide/bridge/react/load-component.html#什么是-createlazycomponent) API 来加载远程组件，并获取数据。

--- a/apps/website-new/docs/zh/_components/data-fetch/provider-tip.mdx
+++ b/apps/website-new/docs/zh/_components/data-fetch/provider-tip.mdx
@@ -1,3 +1,3 @@
 ::: tip
-生产者可以使用 [Rslib](/integrations/build-tool/rslib#ssr) 和 [Modern.js](/integrations/framework/modernjs)。
+生产者可以使用 [Rslib](/integrations/build-tool/rslib.html#ssr) 和 [Modern.js](/integrations/framework/modernjs/index.html)。
 :::

--- a/apps/website-new/docs/zh/_components/secondary-build.mdx
+++ b/apps/website-new/docs/zh/_components/secondary-build.mdx
@@ -1,7 +1,7 @@
 ## 生成二次构建（secondary）共享产物
 
 :::warning 注意
-如果你的诉求是“让单个应用按需裁剪共享依赖”，通常只需要配置 [usedExports](../../../docs/configure/shared#usedexports)。
+如果你的诉求是“让单个应用按需裁剪共享依赖”，通常只需要配置 [usedExports](/configure/shared.html#usedexports)。
 
 本节介绍的是生成一份可被运行时按需加载的独立共享产物（secondary），用于在部署侧统一下发或复用。
 :::


### PR DESCRIPTION
## Summary

- Follow-up to #4817. The previous pass missed `docs/[lang]/_components/**`, which still contained relative paths and `.html`-less internal links.
- Rewrite the remaining internal links to absolute paths with the `.html` suffix, matching the convention used elsewhere in the site.
  - `secondary-build.mdx` (zh/en): `../../../docs/configure/shared#usedexports` → `/configure/shared.html#usedexports`
  - `data-fetch/consumer.mdx` (zh/en): `/integrations/framework/modernjs` → `/integrations/framework/modernjs/index.html`
  - `data-fetch/provider-tip.mdx` (zh/en): `/integrations/build-tool/rslib#ssr` → `/integrations/build-tool/rslib.html#ssr`; `/integrations/framework/modernjs` → `/integrations/framework/modernjs/index.html`

## 摘要

- #4817 的后续修复。上一轮统一站内链接时遗漏了 `docs/[lang]/_components/**` 下的片段文档，里面仍残留相对路径和缺少 `.html` 的内部链接。
- 将这些片段中的内部链接统一改写为带 `.html` 的绝对路径，与站点其他文档保持一致：
  - `secondary-build.mdx`（中/英）：`../../../docs/configure/shared#usedexports` → `/configure/shared.html#usedexports`
  - `data-fetch/consumer.mdx`（中/英）：`/integrations/framework/modernjs` → `/integrations/framework/modernjs/index.html`
  - `data-fetch/provider-tip.mdx`（中/英）：`/integrations/build-tool/rslib#ssr` → `/integrations/build-tool/rslib.html#ssr`；`/integrations/framework/modernjs` → `/integrations/framework/modernjs/index.html`

## Test plan

- [ ] `pnpm run serve:website` and verify each updated link resolves to the right anchor in both `/zh/` and `/en/` builds.
- [ ] Spot-check the pages that include these `_components` partials (data-fetch guide, shared tree-shaking guide) to confirm no broken links remain.