### PR TITLE
feat: add SSR remote cache clearing

### DIFF
--- a/apps/manifest-demo/3010-rspack-provider/rspack.config.js
+++ b/apps/manifest-demo/3010-rspack-provider/rspack.config.js
@@ -60,11 +60,16 @@ module.exports = (_env, argv = {}) => {
           },
           type: 'javascript/auto',
         },
+        {
+          test: /\.module\.css$/,
+          type: 'css/module',
+        },
       ],
     },
     experiments: {
       css: true,
     },
+    lazyCompilation: false,
     plugins: [
       new HtmlRspackPlugin({
         template: path.resolve(__dirname, 'src/index.html'),

--- a/apps/manifest-demo/3011-rspack-manifest-provider/rspack.config.js
+++ b/apps/manifest-demo/3011-rspack-manifest-provider/rspack.config.js
@@ -65,6 +65,7 @@ module.exports = (_env, argv = {}) => {
         },
       ],
     },
+    lazyCompilation: false,
     plugins: [
       new HtmlRspackPlugin({
         template: path.resolve(__dirname, 'src/index.html'),

--- a/apps/manifest-demo/3012-rspack-js-entry-provider/rspack.config.js
+++ b/apps/manifest-demo/3012-rspack-js-entry-provider/rspack.config.js
@@ -65,6 +65,7 @@ module.exports = (_env, argv = {}) => {
         },
       ],
     },
+    lazyCompilation: false,
     plugins: [
       new HtmlRspackPlugin({
         template: path.resolve(__dirname, 'src/index.html'),

--- a/apps/modernjs-ssr/host/README.md
+++ b/apps/modernjs-ssr/host/README.md
@@ -1,0 +1,174 @@
+# Modern SSR removeRemote cache repro
+
+This app contains a manual repro for checking whether a same-name remote can be
+removed from SSR memory and loaded again from a different URL.
+
+## Services
+
+Start the three apps from the repository root:
+
+```bash
+pnpm --dir apps/modernjs-ssr/remote dev
+pnpm --dir apps/modernjs-ssr/remote-new-version dev
+pnpm --dir apps/modernjs-ssr/host dev
+```
+
+The host `dev` script starts Node with `--expose-gc`, so the repro page can
+trigger GC before collecting memory snapshots.
+
+Ports used by this repro:
+
+- Host: `http://localhost:3050`
+- Remote v1: `http://127.0.0.1:3051/static/mf-manifest.json`
+- Remote v2: `http://127.0.0.1:3055/mf-manifest.json`
+
+## Manual Repro
+
+Open:
+
+```text
+http://localhost:3050/remove-remote-cache
+```
+
+The page runs the full flow once:
+
+1. Register remote v1.
+2. Snapshot memory before loading the remote.
+3. Load `remote/Heavy` from v1.
+4. Snapshot memory after loading v1.
+5. Call `removeRemote('remote')`.
+6. Snapshot memory after removal.
+7. Trigger GC and snapshot memory again.
+8. Wait 10s, 20s, and 30s, triggering GC before each delayed snapshot.
+9. Register remote v2.
+10. Load `remote/Heavy` from v2.
+11. Snapshot memory after loading v2.
+
+## What To Check
+
+Check the table on the page. The most useful column is `heap MB`.
+
+Expected remote result:
+
+- `heavy version` is `v1`
+- `reloaded heavy version` is `v2`
+- `initial remote` points to `127.0.0.1:3051/static/mf-manifest.json`
+- `reloaded remote` points to `127.0.0.1:3055/mf-manifest.json`
+
+Expected memory shape:
+
+- `after load` is higher than `before load`, because v1 loads a large payload.
+- `after gc` or one of the delayed GC snapshots should be lower than
+  `after removeRemote`.
+- `after reload` is higher again, because v2 loads another large payload.
+
+The raw JSON is also printed in `#remove-remote-cache-result` at the bottom of
+the page.
+
+## Split Step Repro
+
+Use these routes when heap snapshots make the full route too heavy. Visit them
+in order from the same host process:
+
+```text
+http://localhost:3050/remove-remote-cache/load-remote
+http://localhost:3050/remove-remote-cache/remove-remote
+http://localhost:3050/remove-remote-cache/register-new-remote
+```
+
+Each route returns one memory row and writes one heap snapshot:
+
+- `load-remote`: registers remote v1, loads `remote/Heavy`, then snapshots
+  memory.
+- `remove-remote`: calls `removeRemote('remote')`, triggers GC, then snapshots
+  memory. It does not register remote v2.
+- `register-new-remote`: registers remote v2, loads `remote/Heavy`, then
+  snapshots memory.
+
+## Heap Snapshot Debugging
+
+Heap snapshots are disabled by default because each snapshot pauses the process
+and can use a large amount of memory. Enable them only when you need to inspect
+what is retained after `removeRemote`.
+
+Start the host with heap snapshots enabled:
+
+```bash
+MF_SSR_HEAP_SNAPSHOT=all \
+MF_SSR_HEAP_SNAPSHOT_DIR=/tmp/mf-ssr-cache-probe \
+pnpm --dir apps/modernjs-ssr/host dev
+```
+
+Then open:
+
+```text
+http://localhost:3050/remove-remote-cache
+```
+
+Each memory row will include a `heap snapshot` file path. The files are also
+written to `MF_SSR_HEAP_SNAPSHOT_DIR`.
+
+To reduce the number of files, pass a comma-separated label list instead of
+`all`:
+
+```bash
+MF_SSR_HEAP_SNAPSHOT='before load,after gc,after delayed gc 30s' \
+MF_SSR_HEAP_SNAPSHOT_DIR=/tmp/mf-ssr-cache-probe \
+pnpm --dir apps/modernjs-ssr/host dev
+```
+
+Recommended snapshots to compare:
+
+- `before load`: baseline before loading `remote/Heavy`
+- `after load`: memory after loading remote v1
+- `after gc`: memory after `removeRemote` and immediate GC
+- `after delayed gc 30s`: memory after delayed GC
+- `after reload`: memory after loading remote v2
+
+Open the `.heapsnapshot` files in Chrome DevTools:
+
+1. Open DevTools.
+2. Go to the `Memory` tab.
+3. Use `Load` to load the snapshot files.
+4. Select the later snapshot and switch to `Comparison`.
+5. Compare it against `before load`.
+6. Search for `remote-heavy`, `remote-heavy-v2`, `Heavy`, or `remote/Heavy`.
+7. Select retained objects and inspect `Retainers` to see what still references
+   them.
+
+When reporting retained memory, include:
+
+- the two snapshot files being compared
+- the top retained object names
+- retained size
+- the `Retainers` path for suspicious objects
+- the table from `/remove-remote-cache`
+
+## Fast Route
+
+For repeated checks without the 10s/20s/30s wait, use:
+
+```text
+http://localhost:3050/remove-remote-cache-fast
+```
+
+This route runs the same load, remove, GC, and reload flow, but skips delayed
+snapshots.
+
+## Automated Checks
+
+Run the Cypress check:
+
+```bash
+node tools/scripts/run-modern-e2e.mjs --mode=manifest
+```
+
+Run the local repeated-memory probe:
+
+```bash
+pnpm run probe:modern:ssr-gc -- --iterations=20 --max-growth-mb=20
+```
+
+The repeated probe starts one host process, runs the fast repro route multiple
+times, and fails if heap usage keeps growing beyond the configured limit after
+warmup.

--- a/apps/modernjs-ssr/host/cypress/e2e/remove-remote-cache.cy.ts
+++ b/apps/modernjs-ssr/host/cypress/e2e/remove-remote-cache.cy.ts
@@ -1,0 +1,61 @@
+describe('/remove-remote-cache', () => {
+  it('reloads a same-name remote from a different URL after removeRemote', () => {
+    cy.visit('/remove-remote-cache', {
+      timeout: 120_000,
+    });
+
+    cy.get('#remove-remote-cache-result', { timeout: 60_000 })
+      .invoke('text')
+      .then((text) => {
+        const result = JSON.parse(text);
+
+        expect(result.initialRemoteEntry).to.contain(
+          '127.0.0.1:3051/static/mf-manifest.json',
+        );
+        expect(result.reloadedRemoteEntry).to.contain(
+          '127.0.0.1:3055/mf-manifest.json',
+        );
+        expect(result.gcAvailable).to.equal(true);
+        expect(result.heavyStats.version).to.equal('v1');
+        expect(result.reloadedHeavyStats.version).to.equal('v2');
+        expect(result.heavyStats.items).to.equal(200000);
+        expect(result.reloadedHeavyStats.items).to.equal(200000);
+        expect(result.heavyStats.first).to.not.equal(
+          result.reloadedHeavyStats.first,
+        );
+        expect(result.removeRemoteError).to.equal(undefined);
+        expect(result.clearCacheCalls).to.have.length(1);
+        expect(result.clearCacheCalls[0].result).to.equal('resolved');
+        expect(result.snapshots.map((item) => item.label)).to.deep.equal([
+          'before load',
+          'after load',
+          'after removeRemote',
+          'after gc',
+          'after delayed gc 10s',
+          'after delayed gc 20s',
+          'after delayed gc 30s',
+          'after reload',
+        ]);
+
+        const snapshotsByLabel = Object.fromEntries(
+          result.snapshots.map((item) => [item.label, item]),
+        );
+        const afterRemoveHeap =
+          snapshotsByLabel['after removeRemote'].heapUsedMb;
+        const delayedGcSnapshots = [
+          snapshotsByLabel['after delayed gc 10s'],
+          snapshotsByLabel['after delayed gc 20s'],
+          snapshotsByLabel['after delayed gc 30s'],
+        ];
+
+        expect(
+          delayedGcSnapshots.some(
+            (snapshot) => snapshot.heapUsedMb < afterRemoveHeap,
+          ),
+          `heap should decrease after removeRemote within 30s, afterRemove=${afterRemoveHeap}, delayed=${delayedGcSnapshots
+            .map((snapshot) => snapshot.heapUsedMb)
+            .join(',')}`,
+        ).to.equal(true);
+      });
+  });
+});

--- a/apps/modernjs-ssr/host/module-federation.config.ts
+++ b/apps/modernjs-ssr/host/module-federation.config.ts
@@ -2,8 +2,8 @@ import { createModuleFederationConfig } from '@module-federation/modern-js-v3';
 export default createModuleFederationConfig({
   name: 'host',
   remotes: {
-    remote: 'remote@http://localhost:3051/static/mf-manifest.json',
-    nested_remote: 'nested_remote@http://localhost:3052/mf-manifest.json',
+    remote: 'remote@http://127.0.0.1:3051/static/mf-manifest.json',
+    nested_remote: 'nested_remote@http://127.0.0.1:3052/mf-manifest.json',
   },
   shared: {
     react: { singleton: true },

--- a/apps/modernjs-ssr/host/package.json
+++ b/apps/modernjs-ssr/host/package.json
@@ -4,10 +4,10 @@
   "version": "0.1.34",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
-    "dev": "modern dev",
+    "dev": "node --expose-gc ./node_modules/@modern-js/app-tools/bin/modern.js dev",
     "build": "modern build",
     "start": "modern start",
-    "serve": "modern serve",
+    "serve": "node --expose-gc ./node_modules/@modern-js/app-tools/bin/modern.js serve",
     "new": "modern new",
     "lint": "modern lint",
     "upgrade": "modern upgrade",

--- a/apps/modernjs-ssr/host/src/remotes.d.ts
+++ b/apps/modernjs-ssr/host/src/remotes.d.ts
@@ -1,0 +1,13 @@
+declare module 'remote/Image' {
+  import type { ComponentType } from 'react';
+
+  const Comp: ComponentType<any>;
+  export default Comp;
+}
+
+declare module 'nested_remote/Content' {
+  import type { ComponentType } from 'react';
+
+  const Comp: ComponentType<any>;
+  export default Comp;
+}

--- a/apps/modernjs-ssr/host/src/routes/all/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/all/page.tsx
@@ -4,6 +4,8 @@ import {
   registerRemotes,
 } from '@module-federation/modern-js-v3/runtime';
 
+type LazyRemoteModule = { default: React.ComponentType<any> };
+
 registerRemotes([
   {
     name: 'dynamic_nested_remote',
@@ -17,13 +19,13 @@ registerRemotes([
 
 const DynamicNestedRemote = React.lazy(() =>
   loadRemote('dynamic_nested_remote/Content').then((m) => {
-    return m;
+    return m as LazyRemoteModule;
   }),
 );
 
 const DynamicRemote = React.lazy(() =>
   loadRemote('dynamic_remote').then((m) => {
-    return m;
+    return m as LazyRemoteModule;
   }),
 );
 

--- a/apps/modernjs-ssr/host/src/routes/dynamic-nested-remote/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/dynamic-nested-remote/page.tsx
@@ -4,6 +4,8 @@ import {
   registerRemotes,
 } from '@module-federation/modern-js-v3/runtime';
 
+type LazyRemoteModule = { default: React.ComponentType<any> };
+
 registerRemotes([
   {
     name: 'dynamic_nested_remote',
@@ -13,7 +15,7 @@ registerRemotes([
 
 const DynamicNestedRemote = React.lazy(() =>
   loadRemote('dynamic_nested_remote/Content').then((m) => {
-    return m;
+    return m as LazyRemoteModule;
   }),
 );
 

--- a/apps/modernjs-ssr/host/src/routes/dynamic-remote/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/dynamic-remote/page.tsx
@@ -5,6 +5,8 @@ import {
   registerRemotes,
 } from '@module-federation/modern-js-v3/runtime';
 
+type LazyRemoteModule = { default: React.ComponentType<any> };
+
 registerRemotes([
   {
     name: 'dynamic_remote',
@@ -21,12 +23,12 @@ const RemoteSSRComponent = getInstance()!.createLazyComponent({
     }
     return <div>fallback</div>;
   },
-});
+}) as React.ComponentType<{ text: string }>;
 
 const NewRemoteCom = React.lazy(() =>
   loadRemote('dynamic_remote').then((m) => {
     console.log('加载');
-    return m;
+    return m as LazyRemoteModule;
   }),
 );
 const Index = (): JSX.Element => {

--- a/apps/modernjs-ssr/host/src/routes/remote/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/remote/page.tsx
@@ -5,10 +5,12 @@ import {
   loadRemote,
 } from '@module-federation/modern-js-v3/runtime';
 
+type LazyRemoteModule = { default: React.ComponentType<any> };
+
 const NewRemoteCom = React.lazy(() =>
   loadRemote('remote/Image').then((m) => {
     console.log('加载');
-    return m;
+    return m as LazyRemoteModule;
   }),
 );
 

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache-fast/page.data.ts
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache-fast/page.data.ts
@@ -1,0 +1,8 @@
+import { runProbe } from '../remove-remote-cache/probe';
+
+export const loader = () =>
+  runProbe({
+    delayedGcSeconds: [],
+  });
+
+export type { ProbeResult } from '../remove-remote-cache/probe';

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache-fast/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache-fast/page.tsx
@@ -1,0 +1,10 @@
+import { useLoaderData } from '@modern-js/runtime/router';
+
+import type { ProbeResult } from './page.data';
+import { ProbeView } from '../remove-remote-cache/view';
+
+export default function RemoveRemoteCacheFastPage(): JSX.Element {
+  const result = useLoaderData() as ProbeResult;
+
+  return <ProbeView result={result} />;
+}

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache/load-remote/page.data.ts
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache/load-remote/page.data.ts
@@ -1,0 +1,5 @@
+import { runLoadRemoteStep } from '../probe';
+
+export const loader = () => runLoadRemoteStep();
+
+export type { ProbeResult } from '../probe';

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache/load-remote/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache/load-remote/page.tsx
@@ -1,0 +1,10 @@
+import { useLoaderData } from '@modern-js/runtime/router';
+
+import type { ProbeResult } from './page.data';
+import { ProbeView } from '../view';
+
+export default function LoadRemoteCachePage(): JSX.Element {
+  const result = useLoaderData() as ProbeResult;
+
+  return <ProbeView result={result} />;
+}

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache/page.data.ts
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache/page.data.ts
@@ -1,0 +1,5 @@
+import { runProbe } from './probe';
+
+export const loader = () => runProbe();
+
+export type { ProbeResult } from './probe';

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache/page.tsx
@@ -1,0 +1,10 @@
+import { useLoaderData } from '@modern-js/runtime/router';
+
+import type { ProbeResult } from './page.data';
+import { ProbeView } from './view';
+
+export default function RemoveRemoteCachePage(): JSX.Element {
+  const result = useLoaderData() as ProbeResult;
+
+  return <ProbeView result={result} />;
+}

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache/probe.tsx
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache/probe.tsx
@@ -1,0 +1,517 @@
+import {
+  loadRemote,
+  registerRemotes,
+  removeRemote,
+} from '@module-federation/modern-js-v3/runtime';
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { writeHeapSnapshot } from 'node:v8';
+
+declare const __webpack_require__:
+  | {
+      c?: Record<string, unknown>;
+      m?: Record<string, unknown>;
+      remotesLoadingData?: {
+        remoteKeyToChunkIds?: Record<string, unknown>;
+        remoteKeyToRemoteModuleIds?: Record<string, unknown>;
+        moduleIdToRemoteDataMapping?: Record<string, { remoteName?: string }>;
+      };
+      federation?: {
+        clearCache?: (options: unknown) => Promise<unknown>;
+      };
+    }
+  | undefined;
+
+export type CacheSnapshot = {
+  label: string;
+  rssMb: number;
+  heapUsedMb: number;
+  externalMb: number;
+  requireCacheEntries: number;
+  remoteRequireCacheEntries: number;
+  webpackModuleCacheEntries: number;
+  webpackModuleFactoryEntries: number;
+  bundlerClearCacheInstalled: boolean;
+  bundlerChunkRemoteKeys: string[];
+  bundlerModuleRemoteKeys: string[];
+  bundlerMappedRemoteNames: string[];
+  registeredRemoteEntries: string[];
+  globalSnapshotKeys: string[];
+  hostSnapshotRemotesInfo: Record<string, string>;
+  heavyModuleCacheEntries: Array<{
+    id: string;
+    payloadItems: number;
+  }>;
+  federationInstances: number;
+  moduleCacheKeys: string[];
+  heapSnapshotFile?: string;
+};
+
+export type ClearCacheProbeCall = {
+  options: unknown;
+  result?: 'resolved' | 'rejected';
+  value?: unknown;
+  error?: string;
+  beforeChunkRemoteKeys: string[];
+  beforeModuleRemoteKeys: string[];
+  beforeMappedRemoteNames: string[];
+};
+
+export type HeavyRemoteModule = {
+  getHeavyPayloadStats?: () => {
+    version: string;
+    items: number;
+    first: string;
+    last: string;
+    createdAt: number;
+    loadCount: number;
+  };
+};
+
+export type ProbeResult = {
+  action?: string;
+  gcAvailable: boolean;
+  initialRemoteEntry: string;
+  reloadedRemoteEntry: string;
+  heavyStats?: ReturnType<
+    NonNullable<HeavyRemoteModule['getHeavyPayloadStats']>
+  >;
+  reloadedHeavyStats?: ReturnType<
+    NonNullable<HeavyRemoteModule['getHeavyPayloadStats']>
+  >;
+  clearCacheCalls: ClearCacheProbeCall[];
+  removeRemoteError?: string;
+  snapshots: CacheSnapshot[];
+};
+
+type ProbeOptions = {
+  delayedGcSeconds?: number[];
+};
+
+type SnapshotOptions = {
+  forceHeapSnapshot?: boolean;
+};
+
+const toMb = (value: number) => Math.round((value / 1024 / 1024) * 100) / 100;
+let heapSnapshotSequence = 0;
+
+const isHeapSnapshotEnabledFor = (
+  label: string,
+  { forceHeapSnapshot = false }: SnapshotOptions = {},
+) => {
+  if (forceHeapSnapshot) {
+    return true;
+  }
+
+  const raw = process.env.MF_SSR_HEAP_SNAPSHOT;
+  if (!raw || raw === '0' || raw.toLowerCase() === 'false') {
+    return false;
+  }
+
+  const normalized = raw.toLowerCase();
+  if (normalized === '1' || normalized === 'true' || normalized === 'all') {
+    return true;
+  }
+
+  return normalized
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .includes(label.toLowerCase());
+};
+
+const writeProbeHeapSnapshot = (
+  label: string,
+  options: SnapshotOptions = {},
+) => {
+  if (!isHeapSnapshotEnabledFor(label, options)) {
+    return undefined;
+  }
+
+  const dir = process.env.MF_SSR_HEAP_SNAPSHOT_DIR || '/tmp/mf-ssr-cache-probe';
+  mkdirSync(dir, { recursive: true });
+
+  const sequence = String((heapSnapshotSequence += 1)).padStart(2, '0');
+  const safeLabel = label.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '');
+  const file = join(dir, `${sequence}-${safeLabel}-${Date.now()}.heapsnapshot`);
+  writeHeapSnapshot(file);
+  return file;
+};
+
+const getNodeRequire = () => {
+  try {
+    return (0, eval)('require') as NodeRequire & {
+      cache?: Record<string, unknown>;
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+const getRequireCacheKeys = () => {
+  const nodeRequire = getNodeRequire();
+  return nodeRequire?.cache ? Object.keys(nodeRequire.cache) : [];
+};
+
+const getWebpackRequire = () => {
+  if (typeof __webpack_require__ === 'undefined') {
+    return undefined;
+  }
+  return __webpack_require__;
+};
+
+const getFederationInstances = () => {
+  const federation = getFederationGlobal();
+  return federation?.__INSTANCES__ || [];
+};
+
+const getFederationGlobal = () =>
+  (
+    globalThis as typeof globalThis & {
+      __FEDERATION__?: {
+        moduleInfo?: Record<
+          string,
+          {
+            remotesInfo?: Record<string, { matchedVersion?: string }>;
+            remoteEntry?: string;
+            ssrRemoteEntry?: string;
+          }
+        >;
+        __INSTANCES__?: Array<{
+          name?: string;
+          options?: {
+            remotes?: Array<{ name: string; entry?: string }>;
+          };
+          moduleCache?: Map<string, unknown>;
+        }>;
+      };
+    }
+  ).__FEDERATION__;
+
+const getRemoteLoadingDataSummary = () => {
+  const remotesLoadingData = getWebpackRequire()?.remotesLoadingData;
+  const moduleIdToRemoteDataMapping =
+    remotesLoadingData?.moduleIdToRemoteDataMapping || {};
+
+  return {
+    chunkRemoteKeys: Object.keys(remotesLoadingData?.remoteKeyToChunkIds || {}),
+    moduleRemoteKeys: Object.keys(
+      remotesLoadingData?.remoteKeyToRemoteModuleIds || {},
+    ),
+    mappedRemoteNames: Array.from(
+      new Set(
+        Object.values(moduleIdToRemoteDataMapping)
+          .map((data) => data.remoteName)
+          .filter(Boolean),
+      ),
+    ) as string[],
+  };
+};
+
+const getHeavyModuleCacheEntries = () => {
+  const moduleCache = getWebpackRequire()?.c || {};
+  return Object.entries(moduleCache)
+    .map(([id, module]) => {
+      const exports = (
+        module as {
+          exports?: {
+            heavyPayload?: unknown[];
+            getHeavyPayloadStats?: () => { items: number };
+          };
+        }
+      ).exports;
+      const heavyPayload = exports?.heavyPayload;
+      const payloadItems = Array.isArray(heavyPayload)
+        ? heavyPayload.length
+        : exports?.getHeavyPayloadStats?.().items;
+
+      if (!payloadItems) {
+        return undefined;
+      }
+      return {
+        id,
+        payloadItems,
+      };
+    })
+    .filter(Boolean) as CacheSnapshot['heavyModuleCacheEntries'];
+};
+
+const forceGc = () => {
+  const maybeGc = (
+    globalThis as typeof globalThis & {
+      gc?: () => void;
+    }
+  ).gc;
+  if (typeof maybeGc !== 'function') {
+    return false;
+  }
+  maybeGc();
+  maybeGc();
+  return true;
+};
+
+const snapshot = (
+  label: string,
+  options: SnapshotOptions = {},
+): CacheSnapshot => {
+  const memory = process.memoryUsage();
+  const requireCacheKeys = getRequireCacheKeys();
+  const webpackRequire = getWebpackRequire();
+  const federationInstances = getFederationInstances();
+  const remoteLoadingDataSummary = getRemoteLoadingDataSummary();
+  const hostInstance = federationInstances.find(
+    (instance) => instance.name === 'host',
+  );
+  const federationGlobal = getFederationGlobal();
+  const globalSnapshot = federationGlobal?.moduleInfo || {};
+  const hostSnapshot = globalSnapshot.host;
+  const hostSnapshotRemotesInfo = Object.fromEntries(
+    Object.entries(hostSnapshot?.remotesInfo || {}).map(([key, info]) => [
+      key,
+      info.matchedVersion || '',
+    ]),
+  );
+  const registeredRemotes = (hostInstance?.options?.remotes || []) as Array<{
+    name: string;
+    entry?: string;
+  }>;
+
+  const cacheSnapshot: CacheSnapshot = {
+    label,
+    rssMb: toMb(memory.rss),
+    heapUsedMb: toMb(memory.heapUsed),
+    externalMb: toMb(memory.external),
+    requireCacheEntries: requireCacheKeys.length,
+    remoteRequireCacheEntries: requireCacheKeys.filter((key) =>
+      key.includes('modernjs-ssr/remote'),
+    ).length,
+    webpackModuleCacheEntries: Object.keys(webpackRequire?.c || {}).length,
+    webpackModuleFactoryEntries: Object.keys(webpackRequire?.m || {}).length,
+    bundlerClearCacheInstalled: Boolean(webpackRequire?.federation?.clearCache),
+    bundlerChunkRemoteKeys: remoteLoadingDataSummary.chunkRemoteKeys,
+    bundlerModuleRemoteKeys: remoteLoadingDataSummary.moduleRemoteKeys,
+    bundlerMappedRemoteNames: remoteLoadingDataSummary.mappedRemoteNames,
+    registeredRemoteEntries: Array.from(
+      new Set(
+        registeredRemotes
+          .filter((remote) => remote.name === 'remote')
+          .map((remote) => remote.entry || ''),
+      ),
+    ),
+    globalSnapshotKeys: Object.keys(globalSnapshot),
+    hostSnapshotRemotesInfo,
+    heavyModuleCacheEntries: getHeavyModuleCacheEntries(),
+    federationInstances: federationInstances.length,
+    moduleCacheKeys: Array.from(hostInstance?.moduleCache?.keys?.() || []),
+  };
+  const heapSnapshotFile = writeProbeHeapSnapshot(label, options);
+  if (heapSnapshotFile) {
+    cacheSnapshot.heapSnapshotFile = heapSnapshotFile;
+  }
+  return cacheSnapshot;
+};
+
+const stringifyError = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
+const wrapClearCacheForProbe = (calls: ClearCacheProbeCall[]) => {
+  const webpackRequire = getWebpackRequire();
+  const federation = webpackRequire?.federation;
+  const originalClearCache = federation?.clearCache;
+
+  if (!federation || typeof originalClearCache !== 'function') {
+    return () => {};
+  }
+
+  federation.clearCache = async (options: unknown) => {
+    const before = getRemoteLoadingDataSummary();
+    const call: ClearCacheProbeCall = {
+      options,
+      beforeChunkRemoteKeys: before.chunkRemoteKeys,
+      beforeModuleRemoteKeys: before.moduleRemoteKeys,
+      beforeMappedRemoteNames: before.mappedRemoteNames,
+    };
+    calls.push(call);
+
+    try {
+      const value = await originalClearCache(options);
+      call.result = 'resolved';
+      call.value = value;
+      return value;
+    } catch (error) {
+      call.result = 'rejected';
+      call.error = stringifyError(error);
+      throw error;
+    }
+  };
+
+  return () => {
+    federation.clearCache = originalClearCache;
+  };
+};
+
+const loadHeavyStats = async () => {
+  const heavyModule = (await loadRemote('remote/Heavy')) as HeavyRemoteModule;
+  return heavyModule.getHeavyPayloadStats?.();
+};
+
+const remoteV1Entry = 'http://127.0.0.1:3051/static/mf-manifest.json';
+const remoteV2Entry = 'http://127.0.0.1:3055/mf-manifest.json';
+export const DEFAULT_DELAYED_GC_SECONDS = [10, 20, 30];
+
+const delay = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const collectDelayedGcSnapshots = async (delayedGcSeconds: number[]) => {
+  const snapshots: CacheSnapshot[] = [];
+  let previousSeconds = 0;
+
+  for (const seconds of delayedGcSeconds) {
+    await delay((seconds - previousSeconds) * 1000);
+    forceGc();
+    snapshots.push(snapshot(`after delayed gc ${seconds}s`));
+    previousSeconds = seconds;
+  }
+
+  return snapshots;
+};
+
+const registerRemoteV1 = () => {
+  registerRemotes(
+    [
+      {
+        name: 'remote',
+        entry: remoteV1Entry,
+      },
+    ],
+    { force: true },
+  );
+};
+
+const registerRemoteV2 = () => {
+  registerRemotes(
+    [
+      {
+        name: 'remote',
+        entry: remoteV2Entry,
+      },
+    ],
+    { force: true },
+  );
+};
+
+export const runLoadRemoteStep = async (): Promise<ProbeResult> => {
+  try {
+    await removeRemote('remote');
+  } catch {
+    // This route is the first step and should be repeatable after prior runs.
+  }
+  registerRemoteV1();
+
+  const heavyStats = await loadHeavyStats();
+  const gcAvailable = forceGc();
+  const afterLoad = snapshot('load remote', { forceHeapSnapshot: true });
+
+  return {
+    action: 'load remote',
+    gcAvailable,
+    initialRemoteEntry: remoteV1Entry,
+    reloadedRemoteEntry: remoteV2Entry,
+    heavyStats,
+    clearCacheCalls: [],
+    snapshots: [afterLoad],
+  };
+};
+
+export const runRemoveRemoteStep = async (): Promise<ProbeResult> => {
+  const clearCacheCalls: ClearCacheProbeCall[] = [];
+  const restoreClearCache = wrapClearCacheForProbe(clearCacheCalls);
+  try {
+    await removeRemote('remote');
+  } finally {
+    restoreClearCache();
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const gcAvailable = forceGc();
+  const afterRemove = snapshot('removeRemote', { forceHeapSnapshot: true });
+
+  return {
+    action: 'removeRemote',
+    gcAvailable,
+    initialRemoteEntry: remoteV1Entry,
+    reloadedRemoteEntry: remoteV2Entry,
+    clearCacheCalls,
+    snapshots: [afterRemove],
+  };
+};
+
+export const runRegisterNewRemoteStep = async (): Promise<ProbeResult> => {
+  registerRemoteV2();
+  const reloadedHeavyStats = await loadHeavyStats();
+  const gcAvailable = forceGc();
+  const afterRegister = snapshot('register new remote', {
+    forceHeapSnapshot: true,
+  });
+
+  return {
+    action: 'register new remote',
+    gcAvailable,
+    initialRemoteEntry: remoteV1Entry,
+    reloadedRemoteEntry: remoteV2Entry,
+    reloadedHeavyStats,
+    clearCacheCalls: [],
+    snapshots: [afterRegister],
+  };
+};
+
+export const runProbe = async ({
+  delayedGcSeconds = DEFAULT_DELAYED_GC_SECONDS,
+}: ProbeOptions = {}): Promise<ProbeResult> => {
+  await removeRemote('remote');
+  registerRemoteV1();
+
+  forceGc();
+  const beforeLoad = snapshot('before load');
+  const heavyStats = await loadHeavyStats();
+  const afterLoad = snapshot('after load');
+
+  const clearCacheCalls: ClearCacheProbeCall[] = [];
+  const restoreClearCache = wrapClearCacheForProbe(clearCacheCalls);
+  let removeRemoteError: string | undefined;
+  try {
+    await removeRemote('remote');
+  } catch (error) {
+    removeRemoteError = stringifyError(error);
+  } finally {
+    restoreClearCache();
+  }
+  const afterRemove = snapshot('after removeRemote');
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const gcAvailable = forceGc();
+  const afterGc = snapshot('after gc');
+  const delayedGcSnapshots = await collectDelayedGcSnapshots(delayedGcSeconds);
+  registerRemoteV2();
+  const reloadedHeavyStats = await loadHeavyStats();
+  const afterReload = snapshot('after reload');
+
+  return {
+    gcAvailable,
+    initialRemoteEntry: remoteV1Entry,
+    reloadedRemoteEntry: remoteV2Entry,
+    heavyStats,
+    reloadedHeavyStats,
+    clearCacheCalls,
+    removeRemoteError,
+    snapshots: [
+      beforeLoad,
+      afterLoad,
+      afterRemove,
+      afterGc,
+      ...delayedGcSnapshots,
+      afterReload,
+    ],
+  };
+};

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache/register-new-remote/page.data.ts
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache/register-new-remote/page.data.ts
@@ -1,0 +1,5 @@
+import { runRegisterNewRemoteStep } from '../probe';
+
+export const loader = () => runRegisterNewRemoteStep();
+
+export type { ProbeResult } from '../probe';

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache/register-new-remote/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache/register-new-remote/page.tsx
@@ -1,0 +1,10 @@
+import { useLoaderData } from '@modern-js/runtime/router';
+
+import type { ProbeResult } from './page.data';
+import { ProbeView } from '../view';
+
+export default function RegisterNewRemoteCachePage(): JSX.Element {
+  const result = useLoaderData() as ProbeResult;
+
+  return <ProbeView result={result} />;
+}

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache/remove-remote/page.data.ts
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache/remove-remote/page.data.ts
@@ -1,0 +1,5 @@
+import { runRemoveRemoteStep } from '../probe';
+
+export const loader = () => runRemoveRemoteStep();
+
+export type { ProbeResult } from '../probe';

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache/remove-remote/page.tsx
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache/remove-remote/page.tsx
@@ -1,0 +1,10 @@
+import { useLoaderData } from '@modern-js/runtime/router';
+
+import type { ProbeResult } from './page.data';
+import { ProbeView } from '../view';
+
+export default function RemoveRemoteCacheStepPage(): JSX.Element {
+  const result = useLoaderData() as ProbeResult;
+
+  return <ProbeView result={result} />;
+}

--- a/apps/modernjs-ssr/host/src/routes/remove-remote-cache/view.tsx
+++ b/apps/modernjs-ssr/host/src/routes/remove-remote-cache/view.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+import type { ProbeResult } from './probe';
+
+export const ProbeView = ({ result }: { result: ProbeResult }) => (
+  <div>
+    <h1>removeRemote cache probe</h1>
+    <p id="probe-action">action: {result.action || 'full flow'}</p>
+    <p id="gc-available">gc available: {String(result.gcAvailable)}</p>
+    <p id="initial-remote-entry">initial remote: {result.initialRemoteEntry}</p>
+    <p id="reloaded-remote-entry">
+      reloaded remote: {result.reloadedRemoteEntry}
+    </p>
+    <p id="heavy-version">heavy version: {result.heavyStats?.version || '-'}</p>
+    <p id="reloaded-heavy-version">
+      reloaded heavy version: {result.reloadedHeavyStats?.version || '-'}
+    </p>
+    <p id="heavy-items">heavy items: {result.heavyStats?.items || 0}</p>
+    <p id="heavy-created-at">
+      heavy created at: {result.heavyStats?.createdAt || 0}
+    </p>
+    <p id="reloaded-heavy-created-at">
+      reloaded heavy created at: {result.reloadedHeavyStats?.createdAt || 0}
+    </p>
+    <p id="heavy-load-count">
+      heavy load count: {result.heavyStats?.loadCount || 0}
+    </p>
+    <p id="reloaded-heavy-load-count">
+      reloaded heavy load count: {result.reloadedHeavyStats?.loadCount || 0}
+    </p>
+    <table border={1} cellPadding={5}>
+      <thead>
+        <tr>
+          <td>step</td>
+          <td>rss MB</td>
+          <td>heap MB</td>
+          <td>external MB</td>
+          <td>require cache</td>
+          <td>remote require cache</td>
+          <td>webpack module cache</td>
+          <td>webpack module factories</td>
+          <td>bundler clearCache</td>
+          <td>bundler chunk remote keys</td>
+          <td>bundler module remote keys</td>
+          <td>bundler mapped remote names</td>
+          <td>heavy module cache</td>
+          <td>federation instances</td>
+          <td>module cache keys</td>
+          <td>heap snapshot</td>
+        </tr>
+      </thead>
+      <tbody>
+        {result.snapshots.map((item) => (
+          <tr key={item.label}>
+            <td>{item.label}</td>
+            <td>{item.rssMb}</td>
+            <td>{item.heapUsedMb}</td>
+            <td>{item.externalMb}</td>
+            <td>{item.requireCacheEntries}</td>
+            <td>{item.remoteRequireCacheEntries}</td>
+            <td>{item.webpackModuleCacheEntries}</td>
+            <td>{item.webpackModuleFactoryEntries}</td>
+            <td>{String(item.bundlerClearCacheInstalled)}</td>
+            <td>{item.bundlerChunkRemoteKeys.join(', ') || '-'}</td>
+            <td>{item.bundlerModuleRemoteKeys.join(', ') || '-'}</td>
+            <td>{item.bundlerMappedRemoteNames.join(', ') || '-'}</td>
+            <td>
+              {item.heavyModuleCacheEntries
+                .map((entry) => `${entry.id}:${entry.payloadItems}`)
+                .join(', ') || '-'}
+            </td>
+            <td>{item.federationInstances}</td>
+            <td>{item.moduleCacheKeys.join(', ') || '-'}</td>
+            <td>{item.heapSnapshotFile || '-'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+    <pre id="remove-remote-cache-result">{JSON.stringify(result, null, 2)}</pre>
+  </div>
+);

--- a/apps/modernjs-ssr/remote-new-version/modern.config.ts
+++ b/apps/modernjs-ssr/remote-new-version/modern.config.ts
@@ -3,6 +3,10 @@ import { moduleFederationPlugin } from '@module-federation/modern-js-v3';
 
 // https://modernjs.dev/en/configure/app/usage
 export default defineConfig({
+  output: {
+    assetPrefix: 'http://127.0.0.1:3055',
+  },
+
   server: {
     ssr: {
       mode: 'stream',

--- a/apps/modernjs-ssr/remote-new-version/module-federation.config.ts
+++ b/apps/modernjs-ssr/remote-new-version/module-federation.config.ts
@@ -3,6 +3,7 @@ export default createModuleFederationConfig({
   name: 'remote',
   exposes: {
     './Image': './src/components/Image.tsx',
+    './Heavy': './src/components/Heavy.tsx',
   },
   shared: {
     react: { singleton: true },

--- a/apps/modernjs-ssr/remote-new-version/src/components/Heavy.tsx
+++ b/apps/modernjs-ssr/remote-new-version/src/components/Heavy.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const ITEM_COUNT = 200_000;
+const PAYLOAD_SUFFIX = 'y'.repeat(96);
+const createdAt = Date.now();
+const heavyGlobal = globalThis as typeof globalThis & {
+  __remoteNewVersionHeavyLoadCount?: number;
+};
+heavyGlobal.__remoteNewVersionHeavyLoadCount =
+  (heavyGlobal.__remoteNewVersionHeavyLoadCount || 0) + 1;
+const loadCount = heavyGlobal.__remoteNewVersionHeavyLoadCount;
+
+export const heavyPayload = Array.from(
+  { length: ITEM_COUNT },
+  (_, index) => `remote-heavy-v2-${index}-${PAYLOAD_SUFFIX}`,
+);
+
+export const getHeavyPayloadStats = () => ({
+  version: 'v2',
+  items: heavyPayload.length,
+  first: heavyPayload[0],
+  last: heavyPayload[heavyPayload.length - 1],
+  createdAt,
+  loadCount,
+});
+
+export default function Heavy(): JSX.Element {
+  return (
+    <div id="remote-heavy-v2">
+      remote heavy v2 payload: {heavyPayload.length} items
+    </div>
+  );
+}

--- a/apps/modernjs-ssr/remote/modern.config.ts
+++ b/apps/modernjs-ssr/remote/modern.config.ts
@@ -4,7 +4,7 @@ import { moduleFederationPlugin } from '@module-federation/modern-js-v3';
 // https://modernjs.dev/en/configure/app/usage
 export default defineConfig({
   output: {
-    assetPrefix: 'http://localhost:3051',
+    assetPrefix: 'http://127.0.0.1:3051',
   },
 
   plugins: [appTools(), moduleFederationPlugin()],

--- a/apps/modernjs-ssr/remote/module-federation.config.ts
+++ b/apps/modernjs-ssr/remote/module-federation.config.ts
@@ -8,6 +8,7 @@ export default createModuleFederationConfig({
   exposes: {
     './Image': './src/components/Image.tsx',
     './Button': './src/components/Button.tsx',
+    './Heavy': './src/components/Heavy.tsx',
   },
   shared: {
     react: { singleton: true },

--- a/apps/modernjs-ssr/remote/src/components/Heavy.tsx
+++ b/apps/modernjs-ssr/remote/src/components/Heavy.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const ITEM_COUNT = 200_000;
+const PAYLOAD_SUFFIX = 'x'.repeat(96);
+const createdAt = Date.now();
+const heavyGlobal = globalThis as typeof globalThis & {
+  __remoteHeavyLoadCount?: number;
+};
+heavyGlobal.__remoteHeavyLoadCount =
+  (heavyGlobal.__remoteHeavyLoadCount || 0) + 1;
+const loadCount = heavyGlobal.__remoteHeavyLoadCount;
+
+export const heavyPayload = Array.from(
+  { length: ITEM_COUNT },
+  (_, index) => `remote-heavy-${index}-${PAYLOAD_SUFFIX}`,
+);
+
+export const getHeavyPayloadStats = () => ({
+  version: 'v1',
+  items: heavyPayload.length,
+  first: heavyPayload[0],
+  last: heavyPayload[heavyPayload.length - 1],
+  createdAt,
+  loadCount,
+});
+
+export default function Heavy(): JSX.Element {
+  return (
+    <div id="remote-heavy">
+      remote heavy payload: {heavyPayload.length} items
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "@rslib/core": "^0.10.4",
     "@rspack/cli": "npm:@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342",
     "@rspack/core": "npm:@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342",
-    "@rspack/dev-server": "1.1.1",
+    "@rspack/dev-server": "2.1.0",
     "@rstest/core": "^0.8.0",
     "@storybook/addon-docs": "9.0.17",
     "@storybook/nextjs": "9.0.9",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "e2e:treeshake:server": "pnpm exec turbo run test --filter=@module-federation/treeshake-server",
     "e2e:treeshake:frontend": "pnpm exec turbo run e2e --filter=@module-federation/treeshake-frontend",
     "e2e:modern:ssr": "node tools/scripts/run-modern-e2e.mjs --mode=manifest",
+    "probe:modern:ssr-gc": "node tools/scripts/probe-modern-ssr-remove-remote-gc.mjs",
     "e2e:router": "node tools/scripts/run-router-e2e.mjs --mode=dev",
     "e2e:shared-tree-shaking:runtime-infer": "npx kill-port --port 3001,3002 && pnpm exec turbo run test:e2e --filter=shared-tree-shaking-no-server-host && lsof -ti tcp:3001,3002 | xargs kill",
     "e2e:shared-tree-shaking:server-calc": "npx kill-port --port 3001,3002,3003 && pnpm exec turbo run test:e2e --filter=shared-tree-shaking-with-server-host && lsof -ti tcp:3001,3002,3003 | xargs kill",
@@ -141,12 +142,19 @@
     },
     "overrides": {
       "@changesets/assemble-release-plan": "workspace:*",
+      "@rspack/cli": "npm:@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342",
+      "@rspack/core": "npm:@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342",
       "ajv": "8.18.0",
       "eslint>ajv": "6.14.0",
       "@eslint/eslintrc>ajv": "6.14.0",
       "schema-utils@3.3.0>ajv": "6.14.0",
       "flatted": "3.4.2",
       "@remix-run/router": "1.23.2"
+    },
+    "peerDependencyRules": {
+      "allowAny": [
+        "@rspack/*"
+      ]
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",
@@ -202,8 +210,8 @@
     "@rollup/plugin-alias": "5.1.1",
     "@rollup/plugin-replace": "6.0.1",
     "@rslib/core": "^0.10.4",
-    "@rspack/cli": "1.3.9",
-    "@rspack/core": "1.3.9",
+    "@rspack/cli": "npm:@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342",
+    "@rspack/core": "npm:@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342",
     "@rspack/dev-server": "1.1.1",
     "@rstest/core": "^0.8.0",
     "@storybook/addon-docs": "9.0.17",

--- a/packages/enhanced/src/lib/container/ContainerEntryModule.ts
+++ b/packages/enhanced/src/lib/container/ContainerEntryModule.ts
@@ -156,7 +156,7 @@ class ContainerEntryModule extends Module {
     this.buildMeta = {};
     this.buildInfo = {
       strict: true,
-      topLevelDeclarations: new Set(['moduleMap', 'get', 'init']),
+      topLevelDeclarations: new Set(['moduleMap', 'get', 'init', 'clearCache']),
     };
     this.buildMeta.exportsType = 'namespace';
     this.clearDependenciesAndBlocks();
@@ -182,7 +182,7 @@ class ContainerEntryModule extends Module {
     }
     this.addDependency(
       new StaticExportsDependency(
-        ['get', 'init'],
+        ['get', 'init', '__webpack_clear_cache__'],
         false,
       ) as unknown as Dependency,
     );
@@ -202,6 +202,7 @@ class ContainerEntryModule extends Module {
       RuntimeGlobals.definePropertyGetters,
       RuntimeGlobals.hasOwnProperty,
       RuntimeGlobals.exports,
+      RuntimeGlobals.moduleCache,
     ]);
     const getters = [];
     for (const block of this.blocks) {
@@ -312,11 +313,20 @@ class ContainerEntryModule extends Module {
           '})',
         ],
       )};`,
+      `var clearCache = ${runtimeTemplate.basicFunction('', [
+        `var moduleCache = ${RuntimeGlobals.moduleCache};`,
+        'for(var moduleId in moduleCache) {',
+        Template.indent([
+          `${RuntimeGlobals.hasOwnProperty}(moduleCache, moduleId) && delete moduleCache[moduleId];`,
+        ]),
+        '}',
+      ])};`,
       '// This exports getters to disallow modifications',
       `${RuntimeGlobals.definePropertyGetters}(exports, {`,
       Template.indent([
         `get: ${runtimeTemplate.returningFunction('get')},`,
-        `init: ${runtimeTemplate.returningFunction('init')}`,
+        `init: ${runtimeTemplate.returningFunction('init')},`,
+        `__webpack_clear_cache__: ${runtimeTemplate.returningFunction('clearCache')}`,
       ]),
       '});',
     ]);

--- a/packages/enhanced/test/unit/container/ContainerEntryModule.test.ts
+++ b/packages/enhanced/test/unit/container/ContainerEntryModule.test.ts
@@ -450,6 +450,12 @@ describe('ContainerEntryModule', () => {
       expect(result.sources).toBeDefined();
       // Check for the runtime requirement that's actually set in the module
       expect(result.runtimeRequirements).toBeDefined();
+      expect(
+        result.runtimeRequirements.has(webpack.RuntimeGlobals.moduleCache),
+      ).toBe(true);
+      const source = result.sources.get('javascript').source();
+      expect(source).toContain('__webpack_clear_cache__');
+      expect(source).toContain('__webpack_require__.c');
     });
   });
 });

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -328,7 +328,6 @@ export function patchBundlerConfig(options: {
 
   const splitChunkConfig = chain.optimization.splitChunks.entries();
   if (!isServer) {
-    // @ts-expect-error type not the same
     autoDeleteSplitChunkCacheGroups(mfConfig, splitChunkConfig);
   }
 

--- a/packages/runtime-core/__tests__/register-remotes.spec.ts
+++ b/packages/runtime-core/__tests__/register-remotes.spec.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it, expect, vi } from 'vitest';
 import { ModuleFederation } from '../src/index';
+import { Global } from '../src/global';
 
 describe('ModuleFederation', () => {
   it('registers new remotes and loads them correctly', async () => {
@@ -287,5 +288,184 @@ describe('ModuleFederation', () => {
       }),
       origin: FM,
     });
+  });
+
+  it('clears loaded remote entry cache when removing a remote', async () => {
+    const entry =
+      'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
+    const remoteEntryClear = vi.fn();
+    const libClear = vi.fn();
+    const globalClear = vi.fn();
+    const FM = new ModuleFederation({
+      name: '@federation/instance',
+      version: '1.0.1',
+      remotes: [
+        {
+          name: '@register-remotes/app1',
+          alias: 'app1',
+          entry,
+        },
+      ],
+    });
+
+    FM.moduleCache.set('@register-remotes/app1', {
+      remoteInfo: {
+        name: '@register-remotes/app1',
+        alias: 'app1',
+        entry,
+        type: 'global',
+        entryGlobalName: 'app1',
+        shareScope: 'default',
+      },
+      remoteEntryExports: {
+        get: vi.fn(),
+        init: vi.fn(),
+        __webpack_clear_cache__: remoteEntryClear,
+      },
+      lib: {
+        get: vi.fn(),
+        init: vi.fn(),
+        __webpack_clear_cache__: libClear,
+      },
+    } as any);
+    (globalThis as any).app1 = {
+      get: vi.fn(),
+      init: vi.fn(),
+      __webpack_clear_cache__: globalClear,
+    };
+    Global.__FEDERATION__.moduleInfo = {
+      '@federation/instance:1.0.1': {
+        version: '1.0.1',
+        remoteEntry: '',
+        remotesInfo: {
+          '@register-remotes/app1': {
+            matchedVersion: entry,
+          },
+          '@register-remotes/app2': {
+            matchedVersion: 'http://localhost:1111/app2/mf-manifest.json',
+          },
+        },
+      },
+      [`@register-remotes/app1:${entry}`]: {
+        version: entry,
+        remoteEntry: 'static/remoteEntry.js',
+      },
+    } as any;
+    Global.__FEDERATION__.__MANIFEST_LOADING__[entry] = Promise.resolve(
+      {} as any,
+    );
+    FM.snapshotHandler.manifestCache.set(entry, {} as any);
+
+    await FM.removeRemote('app1');
+
+    expect(remoteEntryClear).toHaveBeenCalledTimes(1);
+    expect(libClear).toHaveBeenCalledTimes(1);
+    expect(globalClear).toHaveBeenCalledTimes(1);
+    expect(FM.moduleCache.has('@register-remotes/app1')).toBe(false);
+    expect((globalThis as any).app1).toBeUndefined();
+    expect(
+      Global.__FEDERATION__.moduleInfo['@federation/instance:1.0.1']
+        .remotesInfo?.['@register-remotes/app1'],
+    ).toBeUndefined();
+    expect(
+      Global.__FEDERATION__.moduleInfo['@federation/instance:1.0.1']
+        .remotesInfo?.['@register-remotes/app2'],
+    ).toEqual({
+      matchedVersion: 'http://localhost:1111/app2/mf-manifest.json',
+    });
+    expect(
+      Global.__FEDERATION__.moduleInfo[`@register-remotes/app1:${entry}`],
+    ).toBeUndefined();
+    expect(Global.__FEDERATION__.__MANIFEST_LOADING__[entry]).toBeUndefined();
+    expect(FM.snapshotHandler.manifestCache.has(entry)).toBe(false);
+  });
+
+  it('keeps loaded remote cleanup context when removeRemote hook clears moduleCache first', async () => {
+    const entry =
+      'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
+    const remoteEntryClear = vi.fn();
+    const libClear = vi.fn();
+    const globalClear = vi.fn();
+    const FM = new ModuleFederation({
+      name: '@federation/instance',
+      version: '1.0.1',
+      remotes: [
+        {
+          name: '@register-remotes/app1',
+          alias: 'app1',
+          entry,
+        },
+      ],
+      plugins: [
+        {
+          name: 'module-cache-first-remove-plugin',
+          removeRemote({ origin }) {
+            origin.moduleCache.delete('@register-remotes/app1');
+          },
+        },
+      ],
+    });
+
+    FM.moduleCache.set('@register-remotes/app1', {
+      remoteInfo: {
+        name: '@register-remotes/app1',
+        alias: 'app1',
+        entry,
+        type: 'global',
+        entryGlobalName: 'app1',
+        shareScope: 'default',
+      },
+      remoteEntryExports: {
+        get: vi.fn(),
+        init: vi.fn(),
+        __webpack_clear_cache__: remoteEntryClear,
+      },
+      lib: {
+        get: vi.fn(),
+        init: vi.fn(),
+        __webpack_clear_cache__: libClear,
+      },
+    } as any);
+    (globalThis as any).app1 = {
+      get: vi.fn(),
+      init: vi.fn(),
+      __webpack_clear_cache__: globalClear,
+    };
+    Global.__FEDERATION__.moduleInfo = {
+      '@federation/instance:1.0.1': {
+        version: '1.0.1',
+        remoteEntry: '',
+        remotesInfo: {
+          '@register-remotes/app1': {
+            matchedVersion: entry,
+          },
+        },
+      },
+      [`@register-remotes/app1:${entry}`]: {
+        version: entry,
+        remoteEntry: 'static/remoteEntry.js',
+      },
+    } as any;
+    Global.__FEDERATION__.__MANIFEST_LOADING__[entry] = Promise.resolve(
+      {} as any,
+    );
+    FM.snapshotHandler.manifestCache.set(entry, {} as any);
+
+    await FM.removeRemote('app1');
+
+    expect(remoteEntryClear).toHaveBeenCalledTimes(1);
+    expect(libClear).toHaveBeenCalledTimes(1);
+    expect(globalClear).toHaveBeenCalledTimes(1);
+    expect(FM.moduleCache.has('@register-remotes/app1')).toBe(false);
+    expect((globalThis as any).app1).toBeUndefined();
+    expect(
+      Global.__FEDERATION__.moduleInfo['@federation/instance:1.0.1']
+        .remotesInfo?.['@register-remotes/app1'],
+    ).toBeUndefined();
+    expect(
+      Global.__FEDERATION__.moduleInfo[`@register-remotes/app1:${entry}`],
+    ).toBeUndefined();
+    expect(Global.__FEDERATION__.__MANIFEST_LOADING__[entry]).toBeUndefined();
+    expect(FM.snapshotHandler.manifestCache.has(entry)).toBe(false);
   });
 });

--- a/packages/runtime-core/__tests__/register-remotes.spec.ts
+++ b/packages/runtime-core/__tests__/register-remotes.spec.ts
@@ -209,4 +209,83 @@ describe('ModuleFederation', () => {
     expect(await nextAppModule()).toBe('hello world "@snapshot/remote2"');
     expect(manifestFetch).toHaveBeenCalledTimes(2);
   });
+
+  it('emits removeRemote hook before force registering an existing remote', () => {
+    const removeRemote = vi.fn();
+    const FM = new ModuleFederation({
+      name: '@federation/instance',
+      version: '1.0.1',
+      remotes: [
+        {
+          name: '@register-remotes/app1',
+          entry:
+            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js',
+        },
+      ],
+      plugins: [
+        {
+          name: 'remove-remote-test-plugin',
+          removeRemote,
+        },
+      ],
+    });
+
+    FM.registerRemotes(
+      [
+        {
+          name: '@register-remotes/app1',
+          entry:
+            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry2.js',
+        },
+      ],
+      { force: true },
+    );
+
+    expect(removeRemote).toHaveBeenCalledWith({
+      remote: expect.objectContaining({ name: '@register-remotes/app1' }),
+      origin: FM,
+    });
+  });
+
+  it('removes a registered remote by name and emits removeRemote hook', async () => {
+    const removeRemote = vi.fn();
+    const FM = new ModuleFederation({
+      name: '@federation/instance',
+      version: '1.0.1',
+      remotes: [
+        {
+          name: '@register-remotes/app1',
+          alias: 'app1',
+          entry:
+            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js',
+        },
+      ],
+      plugins: [
+        {
+          name: 'direct-remove-remote-test-plugin',
+          removeRemote,
+        },
+      ],
+    });
+
+    await FM.removeRemote('app1');
+
+    expect(FM.options.remotes).toHaveLength(0);
+    expect(removeRemote).toHaveBeenCalledWith({
+      remote: expect.objectContaining({
+        name: '@register-remotes/app1',
+        alias: 'app1',
+      }),
+      origin: FM,
+    });
+
+    await FM.removeRemote('app1');
+    expect(removeRemote).toHaveBeenCalledTimes(2);
+    expect(removeRemote).toHaveBeenLastCalledWith({
+      remote: expect.objectContaining({
+        name: 'app1',
+      }),
+      origin: FM,
+    });
+  });
 });

--- a/packages/runtime-core/src/core.ts
+++ b/packages/runtime-core/src/core.ts
@@ -459,6 +459,20 @@ export class ModuleFederation {
     return this.remoteHandler.registerRemotes(remotes, options);
   }
 
+  removeRemote(remote: Remote | string): Promise<void> {
+    let targetRemote: Remote | undefined =
+      typeof remote === 'string' ? undefined : remote;
+    if (typeof remote === 'string') {
+      targetRemote = this.options.remotes.find(
+        (item) => item.name === remote || item.alias === remote,
+      );
+      targetRemote ||= { name: remote, alias: remote } as Remote;
+    }
+    if (!targetRemote) return Promise.resolve();
+
+    return this.remoteHandler.removeRemote(targetRemote);
+  }
+
   registerShared(shared: UserOptions['shared']) {
     this.sharedHandler.registerShared(this.options, {
       ...this.options,

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -37,7 +37,6 @@ import {
   error,
   getRemoteInfo,
   getRemoteEntryUniqueKey,
-  getFMId,
   composeRemoteRequestId,
   matchRemoteWithNameAndExpose,
   optionsToMFContext,
@@ -47,7 +46,6 @@ import { DEFAULT_REMOTE_TYPE, DEFAULT_SCOPE } from '../constant';
 import { Module, ModuleOptions } from '../module';
 import { formatPreloadArgs, preloadAssets } from '../utils/preload';
 import { getGlobalShareScope } from '../utils/share';
-import { getGlobalRemoteInfo } from '../plugins/snapshot/SnapshotHandler';
 
 export interface LoadRemoteMatch {
   id: string;
@@ -59,6 +57,60 @@ export interface LoadRemoteMatch {
   remoteInfo: RemoteInfo;
   remoteSnapshot?: ModuleInfo;
 }
+
+const clearRemoteEntryCache = (
+  remoteEntryExports: RemoteEntryExports | undefined,
+): void => {
+  remoteEntryExports?.__webpack_clear_cache__?.();
+};
+
+const getRemoteEntry = (remote: Remote): string | undefined =>
+  'entry' in remote ? remote.entry : undefined;
+
+const clearRemoteSnapshotCache = (
+  host: ModuleFederation,
+  remote: Remote,
+  remoteInfo?: RemoteInfo,
+): void => {
+  const remoteNames = new Set(
+    [remote.name, remoteInfo?.name].filter(Boolean) as string[],
+  );
+  const remoteEntries = new Set(
+    [getRemoteEntry(remote), remoteInfo?.entry].filter(Boolean) as string[],
+  );
+  const globalModuleInfo = Global.__FEDERATION__.moduleInfo;
+
+  Object.values(globalModuleInfo).forEach((moduleInfo) => {
+    if (!('remotesInfo' in moduleInfo) || !moduleInfo.remotesInfo) {
+      return;
+    }
+
+    remoteNames.forEach((remoteName) => {
+      const remoteRecord = getInfoWithoutType(
+        moduleInfo.remotesInfo,
+        remoteName,
+      );
+      if (remoteRecord.value) {
+        delete moduleInfo.remotesInfo?.[remoteRecord.key];
+      }
+    });
+  });
+
+  Object.keys(globalModuleInfo).forEach((moduleKey) => {
+    remoteNames.forEach((remoteName) => {
+      if (moduleKey === remoteName || moduleKey.startsWith(`${remoteName}:`)) {
+        delete globalModuleInfo[moduleKey];
+      }
+    });
+  });
+
+  remoteEntries.forEach((entry) => {
+    host.snapshotHandler.manifestCache.delete(entry);
+    if (Global.__FEDERATION__.__MANIFEST_LOADING__[entry]) {
+      delete Global.__FEDERATION__.__MANIFEST_LOADING__[entry];
+    }
+  });
+};
 
 export class RemoteHandler {
   host: ModuleFederation;
@@ -682,105 +734,96 @@ export class RemoteHandler {
   removeRemote(remote: Remote): Promise<void> {
     const { host } = this;
     const { name } = remote;
+    const loadedModule = host.moduleCache.get(remote.name);
     return Promise.resolve(
       this.hooks.lifecycle.removeRemote.emit({ remote, origin: host }),
     )
       .then(() => {
-      const remoteIndex = host.options.remotes.findIndex(
-        (item) => item.name === name,
-      );
-      if (remoteIndex !== -1) {
-        host.options.remotes.splice(remoteIndex, 1);
-      }
-      const globalSnapshotKey = getInfoWithoutType(
-        CurrentGlobal.__FEDERATION__.moduleInfo,
-        getFMId(remote),
-      ).key;
-      delete CurrentGlobal.__FEDERATION__.moduleInfo[globalSnapshotKey];
-
-      if ('entry' in remote) {
-        host.snapshotHandler.manifestCache.delete(remote.entry);
-        delete Global.__FEDERATION__.__MANIFEST_LOADING__[remote.entry];
-      }
-
-      const { hostGlobalSnapshot } = getGlobalRemoteInfo(remote, host);
-      if (hostGlobalSnapshot) {
-        const remoteKey =
-          hostGlobalSnapshot &&
-          'remotesInfo' in hostGlobalSnapshot &&
-          hostGlobalSnapshot.remotesInfo &&
-          getInfoWithoutType(hostGlobalSnapshot.remotesInfo, remote.name).key;
-        if (remoteKey) {
-          delete hostGlobalSnapshot.remotesInfo[remoteKey];
-        }
-      }
-
-      const loadedModule = host.moduleCache.get(remote.name);
-      if (loadedModule) {
-        const remoteInfo = loadedModule.remoteInfo;
-        const key = remoteInfo.entryGlobalName as keyof typeof CurrentGlobal;
-
-        if (CurrentGlobal[key]) {
-          if (
-            Object.getOwnPropertyDescriptor(CurrentGlobal, key)?.configurable
-          ) {
-            delete CurrentGlobal[key];
-          } else {
-            // @ts-ignore
-            CurrentGlobal[key] = undefined;
-          }
-        }
-        const remoteEntryUniqueKey = getRemoteEntryUniqueKey(
-          loadedModule.remoteInfo,
+        const remoteIndex = host.options.remotes.findIndex(
+          (item) => item.name === name,
         );
-
-        if (globalLoading[remoteEntryUniqueKey]) {
-          delete globalLoading[remoteEntryUniqueKey];
+        if (remoteIndex !== -1) {
+          host.options.remotes.splice(remoteIndex, 1);
         }
+        clearRemoteSnapshotCache(host, remote, loadedModule?.remoteInfo);
+        if (loadedModule) {
+          const remoteInfo = loadedModule.remoteInfo;
+          const key = remoteInfo.entryGlobalName as keyof typeof CurrentGlobal;
+          clearRemoteEntryCache(loadedModule.remoteEntryExports);
+          clearRemoteEntryCache(loadedModule.lib);
+          clearRemoteEntryCache(CurrentGlobal[key] as RemoteEntryExports);
 
-        // delete unloaded shared and instance
-        let remoteInsId = remoteInfo.buildVersion
-          ? composeKeyWithSeparator(remoteInfo.name, remoteInfo.buildVersion)
-          : remoteInfo.name;
-        const remoteInsIndex =
-          CurrentGlobal.__FEDERATION__.__INSTANCES__.findIndex((ins) => {
-            if (remoteInfo.buildVersion) {
-              return ins.options.id === remoteInsId;
+          if (CurrentGlobal[key]) {
+            if (
+              Object.getOwnPropertyDescriptor(CurrentGlobal, key)?.configurable
+            ) {
+              delete CurrentGlobal[key];
             } else {
-              return ins.name === remoteInsId;
+              // @ts-ignore
+              CurrentGlobal[key] = undefined;
             }
-          });
-        if (remoteInsIndex !== -1) {
-          const remoteIns =
-            CurrentGlobal.__FEDERATION__.__INSTANCES__[remoteInsIndex];
-          remoteInsId = remoteIns.options.id || remoteInsId;
-          const globalShareScopeMap = getGlobalShareScope();
+          }
+          const remoteEntryUniqueKey = getRemoteEntryUniqueKey(
+            loadedModule.remoteInfo,
+          );
 
-          let isAllSharedNotUsed = true;
-          const needDeleteKeys: Array<[string, string, string, string]> = [];
-          Object.keys(globalShareScopeMap).forEach((instId) => {
-            const shareScopeMap = globalShareScopeMap[instId];
-            shareScopeMap &&
-              Object.keys(shareScopeMap).forEach((shareScope) => {
-                const shareScopeVal = shareScopeMap[shareScope];
-                shareScopeVal &&
-                  Object.keys(shareScopeVal).forEach((shareName) => {
-                    const sharedPkgs = shareScopeVal[shareName];
-                    sharedPkgs &&
-                      Object.keys(sharedPkgs).forEach((shareVersion) => {
-                        const shared = sharedPkgs[shareVersion];
-                        if (
-                          shared &&
-                          typeof shared === 'object' &&
-                          shared.from === remoteInfo.name
-                        ) {
-                          if (shared.loaded || shared.loading) {
-                            shared.useIn = shared.useIn.filter(
-                              (usedHostName) =>
-                                usedHostName !== remoteInfo.name,
-                            );
-                            if (shared.useIn.length) {
-                              isAllSharedNotUsed = false;
+          if (globalLoading[remoteEntryUniqueKey]) {
+            delete globalLoading[remoteEntryUniqueKey];
+          }
+
+          host.snapshotHandler.manifestCache.delete(remoteInfo.entry);
+
+          // delete unloaded shared and instance
+          let remoteInsId = remoteInfo.buildVersion
+            ? composeKeyWithSeparator(remoteInfo.name, remoteInfo.buildVersion)
+            : remoteInfo.name;
+          const remoteInsIndex =
+            CurrentGlobal.__FEDERATION__.__INSTANCES__.findIndex((ins) => {
+              if (remoteInfo.buildVersion) {
+                return ins.options.id === remoteInsId;
+              } else {
+                return ins.name === remoteInsId;
+              }
+            });
+          if (remoteInsIndex !== -1) {
+            const remoteIns =
+              CurrentGlobal.__FEDERATION__.__INSTANCES__[remoteInsIndex];
+            remoteInsId = remoteIns.options.id || remoteInsId;
+            const globalShareScopeMap = getGlobalShareScope();
+
+            let isAllSharedNotUsed = true;
+            const needDeleteKeys: Array<[string, string, string, string]> = [];
+            Object.keys(globalShareScopeMap).forEach((instId) => {
+              const shareScopeMap = globalShareScopeMap[instId];
+              shareScopeMap &&
+                Object.keys(shareScopeMap).forEach((shareScope) => {
+                  const shareScopeVal = shareScopeMap[shareScope];
+                  shareScopeVal &&
+                    Object.keys(shareScopeVal).forEach((shareName) => {
+                      const sharedPkgs = shareScopeVal[shareName];
+                      sharedPkgs &&
+                        Object.keys(sharedPkgs).forEach((shareVersion) => {
+                          const shared = sharedPkgs[shareVersion];
+                          if (
+                            shared &&
+                            typeof shared === 'object' &&
+                            shared.from === remoteInfo.name
+                          ) {
+                            if (shared.loaded || shared.loading) {
+                              shared.useIn = shared.useIn.filter(
+                                (usedHostName) =>
+                                  usedHostName !== remoteInfo.name,
+                              );
+                              if (shared.useIn.length) {
+                                isAllSharedNotUsed = false;
+                              } else {
+                                needDeleteKeys.push([
+                                  instId,
+                                  shareScope,
+                                  shareName,
+                                  shareVersion,
+                                ]);
+                              }
                             } else {
                               needDeleteKeys.push([
                                 instId,
@@ -789,36 +832,33 @@ export class RemoteHandler {
                                 shareVersion,
                               ]);
                             }
-                          } else {
-                            needDeleteKeys.push([
-                              instId,
-                              shareScope,
-                              shareName,
-                              shareVersion,
-                            ]);
                           }
-                        }
-                      });
-                  });
-              });
-          });
+                        });
+                    });
+                });
+            });
 
-          if (isAllSharedNotUsed) {
-            remoteIns.shareScopeMap = {};
-            delete globalShareScopeMap[remoteInsId];
+            if (isAllSharedNotUsed) {
+              remoteIns.shareScopeMap = {};
+              delete globalShareScopeMap[remoteInsId];
+            }
+            needDeleteKeys.forEach(
+              ([insId, shareScope, shareName, shareVersion]) => {
+                delete globalShareScopeMap[insId]?.[shareScope]?.[shareName]?.[
+                  shareVersion
+                ];
+              },
+            );
+            CurrentGlobal.__FEDERATION__.__INSTANCES__.splice(
+              remoteInsIndex,
+              1,
+            );
+
+            host.moduleCache.delete(remote.name);
           }
-          needDeleteKeys.forEach(
-            ([insId, shareScope, shareName, shareVersion]) => {
-              delete globalShareScopeMap[insId]?.[shareScope]?.[shareName]?.[
-                shareVersion
-              ];
-            },
-          );
-          CurrentGlobal.__FEDERATION__.__INSTANCES__.splice(remoteInsIndex, 1);
-        }
 
-        host.moduleCache.delete(remote.name);
-      }
+          host.moduleCache.delete(remote.name);
+        }
       })
       .catch((err) => {
         logger.error(

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -670,7 +670,7 @@ export class RemoteHandler {
       ];
       if (options?.force) {
         // remove registered remote
-        this.removeRemote(registeredRemote);
+        void this.removeRemote(registeredRemote);
         normalizeRemote();
         targetRemotes.push(remote);
         this.hooks.lifecycle.registerRemote.emit({ remote, origin: host });
@@ -679,10 +679,13 @@ export class RemoteHandler {
     }
   }
 
-  private removeRemote(remote: Remote): void {
-    try {
-      const { host } = this;
-      const { name } = remote;
+  removeRemote(remote: Remote): Promise<void> {
+    const { host } = this;
+    const { name } = remote;
+    return Promise.resolve(
+      this.hooks.lifecycle.removeRemote.emit({ remote, origin: host }),
+    )
+      .then(() => {
       const remoteIndex = host.options.remotes.findIndex(
         (item) => item.name === name,
       );
@@ -816,10 +819,12 @@ export class RemoteHandler {
 
         host.moduleCache.delete(remote.name);
       }
-    } catch (err) {
-      logger.error(
-        `removeRemote failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+      })
+      .catch((err) => {
+        logger.error(
+          `removeRemote failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        throw err;
+      });
   }
 }

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -125,6 +125,15 @@ export class RemoteHandler {
       remote: Remote;
       origin: ModuleFederation;
     }>('registerRemote'),
+    removeRemote: new AsyncHook<
+      [
+        {
+          remote: Remote;
+          origin: ModuleFederation;
+        },
+      ],
+      void
+    >('removeRemote'),
     beforeRequest: new AsyncWaterfallHook<{
       id: string;
       options: Options;

--- a/packages/runtime-core/src/type/config.ts
+++ b/packages/runtime-core/src/type/config.ts
@@ -163,4 +163,5 @@ export type RemoteEntryExports = {
     initScope?: InitScope,
     remoteEntryInitOPtions?: RemoteEntryInitOptions,
   ) => void | Promise<void>;
+  __webpack_clear_cache__?: () => void;
 };

--- a/packages/runtime/__tests__/api.spec.ts
+++ b/packages/runtime/__tests__/api.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { createInstance, getInstance, init } from '../src';
+import { describe, it, expect, vi } from 'vitest';
+import { createInstance, getInstance, init, removeRemote } from '../src';
 
 // eslint-disable-next-line max-lines-per-function
 describe('api', () => {
@@ -138,6 +138,47 @@ describe('api', () => {
     });
 
     expect(FM.options.id).toBe('');
+  });
+
+  it('removes a remote through the public runtime API', async () => {
+    const onRemoveRemote = vi.fn();
+    const FM = init({
+      name: '@federation/remove-remote-api',
+      remotes: [
+        {
+          name: '@federation/sub-remove',
+          alias: 'sub-remove',
+          entry:
+            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js',
+        },
+      ],
+      plugins: [
+        {
+          name: 'runtime-api-remove-remote-test-plugin',
+          removeRemote: onRemoveRemote,
+        },
+      ],
+    });
+
+    await removeRemote('sub-remove');
+
+    expect(FM.options.remotes).toHaveLength(0);
+    expect(onRemoveRemote).toHaveBeenCalledWith({
+      remote: expect.objectContaining({
+        name: '@federation/sub-remove',
+        alias: 'sub-remove',
+      }),
+      origin: FM,
+    });
+
+    await removeRemote('sub-remove');
+    expect(onRemoveRemote).toHaveBeenCalledTimes(2);
+    expect(onRemoveRemote).toHaveBeenLastCalledWith({
+      remote: expect.objectContaining({
+        name: 'sub-remove',
+      }),
+      origin: FM,
+    });
   });
 
   it('alias check', () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -99,6 +99,14 @@ export function registerRemotes(
   return FederationInstance.registerRemotes.apply(FederationInstance, args);
 }
 
+export function removeRemote(
+  ...args: Parameters<ModuleFederation['removeRemote']>
+): ReturnType<ModuleFederation['removeRemote']> {
+  assert(FederationInstance, RUNTIME_009, runtimeDescMap);
+  // eslint-disable-next-line prefer-spread
+  return FederationInstance.removeRemote.apply(FederationInstance, args);
+}
+
 export function registerPlugins(
   ...args: Parameters<ModuleFederation['registerPlugins']>
 ): ReturnType<ModuleFederation['registerRemotes']> {

--- a/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
+++ b/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
@@ -38,6 +38,16 @@ function createWebpackRequire() {
   return { instance, webpackRequire };
 }
 
+function createDeferred() {
+  let resolve!: (value?: unknown) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('clearCache', () => {
   test('should install clearCache on federation instead of the instance', () => {
     const { instance, webpackRequire } = createWebpackRequire();
@@ -81,5 +91,155 @@ describe('clearCache', () => {
     } as any);
 
     expect(clearCache).toHaveBeenCalledWith({ name: 'remoteA' });
+  });
+
+  test('should clear remote entry internal module cache', async () => {
+    const { instance, webpackRequire } = createWebpackRequire();
+    const remoteEntryClear = jest.fn();
+    const libClear = jest.fn();
+    const globalClear = jest.fn();
+
+    instance.moduleCache.set('remoteA', {
+      remoteEntryExports: {
+        __webpack_clear_cache__: remoteEntryClear,
+      },
+      lib: {
+        __webpack_clear_cache__: libClear,
+      },
+    });
+    (globalThis as any).remoteA = {
+      __webpack_clear_cache__: globalClear,
+    };
+    webpackRequire.federation.bundlerRuntimeOptions.remotes.remoteInfos = {
+      remoteA: [
+        {
+          name: 'remoteA',
+          entry: 'http://localhost:3001/remoteEntry.js',
+          entryGlobalName: 'remoteA',
+        },
+      ],
+    };
+    webpackRequire.remotesLoadingData = {
+      moduleIdToRemoteDataMapping: {
+        101: {
+          shareScope: 'default',
+          name: './Widget',
+          externalModuleId: 201,
+          remoteName: 'remoteA',
+        },
+      },
+      remoteKeyToRemoteModuleIds: {
+        remoteA: [101],
+      },
+      remoteKeyToExternalModuleIds: {
+        remoteA: [201],
+      },
+      remoteKeyToChunkIds: {
+        remoteA: [],
+      },
+    };
+
+    await clearCache({
+      name: 'remoteA',
+      webpackRequire: webpackRequire as any,
+    });
+
+    expect(remoteEntryClear).toHaveBeenCalledTimes(1);
+    expect(libClear).toHaveBeenCalledTimes(1);
+    expect(globalClear).toHaveBeenCalledTimes(1);
+    expect(instance.moduleCache.has('remoteA')).toBe(false);
+    expect((globalThis as any).remoteA).toBeUndefined();
+  });
+
+  test('should evict old caches before pending remote load settles', async () => {
+    const { instance, webpackRequire } = createWebpackRequire();
+    const pendingLoad = createDeferred();
+    const remoteEntryClear = jest.fn();
+    const hadWindow = Object.prototype.hasOwnProperty.call(
+      globalThis,
+      'window',
+    );
+    const hadDocument = Object.prototype.hasOwnProperty.call(
+      globalThis,
+      'document',
+    );
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+
+    instance.moduleCache.set('remoteA', {
+      remoteEntryExports: {
+        __webpack_clear_cache__: remoteEntryClear,
+      },
+    });
+    webpackRequire.federation.bundlerRuntimeOptions.remotes.remoteInfos = {
+      remoteA: [
+        {
+          name: 'remoteA',
+          entry: 'http://localhost:3001/remoteEntry.js',
+          entryGlobalName: 'remoteA',
+        },
+      ],
+    };
+    webpackRequire.remotesLoadingData = {
+      moduleIdToRemoteDataMapping: {
+        101: {
+          shareScope: 'default',
+          name: './Widget',
+          externalModuleId: 201,
+          remoteName: 'remoteA',
+          p: pendingLoad.promise,
+        },
+      },
+      remoteKeyToRemoteModuleIds: {
+        remoteA: [101],
+      },
+      remoteKeyToExternalModuleIds: {
+        remoteA: [201],
+      },
+      remoteKeyToChunkIds: {
+        remoteA: [],
+      },
+      remoteModuleIdToConsumerModuleIds: {
+        101: [301],
+      },
+    };
+    webpackRequire.m[101] = () => null;
+    webpackRequire.c[101] = { exports: {} };
+    webpackRequire.c[201] = { exports: {} };
+    webpackRequire.c[301] = { exports: {} };
+
+    delete (globalThis as any).window;
+    delete (globalThis as any).document;
+    try {
+      const clearPromise = clearCache({
+        name: 'remoteA',
+        webpackRequire: webpackRequire as any,
+      });
+      let settled = false;
+      void clearPromise.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(webpackRequire.m[101]).toBeUndefined();
+      expect(webpackRequire.c[101]).toBeUndefined();
+      expect(webpackRequire.c[201]).toBeUndefined();
+      expect(webpackRequire.c[301]).toBeUndefined();
+      expect(instance.moduleCache.has('remoteA')).toBe(false);
+      expect(remoteEntryClear).toHaveBeenCalledTimes(1);
+      expect(settled).toBe(false);
+
+      pendingLoad.resolve();
+      await clearPromise;
+      expect(settled).toBe(true);
+    } finally {
+      if (hadWindow) {
+        (globalThis as any).window = previousWindow;
+      }
+      if (hadDocument) {
+        (globalThis as any).document = previousDocument;
+      }
+    }
   });
 });

--- a/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
+++ b/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
@@ -1,0 +1,85 @@
+import {
+  clearCache,
+  createClearCacheRuntimePlugin,
+  installClearCache,
+} from '../src/clearCache';
+
+function createWebpackRequire() {
+  const instance = {
+    moduleCache: new Map(),
+    options: {
+      remotes: [],
+    },
+    loadRemote: jest.fn((id, options) => Promise.resolve({ id, options })),
+    registerRemotes: jest.fn(),
+    loaderHook: {
+      lifecycle: {
+        createScript: {
+          on: jest.fn(),
+        },
+      },
+    },
+  };
+  const webpackRequire = {
+    federation: {
+      instance,
+      bundlerRuntimeOptions: {
+        remotes: {
+          remoteInfos: {},
+          idToExternalAndNameMapping: {},
+          idToRemoteMap: {},
+        },
+      },
+    },
+    remotesLoadingData: {},
+    m: {},
+    c: {},
+  };
+  return { instance, webpackRequire };
+}
+
+describe('clearCache', () => {
+  test('should install clearCache on federation instead of the instance', () => {
+    const { instance, webpackRequire } = createWebpackRequire();
+
+    installClearCache({ webpackRequire: webpackRequire as any });
+
+    expect(typeof webpackRequire.federation.clearCache).toBe('function');
+    expect((instance as any).clearCache).toBeUndefined();
+    expect((instance as any).clearRemoteCache).toBeUndefined();
+    expect(instance.loaderHook.lifecycle.createScript.on).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  test('should reject when remote name is missing', async () => {
+    const { webpackRequire } = createWebpackRequire();
+
+    await expect(
+      clearCache({
+        name: '',
+        webpackRequire: webpackRequire as any,
+      }),
+    ).rejects.toThrow('clearCache requires a remote name');
+  });
+
+  test('should clear bundler cache after runtime removes a remote', async () => {
+    const { webpackRequire } = createWebpackRequire();
+    const clearCache = jest.fn(() =>
+      Promise.resolve({
+        name: 'remoteA',
+        cleared: true as const,
+      }),
+    );
+    webpackRequire.federation.clearCache = clearCache;
+
+    await createClearCacheRuntimePlugin({
+      webpackRequire: webpackRequire as any,
+    }).removeRemote?.({
+      remote: { name: 'remoteA' },
+      origin: {},
+    } as any);
+
+    expect(clearCache).toHaveBeenCalledWith({ name: 'remoteA' });
+  });
+});

--- a/packages/webpack-bundler-runtime/src/clearCache.ts
+++ b/packages/webpack-bundler-runtime/src/clearCache.ts
@@ -79,10 +79,7 @@ const getOwn = <T>(
   return obj[key];
 };
 
-const deleteOwn = (
-  obj: object | undefined | null,
-  key: string | number,
-) => {
+const deleteOwn = (obj: object | undefined | null, key: string | number) => {
   if (!obj || obj === Object.prototype || !hasOwn(obj, key)) {
     return;
   }

--- a/packages/webpack-bundler-runtime/src/clearCache.ts
+++ b/packages/webpack-bundler-runtime/src/clearCache.ts
@@ -553,6 +553,18 @@ const createClearSnapshot = (
   };
 };
 
+const cleanupRemoteEntryInternalCache = (remoteEntryExports: unknown) => {
+  const clear = (
+    remoteEntryExports as
+      | { __webpack_clear_cache__?: () => void }
+      | null
+      | undefined
+  )?.__webpack_clear_cache__;
+  if (typeof clear === 'function') {
+    clear();
+  }
+};
+
 const cleanupRemoteEntryCache = (
   webpackRequire: WebpackRequire,
   target: ClearCacheTarget,
@@ -567,6 +579,7 @@ const cleanupRemoteEntryCache = (
       if (!Object.prototype.hasOwnProperty.call(globalThis, globalKey)) {
         continue;
       }
+      cleanupRemoteEntryInternalCache((globalThis as any)[globalKey]);
       const descriptor = Object.getOwnPropertyDescriptor(globalThis, globalKey);
       if (descriptor?.configurable) {
         delete (globalThis as any)[globalKey];
@@ -601,7 +614,17 @@ const cleanupRemoteRuntimeCache = (
     return;
   }
   for (const remoteName of target.remoteNames) {
+    const module = instance.moduleCache?.get(remoteName) as
+      | Record<string, unknown>
+      | undefined;
+    cleanupRemoteEntryInternalCache(module?.remoteEntryExports);
+    cleanupRemoteEntryInternalCache(module?.lib);
     instance.moduleCache?.delete(remoteName);
+  }
+  for (const remoteInfo of target.remoteInfos) {
+    for (const globalKey of getRemoteEntryGlobalKeys(remoteInfo)) {
+      cleanupRemoteEntryInternalCache((globalThis as any)[globalKey]);
+    }
   }
   const idToRemoteMap = instance.remoteHandler?.idToRemoteMap;
   if (idToRemoteMap) {
@@ -796,25 +819,6 @@ const invalidateNodeChunkGenerations = (
   }
 };
 
-const waitForPendingNodeChunkLoads = (
-  webpackRequire: WebpackRequire,
-  target: ClearCacheTarget,
-) => {
-  if (target.chunkIds.length === 0) {
-    return;
-  }
-  const waits: Promise<unknown>[] = [];
-  for (const control of getNodeChunkCacheControls(webpackRequire)) {
-    if (typeof control?.wait === 'function') {
-      waits.push(control.wait(target.chunkIds));
-    }
-  }
-  if (waits.length === 0) {
-    return;
-  }
-  return waitWithTimeout(Promise.all(waits));
-};
-
 const cleanupNodeChunkCache = (
   webpackRequire: WebpackRequire,
   target: ClearCacheTarget,
@@ -855,8 +859,8 @@ const cleanupStaleRemoteCache = (
   deleteModuleCache(webpackRequire, target.remoteModuleIds);
   deleteModuleCache(webpackRequire, target.externalModuleIds);
   deleteModuleCache(webpackRequire, consumerModuleIds);
-  cleanupRemoteRuntimeCache(webpackRequire, target);
   cleanupRemoteEntryCache(webpackRequire, target);
+  cleanupRemoteRuntimeCache(webpackRequire, target);
 };
 
 export const runStaleRemoteCleanups = (
@@ -933,98 +937,79 @@ const clearRemoteTarget = (
   webpackRequire: WebpackRequire,
 ): Promise<ClearCacheResult> => {
   const releaseBarrier = beginRemoteClear(webpackRequire, target.remoteNames);
-  let chunkCacheSnapshot = { restore() {} };
+  const idToExternalAndNameMapping =
+    webpackRequire.federation.bundlerRuntimeOptions.remotes
+      ?.idToExternalAndNameMapping ?? {};
+  const pendingRemoteLoads: Promise<unknown>[] = [];
+  for (const remoteModuleId of target.remoteModuleIds) {
+    for (const data of [
+      webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping?.[
+        remoteModuleId
+      ],
+      idToExternalAndNameMapping[remoteModuleId],
+    ]) {
+      if (data?.p && typeof data.p === 'object' && 'then' in data.p) {
+        pendingRemoteLoads.push(data.p.catch(() => {}));
+      }
+    }
+  }
+  const consumerModuleIds = isBrowserRuntime()
+    ? []
+    : getAffectedConsumerModuleIds(webpackRequire, target.remoteModuleIds);
+  const chunkCacheSnapshot = createNodeChunkCacheSnapshot(
+    webpackRequire,
+    target,
+  );
+  let snapshot: ReturnType<typeof createClearSnapshot> | undefined;
   let clearSucceeded = false;
 
-  return Promise.resolve()
-    .then(() => waitForPendingNodeChunkLoads(webpackRequire, target))
-    .then(() => {
-      chunkCacheSnapshot = createNodeChunkCacheSnapshot(webpackRequire, target);
-      const idToExternalAndNameMapping =
-        webpackRequire.federation.bundlerRuntimeOptions.remotes
-          ?.idToExternalAndNameMapping ?? {};
+  try {
+    const state = getState(webpackRequire);
+    for (const remoteName of target.remoteNames) {
+      state.remoteGenerations[remoteName] =
+        getRemoteGeneration(webpackRequire, remoteName) + 1;
+    }
+    invalidateNodeChunkGenerations(webpackRequire, target);
+    snapshot = createClearSnapshot(webpackRequire, target, consumerModuleIds);
+    cleanupStaleRemoteCache(webpackRequire, target, consumerModuleIds);
+    invalidateRemoteEntryUrlGenerations(webpackRequire, target);
+    cleanupSharedCache(webpackRequire, target);
+  } catch (error) {
+    if (snapshot) {
+      snapshot.restore();
+    }
+    chunkCacheSnapshot.restore();
+    restoreRemoteGenerations(webpackRequire, target);
+    releaseBarrier();
+    return Promise.reject(error);
+  }
 
-      const pendingRemoteLoads: Promise<unknown>[] = [];
-      for (const remoteModuleId of target.remoteModuleIds) {
-        for (const data of [
-          webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping?.[
-            remoteModuleId
-          ],
-          idToExternalAndNameMapping[remoteModuleId],
-        ]) {
-          if (data?.p && typeof data.p === 'object' && 'then' in data.p) {
-            pendingRemoteLoads.push(data.p.catch(() => {}));
-          }
-        }
+  return waitWithTimeout(Promise.all(pendingRemoteLoads))
+    .then((timedOut) =>
+      waitForSettledLoadConsumers().then(() => {
+        cleanupStaleRemoteCache(webpackRequire, target, consumerModuleIds);
+        return timedOut;
+      }),
+    )
+    .then((timedOut) => {
+      if (timedOut) {
+        trackStaleRemoteCleanup(
+          webpackRequire,
+          target,
+          consumerModuleIds,
+          pendingRemoteLoads,
+        );
       }
-      const consumerModuleIds = isBrowserRuntime()
-        ? []
-        : getAffectedConsumerModuleIds(webpackRequire, target.remoteModuleIds);
+      clearSucceeded = true;
 
-      return waitWithTimeout(Promise.all(pendingRemoteLoads))
-        .then((timedOut) => waitForSettledLoadConsumers().then(() => timedOut))
-        .then((timedOut) => {
-          const state = getState(webpackRequire);
-          for (const remoteName of target.remoteNames) {
-            state.remoteGenerations[remoteName] =
-              getRemoteGeneration(webpackRequire, remoteName) + 1;
-          }
-          invalidateNodeChunkGenerations(webpackRequire, target);
-
-          let snapshot: ReturnType<typeof createClearSnapshot> | undefined;
-          try {
-            snapshot = createClearSnapshot(
-              webpackRequire,
-              target,
-              consumerModuleIds,
-            );
-            for (const remoteModuleId of target.remoteModuleIds) {
-              const data =
-                webpackRequire.remotesLoadingData
-                  ?.moduleIdToRemoteDataMapping?.[remoteModuleId];
-              const runtimeData = idToExternalAndNameMapping[remoteModuleId];
-              if (data) {
-                delete data.p;
-              }
-              if (runtimeData) {
-                delete runtimeData.p;
-              }
-              delete webpackRequire.m[remoteModuleId];
-            }
-            deleteModuleCache(webpackRequire, target.remoteModuleIds);
-            deleteModuleCache(webpackRequire, target.externalModuleIds);
-            deleteModuleCache(webpackRequire, consumerModuleIds);
-            invalidateRemoteEntryUrlGenerations(webpackRequire, target);
-            cleanupRemoteEntryCache(webpackRequire, target);
-            cleanupRemoteRuntimeCache(webpackRequire, target);
-            cleanupNodeChunkCache(webpackRequire, target);
-            cleanupSharedCache(webpackRequire, target);
-            if (timedOut) {
-              trackStaleRemoteCleanup(
-                webpackRequire,
-                target,
-                consumerModuleIds,
-                pendingRemoteLoads,
-              );
-            }
-            clearSucceeded = true;
-          } catch (error) {
-            if (snapshot) {
-              snapshot.restore();
-            } else {
-              restoreRemoteGenerations(webpackRequire, target);
-            }
-            throw error;
-          }
-
-          return {
-            name: target.name,
-            cleared: true as const,
-          };
-        });
+      return {
+        name: target.name,
+        cleared: true as const,
+      };
     })
     .catch((error) => {
       if (!clearSucceeded) {
+        snapshot?.restore();
         chunkCacheSnapshot.restore();
         restoreRemoteGenerations(webpackRequire, target);
       }

--- a/packages/webpack-bundler-runtime/src/clearCache.ts
+++ b/packages/webpack-bundler-runtime/src/clearCache.ts
@@ -1,0 +1,1319 @@
+import type {
+  ClearCacheOptions,
+  ClearCacheResult,
+  ClearCacheRuntimeOptions,
+  IdToExternalAndNameMapping,
+  ModuleId,
+  RemoteInfos,
+  RemotesLoadingData,
+  InstallClearCacheOptions,
+  WebpackRequire,
+} from './types';
+
+type ClearCacheTarget = {
+  name: string;
+  remoteKey: string;
+  remoteInfos: NonNullable<RemoteInfos[string]>;
+  remoteNames: string[];
+  chunkIds: ModuleId[];
+  generations: Array<{ key: string; value: number }>;
+  remoteModuleIds: ModuleId[];
+  externalModuleIds: ModuleId[];
+};
+
+type ChunkCacheControl = {
+  clear?: (chunkIds: ModuleId[]) => unknown;
+  invalidate?: (chunkIds: ModuleId[]) => unknown;
+  wait?: (chunkIds: ModuleId[]) => Promise<unknown>;
+  snapshot?: (chunkIds: ModuleId[]) => unknown;
+  restore?: (states: unknown) => void;
+  getGeneration?: (chunkId: ModuleId) => number;
+  restoreGenerations?: (generations: Record<string, number>) => void;
+};
+
+type RemoteInfoLike = {
+  name?: string;
+  alias?: string;
+  entry?: string;
+  type?: string;
+  globalName?: string;
+  entryGlobalName?: string;
+};
+
+type RuntimeRemote = {
+  name: string;
+  alias?: string;
+  shareScope?: string | string[];
+  type?: string;
+} & Record<string, any>;
+
+type EntrySnapshot = Array<{
+  key: string | number;
+  had: boolean;
+  value: unknown;
+}>;
+
+type ClearCacheState = {
+  remoteClearBarriers: Record<
+    string,
+    { promise: Promise<unknown>; resolve: () => void; count: number }
+  >;
+  remoteGenerations: Record<string, number>;
+  remoteEntryUrlGenerations: Record<string, number>;
+  staleRemoteCleanups: Record<string, { run: () => void; pending: number }>;
+  installed?: boolean;
+};
+
+const clearCacheStates = new WeakMap<WebpackRequire, ClearCacheState>();
+
+const hasOwn = (obj: Record<string | number, unknown>, key: string | number) =>
+  Object.prototype.hasOwnProperty.call(obj, key);
+
+const toList = <T>(value: T[] | undefined | null): T[] =>
+  Array.isArray(value) ? value : [];
+
+const pushUnique = <T>(target: T[], values: Array<T | undefined | null>) => {
+  for (const value of values) {
+    if (value !== undefined && value !== null && !target.includes(value)) {
+      target.push(value);
+    }
+  }
+};
+
+const getState = (webpackRequire: WebpackRequire): ClearCacheState => {
+  let state = clearCacheStates.get(webpackRequire);
+  if (!state) {
+    state = {
+      remoteClearBarriers: {},
+      remoteGenerations: {},
+      remoteEntryUrlGenerations: {},
+      staleRemoteCleanups: {},
+    };
+    clearCacheStates.set(webpackRequire, state);
+  }
+  return state;
+};
+
+const getAffectedConsumerModuleIds = (
+  webpackRequire: WebpackRequire,
+  remoteModuleIds: ModuleId[],
+) => {
+  const consumerModuleIds: ModuleId[] = [];
+  const queue: ModuleId[] = [];
+  const consumerMapping =
+    webpackRequire.remotesLoadingData?.remoteModuleIdToConsumerModuleIds ?? {};
+  const parentMapping =
+    webpackRequire.remotesLoadingData?.consumerModuleIdToParentModuleIds ?? {};
+
+  for (const remoteModuleId of remoteModuleIds) {
+    pushUnique(queue, toList(consumerMapping[remoteModuleId]));
+  }
+  for (let i = 0; i < queue.length; i++) {
+    const consumerModuleId = queue[i];
+    if (consumerModuleIds.includes(consumerModuleId)) {
+      continue;
+    }
+    consumerModuleIds.push(consumerModuleId);
+    pushUnique(queue, toList(parentMapping[consumerModuleId]));
+  }
+  return consumerModuleIds;
+};
+
+const getRemoteGeneration = (
+  webpackRequire: WebpackRequire,
+  remoteKey: string,
+) => getState(webpackRequire).remoteGenerations[remoteKey] ?? 0;
+
+const isNodeEsmRemoteEntry = (remoteInfo: RemoteInfoLike) =>
+  remoteInfo?.type === 'esm' || remoteInfo?.type === 'module';
+
+const getRemoteEntryUrlGenerationKey = (remoteInfo: RemoteInfoLike) => {
+  if (!isNodeEsmRemoteEntry(remoteInfo) || !remoteInfo.entry) {
+    return;
+  }
+  return `${remoteInfo.name}:${remoteInfo.entry}`;
+};
+
+const withRemoteEntryUrlGeneration = (url: string, generation: number) => {
+  if (!url || !generation) {
+    return url;
+  }
+  const key = '__rspack_mf_clear_cache';
+  try {
+    const parsed = new URL(url);
+    parsed.searchParams.set(key, String(generation));
+    return parsed.href;
+  } catch {
+    const hashIndex = url.indexOf('#');
+    const base = hashIndex === -1 ? url : url.slice(0, hashIndex);
+    const hash = hashIndex === -1 ? '' : url.slice(hashIndex);
+    const separator = base.includes('?') ? '&' : '?';
+    return `${base}${separator}${key}=${generation}${hash}`;
+  }
+};
+
+const getRemoteNames = (
+  webpackRequire: WebpackRequire,
+  name: string,
+  remoteKey: string,
+) => {
+  const remoteNames: string[] = [];
+  pushUnique(remoteNames, [name, remoteKey]);
+  for (const remoteInfo of toList(
+    webpackRequire.federation.bundlerRuntimeOptions.remotes?.remoteInfos?.[
+      remoteKey
+    ],
+  )) {
+    pushUnique(remoteNames, [remoteInfo.name, remoteInfo.alias]);
+  }
+  return remoteNames;
+};
+
+const getRemoteEntryGlobalKeys = (remoteInfo: RemoteInfoLike) => {
+  const keys: string[] = [];
+  pushUnique(keys, [
+    remoteInfo.entryGlobalName,
+    remoteInfo.globalName,
+    remoteInfo.name,
+  ]);
+  if (remoteInfo.name) {
+    pushUnique(keys, [`__FEDERATION_${remoteInfo.name}:custom__`]);
+  }
+  return keys;
+};
+
+const getRemoteEntryLoadingKey = (remoteInfo: RemoteInfoLike) => {
+  if (!remoteInfo.name || !remoteInfo.entry) {
+    return;
+  }
+  return `${remoteInfo.name}:${remoteInfo.entry}`;
+};
+
+export const getRemoteKeysForChunk = (
+  webpackRequire: WebpackRequire,
+  chunkId: ModuleId,
+) => {
+  const remoteKeys: string[] = [];
+  const chunkMapping = webpackRequire.remotesLoadingData?.chunkMapping ?? {};
+  const moduleIdToRemoteDataMapping =
+    webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping ?? {};
+
+  for (const remoteModuleId of toList(chunkMapping[chunkId])) {
+    const data = moduleIdToRemoteDataMapping[remoteModuleId];
+    if (data) {
+      pushUnique(remoteKeys, [data.remoteName]);
+    }
+  }
+  return remoteKeys;
+};
+
+const getRemoteKeysForRequest = (
+  webpackRequire: WebpackRequire,
+  request: string,
+) => {
+  const remoteKeys: string[] = [];
+  if (typeof request !== 'string') {
+    return remoteKeys;
+  }
+  for (const [remoteKey, remoteInfos] of Object.entries(
+    webpackRequire.federation.bundlerRuntimeOptions.remotes?.remoteInfos ?? {},
+  )) {
+    const candidates: string[] = [];
+    pushUnique(candidates, [remoteKey]);
+    for (const remoteInfo of toList(remoteInfos)) {
+      pushUnique(candidates, [remoteInfo.name, remoteInfo.alias]);
+    }
+    if (
+      candidates.some(
+        (candidate) =>
+          request === candidate || request.startsWith(`${candidate}/`),
+      )
+    ) {
+      pushUnique(remoteKeys, candidates);
+    }
+  }
+  for (const remote of toList(
+    webpackRequire.federation.instance?.options?.remotes,
+  )) {
+    const candidates: string[] = [];
+    pushUnique(candidates, [remote.name, remote.alias]);
+    if (
+      candidates.some(
+        (candidate) =>
+          request === candidate || request.startsWith(`${candidate}/`),
+      )
+    ) {
+      pushUnique(remoteKeys, candidates);
+    }
+  }
+  return remoteKeys;
+};
+
+export const waitForRemoteClear = (
+  webpackRequire: WebpackRequire,
+  remoteKeys: string[],
+) => {
+  const waits: Promise<unknown>[] = [];
+  const { remoteClearBarriers } = getState(webpackRequire);
+  for (const remoteKey of remoteKeys) {
+    const barrier = remoteClearBarriers[remoteKey];
+    if (barrier) {
+      pushUnique(waits, [barrier.promise]);
+    }
+  }
+  if (waits.length === 0) {
+    return;
+  }
+  return Promise.all(waits);
+};
+
+const beginRemoteClear = (
+  webpackRequire: WebpackRequire,
+  remoteKeys: string[],
+) => {
+  const releaseKeys: string[] = [];
+  const { remoteClearBarriers } = getState(webpackRequire);
+  for (const remoteKey of remoteKeys) {
+    if (!remoteClearBarriers[remoteKey]) {
+      let resolve: () => void = () => {};
+      const promise = new Promise<void>((r) => {
+        resolve = r;
+      });
+      remoteClearBarriers[remoteKey] = {
+        promise,
+        resolve,
+        count: 0,
+      };
+    }
+    remoteClearBarriers[remoteKey].count++;
+    releaseKeys.push(remoteKey);
+  }
+  return () => {
+    for (const remoteKey of releaseKeys) {
+      const barrier = remoteClearBarriers[remoteKey];
+      if (!barrier) {
+        continue;
+      }
+      barrier.count--;
+      if (barrier.count === 0) {
+        delete remoteClearBarriers[remoteKey];
+        barrier.resolve();
+      }
+    }
+  };
+};
+
+const captureEntries = (
+  obj: Record<string | number, unknown>,
+  keys: Array<string | number>,
+): EntrySnapshot =>
+  keys.map((key) => ({
+    key,
+    had: hasOwn(obj, key),
+    value: obj[key],
+  }));
+
+const restoreEntries = (
+  obj: Record<string | number, unknown>,
+  entries: EntrySnapshot,
+) => {
+  for (const entry of entries) {
+    if (entry.had) {
+      obj[entry.key] = entry.value;
+    } else {
+      delete obj[entry.key];
+    }
+  }
+};
+
+const deleteModuleCache = (
+  webpackRequire: WebpackRequire,
+  moduleIds: ModuleId[],
+) => {
+  for (const moduleId of moduleIds) {
+    delete webpackRequire.c[moduleId];
+  }
+};
+
+const isBrowserRuntime = () =>
+  typeof window !== 'undefined' && typeof document !== 'undefined';
+
+const emptyRemotesLoadingData = {} as RemotesLoadingData;
+
+const getClearTarget = (
+  options: ClearCacheRuntimeOptions,
+): ClearCacheTarget => {
+  const { webpackRequire } = options;
+  const name = options.name;
+  if (!name) {
+    throw new Error('clearCache requires a remote name');
+  }
+
+  const remoteKey = options.remoteKey || name;
+  const remotesLoadingData =
+    webpackRequire.remotesLoadingData ?? emptyRemotesLoadingData;
+  const remoteModuleIds: ModuleId[] = [];
+  const moduleIdToRemoteDataMapping =
+    remotesLoadingData.moduleIdToRemoteDataMapping ?? {};
+
+  pushUnique(
+    remoteModuleIds,
+    toList(remotesLoadingData.remoteKeyToRemoteModuleIds?.[remoteKey]),
+  );
+  if (remoteModuleIds.length === 0) {
+    for (const [moduleId, data] of Object.entries(
+      moduleIdToRemoteDataMapping,
+    )) {
+      if (data.remoteName === remoteKey || data.remoteName === name) {
+        remoteModuleIds.push(moduleId);
+      }
+    }
+  }
+  if (remoteModuleIds.length === 0) {
+    throw new Error(`Cannot find remote "${name}" in remote loading data`);
+  }
+
+  const externalModuleIds: ModuleId[] = [];
+  pushUnique(
+    externalModuleIds,
+    toList(remotesLoadingData.remoteKeyToExternalModuleIds?.[remoteKey]),
+  );
+  for (const remoteModuleId of remoteModuleIds) {
+    const data = moduleIdToRemoteDataMapping[remoteModuleId];
+    if (data) {
+      pushUnique(externalModuleIds, [data.externalModuleId]);
+    }
+  }
+
+  const remoteNames = getRemoteNames(webpackRequire, name, remoteKey);
+  const remoteInfos = toList(
+    webpackRequire.federation.bundlerRuntimeOptions.remotes?.remoteInfos?.[
+      remoteKey
+    ],
+  );
+  return {
+    name,
+    remoteKey,
+    remoteInfos,
+    remoteNames,
+    chunkIds: toList(remotesLoadingData.remoteKeyToChunkIds?.[remoteKey]),
+    generations: remoteNames.map((remoteName) => ({
+      key: remoteName,
+      value: getRemoteGeneration(webpackRequire, remoteName),
+    })),
+    remoteModuleIds,
+    externalModuleIds,
+  };
+};
+
+const createClearSnapshot = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+  consumerModuleIds: ModuleId[],
+) => {
+  const remoteModuleIds = target.remoteModuleIds;
+  const externalModuleIds = target.externalModuleIds;
+  const moduleIds = [
+    ...remoteModuleIds,
+    ...externalModuleIds,
+    ...consumerModuleIds,
+  ];
+  const idToExternalAndNameMapping =
+    webpackRequire.federation.bundlerRuntimeOptions.remotes
+      ?.idToExternalAndNameMapping ?? {};
+  const remoteLoadingPromises = remoteModuleIds.map((remoteModuleId) => {
+    const data =
+      webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping?.[
+        remoteModuleId
+      ];
+    return {
+      data,
+      had: data ? Object.prototype.hasOwnProperty.call(data, 'p') : false,
+      value: data?.p,
+    };
+  });
+  const runtimeLoadingPromises = remoteModuleIds.map((remoteModuleId) => {
+    const data = idToExternalAndNameMapping[remoteModuleId];
+    return {
+      data,
+      had: data ? Object.prototype.hasOwnProperty.call(data, 'p') : false,
+      value: data?.p,
+    };
+  });
+  const instance = webpackRequire.federation.instance;
+  const moduleCacheEntries = instance?.moduleCache
+    ? target.remoteNames.map((remoteName) => ({
+        key: remoteName,
+        had: instance.moduleCache.has(remoteName),
+        value: instance.moduleCache.get(remoteName),
+      }))
+    : [];
+  const idToRemoteMap = instance?.remoteHandler?.idToRemoteMap;
+  const idToRemoteMapEntries = idToRemoteMap
+    ? Object.entries(idToRemoteMap).map(([key, value]) => ({
+        key,
+        value,
+      }))
+    : [];
+  const federationInstances = Array.isArray(
+    (globalThis as any).__FEDERATION__?.__INSTANCES__,
+  )
+    ? (globalThis as any).__FEDERATION__.__INSTANCES__
+    : undefined;
+  const federationInstanceSnapshot = federationInstances
+    ? [...federationInstances]
+    : undefined;
+  const remoteEntryGlobalKeys: string[] = [];
+  const remoteEntryLoadingKeys: string[] = [];
+  for (const remoteInfo of target.remoteInfos) {
+    pushUnique(remoteEntryGlobalKeys, getRemoteEntryGlobalKeys(remoteInfo));
+    pushUnique(remoteEntryLoadingKeys, [getRemoteEntryLoadingKey(remoteInfo)]);
+  }
+  const state = getState(webpackRequire);
+  const remoteEntryUrlGenerationEntries = target.remoteInfos
+    .map((remoteInfo) => getRemoteEntryUrlGenerationKey(remoteInfo))
+    .filter((key): key is string => Boolean(key))
+    .map((key) => ({
+      key,
+      had: Object.prototype.hasOwnProperty.call(
+        state.remoteEntryUrlGenerations,
+        key,
+      ),
+      value: state.remoteEntryUrlGenerations[key],
+    }));
+  const globalLoading = globalThis.__GLOBAL_LOADING_REMOTE_ENTRY__ ?? {};
+  return {
+    restore() {
+      restoreEntries(webpackRequire.m, this.moduleFactories);
+      restoreEntries(webpackRequire.c, this.moduleCache);
+      restoreEntries(globalThis as any, this.remoteEntryGlobals);
+      restoreEntries(globalLoading, this.remoteEntryLoading);
+      for (const entry of remoteLoadingPromises) {
+        if (!entry.data) {
+          continue;
+        }
+        if (entry.had) {
+          entry.data.p = entry.value as Promise<any> | number;
+        } else {
+          delete entry.data.p;
+        }
+      }
+      for (const entry of runtimeLoadingPromises) {
+        if (!entry.data) {
+          continue;
+        }
+        if (entry.had) {
+          entry.data.p = entry.value as Promise<any> | number;
+        } else {
+          delete entry.data.p;
+        }
+      }
+      if (instance?.moduleCache) {
+        for (const entry of moduleCacheEntries) {
+          if (entry.had) {
+            instance.moduleCache.set(entry.key, entry.value as any);
+          } else {
+            instance.moduleCache.delete(entry.key);
+          }
+        }
+      }
+      if (idToRemoteMap) {
+        for (const key of Object.keys(idToRemoteMap)) {
+          delete idToRemoteMap[key];
+        }
+        for (const entry of idToRemoteMapEntries) {
+          idToRemoteMap[entry.key] = entry.value;
+        }
+      }
+      if (federationInstances && federationInstanceSnapshot) {
+        federationInstances.splice(
+          0,
+          federationInstances.length,
+          ...federationInstanceSnapshot,
+        );
+      }
+      for (const entry of target.generations) {
+        state.remoteGenerations[entry.key] = entry.value;
+      }
+      for (const entry of remoteEntryUrlGenerationEntries) {
+        if (entry.had) {
+          state.remoteEntryUrlGenerations[entry.key] = entry.value;
+        } else {
+          delete state.remoteEntryUrlGenerations[entry.key];
+        }
+      }
+    },
+    moduleFactories: captureEntries(webpackRequire.m, remoteModuleIds),
+    moduleCache: captureEntries(webpackRequire.c, moduleIds),
+    remoteEntryGlobals: captureEntries(
+      globalThis as any,
+      remoteEntryGlobalKeys,
+    ),
+    remoteEntryLoading: captureEntries(globalLoading, remoteEntryLoadingKeys),
+  };
+};
+
+const cleanupRemoteEntryCache = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+) => {
+  const globalLoading = globalThis.__GLOBAL_LOADING_REMOTE_ENTRY__;
+  for (const remoteInfo of target.remoteInfos) {
+    const loadingKey = getRemoteEntryLoadingKey(remoteInfo);
+    if (loadingKey && globalLoading) {
+      delete globalLoading[loadingKey];
+    }
+    for (const globalKey of getRemoteEntryGlobalKeys(remoteInfo)) {
+      if (!Object.prototype.hasOwnProperty.call(globalThis, globalKey)) {
+        continue;
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(globalThis, globalKey);
+      if (descriptor?.configurable) {
+        delete (globalThis as any)[globalKey];
+      } else {
+        (globalThis as any)[globalKey] = undefined;
+      }
+    }
+  }
+};
+
+const invalidateRemoteEntryUrlGenerations = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+) => {
+  const state = getState(webpackRequire);
+  for (const remoteInfo of target.remoteInfos) {
+    const key = getRemoteEntryUrlGenerationKey(remoteInfo);
+    if (!key) {
+      continue;
+    }
+    state.remoteEntryUrlGenerations[key] =
+      (state.remoteEntryUrlGenerations[key] ?? 0) + 1;
+  }
+};
+
+const cleanupRemoteRuntimeCache = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+) => {
+  const instance = webpackRequire.federation.instance;
+  if (!instance) {
+    return;
+  }
+  for (const remoteName of target.remoteNames) {
+    instance.moduleCache?.delete(remoteName);
+  }
+  const idToRemoteMap = instance.remoteHandler?.idToRemoteMap;
+  if (idToRemoteMap) {
+    for (const [id, remote] of Object.entries(idToRemoteMap)) {
+      if (
+        target.remoteNames.includes(remote.name) ||
+        target.remoteNames.some((remoteName) => id.startsWith(remoteName))
+      ) {
+        delete idToRemoteMap[id];
+      }
+    }
+  }
+  const federationInstances = (globalThis as any).__FEDERATION__?.__INSTANCES__;
+  if (Array.isArray(federationInstances)) {
+    for (let i = federationInstances.length - 1; i >= 0; i--) {
+      const remoteInstance = federationInstances[i];
+      const instanceNames = [
+        remoteInstance?.name,
+        remoteInstance?.options?.name,
+        remoteInstance?.options?.id,
+      ].filter((name): name is string => typeof name === 'string');
+      if (instanceNames.some((name) => target.remoteNames.includes(name))) {
+        federationInstances.splice(i, 1);
+      }
+    }
+  }
+};
+
+const cleanupSharedCache = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+) => {
+  const shareScopeMap = globalThis.__FEDERATION__?.__SHARE__;
+  if (!shareScopeMap) {
+    return;
+  }
+  for (const instanceId of Object.keys(shareScopeMap)) {
+    const scopes = shareScopeMap[instanceId];
+    if (!scopes || typeof scopes !== 'object') {
+      continue;
+    }
+    for (const scopeName of Object.keys(scopes)) {
+      const scope = scopes[scopeName];
+      if (!scope || typeof scope !== 'object') {
+        continue;
+      }
+      for (const shareName of Object.keys(scope)) {
+        const versions = scope[shareName];
+        if (!versions || typeof versions !== 'object') {
+          continue;
+        }
+        for (const shareVersion of Object.keys(versions)) {
+          const shared = versions[shareVersion];
+          if (
+            !shared ||
+            typeof shared !== 'object' ||
+            !target.remoteNames.includes(shared.from)
+          ) {
+            continue;
+          }
+          if (shared.loaded || typeof shared.lib === 'function') {
+            continue;
+          }
+          delete versions[shareVersion];
+        }
+      }
+    }
+  }
+};
+
+const getNodeChunkCacheControls = (webpackRequire: WebpackRequire) => {
+  const controls = webpackRequire.chunkCacheControls;
+  if (!controls) {
+    return [];
+  }
+  return Object.values(controls) as ChunkCacheControl[];
+};
+
+const getClearCacheWaitTimeout = () => {
+  const timeout = (globalThis as any).__rspack_clear_cache_wait_timeout__;
+  if (typeof timeout === 'number' && timeout >= 0) {
+    return timeout;
+  }
+  return 30000;
+};
+
+const waitWithTimeout = (promise: Promise<unknown> | undefined) => {
+  if (!promise || typeof promise.then !== 'function') {
+    return Promise.resolve(false);
+  }
+  const timeout = getClearCacheWaitTimeout();
+  if (timeout === Infinity) {
+    return promise.then(
+      () => false,
+      () => false,
+    );
+  }
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(true);
+    }, timeout);
+    promise.then(
+      () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        resolve(false);
+      },
+      () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        resolve(false);
+      },
+    );
+  });
+};
+
+const createNodeChunkCacheSnapshot = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+) => {
+  const entries: Array<{
+    control: ChunkCacheControl;
+    states?: unknown;
+    generations?: Record<string, number>;
+  }> = [];
+  if (target.chunkIds.length === 0) {
+    return { restore() {} };
+  }
+  for (const control of getNodeChunkCacheControls(webpackRequire)) {
+    const entry: {
+      control: ChunkCacheControl;
+      states?: unknown;
+      generations?: Record<string, number>;
+    } = { control };
+    if (typeof control?.snapshot === 'function') {
+      entry.states = control.snapshot(target.chunkIds);
+    }
+    if (
+      typeof control?.getGeneration === 'function' &&
+      typeof control?.restoreGenerations === 'function'
+    ) {
+      const generations: Record<string, number> = {};
+      for (const chunkId of target.chunkIds) {
+        generations[String(chunkId)] = control.getGeneration(chunkId);
+      }
+      entry.generations = generations;
+    }
+    if (!entry.states && !entry.generations) {
+      continue;
+    }
+    entries.push(entry);
+  }
+  return {
+    restore() {
+      for (const entry of entries) {
+        if (entry.states && typeof entry.control.restore === 'function') {
+          entry.control.restore(entry.states);
+        }
+        if (
+          entry.generations &&
+          typeof entry.control.restoreGenerations === 'function'
+        ) {
+          entry.control.restoreGenerations(entry.generations);
+        }
+      }
+    },
+  };
+};
+
+const invalidateNodeChunkGenerations = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+) => {
+  if (target.chunkIds.length === 0) {
+    return;
+  }
+  for (const control of getNodeChunkCacheControls(webpackRequire)) {
+    if (typeof control?.invalidate === 'function') {
+      control.invalidate(target.chunkIds);
+    }
+  }
+};
+
+const waitForPendingNodeChunkLoads = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+) => {
+  if (target.chunkIds.length === 0) {
+    return;
+  }
+  const waits: Promise<unknown>[] = [];
+  for (const control of getNodeChunkCacheControls(webpackRequire)) {
+    if (typeof control?.wait === 'function') {
+      waits.push(control.wait(target.chunkIds));
+    }
+  }
+  if (waits.length === 0) {
+    return;
+  }
+  return waitWithTimeout(Promise.all(waits));
+};
+
+const cleanupNodeChunkCache = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+) => {
+  if (target.chunkIds.length === 0) {
+    return;
+  }
+  for (const control of getNodeChunkCacheControls(webpackRequire)) {
+    if (typeof control?.clear === 'function') {
+      control.clear(target.chunkIds);
+    }
+  }
+};
+
+const cleanupStaleRemoteCache = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+  consumerModuleIds: ModuleId[],
+) => {
+  const idToExternalAndNameMapping =
+    webpackRequire.federation.bundlerRuntimeOptions.remotes
+      ?.idToExternalAndNameMapping ?? {};
+  cleanupNodeChunkCache(webpackRequire, target);
+  for (const remoteModuleId of target.remoteModuleIds) {
+    const data =
+      webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping?.[
+        remoteModuleId
+      ];
+    const runtimeData = idToExternalAndNameMapping[remoteModuleId];
+    if (data) {
+      delete data.p;
+    }
+    if (runtimeData) {
+      delete runtimeData.p;
+    }
+    delete webpackRequire.m[remoteModuleId];
+  }
+  deleteModuleCache(webpackRequire, target.remoteModuleIds);
+  deleteModuleCache(webpackRequire, target.externalModuleIds);
+  deleteModuleCache(webpackRequire, consumerModuleIds);
+  cleanupRemoteRuntimeCache(webpackRequire, target);
+  cleanupRemoteEntryCache(webpackRequire, target);
+};
+
+export const runStaleRemoteCleanups = (
+  webpackRequire: WebpackRequire,
+  remoteKeys: string[],
+) => {
+  const cleanups: Array<{ run: () => void }> = [];
+  const { staleRemoteCleanups } = getState(webpackRequire);
+  for (const remoteKey of remoteKeys) {
+    const cleanup = staleRemoteCleanups[remoteKey];
+    if (cleanup && !cleanups.includes(cleanup)) {
+      cleanups.push(cleanup);
+    }
+  }
+  for (const cleanup of cleanups) {
+    cleanup.run();
+  }
+};
+
+const trackStaleRemoteCleanup = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+  consumerModuleIds: ModuleId[],
+  pendingRemoteLoads: Promise<unknown>[],
+) => {
+  if (pendingRemoteLoads.length === 0) {
+    return;
+  }
+  const cleanup = {
+    pending: pendingRemoteLoads.length,
+    run() {
+      cleanupStaleRemoteCache(webpackRequire, target, consumerModuleIds);
+    },
+  };
+  const { staleRemoteCleanups } = getState(webpackRequire);
+  for (const remoteName of target.remoteNames) {
+    staleRemoteCleanups[remoteName] = cleanup;
+  }
+  const finish = () => {
+    cleanup.run();
+    cleanup.pending--;
+    if (cleanup.pending > 0) {
+      return;
+    }
+    for (const remoteName of target.remoteNames) {
+      if (staleRemoteCleanups[remoteName] === cleanup) {
+        delete staleRemoteCleanups[remoteName];
+      }
+    }
+  };
+  for (const pendingRemoteLoad of pendingRemoteLoads) {
+    pendingRemoteLoad.then(
+      () => Promise.resolve().then(finish),
+      () => Promise.resolve().then(finish),
+    );
+  }
+};
+
+const restoreRemoteGenerations = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+) => {
+  const state = getState(webpackRequire);
+  for (const entry of target.generations) {
+    state.remoteGenerations[entry.key] = entry.value;
+  }
+};
+
+const waitForSettledLoadConsumers = () =>
+  new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+const clearRemoteTarget = (
+  target: ClearCacheTarget,
+  webpackRequire: WebpackRequire,
+): Promise<ClearCacheResult> => {
+  const releaseBarrier = beginRemoteClear(webpackRequire, target.remoteNames);
+  let chunkCacheSnapshot = { restore() {} };
+  let clearSucceeded = false;
+
+  return Promise.resolve()
+    .then(() => waitForPendingNodeChunkLoads(webpackRequire, target))
+    .then(() => {
+      chunkCacheSnapshot = createNodeChunkCacheSnapshot(webpackRequire, target);
+      const idToExternalAndNameMapping =
+        webpackRequire.federation.bundlerRuntimeOptions.remotes
+          ?.idToExternalAndNameMapping ?? {};
+
+      const pendingRemoteLoads: Promise<unknown>[] = [];
+      for (const remoteModuleId of target.remoteModuleIds) {
+        for (const data of [
+          webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping?.[
+            remoteModuleId
+          ],
+          idToExternalAndNameMapping[remoteModuleId],
+        ]) {
+          if (data?.p && typeof data.p === 'object' && 'then' in data.p) {
+            pendingRemoteLoads.push(data.p.catch(() => {}));
+          }
+        }
+      }
+      const consumerModuleIds = isBrowserRuntime()
+        ? []
+        : getAffectedConsumerModuleIds(webpackRequire, target.remoteModuleIds);
+
+      return waitWithTimeout(Promise.all(pendingRemoteLoads))
+        .then((timedOut) => waitForSettledLoadConsumers().then(() => timedOut))
+        .then((timedOut) => {
+          const state = getState(webpackRequire);
+          for (const remoteName of target.remoteNames) {
+            state.remoteGenerations[remoteName] =
+              getRemoteGeneration(webpackRequire, remoteName) + 1;
+          }
+          invalidateNodeChunkGenerations(webpackRequire, target);
+
+          let snapshot: ReturnType<typeof createClearSnapshot> | undefined;
+          try {
+            snapshot = createClearSnapshot(
+              webpackRequire,
+              target,
+              consumerModuleIds,
+            );
+            for (const remoteModuleId of target.remoteModuleIds) {
+              const data =
+                webpackRequire.remotesLoadingData
+                  ?.moduleIdToRemoteDataMapping?.[remoteModuleId];
+              const runtimeData = idToExternalAndNameMapping[remoteModuleId];
+              if (data) {
+                delete data.p;
+              }
+              if (runtimeData) {
+                delete runtimeData.p;
+              }
+              delete webpackRequire.m[remoteModuleId];
+            }
+            deleteModuleCache(webpackRequire, target.remoteModuleIds);
+            deleteModuleCache(webpackRequire, target.externalModuleIds);
+            deleteModuleCache(webpackRequire, consumerModuleIds);
+            invalidateRemoteEntryUrlGenerations(webpackRequire, target);
+            cleanupRemoteEntryCache(webpackRequire, target);
+            cleanupRemoteRuntimeCache(webpackRequire, target);
+            cleanupNodeChunkCache(webpackRequire, target);
+            cleanupSharedCache(webpackRequire, target);
+            if (timedOut) {
+              trackStaleRemoteCleanup(
+                webpackRequire,
+                target,
+                consumerModuleIds,
+                pendingRemoteLoads,
+              );
+            }
+            clearSucceeded = true;
+          } catch (error) {
+            if (snapshot) {
+              snapshot.restore();
+            } else {
+              restoreRemoteGenerations(webpackRequire, target);
+            }
+            throw error;
+          }
+
+          return {
+            name: target.name,
+            cleared: true as const,
+          };
+        });
+    })
+    .catch((error) => {
+      if (!clearSucceeded) {
+        chunkCacheSnapshot.restore();
+        restoreRemoteGenerations(webpackRequire, target);
+      }
+      throw error;
+    })
+    .finally(releaseBarrier);
+};
+
+export const clearCache = (
+  options: ClearCacheRuntimeOptions,
+): Promise<ClearCacheResult> => {
+  let target: ClearCacheTarget;
+  try {
+    target = getClearTarget(options);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+  return clearRemoteTarget(target, options.webpackRequire);
+};
+
+const normalizeRemote = (remote: RuntimeRemote): RuntimeRemote => ({
+  ...remote,
+  shareScope: remote.shareScope || 'default',
+  type: remote.type || 'global',
+});
+
+const captureRemoteRegistrationSnapshot = (instance: any) => {
+  const remotes = toList<RuntimeRemote>(instance.options?.remotes).map(
+    (remote) => ({
+      ...remote,
+    }),
+  );
+  return {
+    restore() {
+      instance.options.remotes.splice(0, instance.options.remotes.length);
+      instance.options.remotes.push(
+        ...remotes.map((remote) => ({
+          ...remote,
+        })),
+      );
+    },
+  };
+};
+
+const createBundlerRemoteInfo = (remote: RuntimeRemote) => {
+  const shareScope = Array.isArray(remote.shareScope)
+    ? remote.shareScope[0]
+    : remote.shareScope;
+
+  return {
+    ...remote,
+    alias: remote.alias || remote.name,
+    externalType: 'script',
+    shareScope: shareScope || 'default',
+  };
+};
+
+const captureBundlerRemoteInfoSnapshot = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+) => {
+  const remotesOptions =
+    webpackRequire.federation.bundlerRuntimeOptions.remotes!;
+  const idToRemoteMap = remotesOptions.idToRemoteMap ?? {};
+  const remoteInfos = remotesOptions.remoteInfos ?? {};
+  const idToRemoteMapEntries = target.remoteModuleIds.map((remoteModuleId) => ({
+    key: remoteModuleId,
+    had: Object.prototype.hasOwnProperty.call(idToRemoteMap, remoteModuleId),
+    value: idToRemoteMap[remoteModuleId],
+  }));
+  const remoteInfoEntry = {
+    key: target.remoteKey,
+    had: Object.prototype.hasOwnProperty.call(remoteInfos, target.remoteKey),
+    value: remoteInfos[target.remoteKey],
+  };
+  return {
+    restore() {
+      restoreEntries(idToRemoteMap as any, idToRemoteMapEntries);
+      restoreEntries(remoteInfos as any, [remoteInfoEntry]);
+    },
+  };
+};
+
+const updateBundlerRemoteInfo = (
+  webpackRequire: WebpackRequire,
+  target: ClearCacheTarget,
+  remote: RuntimeRemote,
+) => {
+  const remotesOptions =
+    webpackRequire.federation.bundlerRuntimeOptions.remotes!;
+  const remoteInfo = createBundlerRemoteInfo(remote);
+  for (const remoteModuleId of target.remoteModuleIds) {
+    remotesOptions.idToRemoteMap[remoteModuleId] = [remoteInfo];
+  }
+  remotesOptions.remoteInfos ||= {};
+  remotesOptions.remoteInfos[target.remoteKey] = [remoteInfo];
+};
+
+const replaceRemoteRegistration = (instance: any, remote: RuntimeRemote) => {
+  const normalizedRemote = normalizeRemote(remote);
+  const targetRemotes = instance.options.remotes;
+  const hooks = instance.remoteHandler?.hooks?.lifecycle;
+  hooks?.beforeRegisterRemote?.emit({
+    remote: normalizedRemote,
+    origin: instance,
+  });
+  const index = targetRemotes.findIndex(
+    (item: RuntimeRemote) => item.name === normalizedRemote.name,
+  );
+  if (index === -1) {
+    targetRemotes.push(normalizedRemote);
+  } else {
+    targetRemotes.splice(index, 1, normalizedRemote);
+  }
+  hooks?.registerRemote?.emit({
+    remote: normalizedRemote,
+    origin: instance,
+  });
+  return normalizedRemote;
+};
+
+const registerRemotesWithForce = (
+  webpackRequire: WebpackRequire,
+  instance: any,
+  remotes: RuntimeRemote[],
+) => {
+  const remoteList = toList(remotes);
+  const registrationSnapshot = captureRemoteRegistrationSnapshot(instance);
+  const bundlerSnapshots: Array<{ restore: () => void }> = [];
+  const clearTargets: Array<ClearCacheTarget | undefined> = [];
+  try {
+    for (const remote of remoteList) {
+      let clearTarget: ClearCacheTarget | undefined;
+      try {
+        clearTarget = getClearTarget({
+          name: remote.name,
+          webpackRequire,
+        });
+      } catch {
+        clearTarget = undefined;
+      }
+      const normalizedRemote = replaceRemoteRegistration(instance, remote);
+      if (clearTarget) {
+        bundlerSnapshots.push(
+          captureBundlerRemoteInfoSnapshot(webpackRequire, clearTarget),
+        );
+        updateBundlerRemoteInfo(webpackRequire, clearTarget, normalizedRemote);
+      }
+      clearTargets.push(clearTarget);
+    }
+  } catch (error) {
+    for (let i = bundlerSnapshots.length - 1; i >= 0; i--) {
+      bundlerSnapshots[i].restore();
+    }
+    registrationSnapshot.restore();
+    return Promise.reject(error);
+  }
+  return clearTargets
+    .reduce(
+      (promise, target) =>
+        promise.then(() =>
+          target ? clearRemoteTarget(target, webpackRequire) : undefined,
+        ),
+      Promise.resolve<unknown>(undefined),
+    )
+    .catch((error) => {
+      for (let i = bundlerSnapshots.length - 1; i >= 0; i--) {
+        bundlerSnapshots[i].restore();
+      }
+      registrationSnapshot.restore();
+      throw error;
+    });
+};
+
+const markRemoteModuleGeneration = (
+  webpackRequire: WebpackRequire,
+  remoteName: string,
+  module: Record<string, any> | undefined,
+) => {
+  if (module && typeof module === 'object') {
+    module['__rspack_remote_generation__'] = getRemoteGeneration(
+      webpackRequire,
+      remoteName,
+    );
+  }
+};
+
+export const installClearCache = ({
+  webpackRequire,
+  instance,
+}: InstallClearCacheOptions) => {
+  const state = getState(webpackRequire);
+  if (state.installed) {
+    return;
+  }
+  const federation = webpackRequire.federation;
+  instance ??= federation.instance;
+  if (!instance) {
+    return;
+  }
+  state.installed = true;
+
+  federation.clearCache = (options: ClearCacheOptions) =>
+    clearCache({ ...options, webpackRequire });
+
+  const moduleCache = instance.moduleCache;
+  if (moduleCache && typeof moduleCache.set === 'function') {
+    const originalSet = moduleCache.set.bind(moduleCache);
+    (moduleCache as any).set = (
+      remoteName: string,
+      module: Record<string, any>,
+    ) => {
+      markRemoteModuleGeneration(webpackRequire, remoteName, module);
+      return originalSet(remoteName, module as any);
+    };
+  }
+
+  if (typeof instance.loadRemote === 'function') {
+    const originalLoadRemote = instance.loadRemote.bind(instance);
+    (instance as any).loadRemote = (
+      id: string,
+      options?: Record<string, any>,
+    ) => {
+      const remoteKeys = getRemoteKeysForRequest(webpackRequire, id);
+      runStaleRemoteCleanups(webpackRequire, remoteKeys);
+      const load = () => originalLoadRemote(id, options as any);
+      return (
+        waitForRemoteClear(webpackRequire, remoteKeys)?.then(load) ?? load()
+      );
+    };
+  }
+
+  if (typeof instance.registerRemotes === 'function') {
+    const originalRegisterRemotes = instance.registerRemotes.bind(instance);
+    (instance as any).registerRemotes = (
+      remotes: RuntimeRemote[],
+      options?: { force?: boolean },
+    ) => {
+      if (!options?.force) {
+        return originalRegisterRemotes(remotes as any, options as any);
+      }
+      return registerRemotesWithForce(webpackRequire, instance, remotes);
+    };
+  }
+
+  instance.loaderHook?.lifecycle?.createScript?.on?.(
+    ({ url, remoteInfo }: { url: string; remoteInfo?: RemoteInfoLike }) => {
+      if (!remoteInfo) {
+        return;
+      }
+      const key = getRemoteEntryUrlGenerationKey(remoteInfo);
+      const generation = key ? state.remoteEntryUrlGenerations[key] : undefined;
+      if (!generation) {
+        return;
+      }
+      return {
+        url: withRemoteEntryUrlGeneration(url, generation),
+      };
+    },
+  );
+};
+
+const reportRemoveRemoteClearCacheError = (error: unknown) => {
+  if (typeof console === 'undefined' || typeof console.warn !== 'function') {
+    return;
+  }
+  console.warn(
+    `clearCache after removeRemote failed: ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+};
+
+export const createClearCacheRuntimePlugin = ({
+  webpackRequire,
+}: {
+  webpackRequire: WebpackRequire;
+}) => ({
+  name: 'bundler-runtime-clear-cache-plugin',
+  removeRemote({ remote }: { remote: RuntimeRemote }) {
+    const clear =
+      webpackRequire.federation.clearCache ||
+      ((options: ClearCacheOptions) =>
+        clearCache({ ...options, webpackRequire }));
+    return clear({ name: remote.alias || remote.name })
+      .then(() => undefined)
+      .catch((error) => {
+        reportRemoveRemoteClearCacheError(error);
+        throw error;
+      });
+  },
+});

--- a/packages/webpack-bundler-runtime/src/clearCache.ts
+++ b/packages/webpack-bundler-runtime/src/clearCache.ts
@@ -66,8 +66,28 @@ type ClearCacheState = {
 
 const clearCacheStates = new WeakMap<WebpackRequire, ClearCacheState>();
 
-const hasOwn = (obj: Record<string | number, unknown>, key: string | number) =>
+const hasOwn = (obj: object, key: string | number) =>
   Object.prototype.hasOwnProperty.call(obj, key);
+
+const getOwn = <T>(
+  obj: Record<string | number, T> | undefined | null,
+  key: string | number,
+): T | undefined => {
+  if (!obj || !hasOwn(obj, key)) {
+    return undefined;
+  }
+  return obj[key];
+};
+
+const deleteOwn = (
+  obj: object | undefined | null,
+  key: string | number,
+) => {
+  if (!obj || obj === Object.prototype || !hasOwn(obj, key)) {
+    return;
+  }
+  Reflect.deleteProperty(obj, key);
+};
 
 const toList = <T>(value: T[] | undefined | null): T[] =>
   Array.isArray(value) ? value : [];
@@ -199,7 +219,7 @@ export const getRemoteKeysForChunk = (
     webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping ?? {};
 
   for (const remoteModuleId of toList(chunkMapping[chunkId])) {
-    const data = moduleIdToRemoteDataMapping[remoteModuleId];
+    const data = getOwn(moduleIdToRemoteDataMapping, remoteModuleId);
     if (data) {
       pushUnique(remoteKeys, [data.remoteName]);
     }
@@ -379,7 +399,7 @@ const getClearTarget = (
     toList(remotesLoadingData.remoteKeyToExternalModuleIds?.[remoteKey]),
   );
   for (const remoteModuleId of remoteModuleIds) {
-    const data = moduleIdToRemoteDataMapping[remoteModuleId];
+    const data = getOwn(moduleIdToRemoteDataMapping, remoteModuleId);
     if (data) {
       pushUnique(externalModuleIds, [data.externalModuleId]);
     }
@@ -421,11 +441,10 @@ const createClearSnapshot = (
   const idToExternalAndNameMapping =
     webpackRequire.federation.bundlerRuntimeOptions.remotes
       ?.idToExternalAndNameMapping ?? {};
+  const moduleIdToRemoteDataMapping =
+    webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping;
   const remoteLoadingPromises = remoteModuleIds.map((remoteModuleId) => {
-    const data =
-      webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping?.[
-        remoteModuleId
-      ];
+    const data = getOwn(moduleIdToRemoteDataMapping, remoteModuleId);
     return {
       data,
       had: data ? Object.prototype.hasOwnProperty.call(data, 'p') : false,
@@ -433,7 +452,7 @@ const createClearSnapshot = (
     };
   });
   const runtimeLoadingPromises = remoteModuleIds.map((remoteModuleId) => {
-    const data = idToExternalAndNameMapping[remoteModuleId];
+    const data = getOwn(idToExternalAndNameMapping, remoteModuleId);
     return {
       data,
       had: data ? Object.prototype.hasOwnProperty.call(data, 'p') : false,
@@ -841,19 +860,21 @@ const cleanupStaleRemoteCache = (
   const idToExternalAndNameMapping =
     webpackRequire.federation.bundlerRuntimeOptions.remotes
       ?.idToExternalAndNameMapping ?? {};
+  const moduleIdToRemoteDataMapping =
+    webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping;
   cleanupNodeChunkCache(webpackRequire, target);
   for (const remoteModuleId of target.remoteModuleIds) {
-    const data =
-      webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping?.[
-        remoteModuleId
-      ];
-    const runtimeData = idToExternalAndNameMapping[remoteModuleId];
-    if (data) {
-      delete data.p;
+    if (
+      remoteModuleId === '__proto__' ||
+      remoteModuleId === 'constructor' ||
+      remoteModuleId === 'prototype'
+    ) {
+      continue;
     }
-    if (runtimeData) {
-      delete runtimeData.p;
-    }
+    const data = getOwn(moduleIdToRemoteDataMapping, remoteModuleId);
+    const runtimeData = getOwn(idToExternalAndNameMapping, remoteModuleId);
+    deleteOwn(data, 'p');
+    deleteOwn(runtimeData, 'p');
     delete webpackRequire.m[remoteModuleId];
   }
   deleteModuleCache(webpackRequire, target.remoteModuleIds);
@@ -940,13 +961,13 @@ const clearRemoteTarget = (
   const idToExternalAndNameMapping =
     webpackRequire.federation.bundlerRuntimeOptions.remotes
       ?.idToExternalAndNameMapping ?? {};
+  const moduleIdToRemoteDataMapping =
+    webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping;
   const pendingRemoteLoads: Promise<unknown>[] = [];
   for (const remoteModuleId of target.remoteModuleIds) {
     for (const data of [
-      webpackRequire.remotesLoadingData?.moduleIdToRemoteDataMapping?.[
-        remoteModuleId
-      ],
-      idToExternalAndNameMapping[remoteModuleId],
+      getOwn(moduleIdToRemoteDataMapping, remoteModuleId),
+      getOwn(idToExternalAndNameMapping, remoteModuleId),
     ]) {
       if (data?.p && typeof data.p === 'object' && 'then' in data.p) {
         pendingRemoteLoads.push(data.p.catch(() => {}));

--- a/packages/webpack-bundler-runtime/src/index.ts
+++ b/packages/webpack-bundler-runtime/src/index.ts
@@ -8,6 +8,7 @@ import { attachShareScopeMap } from './attachShareScopeMap';
 import { initContainerEntry } from './initContainerEntry';
 import { init } from './init';
 import { getSharedFallbackGetter } from './getSharedFallbackGetter';
+import { clearCache, installClearCache } from './clearCache';
 
 export * from './types';
 
@@ -24,6 +25,8 @@ const federation: Federation = {
     initContainerEntry,
     init,
     getSharedFallbackGetter,
+    clearCache,
+    installClearCache,
   },
   attachShareScopeMap,
   bundlerRuntimeOptions: {},

--- a/packages/webpack-bundler-runtime/src/init.ts
+++ b/packages/webpack-bundler-runtime/src/init.ts
@@ -5,6 +5,7 @@ import {
 } from '@module-federation/runtime';
 import { ShareArgs } from '@module-federation/runtime/types';
 import helpers from '@module-federation/runtime/helpers';
+import { createClearCacheRuntimePlugin, installClearCache } from './clearCache';
 
 export function init({ webpackRequire }: { webpackRequire: WebpackRequire }) {
   const { initOptions, runtime, sharedFallback, bundlerRuntime, libraryType } =
@@ -124,7 +125,11 @@ export function init({ webpackRequire }: { webpackRequire: WebpackRequire }) {
       };
     };
 
-  initOptions.plugins ||= [];
-  initOptions.plugins.push(treeShakingSharePlugin());
-  return runtime!.init(initOptions);
+  const plugins = (initOptions['plugins'] ||= []);
+  plugins.push(treeShakingSharePlugin());
+  plugins.push(createClearCacheRuntimePlugin({ webpackRequire }));
+
+  const instance = runtime!.init(initOptions);
+  installClearCache({ webpackRequire, instance });
+  return instance;
 }

--- a/packages/webpack-bundler-runtime/src/remotes.ts
+++ b/packages/webpack-bundler-runtime/src/remotes.ts
@@ -4,8 +4,34 @@ import { RemotesOptions } from './types';
 import { FEDERATION_SUPPORTED_TYPES } from './constant';
 import { decodeName, ENCODE_NAME_PREFIX } from '@module-federation/sdk';
 import { updateRemoteOptions } from './updateOptions';
+import {
+  getRemoteKeysForChunk,
+  runStaleRemoteCleanups,
+  waitForRemoteClear,
+} from './clearCache';
 
 export function remotes(options: RemotesOptions) {
+  const { chunkId, promises, webpackRequire } = options;
+  const remoteKeys = getRemoteKeysForChunk(webpackRequire, chunkId);
+  runStaleRemoteCleanups(webpackRequire, remoteKeys);
+  const wait = waitForRemoteClear(webpackRequire, remoteKeys);
+  if (wait) {
+    promises.push(
+      wait.then(() => {
+        const remotePromises: Promise<any>[] = [];
+        loadRemotes({
+          ...options,
+          promises: remotePromises,
+        });
+        return Promise.all(remotePromises);
+      }),
+    );
+    return;
+  }
+  loadRemotes(options);
+}
+
+function loadRemotes(options: RemotesOptions) {
   updateRemoteOptions(options);
 
   const {

--- a/packages/webpack-bundler-runtime/src/types.ts
+++ b/packages/webpack-bundler-runtime/src/types.ts
@@ -74,6 +74,7 @@ export type RemoteDataItem = {
   name: string;
   externalModuleId: ModuleId;
   remoteName: string;
+  p?: Promise<any> | number;
 };
 export type ModuleIdToRemoteDataMapping = Record<ModuleId, RemoteDataItem>;
 
@@ -95,6 +96,11 @@ export type ConsumesLoadingData = WithStatus<{
 export type RemotesLoadingData = WithStatus<{
   chunkMapping?: Record<string, Array<ModuleId>>;
   moduleIdToRemoteDataMapping?: ModuleIdToRemoteDataMapping;
+  remoteKeyToRemoteModuleIds?: Record<string, Array<ModuleId>>;
+  remoteKeyToExternalModuleIds?: Record<string, Array<ModuleId>>;
+  remoteModuleIdToConsumerModuleIds?: Record<ModuleId, Array<ModuleId>>;
+  consumerModuleIdToParentModuleIds?: Record<ModuleId, Array<ModuleId>>;
+  remoteKeyToChunkIds?: Record<string, Array<ModuleId>>;
 }>;
 
 export type InitializeSharingData = WithStatus<{
@@ -130,6 +136,18 @@ export interface WebpackRequire {
   consumesLoadingData?: ConsumesLoadingData;
   remotesLoadingData?: RemotesLoadingData;
   initializeSharingData?: InitializeSharingData;
+  chunkCacheControls?: Record<
+    string,
+    {
+      clear?: (chunkIds: ModuleId[]) => unknown;
+      invalidate?: (chunkIds: ModuleId[]) => unknown;
+      wait?: (chunkIds: ModuleId[]) => Promise<unknown>;
+      snapshot?: (chunkIds: ModuleId[]) => unknown;
+      restore?: (states: unknown) => void;
+      getGeneration?: (chunkId: ModuleId) => number;
+      restoreGenerations?: (generations: Record<string, number>) => void;
+    }
+  >;
 }
 
 interface ShareInfo {
@@ -159,11 +177,33 @@ export type RemoteInfos = Record<
     IdToRemoteMapItem & {
       alias: string;
       entry?: string;
+      type?: string;
+      globalName?: string;
+      entryGlobalName?: string;
       shareScope: string;
     }
   >
 >;
 export type RemoteChunkMapping = Record<string, Array<ModuleId>>;
+
+export type ClearCacheOptions = {
+  name: string;
+  remoteKey?: string;
+};
+
+export type ClearCacheRuntimeOptions = ClearCacheOptions & {
+  webpackRequire: WebpackRequire;
+};
+
+export type ClearCacheResult = {
+  name: string;
+  cleared: true;
+};
+
+export interface InstallClearCacheOptions {
+  webpackRequire: WebpackRequire;
+  instance?: runtime.ModuleFederation;
+}
 
 export type CoreRemotesOptions = {
   idToRemoteMap: IdToRemoteMap;
@@ -237,7 +277,12 @@ export interface Federation {
     getSharedFallbackGetter: (
       options: GetSharedFallbackGetterOptions,
     ) => SharedGetter;
+    clearCache: (
+      options: ClearCacheRuntimeOptions,
+    ) => Promise<ClearCacheResult>;
+    installClearCache: (options: InstallClearCacheOptions) => void;
   };
+  clearCache?: (options: ClearCacheOptions) => Promise<ClearCacheResult>;
   bundlerRuntimeOptions: {
     remotes?: Exclude<RemotesOptions, 'chunkId' | 'promises'> & {
       remoteInfos?: RemoteInfos;

--- a/packages/webpack-bundler-runtime/tsconfig.json
+++ b/packages/webpack-bundler-runtime/tsconfig.json
@@ -13,16 +13,9 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "declaration": true,
-    "noImplicitReturns": false
+    "noImplicitReturns": false,
+    "types": ["jest", "node"],
+    "noEmit": true
   },
-  "files": [],
-  "include": [],
-  "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
-  ]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/webpack-bundler-runtime/tsconfig.lib.json
+++ b/packages/webpack-bundler-runtime/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "declaration": true,
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
         version: 1.57.0
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@rollup/plugin-alias':
         specifier: 5.1.1
         version: 5.1.1(rollup@4.59.0)
@@ -132,13 +132,13 @@ importers:
         version: 0.10.6(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@rspack/cli':
         specifier: npm:@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342
-        version: '@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@rspack/dev-server@1.1.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1))'
+        version: '@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@rspack/dev-server@2.1.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(selfsigned@5.5.0))'
       '@rspack/core':
         specifier: npm:@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342
         version: '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
       '@rspack/dev-server':
-        specifier: 1.1.1
-        version: 1.1.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)
+        specifier: 2.1.0
+        version: 2.1.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(selfsigned@5.5.0)
       '@rstest/core':
         specifier: ^0.8.0
         version: 0.8.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(jsdom@20.0.3)
@@ -372,7 +372,7 @@ importers:
         version: 3.5.0
       rsbuild-plugin-publint:
         specifier: ^0.2.1
-        version: 0.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+        version: 0.2.1(@rsbuild/core@1.4.16(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       serve:
         specifier: ^14.2.4
         version: 14.2.5
@@ -390,7 +390,7 @@ importers:
         version: 3.4.13(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3))
       terser-webpack-plugin:
         specifier: ^5.3.10
-        version: 5.4.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 5.4.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack@5.104.1)
       ts-jest:
         specifier: 29.1.5
         version: 29.1.5(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.28.1)(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3)))(typescript@5.9.3)
@@ -465,7 +465,7 @@ importers:
         version: 4.17.23
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4)
+        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -502,7 +502,7 @@ importers:
         version: 4.17.23
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4)
+        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -542,7 +542,7 @@ importers:
         version: 4.17.23
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4)
+        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -598,7 +598,7 @@ importers:
         version: link:../../packages/typescript
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@types/react':
         specifier: 18.3.11
         version: 18.3.11
@@ -675,7 +675,7 @@ importers:
         version: link:../../../packages/typescript
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@types/react':
         specifier: 18.3.11
         version: 18.3.11
@@ -706,7 +706,7 @@ importers:
         version: link:../../../packages/enhanced
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@rspack/core':
         specifier: npm:@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342
         version: '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)'
@@ -743,7 +743,7 @@ importers:
         version: link:../../../packages/enhanced
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@rspack/plugin-react-refresh':
         specifier: ^0.7.5
         version: 0.7.5(react-refresh@0.14.2)
@@ -777,7 +777,7 @@ importers:
         version: link:../../../packages/enhanced
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@rspack/plugin-react-refresh':
         specifier: ^0.7.5
         version: 0.7.5(react-refresh@0.14.2)
@@ -817,7 +817,7 @@ importers:
         version: link:../../../packages/typescript
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@types/react':
         specifier: 18.3.11
         version: 18.3.11
@@ -863,7 +863,7 @@ importers:
         version: 0.80.0(@babel/core@7.29.0)
       '@react-native/eslint-config':
         specifier: 0.80.0
-        version: 0.80.0(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)))(prettier@2.8.8)(typescript@5.0.4)
+        version: 0.80.0(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3)))(prettier@2.8.8)(typescript@5.0.4)
       '@react-native/gradle-plugin':
         specifier: 0.80.0
         version: 0.80.0
@@ -902,7 +902,7 @@ importers:
         version: 9.39.3(jiti@2.6.1)
       jest:
         specifier: ^29.6.3
-        version: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))
+        version: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3))
       nodemon:
         specifier: ^3.1.9
         version: 3.1.14
@@ -957,7 +957,7 @@ importers:
         version: 0.80.0(@babel/core@7.29.0)
       '@react-native/eslint-config':
         specifier: 0.80.0
-        version: 0.80.0(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)))(prettier@2.8.8)(typescript@5.0.4)
+        version: 0.80.0(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3)))(prettier@2.8.8)(typescript@5.0.4)
       '@react-native/metro-config':
         specifier: 0.80.0
         version: 0.80.0(@babel/core@7.29.0)
@@ -993,7 +993,7 @@ importers:
         version: 9.39.3(jiti@2.6.1)
       jest:
         specifier: ^29.6.3
-        version: 29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4))
+        version: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3))
       nodemon:
         specifier: ^3.1.9
         version: 3.1.14
@@ -1048,7 +1048,7 @@ importers:
         version: 0.80.0(@babel/core@7.29.0)
       '@react-native/eslint-config':
         specifier: 0.80.0
-        version: 0.80.0(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)))(prettier@2.8.8)(typescript@5.0.4)
+        version: 0.80.0(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3)))(prettier@2.8.8)(typescript@5.0.4)
       '@react-native/metro-config':
         specifier: 0.80.0
         version: 0.80.0(@babel/core@7.29.0)
@@ -1084,7 +1084,7 @@ importers:
         version: 9.39.3(jiti@2.6.1)
       jest:
         specifier: ^29.6.3
-        version: 29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4))
+        version: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3))
       nodemon:
         specifier: ^3.1.9
         version: 3.1.14
@@ -1130,7 +1130,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
@@ -1169,7 +1169,7 @@ importers:
         version: 7.28.2
       '@modern-js/runtime':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)))(react@18.3.1)
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
       '@module-federation/modern-js-v3':
         specifier: workspace:*
         version: link:../../../packages/modernjs-v3
@@ -1188,7 +1188,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
@@ -1282,7 +1282,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
@@ -1371,7 +1371,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
@@ -1429,7 +1429,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
@@ -1487,7 +1487,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
@@ -1545,7 +1545,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
@@ -1603,7 +1603,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
@@ -1901,7 +1901,7 @@ importers:
         version: link:../../packages/runtime
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@types/react':
         specifier: 18.3.11
         version: 18.3.11
@@ -2102,7 +2102,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@26.0.0)(typescript@5.9.3))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.9.3))
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
@@ -2421,7 +2421,7 @@ importers:
         version: 1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rslib/core@0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3))(storybook-builder-rsbuild@1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/react@18.3.28)(storybook@8.6.17(prettier@3.8.1))(tslib@2.8.1)(typescript@5.9.3))(typescript@5.9.3)
       storybook-react-rsbuild:
         specifier: ^1.0.1
-        version: 1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(storybook@8.6.17(prettier@3.8.1))(tslib@2.8.1)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack-cli@5.1.4))
+        version: 1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(storybook@8.6.17(prettier@3.8.1))(tslib@2.8.1)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
 
   apps/runtime-demo/3005-runtime-host:
     dependencies:
@@ -2458,7 +2458,7 @@ importers:
         version: link:../../../packages/typescript
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@types/react':
         specifier: 18.3.11
         version: 18.3.11
@@ -2492,7 +2492,7 @@ importers:
         version: link:../../../packages/typescript
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@types/react':
         specifier: 18.3.11
         version: 18.3.11
@@ -2526,7 +2526,7 @@ importers:
         version: link:../../../packages/typescript
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@types/react':
         specifier: 18.3.11
         version: 18.3.11
@@ -2563,7 +2563,7 @@ importers:
         version: 7.28.2
       '@modern-js/runtime':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: workspace:*
         version: link:../../../../packages/enhanced
@@ -2582,7 +2582,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/plugin-server':
         specifier: 2.68.0
         version: 2.68.0(@babel/traverse@7.29.7)(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2618,7 +2618,7 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ~10.8.1
-        version: 10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)
+        version: 10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@20.19.5)(typescript@5.0.4)
       tsconfig-paths:
         specifier: ~3.14.1
         version: 3.14.2
@@ -2652,7 +2652,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
@@ -2716,7 +2716,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
@@ -2792,7 +2792,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
@@ -3061,7 +3061,7 @@ importers:
         version: 2.66.7(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/runtime':
         specifier: 2.70.8
-        version: 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
+        version: 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.4)
       '@module-federation/observability-plugin':
         specifier: workspace:*
         version: link:../observability-plugin
@@ -3098,7 +3098,7 @@ importers:
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@modern-js/app-tools':
         specifier: 2.70.8
-        version: 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.10(@swc/helpers@0.5.19))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
+        version: 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.10(@swc/helpers@0.5.19))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)
       '@modern-js/eslint-config':
         specifier: 2.59.0
         version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
@@ -3107,7 +3107,7 @@ importers:
         version: 2.70.8(@types/node@20.19.5)(typescript@5.9.3)
       '@modern-js/storybook':
         specifier: 2.70.8
-        version: 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+        version: 2.70.8(a986c9500bd26293c94ebe2f5d942d86)
       '@modern-js/tsconfig':
         specifier: 2.70.8
         version: 2.70.8
@@ -3214,7 +3214,7 @@ importers:
         version: 1.2.5
       rsbuild-plugin-publint:
         specifier: ^0.2.1
-        version: 0.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+        version: 0.2.1(@rsbuild/core@1.4.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
 
   packages/dts-plugin:
     dependencies:
@@ -3486,7 +3486,7 @@ importers:
         version: 0.80.0(@babel/core@7.29.7)(@react-native-community/cli@19.1.2(typescript@5.9.3))(@types/react@19.2.14)(react@19.1.0)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@20.19.5)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.9.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -3619,13 +3619,13 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: 2.70.5
-        version: 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.10(@swc/helpers@0.5.17))(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
+        version: 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.10(@swc/helpers@0.5.17))(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)
       '@modern-js/module-tools':
         specifier: 2.70.5
         version: 2.70.5(@types/node@26.0.0)(typescript@5.9.3)
       '@modern-js/runtime':
         specifier: 2.70.5
-        version: 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@19.2.7)
+        version: 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.7)
       '@modern-js/server-runtime':
         specifier: 2.70.5
         version: 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -3707,13 +3707,13 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/module-tools':
         specifier: 2.70.5
         version: 2.70.5(@types/node@26.0.0)(typescript@5.9.3)
       '@modern-js/runtime':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@18.3.1)
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
       '@modern-js/server-runtime':
         specifier: 3.0.1
         version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3841,7 +3841,7 @@ importers:
         version: 3.3.3
       next:
         specifier: ^12 || ^13 || ^14 || ^15
-        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4)
+        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       react:
         specifier: ^17 || ^18 || ^19
         version: 18.3.1
@@ -4069,10 +4069,10 @@ importers:
         version: link:../sdk
       '@nx/react':
         specifier: '>= 16.0.0'
-        version: 22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@module-federation/runtime-tools@0.21.6)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.5)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)
+        version: 22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.5)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       '@nx/webpack':
         specifier: '>= 16.0.0'
-        version: 22.5.4(@babel/traverse@7.29.7)(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4)
+        version: 22.5.4(@babel/traverse@7.29.7)(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       storybook:
         specifier: '>= 8.2.0'
         version: 8.6.17(prettier@3.8.1)
@@ -4082,10 +4082,10 @@ importers:
         version: link:../utilities
       '@nx/module-federation':
         specifier: '>= 16.0.0'
-        version: 22.5.4(@babel/traverse@7.29.7)(@module-federation/runtime-tools@0.21.6)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)
+        version: 22.5.4(@babel/traverse@7.29.7)(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       '@rsbuild/core':
         specifier: 2.0.0-beta.2
-        version: 2.0.0-beta.2(@module-federation/runtime-tools@0.21.6)(core-js@3.49.0)
+        version: 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
       '@storybook/core':
         specifier: ^8.4.6
         version: 8.6.14(prettier@3.8.1)(storybook@8.6.17(prettier@3.8.1))
@@ -4097,7 +4097,7 @@ importers:
         version: 0.0.9(jest-environment-jsdom@29.7.0)
       webpack:
         specifier: 5.104.1
-        version: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+        version: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       webpack-virtual-modules:
         specifier: 0.6.2
         version: 0.6.2
@@ -4403,7 +4403,7 @@ importers:
         version: 13.1.3
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@20.19.5)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -4418,7 +4418,7 @@ importers:
         version: 4.4.2
       next:
         specifier: '*'
-        version: 16.1.5(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4)
+        version: 16.1.5(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0(encoding@0.1.13)
@@ -11554,11 +11554,24 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/dev-server@1.1.1':
-    resolution: {integrity: sha512-9r7vOml2SrFA8cvbcJdSan9wHEo1TPXezF22+s5jvdyAAywg8w7HqDol6TPVv64NUonP1DOdyLxZ+6UW6WZiwg==}
-    engines: {node: '>= 18.12.0'}
+  '@rspack/dev-middleware@2.0.3':
+    resolution: {integrity: sha512-GxnGj9jy76G3eCPyZei81fwKLAMLZaPEEqFz1/QDYquhwi/qYZX5fekFJ1XVpuwxGEK9KSX3hxZylfwrs4cmLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      '@rspack/core': '*'
+      '@rspack/core': ^2.0.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+
+  '@rspack/dev-server@2.1.0':
+    resolution: {integrity: sha512-WkCi6bWThVX5Ziv04srPaRoCoUY5FJolO4gqzE7xPO0XbXShsGnwn0vGD0DFfnYFcw9VSsxlmeCDV799lNYclA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rspack/core': ^2.0.0
+      selfsigned: ^5.0.0
+    peerDependenciesMeta:
+      selfsigned:
+        optional: true
 
   '@rspack/lite-tapable@1.0.1':
     resolution: {integrity: sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==}
@@ -12486,9 +12499,6 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
-
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -12841,9 +12851,6 @@ packages:
 
   '@types/node-fetch@2.6.11':
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
-
-  '@types/node-forge@1.3.14':
-    resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
 
   '@types/node-schedule@2.1.7':
     resolution: {integrity: sha512-G7Z3R9H7r3TowoH6D2pkzUHPhcJrDF4Jz1JOQ80AX0K2DWTHoN9VC94XzFAPNMdbW9TBzMZ3LjpFi7RYdbxtXA==}
@@ -20482,10 +20489,6 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  node-forge@1.3.3:
-    resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
-    engines: {node: '>= 6.13.0'}
-
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
@@ -23765,10 +23768,6 @@ packages:
   select-hose@2.0.0:
     resolution: {integrity: sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==}
 
-  selfsigned@2.4.1:
-    resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
-    engines: {node: '>=10'}
-
   selfsigned@5.5.0:
     resolution: {integrity: sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==}
     engines: {node: '>=18'}
@@ -25950,19 +25949,6 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.0:
-    resolution: {integrity: sha512-90SqqYXA2SK36KcT6o1bvwvZfJFcmoamqeJY7+boioffX9g9C0wjjJRGUrQIuh43pb0ttX7+ssavmj/WN2RHtA==}
-    engines: {node: '>= 18.12.0'}
-    hasBin: true
-    peerDependencies:
-      webpack: ^5.0.0
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack:
-        optional: true
-      webpack-cli:
-        optional: true
-
   webpack-dev-server@5.2.3:
     resolution: {integrity: sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==}
     engines: {node: '>= 18.12.0'}
@@ -26669,7 +26655,7 @@ snapshots:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.7
       convert-source-map: 1.9.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.23
@@ -26692,7 +26678,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -26712,7 +26698,7 @@ snapshots:
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -26735,17 +26721,17 @@ snapshots:
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
-  '@babel/eslint-parser@7.28.6(@babel/core@7.29.7)(eslint@8.57.1)':
+  '@babel/eslint-parser@7.28.6(@babel/core@7.29.7)(eslint@9.39.3(jiti@2.6.1))':
     dependencies:
       '@babel/core': 7.29.7
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.57.1
+      eslint: 9.39.3(jiti@2.6.1)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
   '@babel/eslint-plugin@7.27.1(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@8.57.1))(eslint@8.57.1)':
     dependencies:
-      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.7)(eslint@8.57.1)
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.7)(eslint@9.39.3(jiti@2.6.1))
       eslint: 8.57.1
       eslint-rule-composer: 0.3.0
 
@@ -26839,7 +26825,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -26850,7 +26836,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -28321,7 +28307,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -28345,7 +28331,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -28902,30 +28888,30 @@ snapshots:
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
+    optional: true
 
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -29592,7 +29578,7 @@ snapshots:
   '@eslint/config-array@0.20.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -29600,7 +29586,7 @@ snapshots:
   '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -29622,7 +29608,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -29636,7 +29622,7 @@ snapshots:
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -29672,7 +29658,7 @@ snapshots:
       '@expo/spawn-async': 1.7.2
       arg: 5.0.2
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       find-up: 5.0.0
       getenv: 1.0.0
       minimatch: 3.1.5
@@ -29762,7 +29748,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -29863,7 +29849,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -29940,76 +29926,6 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
       jest-config: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.19.5
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.19.5
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -30644,12 +30560,12 @@ snapshots:
   '@modern-js-app/eslint-config@2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.7)(eslint@8.57.1)
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.7)(eslint@9.39.3(jiti@2.6.1))
       '@babel/eslint-plugin': 7.27.1(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@8.57.1))(eslint@8.57.1)
       '@modern-js/babel-preset': 2.59.0(@rsbuild/core@1.0.1-rc.4(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@rsbuild/core': 1.0.1-rc.4(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       eslint: 8.57.1
       eslint-config-prettier: 8.10.2(eslint@8.57.1)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.1)
@@ -30714,7 +30630,7 @@ snapshots:
       '@swc/helpers': 0.5.1
       redux: 4.2.1
 
-  '@modern-js/app-tools@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.10(@swc/helpers@0.5.17))(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/app-tools@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.10(@swc/helpers@0.5.17))(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
@@ -30726,12 +30642,12 @@ snapshots:
       '@modern-js/plugin-i18n': 2.70.5
       '@modern-js/plugin-v2': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/prod-server': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@modern-js/rsbuild-plugin-esbuild': 2.70.5(@swc/core@1.15.10(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
+      '@modern-js/rsbuild-plugin-esbuild': 2.70.5(@swc/core@1.15.10(@swc/helpers@0.5.17))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       '@modern-js/server': 2.70.5(@babel/traverse@7.29.0)(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)
       '@modern-js/server-core': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/server-utils': 2.70.5(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@modern-js/types': 2.70.5
-      '@modern-js/uni-builder': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
+      '@modern-js/uni-builder': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)
       '@modern-js/utils': 2.70.5
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
       '@rsbuild/plugin-node-polyfill': 1.4.3(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
@@ -30777,7 +30693,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/app-tools@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.10(@swc/helpers@0.5.19))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/app-tools@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.10(@swc/helpers@0.5.19))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
@@ -30789,12 +30705,12 @@ snapshots:
       '@modern-js/plugin-i18n': 2.70.8
       '@modern-js/plugin-v2': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/prod-server': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@modern-js/rsbuild-plugin-esbuild': 2.70.8(@swc/core@1.15.10(@swc/helpers@0.5.19))(webpack-cli@5.1.4)
+      '@modern-js/rsbuild-plugin-esbuild': 2.70.8(@swc/core@1.15.10(@swc/helpers@0.5.19))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       '@modern-js/server': 2.70.8(@babel/traverse@7.29.0)(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)
       '@modern-js/server-core': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/server-utils': 2.70.8(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@modern-js/types': 2.70.8
-      '@modern-js/uni-builder': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
+      '@modern-js/uni-builder': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)
       '@modern-js/utils': 2.70.8
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-node-polyfill': 1.4.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
@@ -30840,12 +30756,12 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -30891,12 +30807,63 @@ snapshots:
       - webpack
       - webpack-hot-middleware
 
-  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/prod-server': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/server': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)
+      '@modern-js/server-core': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/server-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/types': 3.0.1
+      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
+      '@swc/helpers': 0.5.17
+      es-module-lexer: 1.7.0
+      esbuild: 0.25.5
+      esbuild-register: 3.6.0(esbuild@0.25.5)
+      flatted: 3.4.2
+      mlly: 1.8.1
+      ndepe: 0.1.13(encoding@0.1.13)(rollup@4.59.0)
+      pkg-types: 1.3.1
+      std-env: 3.10.0
+    optionalDependencies:
+      ts-node: 10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@20.19.5)(typescript@5.0.4)
+      tsconfig-paths: 3.14.2
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/css'
+      - bufferutil
+      - clean-css
+      - core-js
+      - csso
+      - debug
+      - devcert
+      - encoding
+      - lightningcss
+      - react
+      - react-dom
+      - rollup
+      - supports-color
+      - tslib
+      - typescript
+      - utf-8-validate
+      - webpack
+      - webpack-hot-middleware
+
+  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -30942,63 +30909,12 @@ snapshots:
       - webpack
       - webpack-hot-middleware
 
-  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
-      '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/prod-server': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/server': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)
-      '@modern-js/server-core': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/server-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/types': 3.0.1
-      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
-      '@swc/helpers': 0.5.17
-      es-module-lexer: 1.7.0
-      esbuild: 0.25.5
-      esbuild-register: 3.6.0(esbuild@0.25.5)
-      flatted: 3.4.2
-      mlly: 1.8.1
-      ndepe: 0.1.13(encoding@0.1.13)(rollup@4.59.0)
-      pkg-types: 1.3.1
-      std-env: 3.10.0
-    optionalDependencies:
-      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)
-      tsconfig-paths: 4.2.0
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/css'
-      - bufferutil
-      - clean-css
-      - core-js
-      - csso
-      - debug
-      - devcert
-      - encoding
-      - lightningcss
-      - react
-      - react-dom
-      - rollup
-      - supports-color
-      - tslib
-      - typescript
-      - utf-8-validate
-      - webpack
-      - webpack-hot-middleware
-
-  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31176,14 +31092,14 @@ snapshots:
       - '@rsbuild/core'
       - supports-color
 
-  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@modern-js/flight-server-transform-plugin': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)
       '@rsbuild/plugin-assets-retry': 1.5.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))
       '@rsbuild/plugin-react': 1.4.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(webpack-hot-middleware@2.26.1)
       '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))
@@ -31227,21 +31143,21 @@ snapshots:
       - webpack
       - webpack-hot-middleware
 
-  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@modern-js/flight-server-transform-plugin': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
       '@rsbuild/plugin-assets-retry': 1.5.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-react': 1.4.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(webpack-hot-middleware@2.26.1)
       '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(typescript@5.0.4)(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)
+      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.0.4)
       '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@swc/core': 1.15.10(@swc/helpers@0.5.17)
       '@swc/helpers': 0.5.17
@@ -31259,7 +31175,7 @@ snapshots:
       postcss-media-minmax: 5.0.0(postcss@8.5.10)
       postcss-nesting: 12.1.5(postcss@8.5.10)
       postcss-page-break: 3.0.4(postcss@8.5.10)
-      rspack-manifest-plugin: 5.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))
+      rspack-manifest-plugin: 5.2.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17))
       ts-deepmerge: 7.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -31278,21 +31194,21 @@ snapshots:
       - webpack
       - webpack-hot-middleware
 
-  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))':
+  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@modern-js/flight-server-transform-plugin': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
       '@rsbuild/plugin-assets-retry': 1.5.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-react': 1.4.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(webpack-hot-middleware@2.26.1)
       '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(typescript@5.0.4)(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)
+      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@5.0.4)
       '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@swc/core': 1.15.10(@swc/helpers@0.5.17)
       '@swc/helpers': 0.5.17
@@ -31310,7 +31226,7 @@ snapshots:
       postcss-media-minmax: 5.0.0(postcss@8.5.10)
       postcss-nesting: 12.1.5(postcss@8.5.10)
       postcss-page-break: 3.0.4(postcss@8.5.10)
-      rspack-manifest-plugin: 5.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))
+      rspack-manifest-plugin: 5.2.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))
       ts-deepmerge: 7.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -31546,7 +31462,7 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@modern-js/plugin-state@2.70.8(@modern-js/runtime@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@modern-js/plugin-state@2.70.8(@modern-js/runtime@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@modern-js-reduck/plugin-auto-actions': 1.1.13(@modern-js-reduck/store@1.1.13)
       '@modern-js-reduck/plugin-devtools': 1.1.13(@modern-js-reduck/store@1.1.13)
@@ -31554,7 +31470,7 @@ snapshots:
       '@modern-js-reduck/plugin-immutable': 1.1.13(@modern-js-reduck/store@1.1.13)
       '@modern-js-reduck/react': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js-reduck/store': 1.1.13
-      '@modern-js/runtime': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
+      '@modern-js/runtime': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.4)
       '@modern-js/runtime-utils': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/types': 2.70.8
       '@modern-js/utils': 2.70.8
@@ -31675,32 +31591,41 @@ snapshots:
       - react
       - react-dom
 
-  '@modern-js/render@2.70.5(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@19.2.7)':
+  '@modern-js/render@2.70.5(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.7)':
     dependencies:
       '@modern-js/types': 2.70.5
       '@modern-js/utils': 2.70.5
       '@swc/helpers': 0.5.17
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-server-dom-webpack: 19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      react-server-dom-webpack: 19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
 
-  '@modern-js/render@2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)':
+  '@modern-js/render@2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.4)':
     dependencies:
       '@modern-js/types': 2.70.8
       '@modern-js/utils': 2.70.8
       '@swc/helpers': 0.5.17
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-server-dom-webpack: 19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      react-server-dom-webpack: 19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
 
-  '@modern-js/render@3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@18.3.1)':
+  '@modern-js/render@3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)':
     dependencies:
       '@modern-js/types': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.17
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-server-dom-webpack: 19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      react-server-dom-webpack: 19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+
+  '@modern-js/render@3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)':
+    dependencies:
+      '@modern-js/types': 3.0.1
+      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@swc/helpers': 0.5.17
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-server-dom-webpack: 19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
 
   '@modern-js/render@3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)':
     dependencies:
@@ -31711,30 +31636,21 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-server-dom-webpack: 19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
 
-  '@modern-js/render@3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)))(react@18.3.1)':
-    dependencies:
-      '@modern-js/types': 3.0.1
-      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@swc/helpers': 0.5.17
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-server-dom-webpack: 19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
-
-  '@modern-js/rsbuild-plugin-esbuild@2.70.5(@swc/core@1.15.10(@swc/helpers@0.5.17))(webpack-cli@5.1.4)':
+  '@modern-js/rsbuild-plugin-esbuild@2.70.5(@swc/core@1.15.10(@swc/helpers@0.5.17))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))':
     dependencies:
       '@swc/helpers': 0.5.17
       esbuild: 0.25.5
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     transitivePeerDependencies:
       - '@swc/core'
       - uglify-js
       - webpack-cli
 
-  '@modern-js/rsbuild-plugin-esbuild@2.70.8(@swc/core@1.15.10(@swc/helpers@0.5.19))(webpack-cli@5.1.4)':
+  '@modern-js/rsbuild-plugin-esbuild@2.70.8(@swc/core@1.15.10(@swc/helpers@0.5.19))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))':
     dependencies:
       '@swc/helpers': 0.5.17
       esbuild: 0.25.5
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     transitivePeerDependencies:
       - '@swc/core'
       - uglify-js
@@ -31791,7 +31707,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@modern-js/runtime@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@19.2.7)':
+  '@modern-js/runtime@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.7)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/types': 7.29.0
@@ -31801,7 +31717,7 @@ snapshots:
       '@modern-js/plugin': 2.70.5
       '@modern-js/plugin-data-loader': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/plugin-v2': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@modern-js/render': 2.70.5(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@19.2.7)
+      '@modern-js/render': 2.70.5(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.7)
       '@modern-js/runtime-utils': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/types': 2.70.5
       '@modern-js/utils': 2.70.5
@@ -31824,7 +31740,7 @@ snapshots:
       - react-server-dom-webpack
       - supports-color
 
-  '@modern-js/runtime@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)':
+  '@modern-js/runtime@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.4)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/types': 7.29.0
@@ -31834,7 +31750,7 @@ snapshots:
       '@modern-js/plugin': 2.70.8
       '@modern-js/plugin-data-loader': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/plugin-v2': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@modern-js/render': 2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
+      '@modern-js/render': 2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.4)
       '@modern-js/runtime-utils': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/types': 2.70.8
       '@modern-js/utils': 2.70.8
@@ -31857,13 +31773,42 @@ snapshots:
       - react-server-dom-webpack
       - supports-color
 
-  '@modern-js/runtime@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@18.3.1)':
+  '@modern-js/runtime@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)':
     dependencies:
       '@loadable/component': 5.16.7(react@18.3.1)
       '@loadable/server': 5.16.7(@loadable/component@5.16.7(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/render': 3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@18.3.1)
+      '@modern-js/render': 3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
+      '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/types': 3.0.1
+      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@swc/helpers': 0.5.17
+      '@swc/plugin-loadable-components': 11.7.0
+      '@types/loadable__component': 5.13.10
+      '@types/react-helmet': 6.1.11
+      cookie: 0.7.2
+      entities: 7.0.1
+      es-module-lexer: 1.7.0
+      esbuild: 0.25.5
+      invariant: 2.2.4
+      isbot: 3.8.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-helmet: 6.1.0(react@18.3.1)
+      react-is: 18.3.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - core-js
+      - react-server-dom-webpack
+
+  '@modern-js/runtime@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)':
+    dependencies:
+      '@loadable/component': 5.16.7(react@18.3.1)
+      '@loadable/server': 5.16.7(@loadable/component@5.16.7(react@18.3.1))(react@18.3.1)
+      '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/render': 3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
       '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/types': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31893,35 +31838,6 @@ snapshots:
       '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/render': 3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
-      '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/types': 3.0.1
-      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@swc/helpers': 0.5.17
-      '@swc/plugin-loadable-components': 11.7.0
-      '@types/loadable__component': 5.13.10
-      '@types/react-helmet': 6.1.11
-      cookie: 0.7.2
-      entities: 7.0.1
-      es-module-lexer: 1.7.0
-      esbuild: 0.25.5
-      invariant: 2.2.4
-      isbot: 3.8.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-helmet: 6.1.0(react@18.3.1)
-      react-is: 18.3.1
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - core-js
-      - react-server-dom-webpack
-
-  '@modern-js/runtime@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)))(react@18.3.1)':
-    dependencies:
-      '@loadable/component': 5.16.7(react@18.3.1)
-      '@loadable/server': 5.16.7(@loadable/component@5.16.7(react@18.3.1))(react@18.3.1)
-      '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/render': 3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)))(react@18.3.1)
       '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/types': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -32203,6 +32119,33 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@modern-js/server@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)':
+    dependencies:
+      '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/server-core': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/server-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/types': 3.0.1
+      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@swc/helpers': 0.5.17
+      axios: 1.16.1
+      connect-history-api-fallback: 2.0.0
+      http-compression: 1.0.6
+      minimatch: 3.1.5
+      path-to-regexp: 6.3.0
+      ws: 8.21.0
+    optionalDependencies:
+      ts-node: 10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@20.19.5)(typescript@5.0.4)
+      tsconfig-paths: 3.14.2
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - bufferutil
+      - core-js
+      - debug
+      - react
+      - react-dom
+      - supports-color
+      - utf-8-validate
+
   '@modern-js/server@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)':
     dependencies:
       '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -32257,12 +32200,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modern-js/storybook-builder@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
+  '@modern-js/storybook-builder@2.70.8(a986c9500bd26293c94ebe2f5d942d86)':
     dependencies:
       '@modern-js/core': 2.70.8
-      '@modern-js/plugin-state': 2.70.8(@modern-js/runtime@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@modern-js/runtime': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
-      '@modern-js/uni-builder': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.18.20)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
+      '@modern-js/plugin-state': 2.70.8(@modern-js/runtime@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@modern-js/runtime': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@19.2.4)
+      '@modern-js/uni-builder': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.18.20)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)
       '@modern-js/utils': 2.70.8
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@storybook/components': 7.6.24(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -32273,7 +32216,7 @@ snapshots:
       '@storybook/mdx2-csf': 1.1.0
       '@storybook/preview': 7.6.24
       '@storybook/preview-api': 7.6.24
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@storybook/router': 7.6.24
       '@storybook/theming': 7.6.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ast-types: 0.14.2
@@ -32312,9 +32255,9 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/storybook@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
+  '@modern-js/storybook@2.70.8(a986c9500bd26293c94ebe2f5d942d86)':
     dependencies:
-      '@modern-js/storybook-builder': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      '@modern-js/storybook-builder': 2.70.8(a986c9500bd26293c94ebe2f5d942d86)
       '@modern-js/utils': 2.70.8
       '@storybook/react': 7.6.24(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       storybook: 7.6.24(encoding@0.1.13)
@@ -32411,7 +32354,7 @@ snapshots:
 
   '@modern-js/types@3.0.1': {}
 
-  '@modern-js/uni-builder@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/uni-builder@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
@@ -32419,12 +32362,12 @@ snapshots:
       '@modern-js/babel-preset': 2.70.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@modern-js/flight-server-transform-plugin': 2.70.5
       '@modern-js/utils': 2.70.5
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
       '@rsbuild/plugin-assets-retry': 1.5.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@rsbuild/plugin-pug': 1.3.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(webpack-hot-middleware@2.26.1)
@@ -32437,11 +32380,11 @@ snapshots:
       '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)
       '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@rsbuild/plugin-yaml': 1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
-      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       '@swc/core': 1.15.8(@swc/helpers@0.5.17)
       '@swc/helpers': 0.5.17
       autoprefixer: 10.4.23(postcss@8.5.10)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       babel-plugin-import: 1.13.8
       babel-plugin-styled-components: 1.13.3(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       babel-plugin-transform-react-remove-prop-types: 0.4.24
@@ -32450,7 +32393,7 @@ snapshots:
       es-module-lexer: 1.5.3
       glob: 9.3.5
       html-minifier-terser: 7.2.0
-      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       jiti: 1.21.7
       lodash: 4.17.23
       magic-string: 0.30.21
@@ -32465,11 +32408,11 @@ snapshots:
       postcss-page-break: 3.0.4(postcss@8.5.10)
       react-refresh: 0.14.2
       rspack-manifest-plugin: 5.0.3(@rspack/core@1.7.9(@swc/helpers@0.5.17))
-      terser-webpack-plugin: 5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       ts-deepmerge: 7.0.2
-      ts-loader: 9.4.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      ts-loader: 9.4.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@parcel/css'
@@ -32492,7 +32435,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/uni-builder@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.18.20)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/uni-builder@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.18.20)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
@@ -32500,12 +32443,12 @@ snapshots:
       '@modern-js/babel-preset': 2.70.8(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@modern-js/flight-server-transform-plugin': 2.70.8
       '@modern-js/utils': 2.70.8
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-assets-retry': 1.5.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@rsbuild/plugin-pug': 1.3.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
@@ -32518,11 +32461,11 @@ snapshots:
       '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(tslib@2.8.1)(typescript@5.9.3)
       '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@rsbuild/plugin-yaml': 1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
-      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       '@swc/core': 1.15.8(@swc/helpers@0.5.17)
       '@swc/helpers': 0.5.17
       autoprefixer: 10.4.23(postcss@8.5.10)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       babel-plugin-import: 1.13.8
       babel-plugin-styled-components: 1.13.3(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       babel-plugin-transform-react-remove-prop-types: 0.4.24
@@ -32531,7 +32474,7 @@ snapshots:
       es-module-lexer: 1.5.3
       glob: 9.3.5
       html-minifier-terser: 7.2.0
-      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       jiti: 1.21.7
       lodash: 4.17.23
       magic-string: 0.30.21
@@ -32546,11 +32489,11 @@ snapshots:
       postcss-page-break: 3.0.4(postcss@8.5.10)
       react-refresh: 0.14.2
       rspack-manifest-plugin: 5.0.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))
-      terser-webpack-plugin: 5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       ts-deepmerge: 7.0.2
-      ts-loader: 9.4.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      ts-loader: 9.4.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@parcel/css'
@@ -32573,7 +32516,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/uni-builder@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/uni-builder@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
@@ -32581,12 +32524,12 @@ snapshots:
       '@modern-js/babel-preset': 2.70.8(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@modern-js/flight-server-transform-plugin': 2.70.8
       '@modern-js/utils': 2.70.8
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-assets-retry': 1.5.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@rsbuild/plugin-pug': 1.3.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
@@ -32599,11 +32542,11 @@ snapshots:
       '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(tslib@2.8.1)(typescript@5.9.3)
       '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@rsbuild/plugin-yaml': 1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
-      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       '@swc/core': 1.15.8(@swc/helpers@0.5.17)
       '@swc/helpers': 0.5.17
       autoprefixer: 10.4.23(postcss@8.5.10)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       babel-plugin-import: 1.13.8
       babel-plugin-styled-components: 1.13.3(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       babel-plugin-transform-react-remove-prop-types: 0.4.24
@@ -32612,7 +32555,7 @@ snapshots:
       es-module-lexer: 1.5.3
       glob: 9.3.5
       html-minifier-terser: 7.2.0
-      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       jiti: 1.21.7
       lodash: 4.17.23
       magic-string: 0.30.21
@@ -32627,11 +32570,11 @@ snapshots:
       postcss-page-break: 3.0.4(postcss@8.5.10)
       react-refresh: 0.14.2
       rspack-manifest-plugin: 5.0.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))
-      terser-webpack-plugin: 5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       ts-deepmerge: 7.0.2
-      ts-loader: 9.4.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      ts-loader: 9.4.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@parcel/css'
@@ -32805,7 +32748,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@module-federation/enhanced@0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.21.6
       '@module-federation/cli': 0.21.6(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
@@ -32815,7 +32758,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.21.6(@module-federation/runtime-tools@0.21.6)
       '@module-federation/managers': 0.21.6
       '@module-federation/manifest': 0.21.6(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
-      '@module-federation/rspack': 0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
+      '@module-federation/rspack': 0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       '@module-federation/runtime-tools': 0.21.6
       '@module-federation/sdk': 0.21.6
       btoa: 1.2.1
@@ -32824,7 +32767,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       vue-tsc: 2.2.12(typescript@5.9.3)
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -32834,7 +32777,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@module-federation/enhanced@2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/cli': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
@@ -32844,7 +32787,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.2.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))
       '@module-federation/managers': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/manifest': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
-      '@module-federation/rspack': 2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
+      '@module-federation/rspack': 2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/webpack-bundler-runtime': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
@@ -32855,7 +32798,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       vue-tsc: 2.2.12(typescript@5.9.3)
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -32929,9 +32872,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.36(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@module-federation/node@2.7.36(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
-      '@module-federation/enhanced': 2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@module-federation/enhanced': 2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@module-federation/runtime': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       btoa: 1.2.1
@@ -32939,7 +32882,7 @@ snapshots:
       node-fetch: 2.7.0(encoding@0.1.13)
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -32951,7 +32894,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rspack@0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))':
+  '@module-federation/rspack@0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.21.6
       '@module-federation/dts-plugin': 0.21.6(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
@@ -32960,7 +32903,7 @@ snapshots:
       '@module-federation/manifest': 0.21.6(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       '@module-federation/runtime-tools': 0.21.6
       '@module-federation/sdk': 0.21.6
-      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19)'
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.3
@@ -32971,7 +32914,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))':
+  '@module-federation/rspack@2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/dts-plugin': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
@@ -32980,7 +32923,7 @@ snapshots:
       '@module-federation/manifest': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
-      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19)'
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.3
@@ -33176,7 +33119,7 @@ snapshots:
       '@open-draft/until': 1.0.3
       '@types/debug': 4.1.12
       '@xmldom/xmldom': 0.8.11
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       headers-polyfill: 3.2.5
       outvariant: 1.4.3
       strict-event-emitter: 0.2.8
@@ -33258,36 +33201,29 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.9.0
 
   '@napi-rs/wasm-runtime@1.0.7':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -33382,21 +33318,21 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@nx/devkit@22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))':
+  '@nx/devkit@22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))':
     dependencies:
       '@zkochan/js-yaml': 0.0.7
       ejs: 3.1.10
       enquirer: 2.3.6
       minimatch: 10.2.4
-      nx: 22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))
+      nx: 22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))
       semver: 7.6.3
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/eslint@22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))':
+  '@nx/eslint@22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(@zkochan/js-yaml@0.0.7)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))':
     dependencies:
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
       eslint: 9.39.3(jiti@2.6.1)
       semver: 7.6.3
       tslib: 2.8.1
@@ -33412,7 +33348,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/js@22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))':
+  '@nx/js@22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -33421,8 +33357,8 @@ snapshots:
       '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.28.2
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/workspace': 22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/workspace': 22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))
       '@zkochan/js-yaml': 0.0.7
       babel-plugin-const-enum: 1.2.0(@babel/core@7.29.0)
       babel-plugin-macros: 3.1.0
@@ -33448,20 +33384,20 @@ snapshots:
       - nx
       - supports-color
 
-  '@nx/module-federation@22.5.4(@babel/traverse@7.29.7)(@module-federation/runtime-tools@0.21.6)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)':
+  '@nx/module-federation@22.5.4(@babel/traverse@7.29.7)(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))':
     dependencies:
-      '@module-federation/enhanced': 0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      '@module-federation/node': 2.7.36(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@module-federation/enhanced': 0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      '@module-federation/node': 2.7.36(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@module-federation/sdk': 0.21.6
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/web': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/web': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19)'
       express: 4.22.1
       http-proxy-middleware: 3.0.5
       picocolors: 1.1.1
       tslib: 2.8.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@module-federation/runtime-tools'
@@ -33512,14 +33448,14 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.5.4':
     optional: true
 
-  '@nx/react@22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@module-federation/runtime-tools@0.21.6)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.5)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)':
+  '@nx/react@22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.5)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))':
     dependencies:
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/eslint': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/module-federation': 22.5.4(@babel/traverse@7.29.7)(@module-federation/runtime-tools@0.21.6)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)
-      '@nx/rollup': 22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/babel__core@7.20.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)
-      '@nx/web': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/eslint': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(@zkochan/js-yaml@0.0.7)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/module-federation': 22.5.4(@babel/traverse@7.29.7)(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
+      '@nx/rollup': 22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/babel__core@7.20.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(typescript@5.9.3)
+      '@nx/web': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
       '@svgr/webpack': 8.1.0(typescript@5.9.3)
       express: 4.22.1
@@ -33529,7 +33465,7 @@ snapshots:
       semver: 7.6.3
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/vite': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)
+      '@nx/vite': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -33556,10 +33492,10 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/rollup@22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/babel__core@7.20.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)':
+  '@nx/rollup@22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/babel__core@7.20.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(typescript@5.9.3)':
     dependencies:
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
       '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.59.0)
       '@rollup/plugin-commonjs': 25.0.8(rollup@4.59.0)
       '@rollup/plugin-image': 3.0.3(rollup@4.59.0)
@@ -33587,11 +33523,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)':
+  '@nx/vite@22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)':
     dependencies:
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/vitest': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/vitest': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
       ajv: 8.18.0
       enquirer: 2.3.6
@@ -33612,10 +33548,10 @@ snapshots:
       - verdaccio
     optional: true
 
-  '@nx/vitest@22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)':
+  '@nx/vitest@22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)':
     dependencies:
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
       semver: 7.6.3
       tslib: 2.8.1
@@ -33633,10 +33569,10 @@ snapshots:
       - verdaccio
     optional: true
 
-  '@nx/web@22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))':
+  '@nx/web@22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))':
     dependencies:
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
       detect-port: 1.6.1
       http-server: 14.1.1
       picocolors: 1.1.1
@@ -33650,44 +33586,44 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/webpack@22.5.4(@babel/traverse@7.29.7)(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4)':
+  '@nx/webpack@22.5.4(@babel/traverse@7.29.7)(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))':
     dependencies:
       '@babel/core': 7.29.0
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
+      '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
       ajv: 8.18.0
       autoprefixer: 10.4.20(postcss@8.4.49)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       browserslist: 4.28.1
-      copy-webpack-plugin: 10.2.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      css-loader: 6.11.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      css-minimizer-webpack-plugin: 5.0.1(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      fork-ts-checker-webpack-plugin: 7.2.13(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      copy-webpack-plugin: 10.2.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      css-loader: 6.11.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      css-minimizer-webpack-plugin: 5.0.1(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      fork-ts-checker-webpack-plugin: 7.2.13(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       less: 4.6.4
-      less-loader: 11.1.4(less@4.6.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      license-webpack-plugin: 4.0.2(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      less-loader: 11.1.4(less@4.6.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      license-webpack-plugin: 4.0.2(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       loader-utils: 2.0.4
-      mini-css-extract-plugin: 2.4.7(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      mini-css-extract-plugin: 2.4.7(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       parse5: 4.0.0
       picocolors: 1.1.1
       postcss: 8.4.49
       postcss-import: 14.1.0(postcss@8.4.49)
-      postcss-loader: 6.2.1(postcss@8.4.49)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      postcss-loader: 6.2.1(postcss@8.4.49)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       rxjs: 7.8.2
       sass: 1.98.0
       sass-embedded: 1.98.0
-      sass-loader: 16.0.7(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(sass-embedded@1.98.0)(sass@1.98.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      source-map-loader: 5.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      style-loader: 3.3.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      ts-loader: 9.5.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      sass-loader: 16.0.7(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(sass-embedded@1.98.0)(sass@1.98.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      source-map-loader: 5.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      style-loader: 3.3.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      ts-loader: 9.5.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       tsconfig-paths-webpack-plugin: 4.2.0
       tslib: 2.8.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       webpack-node-externals: 3.0.0
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@parcel/css'
@@ -33712,13 +33648,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@nx/workspace@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))':
+  '@nx/workspace@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))':
     dependencies:
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)))
       '@zkochan/js-yaml': 0.0.7
       chalk: 4.1.2
       enquirer: 2.3.6
-      nx: 22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))
+      nx: 22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19))
       picomatch: 4.0.2
       semver: 7.6.3
       tslib: 2.8.1
@@ -33952,7 +33888,7 @@ snapshots:
     dependencies:
       playwright: 1.57.0
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.49.0
@@ -33965,10 +33901,10 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
     optionalDependencies:
       type-fest: 2.19.0
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-hot-middleware: 2.26.1
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.49.0
@@ -33978,13 +33914,13 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.0
       source-map: 0.7.6
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       type-fest: 2.19.0
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       webpack-hot-middleware: 2.26.1
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.49.0
@@ -33994,10 +33930,10 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.0
       source-map: 0.7.6
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       type-fest: 2.19.0
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       webpack-hot-middleware: 2.26.1
 
   '@polka/url@1.0.0-next.29': {}
@@ -36037,7 +35973,7 @@ snapshots:
     dependencies:
       '@react-native/dev-middleware': 0.80.0
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       invariant: 2.2.4
       metro: 0.82.5
       metro-config: 0.82.5
@@ -36054,7 +35990,7 @@ snapshots:
     dependencies:
       '@react-native/dev-middleware': 0.80.0
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       invariant: 2.2.4
       metro: 0.82.5
       metro-config: 0.82.5
@@ -36076,7 +36012,7 @@ snapshots:
       chrome-launcher: 0.15.2
       chromium-edge-launcher: 0.2.0
       connect: 3.7.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       invariant: 2.2.4
       nullthrows: 1.1.1
       open: 7.4.2
@@ -36087,7 +36023,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native/eslint-config@0.80.0(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)))(prettier@2.8.8)(typescript@5.0.4)':
+  '@react-native/eslint-config@0.80.0(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3)))(prettier@2.8.8)(typescript@5.0.4)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@9.39.3(jiti@2.6.1))
@@ -36098,28 +36034,7 @@ snapshots:
       eslint-config-prettier: 8.10.2(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-eslint-comments: 3.2.0(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)))(typescript@5.0.4)
-      eslint-plugin-react: 7.37.2(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-react-native: 4.1.0(eslint@9.39.3(jiti@2.6.1))
-      prettier: 2.8.8
-    transitivePeerDependencies:
-      - jest
-      - supports-color
-      - typescript
-
-  '@react-native/eslint-config@0.80.0(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)))(prettier@2.8.8)(typescript@5.0.4)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@9.39.3(jiti@2.6.1))
-      '@react-native/eslint-plugin': 0.80.0
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4)
-      '@typescript-eslint/parser': 7.18.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4)
-      eslint: 9.39.3(jiti@2.6.1)
-      eslint-config-prettier: 8.10.2(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-eslint-comments: 3.2.0(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)))(typescript@5.0.4)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3)))(typescript@5.0.4)
       eslint-plugin-react: 7.37.2(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-react-native: 4.1.0(eslint@9.39.3(jiti@2.6.1))
@@ -36433,7 +36348,7 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -36441,7 +36356,7 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.9(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -36700,9 +36615,9 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@0.21.6)(core-js@3.49.0)':
+  '@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)':
     dependencies:
-      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.19)'
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19)'
       '@swc/helpers': 0.5.19
       jiti: 2.6.1
     optionalDependencies:
@@ -36851,9 +36766,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
 
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       reduce-configs: 1.1.1
     optionalDependencies:
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
@@ -36866,9 +36781,9 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       reduce-configs: 1.1.1
     optionalDependencies:
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
@@ -36881,9 +36796,9 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       reduce-configs: 1.1.1
     optionalDependencies:
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
@@ -36896,9 +36811,9 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       reduce-configs: 1.1.1
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)
@@ -36911,9 +36826,9 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       reduce-configs: 1.1.1
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
@@ -36926,9 +36841,9 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))':
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       reduce-configs: 1.1.1
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
@@ -37326,12 +37241,25 @@ snapshots:
       - tslib
       - typescript
 
-  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)':
+  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.0.4)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.3.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)
+      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.0.4)
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - tslib
+      - typescript
+
+  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@5.0.4)':
+    dependencies:
+      deepmerge: 4.3.1
+      json5: 2.2.3
+      reduce-configs: 1.1.1
+      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@5.0.4)
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
     transitivePeerDependencies:
@@ -37411,16 +37339,16 @@ snapshots:
       - '@module-federation/runtime-tools'
       - '@swc/helpers'
 
-  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)':
+  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))':
     dependencies:
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
-      copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       picocolors: 1.1.1
       reduce-configs: 1.1.1
       tsconfig-paths-webpack-plugin: 4.2.0
-      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -37428,16 +37356,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4)':
+  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))':
     dependencies:
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
-      copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       picocolors: 1.1.1
       reduce-configs: 1.1.1
       tsconfig-paths-webpack-plugin: 4.2.0
-      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -37445,16 +37373,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)':
+  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))':
     dependencies:
       '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
-      copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       picocolors: 1.1.1
       reduce-configs: 1.1.1
       tsconfig-paths-webpack-plugin: 4.2.0
-      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -37564,25 +37492,18 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': '@rspack-canary/binding-win32-ia32-msvc@2.0.9-canary-cb6bd31a-20260617080342'
       '@rspack/binding-win32-x64-msvc': '@rspack-canary/binding-win32-x64-msvc@2.0.9-canary-cb6bd31a-20260617080342'
 
-  '@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@rspack/dev-server@1.1.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1))':
+  '@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@rspack/dev-server@2.1.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(selfsigned@5.5.0))':
     dependencies:
       '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
     optionalDependencies:
-      '@rspack/dev-server': 1.1.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)
+      '@rspack/dev-server': 2.1.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(selfsigned@5.5.0)
 
-  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.19)':
+  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19)':
     dependencies:
       '@rspack/binding': '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342'
     optionalDependencies:
-      '@module-federation/runtime-tools': 0.21.6
+      '@module-federation/runtime-tools': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@swc/helpers': 0.5.19
-
-  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)':
-    dependencies:
-      '@rspack/binding': '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342'
-    optionalDependencies:
-      '@module-federation/runtime-tools': 0.21.6
-      '@swc/helpers': 0.5.23
 
   '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)':
     dependencies:
@@ -37745,6 +37666,14 @@ snapshots:
       '@swc/helpers': 0.5.19
     optional: true
 
+  '@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17)':
+    dependencies:
+      '@rspack/binding': 2.0.8
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.2)
+      '@swc/helpers': 0.5.17
+    optional: true
+
   '@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.0.8
@@ -37753,25 +37682,16 @@ snapshots:
       '@swc/helpers': 0.5.23
     optional: true
 
-  '@rspack/dev-server@1.1.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)':
+  '@rspack/dev-middleware@2.0.3(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))':
+    optionalDependencies:
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
+
+  '@rspack/dev-server@2.1.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(selfsigned@5.5.0)':
     dependencies:
       '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
-      chokidar: 3.6.0
-      express: 4.22.1
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
-      mime-types: 2.1.35
-      p-retry: 6.2.1
-      webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
-      webpack-dev-server: 5.2.0(webpack-cli@5.1.4)(webpack@5.104.1)
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - '@types/express'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-      - webpack-cli
+      '@rspack/dev-middleware': 2.0.3(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))
+    optionalDependencies:
+      selfsigned: 5.5.0
 
   '@rspack/lite-tapable@1.0.1': {}
 
@@ -38205,7 +38125,7 @@ snapshots:
       magic-string: 0.30.21
       storybook: 8.6.17(prettier@3.8.1)
       style-loader: 3.3.4(webpack@5.104.1)
-      terser-webpack-plugin: 5.4.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack@5.104.1)
       ts-dedent: 2.2.0
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
       webpack-dev-middleware: 6.1.3(webpack@5.104.1)
@@ -38548,7 +38468,7 @@ snapshots:
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.28.2
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@storybook/builder-webpack5': 9.0.9(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(storybook@8.6.17(prettier@3.8.1))(typescript@5.9.3)(webpack-cli@5.1.4)
       '@storybook/preset-react-webpack': 9.0.9(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.8.1))(typescript@5.9.3)(webpack-cli@5.1.4)
       '@storybook/react': 9.0.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.8.1))(typescript@5.9.3)
@@ -38644,9 +38564,9 @@ snapshots:
 
   '@storybook/preview@7.6.24': {}
 
-  '@storybook/react-docgen-typescript-plugin@1.0.1(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@storybook/react-docgen-typescript-plugin@1.0.1(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -38654,13 +38574,13 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -38668,13 +38588,13 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     transitivePeerDependencies:
       - supports-color
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1)':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -38936,7 +38856,7 @@ snapshots:
       '@swc-node/sourcemap-support': 0.5.1
       '@swc/core': 1.7.26(@swc/helpers@0.5.13)
       colorette: 2.0.20
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       oxc-resolver: 5.3.0
       pirates: 4.0.7
       tslib: 2.8.1
@@ -39266,7 +39186,7 @@ snapshots:
 
   '@tokenizer/inflate@0.2.7':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       fflate: 0.8.2
       token-types: 6.1.2
     transitivePeerDependencies:
@@ -39290,11 +39210,6 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
-
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -39718,10 +39633,6 @@ snapshots:
       '@types/node': 20.19.5
       form-data: 4.0.5
 
-  '@types/node-forge@1.3.14':
-    dependencies:
-      '@types/node': 20.19.5
-
   '@types/node-schedule@2.1.7':
     dependencies:
       '@types/node': 20.19.5
@@ -39915,7 +39826,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.0.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.0.4)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -39930,11 +39841,11 @@ snapshots:
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -40033,20 +39944,20 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@5.62.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
+      debug: 4.4.3(supports-color@9.3.1)
+      eslint: 9.39.3(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -40058,7 +39969,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.9.3
@@ -40071,7 +39982,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.0.4)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 9.39.3(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.0.4
@@ -40084,7 +39995,7 @@ snapshots:
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.54.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -40096,7 +40007,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -40108,7 +40019,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 8.57.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 9.26.0(jiti@2.6.1)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -40120,7 +40031,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.57.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -40130,7 +40041,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -40139,7 +40050,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -40148,7 +40059,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.4.5)
       '@typescript-eslint/types': 8.57.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -40157,7 +40068,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.6.3)
       '@typescript-eslint/types': 8.57.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -40166,7 +40077,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -40225,7 +40136,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.0.4)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.0.4)
     optionalDependencies:
@@ -40237,7 +40148,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
@@ -40249,7 +40160,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.0.4)
       '@typescript-eslint/utils': 7.18.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 9.39.3(jiti@2.6.1)
       ts-api-utils: 1.4.3(typescript@5.0.4)
     optionalDependencies:
@@ -40262,7 +40173,7 @@ snapshots:
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.54.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 9.39.3(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -40274,7 +40185,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 9.39.3(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -40286,7 +40197,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.4.5)
       '@typescript-eslint/utils': 8.57.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.4.5)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 9.26.0(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.4.5)
       typescript: 5.4.5
@@ -40298,7 +40209,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.6.3)
       '@typescript-eslint/utils': 8.57.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.6.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 9.39.3(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.6.3)
       typescript: 5.6.3
@@ -40321,7 +40232,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -40335,7 +40246,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -40349,7 +40260,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -40364,7 +40275,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.9
@@ -40381,7 +40292,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/visitor-keys': 8.54.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       minimatch: 9.0.9
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -40396,7 +40307,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -40411,7 +40322,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.4.5)
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/visitor-keys': 8.57.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -40426,7 +40337,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.6.3)
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/visitor-keys': 8.57.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -40441,7 +40352,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/visitor-keys': 8.57.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -40888,7 +40799,7 @@ snapshots:
 
   '@vitest/coverage-istanbul@1.6.0(vitest@1.6.0)':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
@@ -40905,7 +40816,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -40985,7 +40896,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 1.6.0(@edge-runtime/vm@3.2.0)(@types/node@26.0.0)(@vitest/ui@1.6.0)(jsdom@20.0.3)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.1)
+      vitest: 1.6.0(@edge-runtime/vm@3.2.0)(@types/node@20.19.5)(@vitest/ui@1.6.0)(jsdom@20.0.3)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.1)
 
   '@vitest/utils@1.2.2':
     dependencies:
@@ -41302,7 +41213,7 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
     optionalDependencies:
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.104.1)
 
   '@xhmikosr/archive-type@7.1.0':
     dependencies:
@@ -41519,7 +41430,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -42313,26 +42224,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.0
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.0
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.0
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1):
     dependencies:
@@ -42712,7 +42623,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -43606,7 +43517,7 @@ snapshots:
     dependencies:
       toggle-selection: 1.0.6
 
-  copy-webpack-plugin@10.2.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  copy-webpack-plugin@10.2.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -43614,9 +43525,9 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
-  copy-webpack-plugin@11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  copy-webpack-plugin@11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -43624,9 +43535,9 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
-  copy-webpack-plugin@11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  copy-webpack-plugin@11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -43634,7 +43545,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   copy-webpack-plugin@11.0.0(webpack@5.104.1):
     dependencies:
@@ -43776,36 +43687,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-require@1.1.1: {}
 
   cron-parser@4.9.0:
@@ -43853,7 +43734,7 @@ snapshots:
     dependencies:
       postcss: 8.5.10
 
-  css-loader@6.11.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  css-loader@6.11.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.49)
       postcss: 8.4.49
@@ -43864,8 +43745,8 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19)'
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   css-loader@6.11.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(webpack@5.104.1):
     dependencies:
@@ -43881,7 +43762,7 @@ snapshots:
       '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
 
-  css-minimizer-webpack-plugin@5.0.1(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  css-minimizer-webpack-plugin@5.0.1(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.5.10)
@@ -43889,11 +43770,11 @@ snapshots:
       postcss: 8.5.10
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       esbuild: 0.25.5
 
-  css-minimizer-webpack-plugin@7.0.2(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  css-minimizer-webpack-plugin@7.0.2(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.3(postcss@8.5.10)
@@ -43901,11 +43782,11 @@ snapshots:
       postcss: 8.5.10
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       esbuild: 0.18.20
 
-  css-minimizer-webpack-plugin@7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  css-minimizer-webpack-plugin@7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.3(postcss@8.5.10)
@@ -43913,11 +43794,11 @@ snapshots:
       postcss: 8.5.10
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       esbuild: 0.25.5
 
-  css-minimizer-webpack-plugin@7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  css-minimizer-webpack-plugin@7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.3(postcss@8.5.10)
@@ -43925,7 +43806,19 @@ snapshots:
       postcss: 8.5.10
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
+    optionalDependencies:
+      esbuild: 0.25.5
+
+  css-minimizer-webpack-plugin@7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      cssnano: 7.1.3(postcss@8.5.10)
+      jest-worker: 29.7.0
+      postcss: 8.5.10
+      schema-utils: 4.3.0
+      serialize-javascript: 6.0.2
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       esbuild: 0.25.5
 
@@ -43938,18 +43831,6 @@ snapshots:
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
-    optionalDependencies:
-      esbuild: 0.25.5
-
-  css-minimizer-webpack-plugin@7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      cssnano: 7.1.3(postcss@8.5.10)
-      jest-worker: 29.7.0
-      postcss: 8.5.10
-      schema-utils: 4.3.0
-      serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)
     optionalDependencies:
       esbuild: 0.25.5
 
@@ -44468,7 +44349,7 @@ snapshots:
   detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -44957,14 +44838,14 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.18.20):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
 
   esbuild-register@3.6.0(esbuild@0.25.5):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       esbuild: 0.25.5
     transitivePeerDependencies:
       - supports-color
@@ -45255,7 +45136,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(jiti@2.6.1)))(eslint@9.26.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 9.26.0(jiti@2.6.1)
       get-tsconfig: 4.13.6
       is-bun-module: 2.0.0
@@ -45281,7 +45162,7 @@ snapshots:
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -45398,7 +45279,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -45462,24 +45343,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)))(typescript@5.0.4):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3)))(typescript@5.0.4):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4)
       eslint: 9.39.3(jiti@2.6.1)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4)
-      jest: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(jest@29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)))(typescript@5.0.4):
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4)
-      eslint: 9.39.3(jiti@2.6.1)
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4))(eslint@9.39.3(jiti@2.6.1))(typescript@5.0.4)
-      jest: 29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4))
+      jest: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -45713,7 +45583,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -45762,7 +45632,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -45805,7 +45675,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -46095,7 +45965,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -46354,7 +46224,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -46462,7 +46332,7 @@ snapshots:
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
 
   follow-redirects@1.16.0: {}
 
@@ -46484,7 +46354,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@7.2.13(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  fork-ts-checker-webpack-plugin@7.2.13(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
@@ -46499,7 +46369,7 @@ snapshots:
       semver: 7.6.3
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       vue-template-compiler: 2.7.16
 
@@ -47358,7 +47228,7 @@ snapshots:
       '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
 
-  html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -47366,11 +47236,11 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19)'
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optional: true
 
-  html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -47379,9 +47249,9 @@ snapshots:
       tapable: 2.3.0
     optionalDependencies:
       '@rspack/core': 1.7.9(@swc/helpers@0.5.17)
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
-  html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -47390,7 +47260,7 @@ snapshots:
       tapable: 2.3.0
     optionalDependencies:
       '@rspack/core': 1.7.9(@swc/helpers@0.5.19)
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   htmlparser2@10.0.0:
     dependencies:
@@ -47466,21 +47336,9 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
-
-  http-proxy-middleware@2.0.9(@types/express@4.17.21):
-    dependencies:
-      '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1(debug@4.4.3)
-      is-glob: 4.0.3
-      is-plain-obj: 3.0.0
-      micromatch: 4.0.8
-    optionalDependencies:
-      '@types/express': 4.17.21
-    transitivePeerDependencies:
-      - debug
 
   http-proxy-middleware@2.0.9(@types/express@4.17.25):
     dependencies:
@@ -47497,7 +47355,7 @@ snapshots:
   http-proxy-middleware@3.0.5:
     dependencies:
       '@types/http-proxy': 1.17.17
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-object: 5.0.0
@@ -47548,21 +47406,21 @@ snapshots:
   https-proxy-agent@4.0.0:
     dependencies:
       agent-base: 5.1.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -48132,7 +47990,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -48141,7 +47999,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -48227,44 +48085,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest-cli@29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -48292,99 +48112,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.5
       ts-node: 10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.0
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.19.5
-      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.0
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.19.5
-      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.0
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 26.0.0
-      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -48642,30 +48369,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@26.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -48936,10 +48639,10 @@ snapshots:
 
   leac@0.6.0: {}
 
-  less-loader@11.1.4(less@4.6.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  less-loader@11.1.4(less@4.6.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       less: 4.6.4
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   less@4.6.4:
     dependencies:
@@ -48961,11 +48664,11 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  license-webpack-plugin@4.0.2(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       webpack-sources: 3.3.4
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   lighthouse-logger@1.4.2:
     dependencies:
@@ -49182,7 +48885,7 @@ snapshots:
   log4js@6.9.1:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       flatted: 3.4.2
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -49688,7 +49391,7 @@ snapshots:
 
   metro-file-map@0.82.5:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -49702,7 +49405,7 @@ snapshots:
 
   metro-file-map@0.83.5:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -49868,7 +49571,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 2.0.0
       connect: 3.7.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -49915,7 +49618,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 2.0.0
       connect: 3.7.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -50232,7 +49935,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -50320,22 +50023,22 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.4.7(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  mini-css-extract-plugin@2.4.7(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       schema-utils: 4.3.0
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
-  mini-css-extract-plugin@2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  mini-css-extract-plugin@2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       schema-utils: 4.3.0
       tapable: 2.3.0
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
-  mini-css-extract-plugin@2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  mini-css-extract-plugin@2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       schema-utils: 4.3.0
       tapable: 2.3.0
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   mini-svg-data-uri@1.4.4: {}
 
@@ -50553,7 +50256,7 @@ snapshots:
   ndepe@0.1.13(encoding@0.1.13)(rollup@4.59.0):
     dependencies:
       '@vercel/nft': 0.29.2(encoding@0.1.13)(rollup@4.59.0)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       fs-extra: 11.3.0
       mlly: 1.6.1
       pkg-types: 1.3.1
@@ -50585,7 +50288,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4):
+  next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -50681,7 +50384,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  next@16.1.5(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4):
+  next@16.1.5(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.100.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)):
     dependencies:
       '@next/env': 16.1.5
       '@swc/helpers': 0.5.15
@@ -50768,8 +50471,6 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-
-  node-forge@1.3.3: {}
 
   node-gyp-build@4.8.4: {}
 
@@ -50903,7 +50604,7 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
-  nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)):
+  nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.19)):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
       '@yarnpkg/lockfile': 1.1.0
@@ -50953,7 +50654,7 @@ snapshots:
       '@nx/nx-win32-arm64-msvc': 22.5.4
       '@nx/nx-win32-x64-msvc': 22.5.4
       '@swc-node/register': 1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3)
-      '@swc/core': 1.15.10(@swc/helpers@0.5.23)
+      '@swc/core': 1.15.10(@swc/helpers@0.5.19)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -51536,7 +51237,7 @@ snapshots:
   portfinder@1.0.38:
     dependencies:
       async: 3.2.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -51707,14 +51408,6 @@ snapshots:
       postcss: 8.4.49
       ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@22.19.15)(typescript@5.6.3)
 
-  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@26.0.0)(typescript@5.9.3)):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.8.2
-    optionalDependencies:
-      postcss: 8.4.49
-      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@26.0.0)(typescript@5.9.3)
-
   postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.9.3)):
     dependencies:
       lilconfig: 3.1.3
@@ -51755,13 +51448,13 @@ snapshots:
       postcss: 8.5.15
       ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.9.3)
 
-  postcss-loader@6.2.1(postcss@8.4.49)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  postcss-loader@6.2.1(postcss@8.4.49)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
       postcss: 8.4.49
       semver: 7.6.3
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   postcss-loader@8.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(postcss@8.4.49)(typescript@5.9.3)(webpack@5.104.1):
     dependencies:
@@ -52421,7 +52114,7 @@ snapshots:
   puppeteer-core@2.1.1:
     dependencies:
       '@types/mime-types': 2.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -54344,13 +54037,22 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
-  react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
+      webpack-sources: 3.5.0
+
+  react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
+    dependencies:
+      acorn-loose: 8.5.2
+      neo-async: 2.6.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       webpack-sources: 3.5.0
 
   react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
@@ -54362,31 +54064,22 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       webpack-sources: 3.5.0
 
-  react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)):
-    dependencies:
-      acorn-loose: 8.5.2
-      neo-async: 2.6.2
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)
-      webpack-sources: 3.5.0
-
-  react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       webpack-sources: 3.5.0
 
-  react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       webpack-sources: 3.5.0
 
   react-shadow@20.6.0(prop-types@15.8.1)(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
@@ -55118,7 +54811,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -55189,6 +54882,20 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
 
+  rsbuild-plugin-publint@0.2.1(@rsbuild/core@1.4.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))):
+    dependencies:
+      picocolors: 1.1.1
+      publint: 0.2.12
+    optionalDependencies:
+      '@rsbuild/core': 1.4.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+
+  rsbuild-plugin-publint@0.2.1(@rsbuild/core@1.4.16(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))):
+    dependencies:
+      picocolors: 1.1.1
+      publint: 0.2.12
+    optionalDependencies:
+      '@rsbuild/core': 1.4.16(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+
   rsbuild-plugin-publint@0.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))):
     dependencies:
       picocolors: 1.1.1
@@ -55218,11 +54925,17 @@ snapshots:
     optionalDependencies:
       '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)'
 
-  rspack-manifest-plugin@5.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)):
+  rspack-manifest-plugin@5.2.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
+      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17)
+
+  rspack-manifest-plugin@5.2.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)):
+    dependencies:
+      '@rspack/lite-tapable': 1.1.0
+    optionalDependencies:
+      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)
 
   rspack-vue-loader@17.5.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
@@ -55464,14 +55177,14 @@ snapshots:
       sass-embedded: 1.100.0
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
 
-  sass-loader@16.0.7(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(sass-embedded@1.98.0)(sass@1.98.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  sass-loader@16.0.7(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(sass-embedded@1.98.0)(sass@1.98.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19)'
       sass: 1.98.0
       sass-embedded: 1.98.0
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   sass@1.100.0:
     dependencies:
@@ -55557,11 +55270,6 @@ snapshots:
 
   select-hose@2.0.0: {}
 
-  selfsigned@2.4.1:
-    dependencies:
-      '@types/node-forge': 1.3.14
-      node-forge: 1.3.3
-
   selfsigned@5.5.0:
     dependencies:
       '@peculiar/x509': 1.14.3
@@ -55609,7 +55317,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -55937,11 +55645,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  source-map-loader@5.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   source-map-resolve@0.5.3:
     dependencies:
@@ -56012,7 +55720,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -56023,7 +55731,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -56126,12 +55834,12 @@ snapshots:
       - '@types/react'
       - tslib
 
-  storybook-react-rsbuild@1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(storybook@8.6.17(prettier@3.8.1))(tslib@2.8.1)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  storybook-react-rsbuild@1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(storybook@8.6.17(prettier@3.8.1))(tslib@2.8.1)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       '@rsbuild/core': 2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
       '@storybook/react': 8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.8.1))(typescript@5.9.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
       '@types/node': 18.19.130
       find-up: 5.0.0
       magic-string: 0.30.21
@@ -56204,7 +55912,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -56381,9 +56089,9 @@ snapshots:
 
   style-inject@0.3.0: {}
 
-  style-loader@3.3.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  style-loader@3.3.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   style-loader@3.3.4(webpack@5.104.1):
     dependencies:
@@ -56666,33 +56374,6 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@26.0.0)(typescript@5.9.3)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 2.1.0
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.4.49
-      postcss-import: 15.1.0(postcss@8.4.49)
-      postcss-js: 4.1.0(postcss@8.4.49)
-      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@26.0.0)(typescript@5.9.3))
-      postcss-nested: 6.2.0(postcss@8.4.49)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.8
-      sucrase: 3.35.1
-    transitivePeerDependencies:
-      - ts-node
-
   tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.9.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -56885,84 +56566,84 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.46.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       '@swc/core': 1.15.8(@swc/helpers@0.5.17)
       esbuild: 0.18.20
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.46.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       '@swc/core': 1.15.8(@swc/helpers@0.5.17)
       esbuild: 0.25.5
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.3.14(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.46.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       '@swc/core': 1.15.8(@swc/helpers@0.5.17)
       esbuild: 0.25.5
 
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       terser: 5.46.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       '@swc/core': 1.15.10(@swc/helpers@0.5.17)
       esbuild: 0.25.5
 
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       terser: 5.46.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
+    optionalDependencies:
+      '@swc/core': 1.15.10(@swc/helpers@0.5.17)
+      esbuild: 0.28.1
+
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.0
+      terser: 5.46.1
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       '@swc/core': 1.15.10(@swc/helpers@0.5.19)
       esbuild: 0.18.20
 
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       terser: 5.46.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       '@swc/core': 1.15.10(@swc/helpers@0.5.19)
-      esbuild: 0.25.5
-
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.0
-      terser: 5.46.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
-    optionalDependencies:
-      '@swc/core': 1.15.10(@swc/helpers@0.5.23)
       esbuild: 0.25.5
 
   terser-webpack-plugin@5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
@@ -56976,51 +56657,29 @@ snapshots:
       '@swc/core': 1.15.10(@swc/helpers@0.5.23)
       esbuild: 0.28.1
 
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       terser: 5.46.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)
-    optionalDependencies:
-      '@swc/core': 1.15.10(@swc/helpers@0.5.23)
-      esbuild: 0.28.1
-
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.0
-      terser: 5.46.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       '@swc/core': 1.15.8(@swc/helpers@0.5.17)
       esbuild: 0.18.20
 
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       terser: 5.46.1
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
       '@swc/core': 1.15.8(@swc/helpers@0.5.17)
       esbuild: 0.25.5
 
-  terser-webpack-plugin@5.4.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack-cli@5.1.4)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.0
-      terser: 5.46.1
-      webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack-cli@5.1.4)
-    optionalDependencies:
-      '@swc/core': 1.7.26(@swc/helpers@0.5.13)
-      esbuild: 0.25.5
-
-  terser-webpack-plugin@5.4.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.4.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -57243,18 +56902,6 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  ts-checker-rspack-plugin@1.3.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4):
-    dependencies:
-      '@rspack/lite-tapable': 1.1.0
-      chokidar: 3.6.0
-      memfs: 4.56.11(tslib@2.8.1)
-      picocolors: 1.1.1
-      typescript: 5.0.4
-    optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
-    transitivePeerDependencies:
-      - tslib
-
   ts-checker-rspack-plugin@1.3.0(@rspack/core@1.7.9(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
@@ -57276,6 +56923,30 @@ snapshots:
       typescript: 5.9.3
     optionalDependencies:
       '@rspack/core': 1.7.9(@swc/helpers@0.5.19)
+    transitivePeerDependencies:
+      - tslib
+
+  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.0.4):
+    dependencies:
+      '@rspack/lite-tapable': 1.1.0
+      chokidar: 3.6.0
+      memfs: 4.56.11(tslib@2.8.1)
+      picocolors: 1.1.1
+      typescript: 5.0.4
+    optionalDependencies:
+      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17)
+    transitivePeerDependencies:
+      - tslib
+
+  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@5.0.4):
+    dependencies:
+      '@rspack/lite-tapable': 1.1.0
+      chokidar: 3.6.0
+      memfs: 4.56.11(tslib@2.8.1)
+      picocolors: 1.1.1
+      typescript: 5.0.4
+    optionalDependencies:
+      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - tslib
 
@@ -57318,25 +56989,25 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.29.0)
       esbuild: 0.28.1
 
-  ts-loader@9.4.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  ts-loader@9.4.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.20.1
       micromatch: 4.0.8
       semver: 7.6.3
       typescript: 5.9.3
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
-  ts-loader@9.4.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  ts-loader@9.4.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.20.1
       micromatch: 4.0.8
       semver: 7.6.3
       typescript: 5.9.3
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
-  ts-loader@9.5.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  ts-loader@9.5.4(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.20.1
@@ -57344,12 +57015,32 @@ snapshots:
       semver: 7.6.3
       source-map: 0.7.6
       typescript: 5.9.3
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
   ts-morph@12.0.0:
     dependencies:
       '@ts-morph/common': 0.11.1
       code-block-writer: 10.1.1
+
+  ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@20.19.5)(typescript@5.0.4):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.5
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.0.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.10(@swc/helpers@0.5.17)
 
   ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4):
     dependencies:
@@ -57494,27 +57185,6 @@ snapshots:
       '@swc/core': 1.15.10(@swc/helpers@0.5.19)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@26.0.0)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 26.0.0
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.10(@swc/helpers@0.5.19)
-    optional: true
-
   ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -57576,27 +57246,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.10(@swc/helpers@0.5.23)
-
-  ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.0.4):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 26.0.0
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.0.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.10(@swc/helpers@0.5.23)
-    optional: true
 
   ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.9.3):
     dependencies:
@@ -57705,7 +57354,7 @@ snapshots:
       bundle-require: 4.2.1(esbuild@0.19.12)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       esbuild: 0.19.12
       execa: 5.1.1
       globby: 11.1.0
@@ -57729,7 +57378,7 @@ snapshots:
       bundle-require: 4.2.1(esbuild@0.19.12)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       esbuild: 0.19.12
       execa: 5.1.1
       globby: 11.1.0
@@ -58430,7 +58079,7 @@ snapshots:
   vite-node@1.2.2(@types/node@20.19.5)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       pathe: 1.1.2
       picocolors: 1.1.1
       vite: 5.4.21(@types/node@20.19.5)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.1)
@@ -58448,7 +58097,7 @@ snapshots:
   vite-node@1.6.0(@types/node@20.19.5)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       pathe: 1.1.2
       picocolors: 1.1.1
       vite: 5.4.21(@types/node@20.19.5)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.1)
@@ -58466,7 +58115,7 @@ snapshots:
   vite-node@1.6.0(@types/node@26.0.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       pathe: 1.1.2
       picocolors: 1.1.1
       vite: 5.4.21(@types/node@26.0.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.1)
@@ -58484,7 +58133,7 @@ snapshots:
   vite-node@1.6.0(@types/node@26.0.0)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       pathe: 1.1.2
       picocolors: 1.1.1
       vite: 5.4.21(@types/node@26.0.0)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)
@@ -58507,7 +58156,7 @@ snapshots:
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@5.9.3)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -58526,7 +58175,7 @@ snapshots:
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@5.9.3)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -58540,7 +58189,7 @@ snapshots:
 
   vite-tsconfig-paths@4.2.3(typescript@5.9.3)(vite@7.3.5(@types/node@20.19.5)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.1)(yaml@2.8.2)):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       globrex: 0.1.2
       tsconfck: 2.1.2(typescript@5.9.3)
     optionalDependencies:
@@ -58643,7 +58292,7 @@ snapshots:
       acorn-walk: 8.3.5
       cac: 6.7.14
       chai: 4.5.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       execa: 8.0.1
       local-pkg: 0.5.1
       magic-string: 0.30.21
@@ -58680,7 +58329,7 @@ snapshots:
       '@vitest/utils': 1.6.0
       acorn-walk: 8.3.5
       chai: 4.5.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       execa: 8.0.1
       local-pkg: 0.5.1
       magic-string: 0.30.21
@@ -58717,7 +58366,7 @@ snapshots:
       '@vitest/utils': 1.6.0
       acorn-walk: 8.3.5
       chai: 4.5.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       execa: 8.0.1
       local-pkg: 0.5.1
       magic-string: 0.30.21
@@ -58754,7 +58403,7 @@ snapshots:
       '@vitest/utils': 1.6.0
       acorn-walk: 8.3.5
       chai: 4.5.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       execa: 8.0.1
       local-pkg: 0.5.1
       magic-string: 0.30.21
@@ -58793,7 +58442,7 @@ snapshots:
 
   vue-eslint-parser@9.4.3(eslint@8.57.1):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@9.3.1)
       eslint: 8.57.1
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -58906,7 +58555,7 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.104.1)
 
   webpack-dev-middleware@6.1.3(webpack@5.104.1):
     dependencies:
@@ -58918,7 +58567,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
 
-  webpack-dev-middleware@7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  webpack-dev-middleware@7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       colorette: 2.0.20
       memfs: 4.46.0
@@ -58927,10 +58576,10 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.0
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optional: true
 
-  webpack-dev-middleware@7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  webpack-dev-middleware@7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       colorette: 2.0.20
       memfs: 4.46.0
@@ -58939,10 +58588,10 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.0
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optional: true
 
-  webpack-dev-middleware@7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  webpack-dev-middleware@7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       colorette: 2.0.20
       memfs: 4.46.0
@@ -58951,9 +58600,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.0
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
 
-  webpack-dev-middleware@7.4.5(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)):
+  webpack-dev-middleware@7.4.5(webpack@5.104.1):
     dependencies:
       colorette: 2.0.20
       memfs: 4.46.0
@@ -58963,46 +58612,9 @@ snapshots:
       schema-utils: 4.3.0
     optionalDependencies:
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
+    optional: true
 
-  webpack-dev-server@5.2.0(webpack-cli@5.1.4)(webpack@5.104.1):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.21
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.10
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.5.12
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.3.0
-      chokidar: 3.6.0
-      colorette: 2.0.20
-      compression: 1.8.1
-      connect-history-api-fallback: 2.0.0
-      express: 4.22.1
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
-      ipaddr.js: 2.3.0
-      launch-editor: 2.13.1
-      open: 10.2.0
-      p-retry: 6.2.1
-      schema-utils: 4.3.0
-      selfsigned: 2.4.1
-      serve-index: 1.9.2
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
-      ws: 8.21.0
-    optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
-  webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -59030,10 +58642,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
     transitivePeerDependencies:
       - bufferutil
@@ -59042,7 +58654,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -59070,10 +58682,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
     transitivePeerDependencies:
       - bufferutil
@@ -59082,7 +58694,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -59110,10 +58722,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
     transitivePeerDependencies:
       - bufferutil
@@ -59121,7 +58733,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)):
+  webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -59149,7 +58761,7 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      webpack-dev-middleware: 7.4.5(webpack@5.104.1)
       ws: 8.21.0
     optionalDependencies:
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
@@ -59179,30 +58791,30 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
-      html-webpack-plugin: 5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      html-webpack-plugin: 5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
-      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
     optionalDependencies:
-      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4):
+  webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -59226,7 +58838,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
@@ -59236,7 +58848,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4):
+  webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -59260,7 +58872,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
@@ -59270,7 +58882,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4):
+  webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -59294,7 +58906,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
@@ -59304,7 +58916,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4):
+  webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -59328,7 +58940,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
@@ -59372,7 +58984,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4):
+  webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -59396,7 +59008,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
@@ -59406,7 +59018,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4):
+  webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -59430,75 +59042,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      watchpack: 2.5.1
-      webpack-sources: 3.3.4
-    optionalDependencies:
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.20.1
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      watchpack: 2.5.1
-      webpack-sources: 3.3.4
-    optionalDependencies:
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack-cli@5.1.4):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.20.1
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
@@ -59532,7 +59076,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack@5.104.1)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   '@changesets/assemble-release-plan': workspace:*
+  '@rspack/cli': npm:@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342
+  '@rspack/core': npm:@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342
   ajv: 8.18.0
   eslint>ajv: 6.14.0
   '@eslint/eslintrc>ajv': 6.14.0
@@ -127,25 +129,25 @@ importers:
         version: 6.0.1(rollup@4.59.0)
       '@rslib/core':
         specifier: ^0.10.4
-        version: 0.10.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(typescript@5.9.3)
+        version: 0.10.6(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@rspack/cli':
-        specifier: 1.3.9
-        version: 1.3.9(@rspack/core@1.3.9(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)
+        specifier: npm:@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342
+        version: '@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@rspack/dev-server@1.1.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1))'
       '@rspack/core':
-        specifier: 1.3.9
-        version: 1.3.9(@swc/helpers@0.5.13)
+        specifier: npm:@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342
+        version: '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
       '@rspack/dev-server':
         specifier: 1.1.1
-        version: 1.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)
+        version: 1.1.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)
       '@rstest/core':
         specifier: ^0.8.0
-        version: 0.8.5(jsdom@20.0.3)
+        version: 0.8.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(jsdom@20.0.3)
       '@storybook/addon-docs':
         specifier: 9.0.17
         version: 9.0.17(@types/react@19.2.14)(storybook@8.6.17(prettier@3.8.1))
       '@storybook/nextjs':
         specifier: 9.0.9
-        version: 9.0.9(@rspack/core@1.3.9(@swc/helpers@0.5.13))(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)(webpack-cli@5.1.4))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(storybook@8.6.17(prettier@3.8.1))(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
+        version: 9.0.9(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)(webpack-cli@5.1.4))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(storybook@8.6.17(prettier@3.8.1))(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@svgr/webpack':
         specifier: 8.1.0
         version: 8.1.0(typescript@5.9.3)
@@ -250,7 +252,7 @@ importers:
         version: 11.0.0(webpack@5.104.1)
       css-loader:
         specifier: ^6.11.0
-        version: 6.11.0(@rspack/core@1.3.9(@swc/helpers@0.5.13))(webpack@5.104.1)
+        version: 6.11.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(webpack@5.104.1)
       cypress:
         specifier: 14.3.3
         version: 14.3.3
@@ -295,7 +297,7 @@ importers:
         version: 4.2.11
       html-webpack-plugin:
         specifier: 5.6.2
-        version: 5.6.2(@rspack/core@1.3.9(@swc/helpers@0.5.13))(webpack@5.104.1)
+        version: 5.6.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(webpack@5.104.1)
       husky:
         specifier: 8.0.3
         version: 8.0.3
@@ -370,7 +372,7 @@ importers:
         version: 3.5.0
       rsbuild-plugin-publint:
         specifier: ^0.2.1
-        version: 0.2.1(@rsbuild/core@1.7.3)
+        version: 0.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       serve:
         specifier: ^14.2.4
         version: 14.2.5
@@ -397,7 +399,7 @@ importers:
         version: 10.9.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@20.19.5)(typescript@5.9.3)
       tsdown:
         specifier: 0.20.3
-        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(publint@0.3.18)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
+        version: 0.20.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(publint@0.3.18)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -706,8 +708,8 @@ importers:
         specifier: 0.5.15
         version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
       '@rspack/core':
-        specifier: ^1.0.2
-        version: 1.3.9(@swc/helpers@0.5.23)
+        specifier: npm:@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342
+        version: '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)'
       '@rspack/plugin-react-refresh':
         specifier: ^0.7.5
         version: 0.7.5(react-refresh@0.14.2)
@@ -1109,7 +1111,7 @@ importers:
         version: 7.28.2
       '@modern-js/runtime':
         specifier: 3.0.1
-        version: 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
       '@module-federation/modern-js-v3':
         specifier: workspace:*
         version: link:../../../packages/modernjs-v3
@@ -1125,13 +1127,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/tsconfig':
         specifier: 3.0.1
         version: 3.0.1
@@ -1167,7 +1169,7 @@ importers:
         version: 7.28.2
       '@modern-js/runtime':
         specifier: 3.0.1
-        version: 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)))(react@18.3.1)
       '@module-federation/modern-js-v3':
         specifier: workspace:*
         version: link:../../../packages/modernjs-v3
@@ -1183,13 +1185,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/tsconfig':
         specifier: 3.0.1
         version: 3.0.1
@@ -1237,7 +1239,7 @@ importers:
         version: 1.4.5(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(webpack-hot-middleware@2.26.1)
       '@rslib/core':
         specifier: ^0.9.0
-        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)
+        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.28
@@ -1261,7 +1263,7 @@ importers:
         version: 7.28.2
       '@modern-js/runtime':
         specifier: 3.0.1
-        version: 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
       '@module-federation/modern-js-v3':
         specifier: workspace:*
         version: link:../../../packages/modernjs-v3
@@ -1277,13 +1279,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/tsconfig':
         specifier: 3.0.1
         version: 3.0.1
@@ -1335,7 +1337,7 @@ importers:
         version: 1.4.5(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(webpack-hot-middleware@2.26.1)
       '@rslib/core':
         specifier: ^0.9.0
-        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)
+        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.28
@@ -1350,7 +1352,7 @@ importers:
         version: 7.28.2
       '@modern-js/runtime':
         specifier: 3.0.1
-        version: 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
       '@module-federation/modern-js-v3':
         specifier: workspace:*
         version: link:../../../packages/modernjs-v3
@@ -1366,13 +1368,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/tsconfig':
         specifier: 3.0.1
         version: 3.0.1
@@ -1408,7 +1410,7 @@ importers:
         version: 7.28.2
       '@modern-js/runtime':
         specifier: 3.0.1
-        version: 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
       '@module-federation/modern-js-v3':
         specifier: workspace:*
         version: link:../../../packages/modernjs-v3
@@ -1424,13 +1426,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/tsconfig':
         specifier: 3.0.1
         version: 3.0.1
@@ -1466,7 +1468,7 @@ importers:
         version: 7.28.2
       '@modern-js/runtime':
         specifier: 3.0.1
-        version: 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
       '@module-federation/modern-js-v3':
         specifier: workspace:*
         version: link:../../../packages/modernjs-v3
@@ -1482,13 +1484,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/tsconfig':
         specifier: 3.0.1
         version: 3.0.1
@@ -1524,7 +1526,7 @@ importers:
         version: 7.28.2
       '@modern-js/runtime':
         specifier: 3.0.1
-        version: 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
       '@module-federation/modern-js-v3':
         specifier: workspace:*
         version: link:../../../packages/modernjs-v3
@@ -1540,13 +1542,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/tsconfig':
         specifier: 3.0.1
         version: 3.0.1
@@ -1582,7 +1584,7 @@ importers:
         version: 7.28.2
       '@modern-js/runtime':
         specifier: 3.0.1
-        version: 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
       '@module-federation/modern-js-v3':
         specifier: workspace:*
         version: link:../../../packages/modernjs-v3
@@ -1598,13 +1600,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/tsconfig':
         specifier: 3.0.1
         version: 3.0.1
@@ -1874,7 +1876,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: ^0.9.0
-        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)
+        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
 
   apps/react-ts-host:
     dependencies:
@@ -2039,10 +2041,10 @@ importers:
         version: link:../../../packages/rsbuild-plugin
       '@rsbuild/core':
         specifier: 1.7.3
-        version: 1.7.3
+        version: 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
+        version: 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.28
@@ -2051,7 +2053,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@26.0.0)(typescript@5.9.3))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.9.3))
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
@@ -2088,10 +2090,10 @@ importers:
         version: link:../../../packages/rsbuild-plugin
       '@rsbuild/core':
         specifier: 1.7.3
-        version: 1.7.3
+        version: 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
+        version: 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.28
@@ -2100,7 +2102,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.9.3))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@26.0.0)(typescript@5.9.3))
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
@@ -2125,10 +2127,10 @@ importers:
         version: link:../../../packages/rsbuild-plugin
       '@rsbuild/core':
         specifier: 1.7.3
-        version: 1.7.3
+        version: 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(vue@3.5.30(typescript@5.9.3))
+        version: 1.2.7(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(vue@3.5.30(typescript@5.9.3))
       tailwindcss:
         specifier: ^3.4.3
         version: 3.4.13(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@26.0.0)(typescript@5.9.3))
@@ -2165,13 +2167,13 @@ importers:
         version: 1.24.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@rsbuild/core':
         specifier: 1.7.3
-        version: 1.7.3
+        version: 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
+        version: 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
       '@rsbuild/shared':
         specifier: ^0.7.10
-        version: 0.7.10(@swc/helpers@0.5.23)
+        version: 0.7.10(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.28
@@ -2211,10 +2213,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 1.7.3
-        version: 1.7.3
+        version: 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
+        version: 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.28
@@ -2242,10 +2244,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 1.7.3
-        version: 1.7.3
+        version: 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(vue@3.5.30(typescript@5.9.3))
+        version: 1.2.7(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(vue@3.5.30(typescript@5.9.3))
       '@vue/tsconfig':
         specifier: ^0.5.1
         version: 0.5.1
@@ -2285,10 +2287,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 1.7.3
-        version: 1.7.3
+        version: 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
+        version: 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.28
@@ -2325,10 +2327,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 1.7.3
-        version: 1.7.3
+        version: 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
+        version: 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2368,10 +2370,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 1.7.3
-        version: 1.7.3
+        version: 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
+        version: 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.28
@@ -2398,7 +2400,7 @@ importers:
         version: 1.4.5(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(webpack-hot-middleware@2.26.1)
       '@rslib/core':
         specifier: ^0.9.0
-        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)
+        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.28
@@ -2416,7 +2418,7 @@ importers:
         version: 8.6.17(prettier@3.8.1)
       storybook-addon-rslib:
         specifier: ^1.0.1
-        version: 1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rslib/core@0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3))(storybook-builder-rsbuild@1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/react@18.3.28)(storybook@8.6.17(prettier@3.8.1))(tslib@2.8.1)(typescript@5.9.3))(typescript@5.9.3)
+        version: 1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rslib/core@0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3))(storybook-builder-rsbuild@1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/react@18.3.28)(storybook@8.6.17(prettier@3.8.1))(tslib@2.8.1)(typescript@5.9.3))(typescript@5.9.3)
       storybook-react-rsbuild:
         specifier: ^1.0.1
         version: 1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(storybook@8.6.17(prettier@3.8.1))(tslib@2.8.1)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.25.5)(webpack-cli@5.1.4))
@@ -2549,10 +2551,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 1.7.3
-        version: 1.7.3
+        version: 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
+        version: 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
 
   apps/shared-tree-shaking/no-server/host:
     dependencies:
@@ -2577,10 +2579,10 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/plugin-server':
         specifier: 2.68.0
         version: 2.68.0(@babel/traverse@7.29.7)(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2647,13 +2649,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/plugin-server':
         specifier: 2.68.0
         version: 2.68.0(@babel/traverse@7.29.7)(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2711,13 +2713,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/plugin-server':
         specifier: 2.68.0
         version: 2.68.0(@babel/traverse@7.29.7)(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2787,13 +2789,13 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.0.4)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
       '@modern-js/plugin-server':
         specifier: 2.68.0
         version: 2.68.0(@babel/traverse@7.29.7)(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3059,7 +3061,7 @@ importers:
         version: 2.66.7(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/runtime':
         specifier: 2.70.8
-        version: 2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
+        version: 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
       '@module-federation/observability-plugin':
         specifier: workspace:*
         version: link:../observability-plugin
@@ -3093,19 +3095,19 @@ importers:
     devDependencies:
       '@modern-js-app/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.9.3)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@modern-js/app-tools':
         specifier: 2.70.8
-        version: 2.70.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.10(@swc/helpers@0.5.19))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
+        version: 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.10(@swc/helpers@0.5.19))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
       '@modern-js/eslint-config':
         specifier: 2.59.0
-        version: 2.59.0(typescript@5.9.3)
+        version: 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@modern-js/module-tools':
         specifier: 2.70.8
         version: 2.70.8(@types/node@20.19.5)(typescript@5.9.3)
       '@modern-js/storybook':
         specifier: 2.70.8
-        version: 2.70.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+        version: 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
       '@modern-js/tsconfig':
         specifier: 2.70.8
         version: 2.70.8
@@ -3203,7 +3205,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: ^0.9.0
-        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)
+        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@types/glob':
         specifier: 7.2.0
         version: 7.2.0
@@ -3212,7 +3214,7 @@ importers:
         version: 1.2.5
       rsbuild-plugin-publint:
         specifier: ^0.2.1
-        version: 0.2.1(@rsbuild/core@1.7.3)
+        version: 0.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
 
   packages/dts-plugin:
     dependencies:
@@ -3391,7 +3393,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: ^0.12.4
-        version: 0.12.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)
+        version: 0.12.4(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
 
   packages/managers:
     dependencies:
@@ -3445,7 +3447,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: ^0.10.0
-        version: 0.10.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(typescript@5.9.3)
+        version: 0.10.6(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@types/node':
         specifier: ^20.19.5
         version: 20.19.5
@@ -3514,7 +3516,7 @@ importers:
         version: 0.7.28
       '@rslib/core':
         specifier: ^0.10.0
-        version: 0.10.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(typescript@5.9.3)
+        version: 0.10.6(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.5
@@ -3541,7 +3543,7 @@ importers:
         version: 0.13.0
       '@rslib/core':
         specifier: ^0.10.0
-        version: 0.10.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(typescript@5.9.3)
+        version: 0.10.6(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.5
@@ -3617,16 +3619,16 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: 2.70.5
-        version: 2.70.5(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.10(@swc/helpers@0.5.17))(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
+        version: 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.10(@swc/helpers@0.5.17))(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
       '@modern-js/module-tools':
         specifier: 2.70.5
         version: 2.70.5(@types/node@26.0.0)(typescript@5.9.3)
       '@modern-js/runtime':
         specifier: 2.70.5
-        version: 2.70.5(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@19.2.7)
+        version: 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@19.2.7)
       '@modern-js/server-runtime':
         specifier: 2.70.5
-        version: 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/tsconfig':
         specifier: 2.70.5
         version: 2.70.5
@@ -3635,13 +3637,13 @@ importers:
         version: link:../manifest
       '@rsbuild/core':
         specifier: 1.3.21
-        version: 1.3.21
+        version: 1.3.21(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
       '@rsbuild/plugin-react':
         specifier: 1.4.5
-        version: 1.4.5(@rsbuild/core@1.3.21)(webpack-hot-middleware@2.26.1)
+        version: 1.4.5(@rsbuild/core@1.3.21(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(webpack-hot-middleware@2.26.1)
       '@rslib/core':
         specifier: 0.18.5
-        version: 0.18.5(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)
+        version: 0.18.5(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(typescript@5.9.3)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.28
@@ -3705,7 +3707,7 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: 3.0.1
-        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+        version: 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
       '@modern-js/module-tools':
         specifier: 2.70.5
         version: 2.70.5(@types/node@26.0.0)(typescript@5.9.3)
@@ -3729,10 +3731,10 @@ importers:
         version: 1.4.5(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(webpack-hot-middleware@2.26.1)
       '@rslib/core':
         specifier: 0.18.5
-        version: 0.18.5(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)
+        version: 0.18.5(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(typescript@5.9.3)
       '@rspack/core':
-        specifier: 2.0.6
-        version: 2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)
+        specifier: npm:@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342
+        version: '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)'
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.28
@@ -3765,7 +3767,7 @@ importers:
         version: 9.2.1
       tsdown:
         specifier: 0.20.3
-        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(publint@0.3.18)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
+        version: 0.20.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(publint@0.3.18)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       unplugin:
         specifier: ^1.10.1
         version: 1.10.1
@@ -3864,7 +3866,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       tsdown:
         specifier: 0.20.3
-        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(publint@0.3.18)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
+        version: 0.20.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(publint@0.3.18)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
 
   packages/node:
     dependencies:
@@ -3927,7 +3929,7 @@ importers:
         version: 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
       '@rslib/core':
         specifier: ^0.12.4
-        version: 0.12.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)
+        version: 0.12.4(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       vitest:
         specifier: 1.6.0
         version: 1.6.0(@edge-runtime/vm@3.2.0)(@types/node@26.0.0)(@vitest/ui@1.6.0)(jsdom@20.0.3)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.1)
@@ -3955,16 +3957,15 @@ importers:
       '@module-federation/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@rspack/core':
+        specifier: npm:@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342
+        version: '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@packages+runtime-tools)(@swc/helpers@0.5.23)'
       typescript:
         specifier: ^4.9.0 || ^5.0.0
         version: 5.9.3
       vue-tsc:
         specifier: '>=1.0.24'
         version: 2.2.12(typescript@5.9.3)
-    devDependencies:
-      '@rspack/core':
-        specifier: ^1.0.2
-        version: 1.3.9(@swc/helpers@0.5.23)
 
   packages/rspress-plugin:
     dependencies:
@@ -3995,7 +3996,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: ^0.9.2
-        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)
+        version: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       '@rspress/core':
         specifier: 2.0.14
         version: 2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.28)(core-js@3.49.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
@@ -4068,10 +4069,10 @@ importers:
         version: link:../sdk
       '@nx/react':
         specifier: '>= 16.0.0'
-        version: 22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.5)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)
+        version: 22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@module-federation/runtime-tools@0.21.6)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.5)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)
       '@nx/webpack':
         specifier: '>= 16.0.0'
-        version: 22.5.4(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(html-webpack-plugin@5.6.6(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4)
+        version: 22.5.4(@babel/traverse@7.29.7)(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4)
       storybook:
         specifier: '>= 8.2.0'
         version: 8.6.17(prettier@3.8.1)
@@ -4081,10 +4082,10 @@ importers:
         version: link:../utilities
       '@nx/module-federation':
         specifier: '>= 16.0.0'
-        version: 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)
+        version: 22.5.4(@babel/traverse@7.29.7)(@module-federation/runtime-tools@0.21.6)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)
       '@rsbuild/core':
         specifier: 2.0.0-beta.2
-        version: 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
+        version: 2.0.0-beta.2(@module-federation/runtime-tools@0.21.6)(core-js@3.49.0)
       '@storybook/core':
         specifier: ^8.4.6
         version: 8.6.14(prettier@3.8.1)(storybook@8.6.17(prettier@3.8.1))
@@ -4296,16 +4297,16 @@ importers:
         version: 1.57.0
       '@rsbuild/core':
         specifier: ^1.6.15
-        version: 1.7.3
+        version: 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rsbuild/plugin-react':
         specifier: ^1.4.2
-        version: 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
+        version: 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
       '@rslib/core':
         specifier: ^0.12.4
-        version: 0.12.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(typescript@5.6.3)
+        version: 0.12.4(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.6.3)
       '@rstest/core':
         specifier: ^0.6.5
-        version: 0.6.9(jsdom@20.0.3)
+        version: 0.6.9(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(jsdom@20.0.3)
       '@types/canvas-confetti':
         specifier: ^1.9.0
         version: 1.9.0
@@ -4390,7 +4391,7 @@ importers:
         version: 1.57.0
       '@rstest/core':
         specifier: ^0.6.5
-        version: 0.6.9(jsdom@20.0.3)
+        version: 0.6.9(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(jsdom@20.0.3)
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.5
@@ -4460,7 +4461,7 @@ importers:
         version: 18.3.1
       rsbuild-plugin-publint:
         specifier: ^0.2.1
-        version: 0.2.1(@rsbuild/core@1.7.3)
+        version: 0.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
 
   packages/webpack-bundler-runtime:
     dependencies:
@@ -5888,20 +5889,20 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/core@1.9.0':
-    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/runtime@1.9.0':
-    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
-
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -8239,21 +8240,6 @@ packages:
       webpack:
         optional: true
 
-  '@module-federation/error-codes@0.13.1':
-    resolution: {integrity: sha512-azgGDBnFRfqlivHOl96ZjlFUFlukESz2Rnnz/pINiSqoBBNjUE0fcAZP4X6jgrVITuEg90YkruZa7pW9I3m7Uw==}
-
-  '@module-federation/error-codes@0.14.3':
-    resolution: {integrity: sha512-sBJ3XKU9g5Up31jFeXPFsD8AgORV7TLO/cCSMuRewSfgYbG/3vSKLJmfHrO6+PvjZSb9VyV2UaF02ojktW65vw==}
-
-  '@module-federation/error-codes@0.17.1':
-    resolution: {integrity: sha512-n6Elm4qKSjwAPxLUGtwnl7qt4y1dxB8OpSgVvXBIzqI9p27a3ZXshLPLnumlpPg1Qudaj8sLnSnFtt9yGpt5yQ==}
-
-  '@module-federation/error-codes@0.18.0':
-    resolution: {integrity: sha512-Woonm8ehyVIUPXChmbu80Zj6uJkC0dD9SJUZ/wOPtO8iiz/m+dkrOugAuKgoiR6qH4F+yorWila954tBz4uKsQ==}
-
-  '@module-federation/error-codes@0.21.1':
-    resolution: {integrity: sha512-h1brnwR9AbwMu1P7ZoJJ9j2O2XWkuMh5p03WhXI1vNEdl3xJheSAvH8RjG8FoKRccVgMnUNDQ+vDVwevUBms/A==}
-
   '@module-federation/error-codes@0.21.6':
     resolution: {integrity: sha512-MLJUCQ05KnoVl8xd6xs9a5g2/8U+eWmVxg7xiBMeR0+7OjdWUbHwcwgVFatRIwSZvFgKHfWEiI7wsU1q1XbTRQ==}
 
@@ -8320,21 +8306,6 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/runtime-core@0.13.1':
-    resolution: {integrity: sha512-TfyKfkSAentKeuvSsAItk8s5tqQSMfIRTPN2e1aoaq/kFhE+7blps719csyWSX5Lg5Es7WXKMsXHy40UgtBtuw==}
-
-  '@module-federation/runtime-core@0.14.3':
-    resolution: {integrity: sha512-xMFQXflLVW/AJTWb4soAFP+LB4XuhE7ryiLIX8oTyUoBBgV6U2OPghnFljPjeXbud72O08NYlQ1qsHw1kN/V8Q==}
-
-  '@module-federation/runtime-core@0.17.1':
-    resolution: {integrity: sha512-LCtIFuKgWPQ3E+13OyrVpuTPOWBMI/Ggwsq1Q874YeT8Px28b8tJRCj09DjyRFyhpSPyV/uG80T6iXPAUoLIfQ==}
-
-  '@module-federation/runtime-core@0.18.0':
-    resolution: {integrity: sha512-ZyYhrDyVAhUzriOsVfgL6vwd+5ebYm595Y13KeMf6TKDRoUHBMTLGQ8WM4TDj8JNsy7LigncK8C03fn97of0QQ==}
-
-  '@module-federation/runtime-core@0.21.1':
-    resolution: {integrity: sha512-COob5bepqDc9mKjTziXbQd4WQMCTzhc0cuXyraZhYddYcjcepzZrMpDIXG1x5p+gdg5p1vsGNWt/ZcU8cFh/pg==}
-
   '@module-federation/runtime-core@0.21.6':
     resolution: {integrity: sha512-5Hd1Y5qp5lU/aTiK66lidMlM/4ji2gr3EXAtJdreJzkY+bKcI5+21GRcliZ4RAkICmvdxQU5PHPL71XmNc7Lsw==}
 
@@ -8347,32 +8318,11 @@ packages:
   '@module-federation/runtime-core@2.5.1':
     resolution: {integrity: sha512-UMuMsWHXeMrm8Isl8YD6/s1jmTVau3SQhp9RO4Ln+eD2lrjM4hQSwOX2xPtfT1C1I4/E6hgyZQV1K1Q/3Zpr0Q==}
 
-  '@module-federation/runtime-tools@0.1.6':
-    resolution: {integrity: sha512-7ILVnzMIa0Dlc0Blck5tVZG1tnk1MmLnuZpLOMpbdW+zl+N6wdMjjHMjEZFCUAJh2E5XJ3BREwfX8Ets0nIkLg==}
-
-  '@module-federation/runtime-tools@0.13.1':
-    resolution: {integrity: sha512-GEF1pxqLc80osIMZmE8j9UKZSaTm2hX2lql8tgIH/O9yK4wnF06k6LL5Ah+wJt+oJv6Dj55ri/MoxMP4SXoPNA==}
-
-  '@module-federation/runtime-tools@0.14.3':
-    resolution: {integrity: sha512-QBETX7iMYXdSa3JtqFlYU+YkpymxETZqyIIRiqg0gW+XGpH3jgU68yjrme2NBJp7URQi/CFZG8KWtfClk0Pjgw==}
-
-  '@module-federation/runtime-tools@0.17.1':
-    resolution: {integrity: sha512-4kr6zTFFwGywJx6whBtxsc84V+COAuuBpEdEbPZN//YLXhNB0iz2IGsy9r9wDl+06h84bD+3dQ05l9euRLgXzQ==}
-
-  '@module-federation/runtime-tools@0.18.0':
-    resolution: {integrity: sha512-fSga9o4t1UfXNV/Kh6qFvRyZpPp3EHSPRISNeyT8ZoTpzDNiYzhtw0BPUSSD8m6C6XQh2s/11rI4g80UY+d+hA==}
-
-  '@module-federation/runtime-tools@0.21.1':
-    resolution: {integrity: sha512-uQmammw3Osg8370yiRqZwKo7eA5zkyml9pAX9x4oS9QAkEBvQpDogERlF9f7gAgcP2P3v+xLg3/bCdquD0gt8A==}
-
   '@module-federation/runtime-tools@0.21.6':
     resolution: {integrity: sha512-fnP+ZOZTFeBGiTAnxve+axGmiYn2D60h86nUISXjXClK3LUY1krUfPgf6MaD4YDJ4i51OGXZWPekeMe16pkd8Q==}
 
   '@module-federation/runtime-tools@0.22.0':
     resolution: {integrity: sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==}
-
-  '@module-federation/runtime-tools@0.5.1':
-    resolution: {integrity: sha512-nfBedkoZ3/SWyO0hnmaxuz0R0iGPSikHZOAZ0N/dVSQaIzlffUo35B5nlC2wgWIc0JdMZfkwkjZRrnuuDIJbzg==}
 
   '@module-federation/runtime-tools@2.2.2':
     resolution: {integrity: sha512-UnlKvy/zrbLTLItrI1tORiS6wdp5pYOCrR2LtDEbjJ2r+avzANSf2vJ7lAIT4SX5Pi9WwY5RhE4Y/BOwhAj4DA==}
@@ -8380,32 +8330,11 @@ packages:
   '@module-federation/runtime-tools@2.5.1':
     resolution: {integrity: sha512-pYUNvaQQBEwP66TLrjmmfkDIrTmPnX0kK86HgClkWLQKkX/oCgnqDxEgNbjeCc75dwUvZP6fW2d0pZ5++XILTw==}
 
-  '@module-federation/runtime@0.1.6':
-    resolution: {integrity: sha512-nj6a+yJ+QxmcE89qmrTl4lphBIoAds0PFPVGnqLRWflwAP88jrCcrrTqRhARegkFDL+wE9AE04+h6jzlbIfMKg==}
-
-  '@module-federation/runtime@0.13.1':
-    resolution: {integrity: sha512-ZHnYvBquDm49LiHfv6fgagMo/cVJneijNJzfPh6S0CJrPS2Tay1bnTXzy8VA5sdIrESagYPaskKMGIj7YfnPug==}
-
-  '@module-federation/runtime@0.14.3':
-    resolution: {integrity: sha512-7ZHpa3teUDVhraYdxQGkfGHzPbjna4LtwbpudgzAxSLLFxLDNanaxCuSeIgSM9c+8sVUNC9kvzUgJEZB0krPJw==}
-
-  '@module-federation/runtime@0.17.1':
-    resolution: {integrity: sha512-vKEN32MvUbpeuB/s6UXfkHDZ9N5jFyDDJnj83UTJ8n4N1jHIJu9VZ6Yi4/Ac8cfdvU8UIK9bIbfVXWbUYZUDsw==}
-
-  '@module-federation/runtime@0.18.0':
-    resolution: {integrity: sha512-+C4YtoSztM7nHwNyZl6dQKGUVJdsPrUdaf3HIKReg/GQbrt9uvOlUWo2NXMZ8vDAnf/QRrpSYAwXHmWDn9Obaw==}
-
-  '@module-federation/runtime@0.21.1':
-    resolution: {integrity: sha512-sfBrP0gEPwXPEiREVKVd0IjEWXtr3G/i7EUZVWTt4D491nNpswog/kuKFatGmhcBb+9uD5v9rxFgmIbgL9njnQ==}
-
   '@module-federation/runtime@0.21.6':
     resolution: {integrity: sha512-+caXwaQqwTNh+CQqyb4mZmXq7iEemRDrTZQGD+zyeH454JAYnJ3s/3oDFizdH6245pk+NiqDyOOkHzzFQorKhQ==}
 
   '@module-federation/runtime@0.22.0':
     resolution: {integrity: sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==}
-
-  '@module-federation/runtime@0.5.1':
-    resolution: {integrity: sha512-xgiMUWwGLWDrvZc9JibuEbXIbhXg6z2oUkemogSvQ4LKvrl/n0kbqP1Blk669mXzyWbqtSp6PpvNdwaE1aN5xQ==}
 
   '@module-federation/runtime@2.2.2':
     resolution: {integrity: sha512-zV6kbAUU1tQZr4KrZXQhzQP3WTb7oMRlIFw4UBhbh2JhAKGYS5CNc/n7+RV+mDxIs//qVmVzdSpJtTOMBLeFCw==}
@@ -8413,32 +8342,11 @@ packages:
   '@module-federation/runtime@2.5.1':
     resolution: {integrity: sha512-Tf33FIpnQMn8FjIUAQMtSTYQgGibfh5vEvJihFO3q/hG9LiWwLMErZvOz/+wcPsE81gzHjYPxQgMKGSP3BuG8g==}
 
-  '@module-federation/sdk@0.1.6':
-    resolution: {integrity: sha512-qifXpyYLM7abUeEOIfv0oTkguZgRZuwh89YOAYIZJlkP6QbRG7DJMQvtM8X2yHXm9PTk0IYNnOJH0vNQCo6auQ==}
-
-  '@module-federation/sdk@0.13.1':
-    resolution: {integrity: sha512-bmf2FGQ0ymZuxYnw9bIUfhV3y6zDhaqgydEjbl4msObKMLGXZqhse2pTIIxBFpIxR1oONKX/y2FAolDCTlWKiw==}
-
-  '@module-federation/sdk@0.14.3':
-    resolution: {integrity: sha512-THJZMfbXpqjQOLblCQ8jjcBFFXsGRJwUWE9l/Q4SmuCSKMgAwie7yLT0qSGrHmyBYrsUjAuy+xNB4nfKP0pnGw==}
-
-  '@module-federation/sdk@0.17.1':
-    resolution: {integrity: sha512-nlUcN6UTEi+3HWF+k8wPy7gH0yUOmCT+xNatihkIVR9REAnr7BUvHFGlPJmx7WEbLPL46+zJUbtQHvLzXwFhng==}
-
-  '@module-federation/sdk@0.18.0':
-    resolution: {integrity: sha512-Lo/Feq73tO2unjmpRfyyoUkTVoejhItXOk/h5C+4cistnHbTV8XHrW/13fD5e1Iu60heVdAhhelJd6F898Ve9A==}
-
-  '@module-federation/sdk@0.21.1':
-    resolution: {integrity: sha512-1cHMrmCCao3NMFM4BkA0GDt4rbYbyneHct5E4z68cu5UBUnI3L/UboP5VNM8lkYMO1nCR8M0FcLkLhK35Nt48A==}
-
   '@module-federation/sdk@0.21.6':
     resolution: {integrity: sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==}
 
   '@module-federation/sdk@0.22.0':
     resolution: {integrity: sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==}
-
-  '@module-federation/sdk@0.5.1':
-    resolution: {integrity: sha512-exvchtjNURJJkpqjQ3/opdbfeT2wPKvrbnGnyRkrwW5o3FH1LaST1tkiNviT6OXTexGaVc2DahbdniQHVtQ7pA==}
 
   '@module-federation/sdk@2.2.2':
     resolution: {integrity: sha512-BgbiLXl0sZ04IE6G2C1iZRLOaawfZqeJi9XjrQyoh3nJOHHL39rDhJ6xFCB5ayAjjoPqwB4Rc6xPpFXbO5PssQ==}
@@ -8462,32 +8370,11 @@ packages:
   '@module-federation/third-party-dts-extractor@2.2.2':
     resolution: {integrity: sha512-BWKLXQ2Me+zw6y2yhk8/URuVcyYFP1aJZlTqb7KpYeSJEp2z5jk8sZX2R42GraAGAwSe9IwcW6Y4Za/eoxt/tA==}
 
-  '@module-federation/webpack-bundler-runtime@0.1.6':
-    resolution: {integrity: sha512-K5WhKZ4RVNaMEtfHsd/9CNCgGKB0ipbm/tgweNNeC11mEuBTNxJ09Y630vg3WPkKv9vfMCuXg2p2Dk+Q/KWTSA==}
-
-  '@module-federation/webpack-bundler-runtime@0.13.1':
-    resolution: {integrity: sha512-QSuSIGa09S8mthbB1L6xERqrz+AzPlHR6D7RwAzssAc+IHf40U6NiTLPzUqp9mmKDhC5Tm0EISU0ZHNeJpnpBQ==}
-
-  '@module-federation/webpack-bundler-runtime@0.14.3':
-    resolution: {integrity: sha512-hIyJFu34P7bY2NeMIUHAS/mYUHEY71VTAsN0A0AqEJFSVPszheopu9VdXq0VDLrP9KQfuXT8SDxeYeJXyj0mgA==}
-
-  '@module-federation/webpack-bundler-runtime@0.17.1':
-    resolution: {integrity: sha512-Swspdgf4PzcbvS9SNKFlBzfq8h/Qxwqjq/xRSqw1pqAZWondZQzwTTqPXhgrg0bFlz7qWjBS/6a8KuH/gRvGaQ==}
-
-  '@module-federation/webpack-bundler-runtime@0.18.0':
-    resolution: {integrity: sha512-TEvErbF+YQ+6IFimhUYKK3a5wapD90d90sLsNpcu2kB3QGT7t4nIluE25duXuZDVUKLz86tEPrza/oaaCWTpvQ==}
-
-  '@module-federation/webpack-bundler-runtime@0.21.1':
-    resolution: {integrity: sha512-yyXX6ugTV07pMxMzAHt6/JDwblS3f1NDyUI7l44CyYgXpl2ItEEUs5aj5h/5xU1c9Px7M//KkY3qW+InW4tR/A==}
-
   '@module-federation/webpack-bundler-runtime@0.21.6':
     resolution: {integrity: sha512-7zIp3LrcWbhGuFDTUMLJ2FJvcwjlddqhWGxi/MW3ur1a+HaO8v5tF2nl+vElKmbG1DFLU/52l3PElVcWf/YcsQ==}
 
   '@module-federation/webpack-bundler-runtime@0.22.0':
     resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
-
-  '@module-federation/webpack-bundler-runtime@0.5.1':
-    resolution: {integrity: sha512-mMhRFH0k2VjwHt3Jol9JkUsmI/4XlrAoBG3E0o7HoyoPYv1UFOWyqAflfANcUPgbYpvqmyLzDcO+3IT36LXnrA==}
 
   '@module-federation/webpack-bundler-runtime@2.2.2':
     resolution: {integrity: sha512-g5UEn5APnNYvajwWQ0oc3Um+HO1z/jBcBkLSKAoSOCI6XxQk5eAV1PNDuDehAgJEtJw5yFD25kZPW3X7m39y7g==}
@@ -8620,6 +8507,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -11462,63 +11355,82 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@0.7.5':
-    resolution: {integrity: sha512-mNBIm36s1BA7v4SL/r4f3IXIsjyH5CZX4eXMRPE52lBc3ClVuUB7d/8zk8dkyjJCMAj8PsZSnAJ3cfXnn7TN4g==}
+  '@rspack-canary/binding-darwin-arm64@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-YNbUFBY4hoFw+WAesljv4dBX/nw2PSyWeFGEmK7SecPTpa6aw2ARuseiB65X91ddGIz1lH3cwP4qm2t12TMJAg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.0.14':
-    resolution: {integrity: sha512-dHvlF6T6ctThGDIdvkSdacroA1xlCxfteuppBj8BX/UxzLPr4xsaEtNilfJmFfd2/J02UQyTQauN/9EBuA+YkA==}
-    cpu: [arm64]
+  '@rspack-canary/binding-darwin-x64@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-aI7n4PpUF9ZOAbIdd0iD8c1A54+yrnwiUZyaTp++swnKqY/wV5qJcbmz1R84e8aTVEHYubpGcqR+NQDjf4CmmQ==}
+    cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.3.11':
-    resolution: {integrity: sha512-sGoFDXYNinubhEiPSjtA/ua3qhMj6VVBPTSDvprZj+MT18YV7tQQtwBpm+8sbqJ1P5y+a3mzsP3IphRWyIQyXw==}
+  '@rspack-canary/binding-linux-arm64-gnu@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-6x5vjvqZYsjrJG10bf+muhc+LmibLANhXJxFVqfvvvFlKShjOqCPdGbnpQ2xwUI7MFN9fp34deZFuiBbmv4Gzw==}
     cpu: [arm64]
-    os: [darwin]
+    os: [linux]
 
-  '@rspack/binding-darwin-arm64@1.3.15':
-    resolution: {integrity: sha512-f+DnVRENRdVe+ufpZeqTtWAUDSTnP48jVo7x9KWsXf8XyJHUi+eHKEPrFoy1HvL1/k5yJ3HVnFBh1Hb9cNIwSg==}
+  '@rspack-canary/binding-linux-arm64-musl@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-KZxKlca1HKQYzdMLqD8fIp6G7hhlsOao42ZDQ7HiyO7OJE629478i7aS+LqcJcm5M2Mg3kRIgwxgh/anA7Z9YQ==}
     cpu: [arm64]
-    os: [darwin]
+    os: [linux]
 
-  '@rspack/binding-darwin-arm64@1.3.9':
-    resolution: {integrity: sha512-lfTmsbUGab9Ak/X6aPLacHLe4MBRra+sLmhoNK8OKEN3qQCjDcomwW5OlmBRV5bcUYWdbK8vgDk2HUUXRuibVg==}
-    cpu: [arm64]
-    os: [darwin]
+  '@rspack-canary/binding-linux-x64-gnu@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-YS7lxAyOybtABXUKUGXhNXFRtTlpfqFAanqytIn4kQJv47v6G1SfQoqtmhUt2eZDI7idGmQbH1pEPko7cHQD5w==}
+    cpu: [x64]
+    os: [linux]
 
-  '@rspack/binding-darwin-arm64@1.4.11':
-    resolution: {integrity: sha512-PrmBVhR8MC269jo6uQ+BMy1uwIDx0HAJYLQRQur8gXiehWabUBCRg/d4U9KR7rLzdaSScRyc5JWXR52T7/4MfA==}
-    cpu: [arm64]
-    os: [darwin]
+  '@rspack-canary/binding-linux-x64-musl@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-WyRfKRmkxgVb46Iqu5OYzigLMPYMMFDrzCGVuLGpmVdPQI03eHp193gEq8CLpLwoLlF5Lizr6OiIxdkznM/R1Q==}
+    cpu: [x64]
+    os: [linux]
 
-  '@rspack/binding-darwin-arm64@1.5.8':
-    resolution: {integrity: sha512-spJfpOSN3f7V90ic45/ET2NKB2ujAViCNmqb0iGurMNQtFRq+7Kd+jvVKKGXKBHBbsQrFhidSWbbqy2PBPGK8g==}
-    cpu: [arm64]
-    os: [darwin]
+  '@rspack-canary/binding-wasm32-wasi@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-O1eqTUlwYL+/9waO3+2c5liijlbaFuxUNfTvKat5dzYjrDDpa7MtFzRQfLAgSY3SLFqYR/ygh5pqTf02Sh++TQ==}
+    cpu: [wasm32]
 
-  '@rspack/binding-darwin-arm64@1.6.0-beta.1':
-    resolution: {integrity: sha512-RXQ97iVXgvQAb/cq265z/txdHOOJ6fQQRBfnn0IfMNk7gT4W2rvsLrOqQpwtMKxYV4N/mfWnycfAVa0OOf22Gg==}
+  '@rspack-canary/binding-win32-arm64-msvc@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-/BMJpPZgdwsVbW4n3I5zakIYka5FFAX3YBET+TdLSXNW723uJlex1vxwkWtcFZ9+TGi8jQgpq+BZmqXxDbnWUw==}
     cpu: [arm64]
-    os: [darwin]
+    os: [win32]
 
-  '@rspack/binding-darwin-arm64@1.6.8':
-    resolution: {integrity: sha512-e8CTQtzaeGnf+BIzR7wRMUwKfIg0jd/sxMRc1Vd0bCMHBhSN9EsGoMuJJaKeRrSmy2nwMCNWHIG+TvT1CEKg+A==}
-    cpu: [arm64]
-    os: [darwin]
+  '@rspack-canary/binding-win32-ia32-msvc@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-fInHjXoXFtBQa4gpK1U4vo+ARZmq404YAZ7utia7TZEuVwN1bBMbrtgYkskqiKa9Jimgto88D/eXzCjCMPC9ww==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack-canary/binding-win32-x64-msvc@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-Oia1vScsagyfERaItEQoIy2sPV/dyLRkAoeZt78rqUeWW23QUInUsrC5raUhUInqsY6x6cCoDiPYRAI5R8436A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-Ka64O5o6VDvN8CeT1t7oFWNrc16gjkfPG3pW8KB9b3HLMFmMuUHgLopqu/Wpn4IBjzf9zscfBAmosW/Ea+hBqA==}
+
+  '@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-4KdnePgSA5e8xNDOpJ3BQKOmmOT+YoLmXC01DmeERSaqbQcueYIY/vE4zvMGmk3GN6UXzV4CJAZOeZaWrVsLHA==}
+    hasBin: true
+    peerDependencies:
+      '@rspack/core': ^2.0.0-0
+      '@rspack/dev-server': ^2.0.0-0
+    peerDependenciesMeta:
+      '@rspack/dev-server':
+        optional: true
+
+  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342':
+    resolution: {integrity: sha512-/Izm5Ist8JkjWDRSmrA2IJ4qux3J5gODS4XiLi1GxaMqe8Yg/nHvS/ngD+PSA8PXxyohY0D1bUMHqxla6Vo5Dg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
 
   '@rspack/binding-darwin-arm64@1.7.9':
     resolution: {integrity: sha512-64dgstte0If5czi9bA/cpOe0ryY6wC9AIQRtyJ3DlOF6Tt+y9cKkmUoGu3V+WYaYIZRT7HNk8V7kL8amVjFTYw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-arm64@2.0.0-beta.0':
-    resolution: {integrity: sha512-PPx1+SPEROSvDKmBuCbsE7W9tk07ajPosyvyuafv2wbBI6PW2rNcz62uzpIFS+FTgwwZ5u/06WXRtlD2xW9bKg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-arm64@2.0.6':
-    resolution: {integrity: sha512-0giCKiWlBfcM4i2scv1j2k9HlSecO9Ybhaa5wsMUyvcFeKr9HbNHh7C2eDFlC6zaI85IUdY71TXF/g/Tcxr9MA==}
     cpu: [arm64]
     os: [darwin]
 
@@ -11527,63 +11439,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@0.7.5':
-    resolution: {integrity: sha512-teLK0TB1x0CsvaaiCopsFx4EvJe+/Hljwii6R7C9qOZs5zSOfbT/LQ202eA0sAGodCncARCGaXVrsekbrRYqeA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.0.14':
-    resolution: {integrity: sha512-q4Da1Bn/4xTLhhnOkT+fjP2STsSCfp4z03/J/h8tCVG/UYz56Ud3q1UEOK33c5Fxw1C4GlhEh5yYOlSAdxFQLQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.3.11':
-    resolution: {integrity: sha512-4zgOkCLxhp4Ki98GuDaZgz4exXcE4+sgvXY/xA/A5FGPVRbfQLQ5psSOk0F/gvMua1r15E66loQRJpuzUK6bTA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.3.15':
-    resolution: {integrity: sha512-TfUvEIBqYUT2OK01BYXb2MNcZeZIhAnJy/5aj0qV0uy4KlvwW63HYcKWa1sFd4Ac7bnGShDkanvP3YEuHOFOyg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.3.9':
-    resolution: {integrity: sha512-rYuOUINhnhLDbG5LHHKurRSuKIsw0LKUHcd6AAsFmijo4RMnGBJ4NOI4tOLAQvkoSTQ+HU5wiTGSQOgHVhYreQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.4.11':
-    resolution: {integrity: sha512-YIV8Wzy+JY0SoSsVtN4wxFXOjzxxVPnVXNswrrfqVUTPr9jqGOFYUWCGpbt8lcCgfuBFm6zN8HpOsKm1xUNsVA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.5.8':
-    resolution: {integrity: sha512-YFOzeL1IBknBcri8vjUp43dfUBylCeQnD+9O9p0wZmLAw7DtpN5JEOe2AkGo8kdTqJjYKI+cczJPKIw6lu1LWw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.6.0-beta.1':
-    resolution: {integrity: sha512-Ulb7Jyyvuf28BwPXZKSbglaSK/19b32ItWT+pgswhbFsnfhzAQQd7Jo7TUEvHNHAdVDiES8VFlrnOhOSnwEOLg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.6.8':
-    resolution: {integrity: sha512-ku1XpTEPt6Za11zhpFWhfwrTQogcgi9RJrOUVC4FESiPO9aKyd4hJ+JiPgLY0MZOqsptK6vEAgOip+uDVXrCpg==}
-    cpu: [x64]
-    os: [darwin]
-
   '@rspack/binding-darwin-x64@1.7.9':
     resolution: {integrity: sha512-2QSLs3w4rLy4UUGVnIlkt6IlIKOzR1e0RPsq2FYQW6s3p9JrwRCtOeHohyh7EJSqF54dtfhe9UZSAwba3LqH1Q==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@2.0.0-beta.0':
-    resolution: {integrity: sha512-GucsfjrSKBZ9cuOTXmHWxeY2wPmaNyvGNxTyzttjRcfwqOWz8r+ku6PCsMSXUqxZRYWW1L9mvtTdlDrzTYJZ0w==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@2.0.6':
-    resolution: {integrity: sha512-/mMo2IpI02aOKMlHbVbZue3TJxFqHGX+ibVTdEO+6bzRSuHs7+R9KM5U3XH2YxcWJy5Sid1X1T1pJAjsXcE3rA==}
     cpu: [x64]
     os: [darwin]
 
@@ -11592,63 +11449,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@0.7.5':
-    resolution: {integrity: sha512-/24UytJXrK+7CsucDb30GCKYIJ8nG6ceqbJyOtsJv9zeArNLHkxrYGSyjHJIpQfwVN17BPP4RNOi+yIZ3ZgDyA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-gnu@1.0.14':
-    resolution: {integrity: sha512-JogYtL3VQS9wJ3p3FNhDqinm7avrMsdwz4erP7YCjD7idob93GYAE7dPrHUzSNVnCBYXRaHJYZHDQs7lKVcYZw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-gnu@1.3.11':
-    resolution: {integrity: sha512-NIOaIfYUmJs1XL4lbGVtcMm1KlA/6ZR6oAbs2ekofKXtJYAFQgnLTf7ZFmIwVjS0mP78BmeSNcIM6pd2w5id4w==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-gnu@1.3.15':
-    resolution: {integrity: sha512-D/YjYk9snKvYm1Elotq8/GsEipB4ZJWVv/V8cZ+ohhFNOPzygENi6JfyI06TryBTQiN0/JDZqt/S9RaWBWnMqw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-gnu@1.3.9':
-    resolution: {integrity: sha512-pBKnS2Fbn9cDtWe1KcD1qRjQlJwQhP9pFW2KpxdjE7qXbaO11IHtem6dLZwdpNqbDn9QgyfdVGXBDvBaP1tGwA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-gnu@1.4.11':
-    resolution: {integrity: sha512-ms6uwECUIcu+6e82C5HJhRMHnfsI+l33v7XQezntzRPN0+sG3EpikEoT7SGbgt4vDwaWLR7wS20suN4qd5r3GA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-gnu@1.5.8':
-    resolution: {integrity: sha512-UAWCsOnpkvy8eAVRo0uipbHXDhnoDq5zmqWTMhpga0/a3yzCp2e+fnjZb/qnFNYb5MeL0O1mwMOYgn1M3oHILQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-gnu@1.6.0-beta.1':
-    resolution: {integrity: sha512-UyUoh5RXHTWCktqPVnqoc5rwlWyLkWqGu6ga+iyJHDxdxlrHFfwJnTSnCd4y8cRadf7CrmjHElxE61GU3WCYhw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-gnu@1.6.8':
-    resolution: {integrity: sha512-fvZX6xZPvBT8qipSpvkKMX5M7yd2BSpZNCZXcefw6gA3uC7LI3gu+er0LrDXY1PtPzVuHTyDx+abwWpagV3PiQ==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rspack/binding-linux-arm64-gnu@1.7.9':
     resolution: {integrity: sha512-qhUGI/uVfvLmKWts4QkVHGL8yfUyJkblZs+OFD5Upa2y676EOsbQgWsCwX4xGB6Tv+TOzFP0SLh/UfO8ZfdE+w==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.0':
-    resolution: {integrity: sha512-nTtYtklRZD4sb2RIFCF9YS8tZ/MjpqIBKVS3YIvdXcfHUdVfmQHTZGtwEuZGg6AxTC5L1hcvkYmTXCG0ok7auw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-gnu@2.0.6':
-    resolution: {integrity: sha512-H6ACzeM1KBxYDEF8YAim3501Jb1aCsSG79Gjm1M4pwJ5OJPK2ydiJEa438ugXmh0962eKYMHI2yZY0sQq8txaw==}
     cpu: [arm64]
     os: [linux]
 
@@ -11657,63 +11459,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@0.7.5':
-    resolution: {integrity: sha512-6RcxG42mLM01Pa6UYycACu/Nu9qusghAPUJumb8b8x5TRIDEtklYC5Ck6Rmagm+8E0ucMude2E/D4rMdIFcS3A==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.0.14':
-    resolution: {integrity: sha512-qgybhxI/nnoa8CUz7zKTC0Oh37NZt9uRxsSV7+ZYrfxqbrVCoNVuutPpY724uUHy1M6W34kVEm1uT1N4Ka5cZg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.3.11':
-    resolution: {integrity: sha512-CRRAQ379uzA2QfD9HHNtxuuqzGksUapMVcTLY5NIXWfvHLUJShdlSJQv3UQcqgAJNrMY7Ex1PnoQs1jZgUiqZA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.3.15':
-    resolution: {integrity: sha512-lJbBsPMOiR0hYPCSM42yp7QiZjfo0ALtX7ws2wURpsQp3BMfRVAmXU3Ixpo2XCRtG1zj8crHaCmAWOJTS0smsA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.3.9':
-    resolution: {integrity: sha512-0B+iiINW0qOEkBE9exsRcdmcHtYIWAoJGnXrz9tUiiewRxX0Cmm0MjD2HAVUAggJZo+9IN8RGz5PopCjJ/dn1g==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.4.11':
-    resolution: {integrity: sha512-9evq0DOdxMN/H8VM8ZmyY9NSuBgILNVV6ydBfVPMHPx4r1E7JZGpWeKDegZcS5Erw3sS9kVSIxyX78L5PDzzKw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.5.8':
-    resolution: {integrity: sha512-GnSvGT4GjokPSD45cTtE+g7LgghuxSP1MRmvd+Vp/I8pnxTVSTsebRod4TAqyiv+l11nuS8yqNveK9qiOkBLWw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.6.0-beta.1':
-    resolution: {integrity: sha512-JAXVKHQieN4Ruvs7MstvsPUtRBSAROqJ0abCh4rXdV+FzncKp/ZkdfjQploDhBWtWfU8rPvIjaxeZcPfHMI5/A==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.6.8':
-    resolution: {integrity: sha512-++XMKcMNrt59HcFBLnRaJcn70k3X0GwkAegZBVpel8xYIAgvoXT5+L8P1ExId/yTFxqedaz8DbcxQnNmMozviw==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rspack/binding-linux-arm64-musl@1.7.9':
     resolution: {integrity: sha512-VjfmR1hgO9n3L6MaE5KG+DXSrrLVqHHOkVcOtS2LMq3bjMTwbBywY7ycymcLnX5KJsol8d3ZGYep6IfSOt3lFA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@2.0.0-beta.0':
-    resolution: {integrity: sha512-S2fshx0Rf7/XYwoMLaqFsVg4y+VAfHzubrczy8AW5xIs6UNC3eRLVTgShLerUPtF6SG+v6NQxQ9JI3vOo2qPOA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@2.0.6':
-    resolution: {integrity: sha512-QTFmBg0n+L397Wi8CIjbd5pe/hxpHnqCDaG1A7e2NWX8Fj9zulAoKLiKflQa1ELEhAY4Foq88aX75+Ilt2tHcw==}
     cpu: [arm64]
     os: [linux]
 
@@ -11722,63 +11469,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@0.7.5':
-    resolution: {integrity: sha512-R0Lu4CJN2nWMW7WzPBuCIju80cQPpcaqwKJDj/quwQySpJJZ6c5qGwB8mntqjxIzZDrNH6u0OkpiUTbvWZj8ww==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@1.0.14':
-    resolution: {integrity: sha512-5vzaDRw3/sGKo3ax/1cU3/cxqNjajwlt2LU288vXNe1/n8oe/pcDfYcTugpOe/A1DqzadanudJszLpFcKsaFtQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@1.3.11':
-    resolution: {integrity: sha512-k3OyvLneX2ZeL8z/OzPojpImqy6PgqKJD+NtOvcr/TgbgADHZ3xQttf6B2X+qnZMAgOZ+RTeTkOFrvsg9AEKmA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@1.3.15':
-    resolution: {integrity: sha512-qGB8ucHklrzNg6lsAS36VrBsCbOw0acgpQNqTE5cuHWrp1Pu3GFTRiFEogenxEmzoRbohMZt0Ev5grivrcgKBQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@1.3.9':
-    resolution: {integrity: sha512-82izGJw/qxJ4xaHJy/A4MF7aTRT9tE6VlWoWM4rJmqRszfujN/w54xJRie9jkt041TPvJWGNpYD4Hjpt0/n/oA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@1.4.11':
-    resolution: {integrity: sha512-bHYFLxPPYBOSaHdQbEoCYGMQ1gOrEWj7Mro/DLfSHZi1a0okcQ2Q1y0i1DczReim3ZhLGNrK7k1IpFXCRbAobQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@1.5.8':
-    resolution: {integrity: sha512-XLxh5n/pzUfxsugz/8rVBv+Tx2nqEM+9rharK69kfooDsQNKyz7PANllBQ/v4svJ+W0BRHnDL4qXSGdteZeEjA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@1.6.0-beta.1':
-    resolution: {integrity: sha512-LqAos71CJS5/V4knX9T7T68oGz0XPRZ2IJmI3jEByRlNcyZdxYeQ7Dw09JO9Y5Xj0T+0cudOeL2MxHcD3gTF/w==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@1.6.8':
-    resolution: {integrity: sha512-tv3BWkTE1TndfX+DsE1rSTg8fBevCxujNZ3MlfZ22Wfy9x1FMXTJlWG8VIOXmaaJ1wUHzv8S7cE2YUUJ2LuiCg==}
-    cpu: [x64]
-    os: [linux]
-
   '@rspack/binding-linux-x64-gnu@1.7.9':
     resolution: {integrity: sha512-0kldV+3WTs/VYDWzxJ7K40hCW26IHtnk8xPK3whKoo1649rgeXXa0EdsU5P7hG8Ef5SWQjHHHZ/fuHYSO3Y6HA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@2.0.0-beta.0':
-    resolution: {integrity: sha512-yx5Fk1gl7lfkvqcjolNLCNeduIs6C2alMsQ/kZ1pLeP5MPquVOYNqs6EcDPIp+fUjo3lZYtnJBiZKK+QosbzYg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@2.0.6':
-    resolution: {integrity: sha512-rerCAz022zf0ewxI+7n3SrqLEaxCL+MXRxKjK5FLUGFa8UkIrivq+VUP/1OB6JLh2Bucebc7Y9WoWHvtk22mLA==}
     cpu: [x64]
     os: [linux]
 
@@ -11787,63 +11479,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@0.7.5':
-    resolution: {integrity: sha512-dDgi/ThikMy1m4llxPeEXDCA2I8F8ezFS/eCPLZGU2/J1b4ALwDjuRsMmo+VXSlFCKgIt98V6h1woeg7nu96yg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.0.14':
-    resolution: {integrity: sha512-4U6QD9xVS1eGme52DuJr6Fg/KdcUfJ+iKwH49Up460dZ/fLvGylnVGA+V0mzPlKi8gfy7NwFuYXZdu3Pwi1YYg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.3.11':
-    resolution: {integrity: sha512-2agcELyyQ95jWGCW0YWD0TvAcN40yUjmxn9NXQBLHPX5Eb07NaHXairMsvV9vqQsPsq0nxxfd9Wsow18Y5r/Hw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.3.15':
-    resolution: {integrity: sha512-qRn6e40fLQP+N2rQD8GAj/h4DakeTIho32VxTIaHRVuzw68ZD7VmKkwn55ssN370ejmey35ZdoNFNE12RBrMZA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.3.9':
-    resolution: {integrity: sha512-V9nDg63iPI6Z7kM11UPV5kBdOdLXPIu3IgI2ObON5Rd4KEZr7RLo/Q4HKzj0IH27Zwl5qeBJdx69zZdu66eOqg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.4.11':
-    resolution: {integrity: sha512-wrm4E7q2k4+cwT6Uhp6hIQ3eUe/YoaUttj6j5TqHYZX6YeLrNPtD9+ne6lQQ17BV8wmm6NZsmoFIJ5xIptpRhQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.5.8':
-    resolution: {integrity: sha512-gE0+MZmwF+01p9/svpEESkzkLpBkVUG2o03YMpwXYC/maeRRhWvF8BJ7R3i/Ls/jFGSE87dKX5NbRLVzqksq/w==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.6.0-beta.1':
-    resolution: {integrity: sha512-E4dRMzIHYaoYkgmDTFLrgnGtdspbAuVbLfaPF9AWW5YkQn52obGAgbbNb1wi1JJ5f29nTBoLauYCucEO5IGFvA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.6.8':
-    resolution: {integrity: sha512-DCGgZ5/in1O3FjHWqXnDsncRy+48cMhfuUAAUyl0yDj1NpsZu9pP+xfGLvGcQTiYrVl7IH9Aojf1eShP/77WGA==}
-    cpu: [x64]
-    os: [linux]
-
   '@rspack/binding-linux-x64-musl@1.7.9':
     resolution: {integrity: sha512-Gi4872cFtc2d83FKATR6Qcf2VBa/tFCqffI/IwRRl6Hx5FulEBqx+tH7gAuRVF693vrbXNxK+FQ+k4iEsEJxrw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@2.0.0-beta.0':
-    resolution: {integrity: sha512-sBX4b2W0PgehlAVT224k0Q6GaH6t9HP+hBNDrbX/g6d0hfxZN56gm5NfOTOD1Rien4v7OBEejJ3/uFbm1WjwYQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@2.0.6':
-    resolution: {integrity: sha512-96IgOFXQjX6Wbxd+DCYJFy2r/VMu1OoHifW4Cr3kGTYDKoQOIMLwb0ieu/ILp2dGWFMZo5S8odiByAmNICAOIA==}
     cpu: [x64]
     os: [linux]
 
@@ -11852,95 +11489,16 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-wasm32-wasi@1.4.11':
-    resolution: {integrity: sha512-hiYxHZjaZ17wQtXyLCK0IdtOvMWreGVTiGsaHCxyeT+SldDG+r16bXNjmlqfZsjlfl1mkAqKz1dg+mMX28OTqw==}
-    cpu: [wasm32]
-
-  '@rspack/binding-wasm32-wasi@1.5.8':
-    resolution: {integrity: sha512-cfg3niNHeJuxuml1Vy9VvaJrI/5TakzoaZvKX2g5S24wfzR50Eyy4JAsZ+L2voWQQp1yMJbmPYPmnTCTxdJQBQ==}
-    cpu: [wasm32]
-
-  '@rspack/binding-wasm32-wasi@1.6.0-beta.1':
-    resolution: {integrity: sha512-PaKEjXOkYprSFlgdgVm/P3pv2E8nAQx9WSGgPmMVIAtxo3Cyz0wwFf0f1Bp9wCw0KkIWgi+9lz8oXNkgKZilug==}
-    cpu: [wasm32]
-
-  '@rspack/binding-wasm32-wasi@1.6.8':
-    resolution: {integrity: sha512-VUwdhl/lI4m6o1OGCZ9JwtMjTV/yLY5VZTQdEPKb40JMTlmZ5MBlr5xk7ByaXXYHr6I+qnqEm73iMKQvg6iknw==}
-    cpu: [wasm32]
-
   '@rspack/binding-wasm32-wasi@1.7.9':
     resolution: {integrity: sha512-5QEzqo6EaolpuZmK6w/mgSueorgGnnzp7dJaAvBj6ECFIg/aLXhXXmWCWbxt7Ws2gKvG5/PgaxDqbUxYL51juA==}
-    cpu: [wasm32]
-
-  '@rspack/binding-wasm32-wasi@2.0.0-beta.0':
-    resolution: {integrity: sha512-o6OatnNvb4kCzXbCaomhENGaCsO3naIyAqqErew90HeAwa1lfY3NhRfDLeIyuANQ+xqFl34/R7n8q3ZDx3nd4Q==}
-    cpu: [wasm32]
-
-  '@rspack/binding-wasm32-wasi@2.0.6':
-    resolution: {integrity: sha512-0aWiF+qmdb0csp1x+MaR2o1pscoquLaEbLTVdKjmoTRs6sguMemtB1ObnVTahAUL73P66WePuNpFAJ81zNdqzQ==}
     cpu: [wasm32]
 
   '@rspack/binding-wasm32-wasi@2.0.8':
     resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@0.7.5':
-    resolution: {integrity: sha512-nEF4cUdLfgEK6FrgJSJhUlr2/7LY1tmqBNQCFsCjtDtUkQbJIEo1b8edT94G9tJcQoFE4cD+Re30yBYbQO2Thg==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@1.0.14':
-    resolution: {integrity: sha512-SjeYw7qqRHYZ5RPClu+ffKZsShQdU3amA1OwC3M0AS6dbfEcji8482St3Y8Z+QSzYRapCEZij9LMM/9ypEhISg==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@1.3.11':
-    resolution: {integrity: sha512-sjGoChazu0krigT/LVwGUsgCv3D3s/4cR/3P4VzuDNVlb4pbh1CDa642Fr0TceqAXCeKW5GiL/EQOfZ4semtcQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@1.3.15':
-    resolution: {integrity: sha512-7uJ7dWhO1nWXJiCss6Rslz8hoAxAhFpwpbWja3eHgRb7O4NPHg6MWw63AQSI2aFVakreenfu9yXQqYfpVWJ2dA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@1.3.9':
-    resolution: {integrity: sha512-owWCJTezFkiBOSRzH+eOTN15H5QYyThHE5crZ0I30UmpoSEchcPSCvddliA0W62ZJIOgG4IUSNamKBiiTwdjLQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@1.4.11':
-    resolution: {integrity: sha512-+HF/mnjmTr8PC1dccRt1bkrD2tPDGeqvXC1BBLYd/Klq1VbtIcnrhfmvQM6KaXbiLcY9VWKzcZPOTmnyZ8TaHQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@1.5.8':
-    resolution: {integrity: sha512-7i3ZTHFXKfU/9Jm9XhpMkrdkxO7lfeYMNVEGkuU5dyBfRMQj69dRgPL7zJwc2plXiqu9LUOl+TwDNTjap7Q36g==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@1.6.0-beta.1':
-    resolution: {integrity: sha512-HWz9Qxrjf3TKLCwiFPJaqw+STvEsBvFYZvBXZ8umIZXqtdfgQP5d91V8JRG4Gg1J6xnGC/KhZexxBuR/y64aBA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@1.6.8':
-    resolution: {integrity: sha512-23YX7zlOZlub+nPGDBUzktb4D5D6ETUAluKjXEeHIZ9m7fSlEYBnGL66YE+3t1DHXGd0OqsdwlvrNGcyo6EXDQ==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rspack/binding-win32-arm64-msvc@1.7.9':
     resolution: {integrity: sha512-MMqvcrIc8aOqTuHjWkjdzilvoZ3Hv07Od0Foogiyq3JMudsS3Wcmh7T1dFerGg19MOJcRUeEkrg2NQOMOQ6xDA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.0':
-    resolution: {integrity: sha512-neCzVllXzIqM8p8qKb89qV7wyk233gC/V9VrHIKbGeQjAEzpBsk5GOWlFbq5DDL6tivQ+uzYaTrZWm9tb2qxXg==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@2.0.6':
-    resolution: {integrity: sha512-BX638A1MXsjc2E3tUskVh3X/WBIHjLKK+lo395v7MmEL9u2BA6l3F6RyW+YaJOt5aEOOv83iA7iCZsviVZ49Uw==}
     cpu: [arm64]
     os: [win32]
 
@@ -11949,63 +11507,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@0.7.5':
-    resolution: {integrity: sha512-hEcHRwJIzpZsePr+5x6V/7TGhrPXhSZYG4sIhsrem1za9W+qqCYYLZ7KzzbRODU07QaAH2RxjcA1bf8F2QDYAQ==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.0.14':
-    resolution: {integrity: sha512-m1gUiVyz3Z3VYIK/Ayo5CVHBjnEeRk9a+KIpKSsq1yhZItnMgjtr4bKabU9vjxalO4UoaSmVzODJI8lJBlnn5Q==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.3.11':
-    resolution: {integrity: sha512-tjywW84oQLSqRmvQZ+fXP7e3eNmjScYrlWEPAQFjf08N19iAJ9UOGuuFw8Fk5ZmrlNZ2Qo9ASSOI7Nnwx2aZYg==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.3.15':
-    resolution: {integrity: sha512-UsaWTYCjDiSCB0A0qETgZk4QvhwfG8gCrO4SJvA+QSEWOmgSai1YV70prFtLLIiyT9mDt1eU3tPWl1UWPRU/EQ==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.3.9':
-    resolution: {integrity: sha512-YUuNA8lkGSXJ07fOjkX+yuWrWcsU5x5uGFuAYsglw+rDTWCS6m9HSwQjbCp7HUp81qPszjSk+Ore5XVh07FKeQ==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.4.11':
-    resolution: {integrity: sha512-EU2fQGwrRfwFd/tcOInlD0jy6gNQE4Q3Ayj0Is+cX77sbhPPyyOz0kZDEaQ4qaN2VU8w4Hu/rrD7c0GAKLFvCw==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.5.8':
-    resolution: {integrity: sha512-7ZPPWO11J+soea1+mnfaPpQt7GIodBM7A86dx6PbXgVEoZmetcWPrCF2NBfXxQWOKJ9L3RYltC4z+ZyXRgMOrw==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.6.0-beta.1':
-    resolution: {integrity: sha512-alAZHRuyPzCH3rJpEC9EBE60EZPnQjzltZ6HN8lsCidACMFTzaLBvuzZyYQah+Zm58O22ok2Eon4BpP1Coizgg==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.6.8':
-    resolution: {integrity: sha512-cFgRE3APxrY4AEdooVk2LtipwNNT/9mrnjdC5lVbsIsz+SxvGbZR231bxDJEqP15+RJOaD07FO1sIjINFqXMEg==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rspack/binding-win32-ia32-msvc@1.7.9':
     resolution: {integrity: sha512-4kYYS+NZ2CuNbKjq40yB/UEyB51o1PHj5wpr+Y943oOJXpEKWU2Q4vkF8VEohPEcnA9cKVotYCnqStme+02suA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.0':
-    resolution: {integrity: sha512-/f0n2eO+DxMKQm9IebeMQJITx8M/+RvY/i8d3sAQZBgR53izn8y7EcDlidXpr24/2DvkLbiub8IyCKPlhLB+1A==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@2.0.6':
-    resolution: {integrity: sha512-DCK/+MlN35uvH7tp4j0hbg8wIs9MHArMIrNZXtiD8xP6DNw2wrXcGC1VaxxR5apyWpqXAfIL/KsXBiWS3ygCvg==}
     cpu: [ia32]
     os: [win32]
 
@@ -12014,63 +11517,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@0.7.5':
-    resolution: {integrity: sha512-PpVpP6J5/2b4T10hzSUwjLvmdpAOj3ozARl1Nrf/lsbYwhiXivoB8Gvoy/xe/Xpgr732Dk9VCeeW8rreWOOUVQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@1.0.14':
-    resolution: {integrity: sha512-Gbeg+bayMF9VP9xmlxySL/TC2XrS6/LZM/pqcNOTLHx6LMG/VXCcmKB0rOZo8MzLXEt8D/lQmQ/B6g7pSaAw0g==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@1.3.11':
-    resolution: {integrity: sha512-pPy3yU6SAMfEPY7ki1KAetiDFfRbkYMiX3F89P9kX01UAePkLRNsjacHF4w7N3EsBsWn1FlGaYZdlzmOI5pg2Q==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@1.3.15':
-    resolution: {integrity: sha512-ZnDIc9Es8EF94MirPDN+hOMt7tkb8nMEbRJFKLMmNd0ElNPgsql+1cY5SqyGRH1hsKB87KfSUQlhFiKZvzbfIg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@1.3.9':
-    resolution: {integrity: sha512-E0gtYBVt5vRj0zBeplEf8wsVDPDQ6XBdRiFVUgmgwYUYYkXaalaIvbD1ioB8cA05vfz8HrPGXcMrgletUP4ojA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@1.4.11':
-    resolution: {integrity: sha512-1Nc5ZzWqfvE+iJc47qtHFzYYnHsC3awavXrCo74GdGip1vxtksM3G30BlvAQHHVtEmULotWqPbjZpflw/Xk9Ag==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@1.5.8':
-    resolution: {integrity: sha512-N/zXQgzIxME3YUzXT8qnyzxjqcnXudWOeDh8CAG9zqTCnCiy16SFfQ/cQgEoLlD9geQntV6jx2GbDDI5kpDGMQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@1.6.0-beta.1':
-    resolution: {integrity: sha512-/WBzhed0Cu0o9XQ9caGgWwzyNnnPKlENlExa2aGbRCbB14/+CwfhCyETyKlc/ID+dtlV/eHKTC9cckUNI8NpTQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@1.6.8':
-    resolution: {integrity: sha512-cIuhVsZYd3o3Neo1JSAhJYw6BDvlxaBoqvgwRkG1rs0ExFmEmgYyG7ip9pFKnKNWph/tmW3rDYypmEfjs1is7g==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@1.7.9':
     resolution: {integrity: sha512-1g+QyXXvs+838Un/4GaUvJfARDGHMCs15eXDYWBl5m/Skubyng8djWAgr6ag1+cVoJZXCPOvybTItcblWF3gbQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@2.0.0-beta.0':
-    resolution: {integrity: sha512-dx4zgiAT88EQE7kEUpr7Z9EZAwLnO5FhzWzvd/cDK4bkqYsx+rTklgf/c0EYPBeroXCxlGiMsuC9wHAFNK7sFw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@2.0.6':
-    resolution: {integrity: sha512-TxutgzdEX9BkAU/5liKxdQmggJ23INz7EZDWtzSJO6C2SiSYzTJdyPQDIJi1ddkM5TX/drzH184gAJMVOQefng==}
     cpu: [x64]
     os: [win32]
 
@@ -12079,131 +11527,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@0.7.5':
-    resolution: {integrity: sha512-XcdOvaCz1mWWwr5vmEY9zncdInrjINEh60EWkYdqtCA67v7X7rB1fe6n4BeAI1+YLS2Eacj+lytlr+n7I+DYVg==}
-
-  '@rspack/binding@1.0.14':
-    resolution: {integrity: sha512-0wWqFvr9hkF4LgNPgWfkTU0hhkZAMvOytoCs2p+wDX1Up1E/SgJ1U1JAsCxsl1XtUKm7mRvdWHzJmHbza3y89Q==}
-
-  '@rspack/binding@1.3.11':
-    resolution: {integrity: sha512-BbMfZHqfH+CzFtZDg+v9nbKifJIJDUPD6KuoWlHq581koKvD3UMx6oVrj9w13JvO2xWNPeHclmqWAFgoD7faEQ==}
-
-  '@rspack/binding@1.3.15':
-    resolution: {integrity: sha512-utNPuJglLO5lW9XbwIqjB7+2ilMo6JkuVLTVdnNVKU94FW7asn9F/qV+d+MgjUVqU1QPCGm0NuGO9xhbgeJ7pg==}
-
-  '@rspack/binding@1.3.9':
-    resolution: {integrity: sha512-3FFen1/0F2aP5uuCm8vPaJOrzM3karCPNMsc5gLCGfEy2rsK38Qinf9W4p1bw7+FhjOTzoSdkX+LFHeMDVxJhw==}
-
-  '@rspack/binding@1.4.11':
-    resolution: {integrity: sha512-maGl/zRwnl0QVwkBCkgjn5PH20L9HdlRIdkYhEsfTepy5x2QZ0ti/0T49djjTJQrqb+S1i6wWQymMMMMMsxx6Q==}
-
-  '@rspack/binding@1.5.8':
-    resolution: {integrity: sha512-/91CzhRl9r5BIQCgGsS7jA6MDbw1I2BQpbfcUUdkdKl2P79K3Zo/Mw/TvKzS86catwLaUQEgkGRmYawOfPg7ow==}
-
-  '@rspack/binding@1.6.0-beta.1':
-    resolution: {integrity: sha512-r3L60ekkDLM5qoRjCMrqsgwU9SQ5e8oA/Omltu/FEEUspIVHawPvAqNZvAXnGB+FoNxM8YgdRRh12PAwXJww0A==}
-
-  '@rspack/binding@1.6.8':
-    resolution: {integrity: sha512-lUeL4mbwGo+nqRKqFDCm9vH2jv9FNMVt1X8jqayWRcOCPlj/2UVMEFgqjR7Pp2vlvnTKq//31KbDBJmDZq31RQ==}
-
   '@rspack/binding@1.7.9':
     resolution: {integrity: sha512-A56e0NdfNwbOSJoilMkxzaPuVYaKCNn1shuiwWnCIBmhV9ix1n9S1XvquDjkGyv+gCdR1+zfJBOa5DMB7htLHw==}
 
-  '@rspack/binding@2.0.0-beta.0':
-    resolution: {integrity: sha512-L6PPqhwZWC2vzwdhBItNPXw+7V4sq+MBDRXLdd8NMqaJSCB5iKdJIbpbEQucST9Nn7V28IYoQTXs6+ol5vWUBA==}
-
-  '@rspack/binding@2.0.6':
-    resolution: {integrity: sha512-z5EO9mPlmYNpHAlRGub0Chr6D+Klgy+tX36n7tCm7VRGRlwTmTU9wSENrYbHcCpFbegtrE0s30rDeTBeOu+JiQ==}
-
   '@rspack/binding@2.0.8':
     resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
-
-  '@rspack/cli@1.3.9':
-    resolution: {integrity: sha512-jGsde6kP1S7QntU4TYNv8KAHRwe5lb21rRVVj6qGFOQ7pckxWadyYyowo6Qg43OYlPAc9ZlDlba3Zg3gQoD73g==}
-    hasBin: true
-    peerDependencies:
-      '@rspack/core': ^1.0.0-alpha || ^1.x
-
-  '@rspack/core@0.7.5':
-    resolution: {integrity: sha512-zVTe4WCyc3qsLPattosiDYZFeOzaJ32/BYukPP2I1VJtCVFa+PxGVRPVZhSoN6fXw5oy48yHg9W9v1T8CaEFhw==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@1.0.14':
-    resolution: {integrity: sha512-xHl23lxJZNjItGc5YuE9alz3yjb56y7EgJmAcBMPHMqgjtUt8rBu4xd/cSUjbr9/lLF9N4hdyoJiPJOFs9LEjw==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@1.3.11':
-    resolution: {integrity: sha512-aSYPtT1gum5MCfcFANdTroJ4JwzozuL3wX0twMGNAB7amq6+nZrbsUKWjcHgneCeZdahxzrKdyYef3FHaJ7lEA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@1.3.15':
-    resolution: {integrity: sha512-QuElIC8jXSKWAp0LSx18pmbhA7NiA5HGoVYesmai90UVxz98tud0KpMxTVCg+0lrLrnKZfCWN9kwjCxM5pGnrA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@1.3.9':
-    resolution: {integrity: sha512-u7usd9srCBPBfNJCSvsfh14AOPq6LCVna0Vb/aA2nyJTawHqzfAMz1QRb/e27nP3NrV6RPiwx03W494Dd6r6wg==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@1.4.11':
-    resolution: {integrity: sha512-JtKnL6p7Kc/YgWQJF3Woo4OccbgKGyT/4187W4dyex8BMkdQcbqCNIdi6dFk02hwQzxpOOxRSBI4hlGRbz7oYQ==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@1.5.8':
-    resolution: {integrity: sha512-sUd2LfiDhqYVfvknuoz0+/c+wSpn693xotnG5g1CSWKZArbtwiYzBIVnNlcHGmuoBRsnj/TkSq8dTQ7gwfBroQ==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@1.6.0-beta.1':
-    resolution: {integrity: sha512-2ff8XWonPPHyQ6mEWogMspg+Sul3lXZUfNQVrbYSjfNpi8CeDV0/ZtRbHHbAXiy6pz5fvBFL6X+i/ATckjTYBw==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@1.6.8':
-    resolution: {integrity: sha512-FolcIAH5FW4J2FET+qwjd1kNeFbCkd0VLuIHO0thyolEjaPSxw5qxG67DA7BZGm6PVcoiSgPLks1DL6eZ8c+fA==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
 
   '@rspack/core@1.7.9':
     resolution: {integrity: sha512-VHuSKvRkuv42Ya+TxEGO0LE0r9+8P4tKGokmomj4R1f/Nu2vtS3yoaIMfC4fR6VuHGd3MZ+KTI0cNNwHfFcskw==}
@@ -12211,30 +11539,6 @@ packages:
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
     peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@2.0.0-beta.0':
-    resolution: {integrity: sha512-aEqlQQjiXixT5i9S4DFtiAap8ZjF6pOgfY2ALHOizins/QqWyB8dyLxSoXdzt7JixmKcFmHkbL9XahO28BlVUA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': '>=0.22.0'
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@2.0.6':
-    resolution: {integrity: sha512-ronRqH1T2dYdMFVOQbGvDNxYaLugQK8qhNYYtS2DbOvPKQYvdIYWDenL9k/WV+hLoknnPWMn2ME2cKJcK3Po+g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': ^0.5.23
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
       '@swc/helpers':
         optional: true
 
@@ -13184,6 +12488,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
@@ -16629,9 +15936,6 @@ packages:
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
-  debounce@1.2.1:
-    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
-
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -17822,10 +17126,6 @@ packages:
     resolution: {integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==}
     engines: {node: '>=4'}
 
-  exit-hook@4.0.0:
-    resolution: {integrity: sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ==}
-    engines: {node: '>=18'}
-
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
@@ -18596,10 +17896,6 @@ packages:
   gunzip-maybe@1.4.2:
     resolution: {integrity: sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==}
     hasBin: true
-
-  gzip-size@6.0.0:
-    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
-    engines: {node: '>=10'}
 
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
@@ -26619,11 +25915,6 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
-  webpack-bundle-analyzer@4.10.2:
-    resolution: {integrity: sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==}
-    engines: {node: '>= 10.13.0'}
-    hasBin: true
-
   webpack-cli@5.1.4:
     resolution: {integrity: sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==}
     engines: {node: '>=14.15.0'}
@@ -26695,10 +25986,6 @@ packages:
   webpack-node-externals@3.0.0:
     resolution: {integrity: sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==}
     engines: {node: '>=6'}
-
-  webpack-sources@3.2.3:
-    resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
-    engines: {node: '>=10.13.0'}
 
   webpack-sources@3.3.4:
     resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
@@ -29616,9 +28903,9 @@ snapshots:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
 
-  '@emnapi/core@1.9.0':
+  '@emnapi/core@1.11.1':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
@@ -29626,12 +28913,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@emnapi/runtime@1.9.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -29639,6 +28921,11 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -30576,7 +29863,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -31327,13 +30614,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modern-js-app/eslint-config@2.59.0(typescript@5.0.4)':
+  '@modern-js-app/eslint-config@2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@8.57.1)
       '@babel/eslint-plugin': 7.27.1(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@8.57.1))(eslint@8.57.1)
-      '@modern-js/babel-preset': 2.59.0(@rsbuild/core@1.0.1-rc.4)
-      '@rsbuild/core': 1.0.1-rc.4
+      '@modern-js/babel-preset': 2.59.0(@rsbuild/core@1.0.1-rc.4(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/core': 1.0.1-rc.4(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.0.4))(eslint@8.57.1)(typescript@5.0.4)
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.0.4)
       eslint: 8.57.1
@@ -31349,17 +30636,18 @@ snapshots:
       prettier: 2.8.8
       typescript: 5.0.4
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  '@modern-js-app/eslint-config@2.59.0(typescript@5.9.3)':
+  '@modern-js-app/eslint-config@2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/eslint-parser': 7.28.6(@babel/core@7.29.7)(eslint@8.57.1)
       '@babel/eslint-plugin': 7.27.1(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@8.57.1))(eslint@8.57.1)
-      '@modern-js/babel-preset': 2.59.0(@rsbuild/core@1.0.1-rc.4)
-      '@rsbuild/core': 1.0.1-rc.4
+      '@modern-js/babel-preset': 2.59.0(@rsbuild/core@1.0.1-rc.4(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/core': 1.0.1-rc.4(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
@@ -31375,6 +30663,7 @@ snapshots:
       prettier: 2.8.8
       typescript: 5.9.3
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
@@ -31425,7 +30714,7 @@ snapshots:
       '@swc/helpers': 0.5.1
       redux: 4.2.1
 
-  '@modern-js/app-tools@2.70.5(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.10(@swc/helpers@0.5.17))(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/app-tools@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.10(@swc/helpers@0.5.17))(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
@@ -31435,17 +30724,17 @@ snapshots:
       '@modern-js/plugin': 2.70.5
       '@modern-js/plugin-data-loader': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/plugin-i18n': 2.70.5
-      '@modern-js/plugin-v2': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@modern-js/prod-server': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modern-js/plugin-v2': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modern-js/prod-server': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/rsbuild-plugin-esbuild': 2.70.5(@swc/core@1.15.10(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
-      '@modern-js/server': 2.70.5(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)
-      '@modern-js/server-core': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@modern-js/server-utils': 2.70.5(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3)
+      '@modern-js/server': 2.70.5(@babel/traverse@7.29.0)(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)
+      '@modern-js/server-core': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modern-js/server-utils': 2.70.5(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@modern-js/types': 2.70.5
-      '@modern-js/uni-builder': 2.70.5(@rspack/core@1.7.9(@swc/helpers@0.5.17))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
+      '@modern-js/uni-builder': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
       '@modern-js/utils': 2.70.5
-      '@rsbuild/core': 1.7.3
-      '@rsbuild/plugin-node-polyfill': 1.4.3(@rsbuild/core@1.7.3)
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
+      '@rsbuild/plugin-node-polyfill': 1.4.3(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@swc/helpers': 0.5.17
       es-module-lexer: 1.5.3
       esbuild: 0.25.5
@@ -31459,6 +30748,7 @@ snapshots:
       ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3)
       tsconfig-paths: 4.2.0
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@parcel/css'
       - '@rspack/core'
       - '@swc/core'
@@ -31487,7 +30777,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/app-tools@2.70.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.10(@swc/helpers@0.5.19))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/app-tools@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.10(@swc/helpers@0.5.19))(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
@@ -31497,17 +30787,17 @@ snapshots:
       '@modern-js/plugin': 2.70.8
       '@modern-js/plugin-data-loader': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/plugin-i18n': 2.70.8
-      '@modern-js/plugin-v2': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@modern-js/prod-server': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@modern-js/plugin-v2': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@modern-js/prod-server': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/rsbuild-plugin-esbuild': 2.70.8(@swc/core@1.15.10(@swc/helpers@0.5.19))(webpack-cli@5.1.4)
-      '@modern-js/server': 2.70.8(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)
-      '@modern-js/server-core': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@modern-js/server-utils': 2.70.8(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3)
+      '@modern-js/server': 2.70.8(@babel/traverse@7.29.0)(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)
+      '@modern-js/server-core': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@modern-js/server-utils': 2.70.8(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@modern-js/types': 2.70.8
-      '@modern-js/uni-builder': 2.70.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
+      '@modern-js/uni-builder': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
       '@modern-js/utils': 2.70.8
-      '@rsbuild/core': 1.7.3
-      '@rsbuild/plugin-node-polyfill': 1.4.4(@rsbuild/core@1.7.3)
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+      '@rsbuild/plugin-node-polyfill': 1.4.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@swc/helpers': 0.5.19
       es-module-lexer: 1.7.0
       esbuild: 0.25.5
@@ -31521,6 +30811,7 @@ snapshots:
       ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3)
       tsconfig-paths: 4.2.0
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@parcel/css'
       - '@rspack/core'
       - '@swc/core'
@@ -31549,12 +30840,12 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
       '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31600,12 +30891,12 @@ snapshots:
       - webpack
       - webpack-hot-middleware
 
-  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.8.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@3.14.2)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31651,12 +30942,12 @@ snapshots:
       - webpack
       - webpack-hot-middleware
 
-  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
       '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31702,22 +30993,22 @@ snapshots:
       - webpack
       - webpack-hot-middleware
 
-  '@modern-js/app-tools@3.0.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+  '@modern-js/app-tools@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(core-js@3.49.0)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@modern-js/builder': 3.0.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      '@modern-js/builder': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
       '@modern-js/i18n-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/plugin': 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/prod-server': 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/server': 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)
-      '@modern-js/server-core': 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/prod-server': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/server': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)
+      '@modern-js/server-core': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/server-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/types': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
+      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
       '@swc/helpers': 0.5.17
       es-module-lexer: 1.7.0
       esbuild: 0.25.5
@@ -31801,7 +31092,7 @@ snapshots:
       reselect: 4.1.8
       resolve: 1.22.11
 
-  '@modern-js/babel-preset@2.59.0(@rsbuild/core@1.0.1-rc.4)':
+  '@modern-js/babel-preset@2.59.0(@rsbuild/core@1.0.1-rc.4(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -31813,7 +31104,7 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.28.2
       '@babel/types': 7.29.0
-      '@rsbuild/plugin-babel': 1.0.1-rc.4(@rsbuild/core@1.0.1-rc.4)
+      '@rsbuild/plugin-babel': 1.0.1-rc.4(@rsbuild/core@1.0.1-rc.4(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@swc/helpers': 0.5.3
       '@types/babel__core': 7.20.5
       babel-plugin-dynamic-import-node: 2.3.3
@@ -31843,7 +31134,7 @@ snapshots:
       - '@rsbuild/core'
       - supports-color
 
-  '@modern-js/babel-preset@2.70.5(@rsbuild/core@1.7.3)':
+  '@modern-js/babel-preset@2.70.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -31855,7 +31146,7 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.28.2
       '@babel/types': 7.29.7
-      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3)
+      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@swc/helpers': 0.5.17
       '@types/babel__core': 7.20.5
       babel-plugin-dynamic-import-node: 2.3.3
@@ -31864,7 +31155,7 @@ snapshots:
       - '@rsbuild/core'
       - supports-color
 
-  '@modern-js/babel-preset@2.70.8(@rsbuild/core@1.7.3)':
+  '@modern-js/babel-preset@2.70.8(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -31876,7 +31167,7 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.28.2
       '@babel/types': 7.29.7
-      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3)
+      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@swc/helpers': 0.5.17
       '@types/babel__core': 7.20.5
       babel-plugin-dynamic-import-node: 2.3.3
@@ -31885,7 +31176,7 @@ snapshots:
       - '@rsbuild/core'
       - supports-color
 
-  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))':
     dependencies:
       '@modern-js/flight-server-transform-plugin': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31899,7 +31190,7 @@ snapshots:
       '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))
       '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))
       '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(typescript@5.9.3)(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)
+      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)
       '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))
       '@swc/core': 1.15.10(@swc/helpers@0.5.17)
       '@swc/helpers': 0.5.17
@@ -31917,7 +31208,7 @@ snapshots:
       postcss-media-minmax: 5.0.0(postcss@8.5.10)
       postcss-nesting: 12.1.5(postcss@8.5.10)
       postcss-page-break: 3.0.4(postcss@8.5.10)
-      rspack-manifest-plugin: 5.2.1(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))
+      rspack-manifest-plugin: 5.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))
       ts-deepmerge: 7.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -31936,7 +31227,7 @@ snapshots:
       - webpack
       - webpack-hot-middleware
 
-  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
     dependencies:
       '@modern-js/flight-server-transform-plugin': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31950,7 +31241,7 @@ snapshots:
       '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(typescript@5.0.4)(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)
+      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)
       '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@swc/core': 1.15.10(@swc/helpers@0.5.17)
       '@swc/helpers': 0.5.17
@@ -31968,7 +31259,7 @@ snapshots:
       postcss-media-minmax: 5.0.0(postcss@8.5.10)
       postcss-nesting: 12.1.5(postcss@8.5.10)
       postcss-page-break: 3.0.4(postcss@8.5.10)
-      rspack-manifest-plugin: 5.2.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))
+      rspack-manifest-plugin: 5.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))
       ts-deepmerge: 7.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -31987,22 +31278,22 @@ snapshots:
       - webpack
       - webpack-hot-middleware
 
-  '@modern-js/builder@3.0.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+  '@modern-js/builder@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))':
     dependencies:
       '@modern-js/flight-server-transform-plugin': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
-      '@rsbuild/plugin-assets-retry': 1.5.1(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
-      '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))
-      '@rsbuild/plugin-react': 1.4.4(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))
-      '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))
-      '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))
-      '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))(typescript@5.0.4)(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)
-      '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))
+      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
+      '@rsbuild/plugin-assets-retry': 1.5.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
+      '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
+      '@rsbuild/plugin-react': 1.4.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(webpack-hot-middleware@2.26.1)
+      '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
+      '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
+      '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
+      '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(typescript@5.0.4)(webpack-hot-middleware@2.26.1)
+      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)
+      '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))
       '@swc/core': 1.15.10(@swc/helpers@0.5.17)
       '@swc/helpers': 0.5.17
       autoprefixer: 10.4.24(postcss@8.5.10)
@@ -32019,7 +31310,7 @@ snapshots:
       postcss-media-minmax: 5.0.0(postcss@8.5.10)
       postcss-nesting: 12.1.5(postcss@8.5.10)
       postcss-page-break: 3.0.4(postcss@8.5.10)
-      rspack-manifest-plugin: 5.2.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))
+      rspack-manifest-plugin: 5.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))
       ts-deepmerge: 7.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -32052,19 +31343,21 @@ snapshots:
       '@modern-js/utils': 2.70.8
       '@swc/helpers': 0.5.17
 
-  '@modern-js/eslint-config@2.59.0(typescript@5.0.4)':
+  '@modern-js/eslint-config@2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)':
     dependencies:
-      '@modern-js-app/eslint-config': 2.59.0(typescript@5.0.4)
+      '@modern-js-app/eslint-config': 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.0.4)
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
       - typescript
 
-  '@modern-js/eslint-config@2.59.0(typescript@5.9.3)':
+  '@modern-js/eslint-config@2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)':
     dependencies:
-      '@modern-js-app/eslint-config': 2.59.0(typescript@5.9.3)
+      '@modern-js-app/eslint-config': 2.59.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
@@ -32253,7 +31546,7 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@modern-js/plugin-state@2.70.8(@modern-js/runtime@2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@modern-js/plugin-state@2.70.8(@modern-js/runtime@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@modern-js-reduck/plugin-auto-actions': 1.1.13(@modern-js-reduck/store@1.1.13)
       '@modern-js-reduck/plugin-devtools': 1.1.13(@modern-js-reduck/store@1.1.13)
@@ -32261,7 +31554,7 @@ snapshots:
       '@modern-js-reduck/plugin-immutable': 1.1.13(@modern-js-reduck/store@1.1.13)
       '@modern-js-reduck/react': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js-reduck/store': 1.1.13
-      '@modern-js/runtime': 2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
+      '@modern-js/runtime': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
       '@modern-js/runtime-utils': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/types': 2.70.8
       '@modern-js/utils': 2.70.8
@@ -32272,27 +31565,29 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@modern-js/plugin-v2@2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@modern-js/plugin-v2@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@modern-js/runtime-utils': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/types': 2.70.5
       '@modern-js/utils': 2.70.5
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
       '@swc/helpers': 0.5.17
       jiti: 1.21.7
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - react
       - react-dom
 
-  '@modern-js/plugin-v2@2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@modern-js/plugin-v2@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@modern-js/runtime-utils': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/types': 2.70.8
       '@modern-js/utils': 2.70.8
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@swc/helpers': 0.5.17
       jiti: 1.21.7
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - react
       - react-dom
 
@@ -32334,37 +31629,25 @@ snapshots:
       - react
       - react-dom
 
-  '@modern-js/plugin@3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/types': 3.0.1
-      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
-      '@swc/helpers': 0.5.17
-      jiti: 2.6.1
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - core-js
-      - react
-      - react-dom
-
-  '@modern-js/prod-server@2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@modern-js/prod-server@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@modern-js/runtime-utils': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@modern-js/server-core': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modern-js/server-core': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/utils': 2.70.5
       '@swc/helpers': 0.5.17
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - react
       - react-dom
 
-  '@modern-js/prod-server@2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@modern-js/prod-server@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@modern-js/runtime-utils': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@modern-js/server-core': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@modern-js/server-core': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/utils': 2.70.8
       '@swc/helpers': 0.5.17
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - react
       - react-dom
 
@@ -32384,18 +31667,6 @@ snapshots:
     dependencies:
       '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/server-core': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@swc/helpers': 0.5.17
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - core-js
-      - react
-      - react-dom
-
-  '@modern-js/prod-server@3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/server-core': 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.17
     transitivePeerDependencies:
@@ -32439,6 +31710,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-server-dom-webpack: 19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+
+  '@modern-js/render@3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)))(react@18.3.1)':
+    dependencies:
+      '@modern-js/types': 3.0.1
+      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@swc/helpers': 0.5.17
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-server-dom-webpack: 19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
 
   '@modern-js/rsbuild-plugin-esbuild@2.70.5(@swc/core@1.15.10(@swc/helpers@0.5.17))(webpack-cli@5.1.4)':
     dependencies:
@@ -32511,7 +31791,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@modern-js/runtime@2.70.5(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@19.2.7)':
+  '@modern-js/runtime@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@19.2.7)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/types': 7.29.0
@@ -32520,7 +31800,7 @@ snapshots:
       '@loadable/server': 5.15.3(@loadable/component@5.15.3(react@19.2.7))(react@19.2.7)
       '@modern-js/plugin': 2.70.5
       '@modern-js/plugin-data-loader': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@modern-js/plugin-v2': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modern-js/plugin-v2': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/render': 2.70.5(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(react@19.2.7)
       '@modern-js/runtime-utils': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/types': 2.70.5
@@ -32540,10 +31820,11 @@ snapshots:
       react-side-effect: 2.1.2(react@19.2.7)
       styled-components: 5.3.11(@babel/core@7.29.0)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - react-server-dom-webpack
       - supports-color
 
-  '@modern-js/runtime@2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)':
+  '@modern-js/runtime@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/types': 7.29.0
@@ -32552,7 +31833,7 @@ snapshots:
       '@loadable/server': 5.15.3(@loadable/component@5.15.3(react@19.2.4))(react@19.2.4)
       '@modern-js/plugin': 2.70.8
       '@modern-js/plugin-data-loader': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@modern-js/plugin-v2': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@modern-js/plugin-v2': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/render': 2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
       '@modern-js/runtime-utils': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/types': 2.70.8
@@ -32572,6 +31853,7 @@ snapshots:
       react-side-effect: 2.1.2(react@19.2.4)
       styled-components: 5.3.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - react-server-dom-webpack
       - supports-color
 
@@ -32633,13 +31915,13 @@ snapshots:
       - core-js
       - react-server-dom-webpack
 
-  '@modern-js/runtime@3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)':
+  '@modern-js/runtime@3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)))(react@18.3.1)':
     dependencies:
       '@loadable/component': 5.16.7(react@18.3.1)
       '@loadable/server': 5.16.7(@loadable/component@5.16.7(react@18.3.1))(react@18.3.1)
-      '@modern-js/plugin': 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modern-js/plugin': 3.0.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/plugin-data-loader': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/render': 3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))))(react@18.3.1)
+      '@modern-js/render': 3.0.1(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)))(react@18.3.1)
       '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modern-js/types': 3.0.1
       '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -32662,10 +31944,10 @@ snapshots:
       - core-js
       - react-server-dom-webpack
 
-  '@modern-js/server-core@2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@modern-js/server-core@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@modern-js/plugin': 2.70.5
-      '@modern-js/plugin-v2': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modern-js/plugin-v2': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/runtime-utils': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modern-js/utils': 2.70.5
       '@swc/helpers': 0.5.17
@@ -32677,13 +31959,14 @@ snapshots:
       hono: 3.12.12
       ts-deepmerge: 7.0.2
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - react
       - react-dom
 
-  '@modern-js/server-core@2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@modern-js/server-core@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@modern-js/plugin': 2.70.8
-      '@modern-js/plugin-v2': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@modern-js/plugin-v2': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/runtime-utils': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modern-js/utils': 2.70.8
       '@swc/helpers': 0.5.17
@@ -32695,6 +31978,7 @@ snapshots:
       hono: 3.12.12
       ts-deepmerge: 7.0.2
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - react
       - react-dom
 
@@ -32736,31 +32020,13 @@ snapshots:
       - react
       - react-dom
 
-  '@modern-js/server-core@3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@modern-js/plugin': 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@swc/helpers': 0.5.17
-      '@web-std/fetch': 4.2.1
-      '@web-std/file': 3.0.3
-      '@web-std/stream': 1.0.3
-      cloneable-readable: 3.0.0
-      flatted: 3.4.2
-      hono: 4.12.25
-      ts-deepmerge: 7.0.3
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - core-js
-      - react
-      - react-dom
-
-  '@modern-js/server-runtime@2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@modern-js/server-runtime@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@modern-js/runtime-utils': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@modern-js/server-core': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modern-js/server-core': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@swc/helpers': 0.5.17
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - react
       - react-dom
 
@@ -32806,7 +32072,7 @@ snapshots:
       - '@rsbuild/core'
       - supports-color
 
-  '@modern-js/server-utils@2.70.5(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3)':
+  '@modern-js/server-utils@2.70.5(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -32815,7 +32081,7 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@modern-js/babel-compiler': 2.70.5
       '@modern-js/babel-plugin-module-resolver': 2.70.5
-      '@modern-js/babel-preset': 2.70.5(@rsbuild/core@1.7.3)
+      '@modern-js/babel-preset': 2.70.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@modern-js/utils': 2.70.5
       '@swc/helpers': 0.5.17
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.29.0)(@babel/traverse@7.29.0)
@@ -32824,7 +32090,7 @@ snapshots:
       - '@rsbuild/core'
       - supports-color
 
-  '@modern-js/server-utils@2.70.8(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3)':
+  '@modern-js/server-utils@2.70.8(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -32833,7 +32099,7 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@modern-js/babel-compiler': 2.70.8
       '@modern-js/babel-plugin-module-resolver': 2.70.8
-      '@modern-js/babel-preset': 2.70.8(@rsbuild/core@1.7.3)
+      '@modern-js/babel-preset': 2.70.8(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@modern-js/utils': 2.70.8
       '@swc/helpers': 0.5.17
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.29.0)(@babel/traverse@7.29.0)
@@ -32850,13 +32116,13 @@ snapshots:
       - react
       - react-dom
 
-  '@modern-js/server@2.70.5(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)':
+  '@modern-js/server@2.70.5(@babel/traverse@7.29.0)(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.17))(@types/node@26.0.0)(typescript@5.9.3))(tsconfig-paths@4.2.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/register': 7.28.6(@babel/core@7.29.0)
       '@modern-js/runtime-utils': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@modern-js/server-core': 2.70.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@modern-js/server-utils': 2.70.5(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3)
+      '@modern-js/server-core': 2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modern-js/server-utils': 2.70.5(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@modern-js/types': 2.70.5
       '@modern-js/utils': 2.70.5
       '@swc/helpers': 0.5.17
@@ -32871,6 +32137,7 @@ snapshots:
       tsconfig-paths: 4.2.0
     transitivePeerDependencies:
       - '@babel/traverse'
+      - '@module-federation/runtime-tools'
       - '@rsbuild/core'
       - bufferutil
       - debug
@@ -32879,13 +32146,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modern-js/server@2.70.8(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)':
+  '@modern-js/server@2.70.8(@babel/traverse@7.29.0)(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.19))(@types/node@20.19.5)(typescript@5.9.3))(tsconfig-paths@4.2.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/register': 7.28.6(@babel/core@7.29.0)
       '@modern-js/runtime-utils': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@modern-js/server-core': 2.70.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@modern-js/server-utils': 2.70.8(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3)
+      '@modern-js/server-core': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@modern-js/server-utils': 2.70.8(@babel/traverse@7.29.0)(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@modern-js/types': 2.70.8
       '@modern-js/utils': 2.70.8
       '@swc/helpers': 0.5.17
@@ -32900,6 +32167,7 @@ snapshots:
       tsconfig-paths: 4.2.0
     transitivePeerDependencies:
       - '@babel/traverse'
+      - '@module-federation/runtime-tools'
       - '@rsbuild/core'
       - bufferutil
       - debug
@@ -32989,41 +32257,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modern-js/server@3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4))(tsconfig-paths@4.2.0)':
-    dependencies:
-      '@modern-js/runtime-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/server-core': 3.0.1(core-js@3.49.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/server-utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modern-js/types': 3.0.1
-      '@modern-js/utils': 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@swc/helpers': 0.5.17
-      axios: 1.16.1
-      connect-history-api-fallback: 2.0.0
-      http-compression: 1.0.6
-      minimatch: 3.1.5
-      path-to-regexp: 6.3.0
-      ws: 8.21.0
-    optionalDependencies:
-      ts-node: 10.9.2(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/node@20.19.5)(typescript@5.0.4)
-      tsconfig-paths: 4.2.0
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - bufferutil
-      - core-js
-      - debug
-      - react
-      - react-dom
-      - supports-color
-      - utf-8-validate
-
-  '@modern-js/storybook-builder@2.70.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
+  '@modern-js/storybook-builder@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
     dependencies:
       '@modern-js/core': 2.70.8
-      '@modern-js/plugin-state': 2.70.8(@modern-js/runtime@2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@modern-js/runtime': 2.70.8(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
-      '@modern-js/uni-builder': 2.70.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.18.20)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
+      '@modern-js/plugin-state': 2.70.8(@modern-js/runtime@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@modern-js/runtime': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)
+      '@modern-js/uni-builder': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.18.20)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)
       '@modern-js/utils': 2.70.8
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@storybook/components': 7.6.24(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/core-common': 7.6.24(encoding@0.1.13)
       '@storybook/csf-plugin': 7.6.24
@@ -33043,6 +32284,7 @@ snapshots:
       serve-static: 1.16.3
       tinypool: 0.8.4
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@parcel/css'
       - '@rspack/core'
       - '@swc/css'
@@ -33070,13 +32312,14 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/storybook@2.70.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
+  '@modern-js/storybook@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
     dependencies:
-      '@modern-js/storybook-builder': 2.70.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      '@modern-js/storybook-builder': 2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(react@19.2.4)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
       '@modern-js/utils': 2.70.8
       '@storybook/react': 7.6.24(encoding@0.1.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       storybook: 7.6.24(encoding@0.1.13)
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@parcel/css'
       - '@rspack/core'
       - '@swc/css'
@@ -33168,33 +32411,33 @@ snapshots:
 
   '@modern-js/types@3.0.1': {}
 
-  '@modern-js/uni-builder@2.70.5(@rspack/core@1.7.9(@swc/helpers@0.5.17))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/uni-builder@2.70.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/types': 7.29.0
-      '@modern-js/babel-preset': 2.70.5(@rsbuild/core@1.7.3)
+      '@modern-js/babel-preset': 2.70.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
       '@modern-js/flight-server-transform-plugin': 2.70.5
       '@modern-js/utils': 2.70.5
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      '@rsbuild/core': 1.7.3
-      '@rsbuild/plugin-assets-retry': 1.5.2(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3)(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-pug': 1.3.2(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-styled-components': 1.6.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@1.7.3)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-toml': 1.1.2(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@1.7.3)(@rspack/core@1.7.9(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)
-      '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-yaml': 1.0.4(@rsbuild/core@1.7.3)
-      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3)(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
+      '@rsbuild/plugin-assets-retry': 1.5.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/plugin-pug': 1.3.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(webpack-hot-middleware@2.26.1)
+      '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/plugin-styled-components': 1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(typescript@5.9.3)(webpack-hot-middleware@2.26.1)
+      '@rsbuild/plugin-toml': 1.1.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)
+      '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/plugin-yaml': 1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))
+      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
       '@swc/core': 1.15.8(@swc/helpers@0.5.17)
       '@swc/helpers': 0.5.17
       autoprefixer: 10.4.23(postcss@8.5.10)
@@ -33228,6 +32471,7 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
       webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@parcel/css'
       - '@rspack/core'
       - '@swc/css'
@@ -33248,33 +32492,33 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/uni-builder@2.70.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.18.20)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/uni-builder@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.18.20)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/types': 7.29.0
-      '@modern-js/babel-preset': 2.70.8(@rsbuild/core@1.7.3)
+      '@modern-js/babel-preset': 2.70.8(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@modern-js/flight-server-transform-plugin': 2.70.8
       '@modern-js/utils': 2.70.8
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      '@rsbuild/core': 1.7.3
-      '@rsbuild/plugin-assets-retry': 1.5.2(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3)(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-pug': 1.3.2(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-styled-components': 1.6.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@1.7.3)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-toml': 1.1.2(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@1.7.3)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(tslib@2.8.1)(typescript@5.9.3)
-      '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-yaml': 1.0.4(@rsbuild/core@1.7.3)
-      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4)
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+      '@rsbuild/plugin-assets-retry': 1.5.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-pug': 1.3.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
+      '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-styled-components': 1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(typescript@5.9.3)(webpack-hot-middleware@2.26.1)
+      '@rsbuild/plugin-toml': 1.1.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(tslib@2.8.1)(typescript@5.9.3)
+      '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-yaml': 1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4)
       '@swc/core': 1.15.8(@swc/helpers@0.5.17)
       '@swc/helpers': 0.5.17
       autoprefixer: 10.4.23(postcss@8.5.10)
@@ -33308,6 +32552,7 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@parcel/css'
       - '@rspack/core'
       - '@swc/css'
@@ -33328,33 +32573,33 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/uni-builder@2.70.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/uni-builder@2.70.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(esbuild@0.25.5)(styled-components@6.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/types': 7.29.0
-      '@modern-js/babel-preset': 2.70.8(@rsbuild/core@1.7.3)
+      '@modern-js/babel-preset': 2.70.8(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
       '@modern-js/flight-server-transform-plugin': 2.70.8
       '@modern-js/utils': 2.70.8
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      '@rsbuild/core': 1.7.3
-      '@rsbuild/plugin-assets-retry': 1.5.2(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3)(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-pug': 1.3.2(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-styled-components': 1.6.0(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@1.7.3)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)
-      '@rsbuild/plugin-toml': 1.1.2(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@1.7.3)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(tslib@2.8.1)(typescript@5.9.3)
-      '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@1.7.3)
-      '@rsbuild/plugin-yaml': 1.0.4(@rsbuild/core@1.7.3)
-      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+      '@rsbuild/plugin-assets-retry': 1.5.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-pug': 1.3.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
+      '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-styled-components': 1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-svgr': 1.3.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(typescript@5.9.3)(webpack-hot-middleware@2.26.1)
+      '@rsbuild/plugin-toml': 1.1.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(tslib@2.8.1)(typescript@5.9.3)
+      '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/plugin-yaml': 1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))
+      '@rsbuild/webpack': 1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
       '@swc/core': 1.15.8(@swc/helpers@0.5.17)
       '@swc/helpers': 0.5.17
       autoprefixer: 10.4.23(postcss@8.5.10)
@@ -33388,6 +32633,7 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)
       webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@parcel/css'
       - '@rspack/core'
       - '@swc/css'
@@ -33559,7 +32805,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.21.6(@rspack/core@1.6.8(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@module-federation/enhanced@0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.21.6
       '@module-federation/cli': 0.21.6(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
@@ -33569,7 +32815,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.21.6(@module-federation/runtime-tools@0.21.6)
       '@module-federation/managers': 0.21.6
       '@module-federation/manifest': 0.21.6(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
-      '@module-federation/rspack': 0.21.6(@rspack/core@1.6.8(@swc/helpers@0.5.23))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
+      '@module-federation/rspack': 0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       '@module-federation/runtime-tools': 0.21.6
       '@module-federation/sdk': 0.21.6
       btoa: 1.2.1
@@ -33588,7 +32834,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.2.2(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@module-federation/enhanced@2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/cli': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
@@ -33598,7 +32844,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.2.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))
       '@module-federation/managers': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/manifest': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
-      '@module-federation/rspack': 2.2.2(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
+      '@module-federation/rspack': 2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/webpack-bundler-runtime': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
@@ -33620,19 +32866,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/error-codes@0.13.1': {}
-
-  '@module-federation/error-codes@0.14.3': {}
-
-  '@module-federation/error-codes@0.17.1': {}
-
-  '@module-federation/error-codes@0.18.0': {}
-
-  '@module-federation/error-codes@0.21.1': {}
-
   '@module-federation/error-codes@0.21.6': {}
 
-  '@module-federation/error-codes@0.22.0': {}
+  '@module-federation/error-codes@0.22.0':
+    optional: true
 
   '@module-federation/error-codes@2.2.2': {}
 
@@ -33692,9 +32929,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.36(@rspack/core@1.6.8(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@module-federation/node@2.7.36(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))':
     dependencies:
-      '@module-federation/enhanced': 2.2.2(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@module-federation/enhanced': 2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
       '@module-federation/runtime': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       btoa: 1.2.1
@@ -33714,7 +32951,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rspack@0.21.6(@rspack/core@1.6.8(@swc/helpers@0.5.23))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))':
+  '@module-federation/rspack@0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.21.6
       '@module-federation/dts-plugin': 0.21.6(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
@@ -33723,7 +32960,7 @@ snapshots:
       '@module-federation/manifest': 0.21.6(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       '@module-federation/runtime-tools': 0.21.6
       '@module-federation/sdk': 0.21.6
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.3
@@ -33734,7 +32971,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.2.2(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))':
+  '@module-federation/rspack@2.2.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/dts-plugin': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
@@ -33743,7 +32980,7 @@ snapshots:
       '@module-federation/manifest': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.3
@@ -33755,31 +32992,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/runtime-core@0.13.1':
-    dependencies:
-      '@module-federation/error-codes': 0.13.1
-      '@module-federation/sdk': 0.13.1
-
-  '@module-federation/runtime-core@0.14.3':
-    dependencies:
-      '@module-federation/error-codes': 0.14.3
-      '@module-federation/sdk': 0.14.3
-
-  '@module-federation/runtime-core@0.17.1':
-    dependencies:
-      '@module-federation/error-codes': 0.17.1
-      '@module-federation/sdk': 0.17.1
-
-  '@module-federation/runtime-core@0.18.0':
-    dependencies:
-      '@module-federation/error-codes': 0.18.0
-      '@module-federation/sdk': 0.18.0
-
-  '@module-federation/runtime-core@0.21.1':
-    dependencies:
-      '@module-federation/error-codes': 0.21.1
-      '@module-federation/sdk': 0.21.1
-
   '@module-federation/runtime-core@0.21.6':
     dependencies:
       '@module-federation/error-codes': 0.21.6
@@ -33789,6 +33001,7 @@ snapshots:
     dependencies:
       '@module-federation/error-codes': 0.22.0
       '@module-federation/sdk': 0.22.0
+    optional: true
 
   '@module-federation/runtime-core@2.2.2(node-fetch@2.7.0(encoding@0.1.13))':
     dependencies:
@@ -33813,36 +33026,6 @@ snapshots:
       - node-fetch
     optional: true
 
-  '@module-federation/runtime-tools@0.1.6':
-    dependencies:
-      '@module-federation/runtime': 0.1.6
-      '@module-federation/webpack-bundler-runtime': 0.1.6
-
-  '@module-federation/runtime-tools@0.13.1':
-    dependencies:
-      '@module-federation/runtime': 0.13.1
-      '@module-federation/webpack-bundler-runtime': 0.13.1
-
-  '@module-federation/runtime-tools@0.14.3':
-    dependencies:
-      '@module-federation/runtime': 0.14.3
-      '@module-federation/webpack-bundler-runtime': 0.14.3
-
-  '@module-federation/runtime-tools@0.17.1':
-    dependencies:
-      '@module-federation/runtime': 0.17.1
-      '@module-federation/webpack-bundler-runtime': 0.17.1
-
-  '@module-federation/runtime-tools@0.18.0':
-    dependencies:
-      '@module-federation/runtime': 0.18.0
-      '@module-federation/webpack-bundler-runtime': 0.18.0
-
-  '@module-federation/runtime-tools@0.21.1':
-    dependencies:
-      '@module-federation/runtime': 0.21.1
-      '@module-federation/webpack-bundler-runtime': 0.21.1
-
   '@module-federation/runtime-tools@0.21.6':
     dependencies:
       '@module-federation/runtime': 0.21.6
@@ -33852,11 +33035,7 @@ snapshots:
     dependencies:
       '@module-federation/runtime': 0.22.0
       '@module-federation/webpack-bundler-runtime': 0.22.0
-
-  '@module-federation/runtime-tools@0.5.1':
-    dependencies:
-      '@module-federation/runtime': 0.5.1
-      '@module-federation/webpack-bundler-runtime': 0.5.1
+    optional: true
 
   '@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13))':
     dependencies:
@@ -33881,40 +33060,6 @@ snapshots:
       - node-fetch
     optional: true
 
-  '@module-federation/runtime@0.1.6':
-    dependencies:
-      '@module-federation/sdk': 0.1.6
-
-  '@module-federation/runtime@0.13.1':
-    dependencies:
-      '@module-federation/error-codes': 0.13.1
-      '@module-federation/runtime-core': 0.13.1
-      '@module-federation/sdk': 0.13.1
-
-  '@module-federation/runtime@0.14.3':
-    dependencies:
-      '@module-federation/error-codes': 0.14.3
-      '@module-federation/runtime-core': 0.14.3
-      '@module-federation/sdk': 0.14.3
-
-  '@module-federation/runtime@0.17.1':
-    dependencies:
-      '@module-federation/error-codes': 0.17.1
-      '@module-federation/runtime-core': 0.17.1
-      '@module-federation/sdk': 0.17.1
-
-  '@module-federation/runtime@0.18.0':
-    dependencies:
-      '@module-federation/error-codes': 0.18.0
-      '@module-federation/runtime-core': 0.18.0
-      '@module-federation/sdk': 0.18.0
-
-  '@module-federation/runtime@0.21.1':
-    dependencies:
-      '@module-federation/error-codes': 0.21.1
-      '@module-federation/runtime-core': 0.21.1
-      '@module-federation/sdk': 0.21.1
-
   '@module-federation/runtime@0.21.6':
     dependencies:
       '@module-federation/error-codes': 0.21.6
@@ -33926,10 +33071,7 @@ snapshots:
       '@module-federation/error-codes': 0.22.0
       '@module-federation/runtime-core': 0.22.0
       '@module-federation/sdk': 0.22.0
-
-  '@module-federation/runtime@0.5.1':
-    dependencies:
-      '@module-federation/sdk': 0.5.1
+    optional: true
 
   '@module-federation/runtime@2.2.2(node-fetch@2.7.0(encoding@0.1.13))':
     dependencies:
@@ -33957,23 +33099,10 @@ snapshots:
       - node-fetch
     optional: true
 
-  '@module-federation/sdk@0.1.6': {}
-
-  '@module-federation/sdk@0.13.1': {}
-
-  '@module-federation/sdk@0.14.3': {}
-
-  '@module-federation/sdk@0.17.1': {}
-
-  '@module-federation/sdk@0.18.0': {}
-
-  '@module-federation/sdk@0.21.1': {}
-
   '@module-federation/sdk@0.21.6': {}
 
-  '@module-federation/sdk@0.22.0': {}
-
-  '@module-federation/sdk@0.5.1': {}
+  '@module-federation/sdk@0.22.0':
+    optional: true
 
   '@module-federation/sdk@2.2.2(node-fetch@2.7.0(encoding@0.1.13))':
     optionalDependencies:
@@ -34001,36 +33130,6 @@ snapshots:
       fs-extra: 9.1.0
       resolve: 1.22.8
 
-  '@module-federation/webpack-bundler-runtime@0.1.6':
-    dependencies:
-      '@module-federation/runtime': 0.1.6
-      '@module-federation/sdk': 0.1.6
-
-  '@module-federation/webpack-bundler-runtime@0.13.1':
-    dependencies:
-      '@module-federation/runtime': 0.13.1
-      '@module-federation/sdk': 0.13.1
-
-  '@module-federation/webpack-bundler-runtime@0.14.3':
-    dependencies:
-      '@module-federation/runtime': 0.14.3
-      '@module-federation/sdk': 0.14.3
-
-  '@module-federation/webpack-bundler-runtime@0.17.1':
-    dependencies:
-      '@module-federation/runtime': 0.17.1
-      '@module-federation/sdk': 0.17.1
-
-  '@module-federation/webpack-bundler-runtime@0.18.0':
-    dependencies:
-      '@module-federation/runtime': 0.18.0
-      '@module-federation/sdk': 0.18.0
-
-  '@module-federation/webpack-bundler-runtime@0.21.1':
-    dependencies:
-      '@module-federation/runtime': 0.21.1
-      '@module-federation/sdk': 0.21.1
-
   '@module-federation/webpack-bundler-runtime@0.21.6':
     dependencies:
       '@module-federation/runtime': 0.21.6
@@ -34040,11 +33139,7 @@ snapshots:
     dependencies:
       '@module-federation/runtime': 0.22.0
       '@module-federation/sdk': 0.22.0
-
-  '@module-federation/webpack-bundler-runtime@0.5.1':
-    dependencies:
-      '@module-federation/runtime': 0.5.1
-      '@module-federation/sdk': 0.5.1
+    optional: true
 
   '@module-federation/webpack-bundler-runtime@2.2.2(node-fetch@2.7.0(encoding@0.1.13))':
     dependencies:
@@ -34163,8 +33258,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.9.0
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -34176,8 +33271,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@1.0.7':
     dependencies:
-      '@emnapi/core': 1.9.0
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -34186,6 +33281,20 @@ snapshots:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@ndelangen/get-tarball@3.0.9':
@@ -34339,15 +33448,15 @@ snapshots:
       - nx
       - supports-color
 
-  '@nx/module-federation@22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)':
+  '@nx/module-federation@22.5.4(@babel/traverse@7.29.7)(@module-federation/runtime-tools@0.21.6)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)':
     dependencies:
-      '@module-federation/enhanced': 0.21.6(@rspack/core@1.6.8(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      '@module-federation/node': 2.7.36(@rspack/core@1.6.8(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@module-federation/enhanced': 0.21.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      '@module-federation/node': 2.7.36(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
       '@module-federation/sdk': 0.21.6
       '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
       '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
       '@nx/web': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
       express: 4.22.1
       http-proxy-middleware: 3.0.5
       picocolors: 1.1.1
@@ -34355,6 +33464,7 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@babel/traverse'
+      - '@module-federation/runtime-tools'
       - '@swc-node/register'
       - '@swc/core'
       - '@swc/helpers'
@@ -34402,12 +33512,12 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.5.4':
     optional: true
 
-  '@nx/react@22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.5)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)':
+  '@nx/react@22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@module-federation/runtime-tools@0.21.6)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.5)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.2))(vitest@1.6.0)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)':
     dependencies:
       '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
       '@nx/eslint': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.39.3(jiti@2.6.1))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
       '@nx/js': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
-      '@nx/module-federation': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)
+      '@nx/module-federation': 22.5.4(@babel/traverse@7.29.7)(@module-federation/runtime-tools@0.21.6)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(esbuild@0.25.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(webpack-cli@5.1.4)
       '@nx/rollup': 22.5.4(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(@types/babel__core@7.20.5)(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)
       '@nx/web': 22.5.4(@babel/traverse@7.29.7)(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
@@ -34423,6 +33533,7 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
+      - '@module-federation/runtime-tools'
       - '@swc-node/register'
       - '@swc/core'
       - '@swc/helpers'
@@ -34539,7 +33650,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/webpack@22.5.4(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(html-webpack-plugin@5.6.6(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4)':
+  '@nx/webpack@22.5.4(@babel/traverse@7.29.7)(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4)':
     dependencies:
       '@babel/core': 7.29.0
       '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.10.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10(@swc/helpers@0.5.23)))
@@ -34550,7 +33661,7 @@ snapshots:
       babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
       browserslist: 4.28.1
       copy-webpack-plugin: 10.2.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
-      css-loader: 6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      css-loader: 6.11.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
       css-minimizer-webpack-plugin: 5.0.1(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
       fork-ts-checker-webpack-plugin: 7.2.13(typescript@5.9.3)(vue-template-compiler@2.7.16)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
       less: 4.6.4
@@ -34566,7 +33677,7 @@ snapshots:
       rxjs: 7.8.2
       sass: 1.98.0
       sass-embedded: 1.98.0
-      sass-loader: 16.0.7(@rspack/core@1.6.8(@swc/helpers@0.5.23))(sass-embedded@1.98.0)(sass@1.98.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      sass-loader: 16.0.7(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(sass-embedded@1.98.0)(sass@1.98.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
       source-map-loader: 5.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
       style-loader: 3.3.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
       terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
@@ -34576,7 +33687,7 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
       webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
       webpack-node-externals: 3.0.0
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@parcel/css'
@@ -37320,17 +36431,17 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -37507,73 +36618,91 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
-  '@rsbuild/core@1.0.1-rc.4':
+  '@rsbuild/core@1.0.1-rc.4(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))':
     dependencies:
-      '@rspack/core': 1.0.14(@swc/helpers@0.5.17)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17)'
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.17
       caniuse-lite: 1.0.30001780
       core-js: 3.38.1
     optionalDependencies:
       fsevents: 2.3.3
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@1.3.21':
+  '@rsbuild/core@1.3.21(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))':
     dependencies:
-      '@rspack/core': 1.3.11(@swc/helpers@0.5.17)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)'
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.17
       core-js: 3.42.0
       jiti: 2.6.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@1.4.0-beta.2':
+  '@rsbuild/core@1.4.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))':
     dependencies:
-      '@rspack/core': 1.3.15(@swc/helpers@0.5.17)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17)'
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.17
       core-js: 3.42.0
       jiti: 2.6.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@1.4.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@rsbuild/core@1.4.16(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))':
     dependencies:
-      '@rspack/core': 1.4.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/helpers@0.5.17)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17)'
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.17
       core-js: 3.45.1
       jiti: 2.6.1
     transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@1.5.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@rsbuild/core@1.5.17(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))':
     dependencies:
-      '@rspack/core': 1.5.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/helpers@0.5.17)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17)'
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.17
       core-js: 3.46.0
       jiti: 2.6.1
     transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@1.6.0-beta.1':
+  '@rsbuild/core@1.6.0-beta.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))':
     dependencies:
-      '@rspack/core': 1.6.0-beta.1(@swc/helpers@0.5.17)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17)'
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.17
       core-js: 3.46.0
       jiti: 2.6.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@1.7.3':
+  '@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))':
     dependencies:
-      '@rspack/core': 1.7.9(@swc/helpers@0.5.19)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.19)'
       '@rspack/lite-tapable': 1.1.0
       '@swc/helpers': 0.5.19
       core-js: 3.47.0
       jiti: 2.6.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)':
+  '@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))':
     dependencies:
-      '@rspack/core': 2.0.0-beta.0(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.19)'
+      '@rspack/lite-tapable': 1.1.0
+      '@swc/helpers': 0.5.19
+      core-js: 3.47.0
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@0.21.6)(core-js@3.49.0)':
+    dependencies:
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.19)'
       '@swc/helpers': 0.5.19
       jiti: 2.6.1
     optionalDependencies:
@@ -37583,7 +36712,7 @@ snapshots:
 
   '@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)':
     dependencies:
-      '@rspack/core': 2.0.0-beta.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.19)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.19)'
       '@swc/helpers': 0.5.19
       jiti: 2.6.1
     optionalDependencies:
@@ -37593,7 +36722,7 @@ snapshots:
 
   '@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)':
     dependencies:
-      '@rspack/core': 2.0.0-beta.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.19)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.19)'
       '@swc/helpers': 0.5.19
       jiti: 2.6.1
     optionalDependencies:
@@ -37603,7 +36732,7 @@ snapshots:
 
   '@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)':
     dependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)'
       '@swc/helpers': 0.5.23
     optionalDependencies:
       core-js: 3.49.0
@@ -37618,21 +36747,21 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
 
-  '@rsbuild/plugin-assets-retry@1.5.1(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))':
+  '@rsbuild/plugin-assets-retry@1.5.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
 
-  '@rsbuild/plugin-assets-retry@1.5.2(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-assets-retry@1.5.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
 
-  '@rsbuild/plugin-babel@1.0.1-rc.4(@rsbuild/core@1.0.1-rc.4)':
+  '@rsbuild/plugin-babel@1.0.1-rc.4(@rsbuild/core@1.0.1-rc.4(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@rsbuild/core': 1.0.1-rc.4
+      '@rsbuild/core': 1.0.1-rc.4(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -37654,13 +36783,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -37668,7 +36797,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+      '@types/babel__core': 7.20.5
+      deepmerge: 4.3.1
+      reduce-configs: 1.1.1
+      upath: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
       acorn: 8.16.0
       browserslist-to-es-version: 1.4.1
@@ -37676,7 +36819,17 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
+
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
+    dependencies:
+      acorn: 8.16.0
+      browserslist-to-es-version: 1.4.1
+      htmlparser2: 10.0.0
+      picocolors: 1.1.1
+      source-map: 0.7.6
+    optionalDependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
 
   '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))':
     dependencies:
@@ -37698,37 +36851,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))':
-    dependencies:
-      acorn: 8.16.0
-      browserslist-to-es-version: 1.4.1
-      htmlparser2: 10.0.0
-      picocolors: 1.1.1
-      source-map: 0.7.6
-    optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
-
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3)(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
-    dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
-      reduce-configs: 1.1.1
-    optionalDependencies:
-      '@rsbuild/core': 1.7.3
-    transitivePeerDependencies:
-      - '@parcel/css'
-      - '@swc/css'
-      - clean-css
-      - csso
-      - esbuild
-      - lightningcss
-      - webpack
-
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3)(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))':
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))':
     dependencies:
       css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
       reduce-configs: 1.1.1
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/css'
@@ -37738,12 +36866,27 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3)(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
+    dependencies:
+      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
+      reduce-configs: 1.1.1
+    optionalDependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@swc/css'
+      - clean-css
+      - csso
+      - esbuild
+      - lightningcss
+      - webpack
+
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))':
     dependencies:
       css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
       reduce-configs: 1.1.1
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/css'
@@ -37783,12 +36926,12 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))':
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))':
     dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      css-minimizer-webpack-plugin: 7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
       reduce-configs: 1.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
+      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/css'
@@ -37798,9 +36941,15 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
+      deepmerge: 4.3.1
+      reduce-configs: 1.1.1
+
+  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
+    dependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
@@ -37816,13 +36965,7 @@ snapshots:
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
-  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))':
-    dependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
-      deepmerge: 4.3.1
-      reduce-configs: 1.1.1
-
-  '@rsbuild/plugin-node-polyfill@1.4.3(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-node-polyfill@1.4.3(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -37848,9 +36991,9 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
 
-  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -37876,16 +37019,25 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
 
-  '@rsbuild/plugin-pug@1.3.2(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-pug@1.3.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
       '@types/pug': 2.0.10
       lodash: 4.17.23
       pug: 3.0.4
       reduce-configs: 1.1.1
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
+
+  '@rsbuild/plugin-pug@1.3.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
+    dependencies:
+      '@types/pug': 2.0.10
+      lodash: 4.17.23
+      pug: 3.0.4
+      reduce-configs: 1.1.1
+    optionalDependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
 
   '@rsbuild/plugin-react@1.4.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(webpack-hot-middleware@2.26.1)':
     dependencies:
@@ -37903,25 +37055,25 @@ snapshots:
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-react@1.4.4(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))(webpack-hot-middleware@2.26.1)':
+  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@1.3.21(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(webpack-hot-middleware@2.26.1)':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
+      '@rsbuild/core': 1.3.21(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)(webpack-hot-middleware@2.26.1)
       react-refresh: 0.18.0
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@1.3.21)(webpack-hot-middleware@2.26.1)':
+  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(webpack-hot-middleware@2.26.1)':
     dependencies:
-      '@rsbuild/core': 1.3.21
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)(webpack-hot-middleware@2.26.1)
       react-refresh: 0.18.0
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)':
+  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)':
     dependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)(webpack-hot-middleware@2.26.1)
       react-refresh: 0.18.0
     transitivePeerDependencies:
@@ -37938,14 +37090,6 @@ snapshots:
   '@rsbuild/plugin-react@1.4.5(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
-      '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)(webpack-hot-middleware@2.26.1)
-      react-refresh: 0.18.0
-    transitivePeerDependencies:
-      - webpack-hot-middleware
-
-  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))(webpack-hot-middleware@2.26.1)':
-    dependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)(webpack-hot-middleware@2.26.1)
       react-refresh: 0.18.0
     transitivePeerDependencies:
@@ -37968,12 +37112,19 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-rem@1.0.5(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-rem@1.0.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
       deepmerge: 4.3.1
       terser: 5.46.1
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
+
+  '@rsbuild/plugin-rem@1.0.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
+    dependencies:
+      deepmerge: 4.3.1
+      terser: 5.46.1
+    optionalDependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
 
   '@rsbuild/plugin-rem@1.0.5(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))':
     dependencies:
@@ -37989,16 +37140,18 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
 
-  '@rsbuild/plugin-rem@1.0.5(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))':
+  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
       deepmerge: 4.3.1
-      terser: 5.46.1
-    optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
+      loader-utils: 2.0.4
+      postcss: 8.5.10
+      reduce-configs: 1.1.1
+      sass-embedded: 1.98.0
 
-  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
     dependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.10
@@ -38023,15 +37176,6 @@ snapshots:
       reduce-configs: 1.1.1
       sass-embedded: 1.98.0
 
-  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))':
-    dependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.10
-      reduce-configs: 1.1.1
-      sass-embedded: 1.98.0
-
   '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))':
     dependencies:
       deepmerge: 4.3.1
@@ -38042,13 +37186,21 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
 
-  '@rsbuild/plugin-source-build@1.0.4(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-source-build@1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
       fast-glob: 3.3.3
       json5: 2.2.3
       yaml: 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
+
+  '@rsbuild/plugin-source-build@1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
+    dependencies:
+      fast-glob: 3.3.3
+      json5: 2.2.3
+      yaml: 2.8.2
+    optionalDependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
 
   '@rsbuild/plugin-source-build@1.0.4(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))':
     dependencies:
@@ -38066,25 +37218,38 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
 
-  '@rsbuild/plugin-source-build@1.0.4(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))':
-    dependencies:
-      fast-glob: 3.3.3
-      json5: 2.2.3
-      yaml: 2.8.2
-    optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
-
-  '@rsbuild/plugin-styled-components@1.6.0(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-styled-components@1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
       '@swc/plugin-styled-components': 12.7.0
       reduce-configs: 1.1.1
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
 
-  '@rsbuild/plugin-svgr@1.3.0(@rsbuild/core@1.7.3)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)':
+  '@rsbuild/plugin-styled-components@1.6.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
     dependencies:
-      '@rsbuild/core': 1.7.3
-      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3)(webpack-hot-middleware@2.26.1)
+      '@swc/plugin-styled-components': 12.7.0
+      reduce-configs: 1.1.1
+    optionalDependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+
+  '@rsbuild/plugin-svgr@1.3.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(typescript@5.9.3)(webpack-hot-middleware@2.26.1)':
+    dependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
+      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(webpack-hot-middleware@2.26.1)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
+      deepmerge: 4.3.1
+      loader-utils: 3.3.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+      - webpack-hot-middleware
+
+  '@rsbuild/plugin-svgr@1.3.0(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(typescript@5.9.3)(webpack-hot-middleware@2.26.1)':
+    dependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(webpack-hot-middleware@2.26.1)
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
@@ -38123,45 +37288,37 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-svgr@1.3.0(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))(typescript@5.0.4)(webpack-hot-middleware@2.26.1)':
-    dependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
-      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))(webpack-hot-middleware@2.26.1)
-      '@svgr/core': 8.1.0(typescript@5.0.4)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.0.4)
-      deepmerge: 4.3.1
-      loader-utils: 3.3.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-      - webpack-hot-middleware
-
-  '@rsbuild/plugin-toml@1.1.2(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-toml@1.1.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     dependencies:
       toml: 3.0.0
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
 
-  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@1.7.3)(@rspack/core@1.7.9(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)':
+  '@rsbuild/plugin-toml@1.1.2(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
+    dependencies:
+      toml: 3.0.0
+    optionalDependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+
+  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
       ts-checker-rspack-plugin: 1.3.0(@rspack/core@1.7.9(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
     transitivePeerDependencies:
       - '@rspack/core'
       - tslib
       - typescript
 
-  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)':
+  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)
+      ts-checker-rspack-plugin: 1.3.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3)
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0)
     transitivePeerDependencies:
@@ -38169,12 +37326,12 @@ snapshots:
       - tslib
       - typescript
 
-  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)':
+  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.3.0(@rspack/core@1.3.9(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)
+      ts-checker-rspack-plugin: 1.3.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
     transitivePeerDependencies:
@@ -38182,27 +37339,14 @@ snapshots:
       - tslib
       - typescript
 
-  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))(@rspack/core@1.3.9(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)':
-    dependencies:
-      deepmerge: 4.3.1
-      json5: 2.2.3
-      reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.3.0(@rspack/core@1.3.9(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4)
-    optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - tslib
-      - typescript
-
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@1.7.3)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(tslib@2.8.1)(typescript@5.9.3)':
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
       ts-checker-rspack-plugin: 1.3.0(@rspack/core@1.7.9(@swc/helpers@0.5.19))(tslib@2.8.1)(typescript@5.9.3)
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
     transitivePeerDependencies:
       - '@rspack/core'
       - tslib
@@ -38221,9 +37365,13 @@ snapshots:
       - tslib
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.1(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-typed-css-modules@1.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
+
+  '@rsbuild/plugin-typed-css-modules@1.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
+    optionalDependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
 
   '@rsbuild/plugin-typed-css-modules@1.2.1(@rsbuild/core@2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(core-js@3.49.0))':
     optionalDependencies:
@@ -38233,38 +37381,39 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
 
-  '@rsbuild/plugin-typed-css-modules@1.2.1(@rsbuild/core@2.0.0-beta.2(core-js@3.49.0))':
-    optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.2(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.49.0)
-
-  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(vue@3.5.30(typescript@5.9.3))':
+  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       rspack-vue-loader: 17.5.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(vue@3.5.30(typescript@5.9.3))
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@1.7.3)':
+  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))':
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
 
-  '@rsbuild/shared@0.7.10(@swc/helpers@0.5.23)':
+  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))':
+    optionalDependencies:
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+
+  '@rsbuild/shared@0.7.10(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/core': 0.7.5(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)'
       caniuse-lite: 1.0.30001780
-      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.5(@swc/helpers@0.5.23))
+      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))
       postcss: 8.4.49
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@swc/helpers'
 
-  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3)(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)':
+  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(@rspack/core@1.7.9(@swc/helpers@0.5.17))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)':
     dependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
       copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
       html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
       mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4))
@@ -38279,9 +37428,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4)':
+  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack-cli@5.1.4)':
     dependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
       html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
       mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
@@ -38296,9 +37445,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)':
+  '@rsbuild/webpack@1.6.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(@rspack/core@1.7.9(@swc/helpers@0.5.19))(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)':
     dependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
       html-webpack-plugin: 5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
       mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4))
@@ -38313,336 +37462,216 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@rslib/core@0.10.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(typescript@5.9.3)':
+  '@rslib/core@0.10.6(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 1.4.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      rsbuild-plugin-dts: 0.10.6(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(@rsbuild/core@1.4.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)
+      '@rsbuild/core': 1.4.16(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+      rsbuild-plugin-dts: 0.10.6(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(@rsbuild/core@1.4.16(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(typescript@5.9.3)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@microsoft/api-extractor': 7.57.7(@types/node@20.19.5)
       typescript: 5.9.3
     transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.12.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(typescript@5.6.3)':
+  '@rslib/core@0.12.4(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.6.3)':
     dependencies:
-      '@rsbuild/core': 1.5.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      rsbuild-plugin-dts: 0.12.4(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@rsbuild/core@1.5.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.6.3)
+      '@rsbuild/core': 1.5.17(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+      rsbuild-plugin-dts: 0.12.4(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@rsbuild/core@1.5.17(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(typescript@5.6.3)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@microsoft/api-extractor': 7.57.7(@types/node@22.19.15)
       typescript: 5.6.3
     transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.12.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)':
+  '@rslib/core@0.12.4(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 1.5.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      rsbuild-plugin-dts: 0.12.4(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.5.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)
+      '@rsbuild/core': 1.5.17(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+      rsbuild-plugin-dts: 0.12.4(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.5.17(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(typescript@5.9.3)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@microsoft/api-extractor': 7.57.7(@types/node@26.0.0)
       typescript: 5.9.3
     transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.18.5(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)':
+  '@rslib/core@0.18.5(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 1.7.3
-      rsbuild-plugin-dts: 0.18.5(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.7.3)(typescript@5.9.3)
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
+      rsbuild-plugin-dts: 0.18.5(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(typescript@5.9.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.57.7(@types/node@26.0.0)
       typescript: 5.9.3
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
 
-  '@rslib/core@0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)':
+  '@rslib/core@0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.2
-      rsbuild-plugin-dts: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.4.0-beta.2)(typescript@5.9.3)
+      '@rsbuild/core': 1.4.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
+      rsbuild-plugin-dts: 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.4.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(typescript@5.9.3)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@microsoft/api-extractor': 7.57.7(@types/node@26.0.0)
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
 
-  '@rspack/binding-darwin-arm64@0.7.5':
+  '@rspack-canary/binding-darwin-arm64@2.0.9-canary-cb6bd31a-20260617080342':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.0.14':
+  '@rspack-canary/binding-darwin-x64@2.0.9-canary-cb6bd31a-20260617080342':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.3.11':
+  '@rspack-canary/binding-linux-arm64-gnu@2.0.9-canary-cb6bd31a-20260617080342':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.3.15':
+  '@rspack-canary/binding-linux-arm64-musl@2.0.9-canary-cb6bd31a-20260617080342':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.3.9':
+  '@rspack-canary/binding-linux-x64-gnu@2.0.9-canary-cb6bd31a-20260617080342':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.4.11':
+  '@rspack-canary/binding-linux-x64-musl@2.0.9-canary-cb6bd31a-20260617080342':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.5.8':
+  '@rspack-canary/binding-wasm32-wasi@2.0.9-canary-cb6bd31a-20260617080342':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.6.0-beta.1':
+  '@rspack-canary/binding-win32-arm64-msvc@2.0.9-canary-cb6bd31a-20260617080342':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.6.8':
+  '@rspack-canary/binding-win32-ia32-msvc@2.0.9-canary-cb6bd31a-20260617080342':
     optional: true
+
+  '@rspack-canary/binding-win32-x64-msvc@2.0.9-canary-cb6bd31a-20260617080342':
+    optional: true
+
+  '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': '@rspack-canary/binding-darwin-arm64@2.0.9-canary-cb6bd31a-20260617080342'
+      '@rspack/binding-darwin-x64': '@rspack-canary/binding-darwin-x64@2.0.9-canary-cb6bd31a-20260617080342'
+      '@rspack/binding-linux-arm64-gnu': '@rspack-canary/binding-linux-arm64-gnu@2.0.9-canary-cb6bd31a-20260617080342'
+      '@rspack/binding-linux-arm64-musl': '@rspack-canary/binding-linux-arm64-musl@2.0.9-canary-cb6bd31a-20260617080342'
+      '@rspack/binding-linux-x64-gnu': '@rspack-canary/binding-linux-x64-gnu@2.0.9-canary-cb6bd31a-20260617080342'
+      '@rspack/binding-linux-x64-musl': '@rspack-canary/binding-linux-x64-musl@2.0.9-canary-cb6bd31a-20260617080342'
+      '@rspack/binding-wasm32-wasi': '@rspack-canary/binding-wasm32-wasi@2.0.9-canary-cb6bd31a-20260617080342'
+      '@rspack/binding-win32-arm64-msvc': '@rspack-canary/binding-win32-arm64-msvc@2.0.9-canary-cb6bd31a-20260617080342'
+      '@rspack/binding-win32-ia32-msvc': '@rspack-canary/binding-win32-ia32-msvc@2.0.9-canary-cb6bd31a-20260617080342'
+      '@rspack/binding-win32-x64-msvc': '@rspack-canary/binding-win32-x64-msvc@2.0.9-canary-cb6bd31a-20260617080342'
+
+  '@rspack-canary/cli@2.0.9-canary-cb6bd31a-20260617080342(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@rspack/dev-server@1.1.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1))':
+    dependencies:
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
+    optionalDependencies:
+      '@rspack/dev-server': 1.1.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)
+
+  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.19)':
+    dependencies:
+      '@rspack/binding': '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342'
+    optionalDependencies:
+      '@module-federation/runtime-tools': 0.21.6
+      '@swc/helpers': 0.5.19
+
+  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342'
+    optionalDependencies:
+      '@module-federation/runtime-tools': 0.21.6
+      '@swc/helpers': 0.5.23
+
+  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)':
+    dependencies:
+      '@rspack/binding': '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342'
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.0)
+      '@swc/helpers': 0.5.17
+
+  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.19)':
+    dependencies:
+      '@rspack/binding': '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342'
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.0)
+      '@swc/helpers': 0.5.19
+
+  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)':
+    dependencies:
+      '@rspack/binding': '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342'
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.2)
+      '@swc/helpers': 0.5.13
+
+  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.17)':
+    dependencies:
+      '@rspack/binding': '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342'
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.2)
+      '@swc/helpers': 0.5.17
+
+  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.19)':
+    dependencies:
+      '@rspack/binding': '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342'
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.2)
+      '@swc/helpers': 0.5.19
+
+  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342'
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.2)
+      '@swc/helpers': 0.5.23
+
+  '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@packages+runtime-tools)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': '@rspack-canary/binding@2.0.9-canary-cb6bd31a-20260617080342'
+    optionalDependencies:
+      '@module-federation/runtime-tools': link:packages/runtime-tools
+      '@swc/helpers': 0.5.23
 
   '@rspack/binding-darwin-arm64@1.7.9':
-    optional: true
-
-  '@rspack/binding-darwin-arm64@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-darwin-arm64@2.0.6':
     optional: true
 
   '@rspack/binding-darwin-arm64@2.0.8':
     optional: true
 
-  '@rspack/binding-darwin-x64@0.7.5':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.0.14':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.3.11':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.3.15':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.3.9':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.4.11':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.5.8':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.6.0-beta.1':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.6.8':
-    optional: true
-
   '@rspack/binding-darwin-x64@1.7.9':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.0.6':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@0.7.5':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@1.0.14':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@1.3.11':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@1.3.15':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@1.3.9':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@1.4.11':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@1.5.8':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@1.6.0-beta.1':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@1.6.8':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@1.7.9':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@2.0.6':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@0.7.5':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.0.14':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.3.11':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.3.15':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.3.9':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.4.11':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.5.8':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.6.0-beta.1':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.6.8':
-    optional: true
-
   '@rspack/binding-linux-arm64-musl@1.7.9':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@2.0.6':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@0.7.5':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@1.0.14':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@1.3.11':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@1.3.15':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@1.3.9':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@1.4.11':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@1.5.8':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@1.6.0-beta.1':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@1.6.8':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@1.7.9':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@2.0.6':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@0.7.5':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.0.14':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.3.11':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.3.15':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.3.9':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.4.11':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.5.8':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.6.0-beta.1':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.6.8':
-    optional: true
-
   '@rspack/binding-linux-x64-musl@1.7.9':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@2.0.6':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.0.8':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@1.4.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@1.5.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@1.6.0-beta.1':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@1.6.8':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
-    optional: true
-
   '@rspack/binding-wasm32-wasi@1.7.9':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.7
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.0.0-beta.0':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.0.6':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.8':
@@ -38652,240 +37681,23 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@0.7.5':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@1.0.14':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@1.3.11':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@1.3.15':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@1.3.9':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@1.4.11':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@1.5.8':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@1.6.0-beta.1':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@1.6.8':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@1.7.9':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@2.0.6':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@0.7.5':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.0.14':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.3.11':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.3.15':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.3.9':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.4.11':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.5.8':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.6.0-beta.1':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.6.8':
-    optional: true
-
   '@rspack/binding-win32-ia32-msvc@1.7.9':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@2.0.6':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@0.7.5':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.0.14':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.3.11':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.3.15':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.3.9':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.4.11':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.5.8':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.6.0-beta.1':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.6.8':
-    optional: true
-
   '@rspack/binding-win32-x64-msvc@1.7.9':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@2.0.6':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.8':
     optional: true
-
-  '@rspack/binding@0.7.5':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.7.5
-      '@rspack/binding-darwin-x64': 0.7.5
-      '@rspack/binding-linux-arm64-gnu': 0.7.5
-      '@rspack/binding-linux-arm64-musl': 0.7.5
-      '@rspack/binding-linux-x64-gnu': 0.7.5
-      '@rspack/binding-linux-x64-musl': 0.7.5
-      '@rspack/binding-win32-arm64-msvc': 0.7.5
-      '@rspack/binding-win32-ia32-msvc': 0.7.5
-      '@rspack/binding-win32-x64-msvc': 0.7.5
-
-  '@rspack/binding@1.0.14':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.0.14
-      '@rspack/binding-darwin-x64': 1.0.14
-      '@rspack/binding-linux-arm64-gnu': 1.0.14
-      '@rspack/binding-linux-arm64-musl': 1.0.14
-      '@rspack/binding-linux-x64-gnu': 1.0.14
-      '@rspack/binding-linux-x64-musl': 1.0.14
-      '@rspack/binding-win32-arm64-msvc': 1.0.14
-      '@rspack/binding-win32-ia32-msvc': 1.0.14
-      '@rspack/binding-win32-x64-msvc': 1.0.14
-
-  '@rspack/binding@1.3.11':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.3.11
-      '@rspack/binding-darwin-x64': 1.3.11
-      '@rspack/binding-linux-arm64-gnu': 1.3.11
-      '@rspack/binding-linux-arm64-musl': 1.3.11
-      '@rspack/binding-linux-x64-gnu': 1.3.11
-      '@rspack/binding-linux-x64-musl': 1.3.11
-      '@rspack/binding-win32-arm64-msvc': 1.3.11
-      '@rspack/binding-win32-ia32-msvc': 1.3.11
-      '@rspack/binding-win32-x64-msvc': 1.3.11
-
-  '@rspack/binding@1.3.15':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.3.15
-      '@rspack/binding-darwin-x64': 1.3.15
-      '@rspack/binding-linux-arm64-gnu': 1.3.15
-      '@rspack/binding-linux-arm64-musl': 1.3.15
-      '@rspack/binding-linux-x64-gnu': 1.3.15
-      '@rspack/binding-linux-x64-musl': 1.3.15
-      '@rspack/binding-win32-arm64-msvc': 1.3.15
-      '@rspack/binding-win32-ia32-msvc': 1.3.15
-      '@rspack/binding-win32-x64-msvc': 1.3.15
-
-  '@rspack/binding@1.3.9':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.3.9
-      '@rspack/binding-darwin-x64': 1.3.9
-      '@rspack/binding-linux-arm64-gnu': 1.3.9
-      '@rspack/binding-linux-arm64-musl': 1.3.9
-      '@rspack/binding-linux-x64-gnu': 1.3.9
-      '@rspack/binding-linux-x64-musl': 1.3.9
-      '@rspack/binding-win32-arm64-msvc': 1.3.9
-      '@rspack/binding-win32-ia32-msvc': 1.3.9
-      '@rspack/binding-win32-x64-msvc': 1.3.9
-
-  '@rspack/binding@1.4.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.4.11
-      '@rspack/binding-darwin-x64': 1.4.11
-      '@rspack/binding-linux-arm64-gnu': 1.4.11
-      '@rspack/binding-linux-arm64-musl': 1.4.11
-      '@rspack/binding-linux-x64-gnu': 1.4.11
-      '@rspack/binding-linux-x64-musl': 1.4.11
-      '@rspack/binding-wasm32-wasi': 1.4.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@rspack/binding-win32-arm64-msvc': 1.4.11
-      '@rspack/binding-win32-ia32-msvc': 1.4.11
-      '@rspack/binding-win32-x64-msvc': 1.4.11
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
-  '@rspack/binding@1.5.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.5.8
-      '@rspack/binding-darwin-x64': 1.5.8
-      '@rspack/binding-linux-arm64-gnu': 1.5.8
-      '@rspack/binding-linux-arm64-musl': 1.5.8
-      '@rspack/binding-linux-x64-gnu': 1.5.8
-      '@rspack/binding-linux-x64-musl': 1.5.8
-      '@rspack/binding-wasm32-wasi': 1.5.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@rspack/binding-win32-arm64-msvc': 1.5.8
-      '@rspack/binding-win32-ia32-msvc': 1.5.8
-      '@rspack/binding-win32-x64-msvc': 1.5.8
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
-  '@rspack/binding@1.6.0-beta.1':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.6.0-beta.1
-      '@rspack/binding-darwin-x64': 1.6.0-beta.1
-      '@rspack/binding-linux-arm64-gnu': 1.6.0-beta.1
-      '@rspack/binding-linux-arm64-musl': 1.6.0-beta.1
-      '@rspack/binding-linux-x64-gnu': 1.6.0-beta.1
-      '@rspack/binding-linux-x64-musl': 1.6.0-beta.1
-      '@rspack/binding-wasm32-wasi': 1.6.0-beta.1
-      '@rspack/binding-win32-arm64-msvc': 1.6.0-beta.1
-      '@rspack/binding-win32-ia32-msvc': 1.6.0-beta.1
-      '@rspack/binding-win32-x64-msvc': 1.6.0-beta.1
-
-  '@rspack/binding@1.6.8':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.6.8
-      '@rspack/binding-darwin-x64': 1.6.8
-      '@rspack/binding-linux-arm64-gnu': 1.6.8
-      '@rspack/binding-linux-arm64-musl': 1.6.8
-      '@rspack/binding-linux-x64-gnu': 1.6.8
-      '@rspack/binding-linux-x64-musl': 1.6.8
-      '@rspack/binding-wasm32-wasi': 1.6.8
-      '@rspack/binding-win32-arm64-msvc': 1.6.8
-      '@rspack/binding-win32-ia32-msvc': 1.6.8
-      '@rspack/binding-win32-x64-msvc': 1.6.8
 
   '@rspack/binding@1.7.9':
     optionalDependencies:
@@ -38899,32 +37711,7 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 1.7.9
       '@rspack/binding-win32-ia32-msvc': 1.7.9
       '@rspack/binding-win32-x64-msvc': 1.7.9
-
-  '@rspack/binding@2.0.0-beta.0':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.0-beta.0
-      '@rspack/binding-darwin-x64': 2.0.0-beta.0
-      '@rspack/binding-linux-arm64-gnu': 2.0.0-beta.0
-      '@rspack/binding-linux-arm64-musl': 2.0.0-beta.0
-      '@rspack/binding-linux-x64-gnu': 2.0.0-beta.0
-      '@rspack/binding-linux-x64-musl': 2.0.0-beta.0
-      '@rspack/binding-wasm32-wasi': 2.0.0-beta.0
-      '@rspack/binding-win32-arm64-msvc': 2.0.0-beta.0
-      '@rspack/binding-win32-ia32-msvc': 2.0.0-beta.0
-      '@rspack/binding-win32-x64-msvc': 2.0.0-beta.0
-
-  '@rspack/binding@2.0.6':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.6
-      '@rspack/binding-darwin-x64': 2.0.6
-      '@rspack/binding-linux-arm64-gnu': 2.0.6
-      '@rspack/binding-linux-arm64-musl': 2.0.6
-      '@rspack/binding-linux-x64-gnu': 2.0.6
-      '@rspack/binding-linux-x64-musl': 2.0.6
-      '@rspack/binding-wasm32-wasi': 2.0.6
-      '@rspack/binding-win32-arm64-msvc': 2.0.6
-      '@rspack/binding-win32-ia32-msvc': 2.0.6
-      '@rspack/binding-win32-x64-msvc': 2.0.6
+    optional: true
 
   '@rspack/binding@2.0.8':
     optionalDependencies:
@@ -38938,118 +37725,7 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 2.0.8
       '@rspack/binding-win32-ia32-msvc': 2.0.8
       '@rspack/binding-win32-x64-msvc': 2.0.8
-
-  '@rspack/cli@1.3.9(@rspack/core@1.3.9(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)':
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@rspack/core': 1.3.9(@swc/helpers@0.5.13)
-      '@rspack/dev-server': 1.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)
-      colorette: 2.0.20
-      exit-hook: 4.0.0
-      interpret: 3.1.1
-      rechoir: 0.8.0
-      webpack-bundle-analyzer: 4.10.2
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/express'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-      - webpack-cli
-
-  '@rspack/core@0.7.5(@swc/helpers@0.5.23)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.1.6
-      '@rspack/binding': 0.7.5
-      caniuse-lite: 1.0.30001780
-      tapable: 2.2.1
-      webpack-sources: 3.2.3
-    optionalDependencies:
-      '@swc/helpers': 0.5.23
-
-  '@rspack/core@1.0.14(@swc/helpers@0.5.17)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.5.1
-      '@rspack/binding': 1.0.14
-      '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001780
-    optionalDependencies:
-      '@swc/helpers': 0.5.17
-
-  '@rspack/core@1.3.11(@swc/helpers@0.5.17)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.13.1
-      '@rspack/binding': 1.3.11
-      '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001780
-    optionalDependencies:
-      '@swc/helpers': 0.5.17
-
-  '@rspack/core@1.3.15(@swc/helpers@0.5.17)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.14.3
-      '@rspack/binding': 1.3.15
-      '@rspack/lite-tapable': 1.0.1
-    optionalDependencies:
-      '@swc/helpers': 0.5.17
-
-  '@rspack/core@1.3.9(@swc/helpers@0.5.13)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.13.1
-      '@rspack/binding': 1.3.9
-      '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001780
-    optionalDependencies:
-      '@swc/helpers': 0.5.13
-
-  '@rspack/core@1.3.9(@swc/helpers@0.5.23)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.13.1
-      '@rspack/binding': 1.3.9
-      '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001780
-    optionalDependencies:
-      '@swc/helpers': 0.5.23
-
-  '@rspack/core@1.4.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/helpers@0.5.17)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.17.1
-      '@rspack/binding': 1.4.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@rspack/lite-tapable': 1.0.1
-    optionalDependencies:
-      '@swc/helpers': 0.5.17
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
-  '@rspack/core@1.5.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/helpers@0.5.17)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.18.0
-      '@rspack/binding': 1.5.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@rspack/lite-tapable': 1.0.1
-    optionalDependencies:
-      '@swc/helpers': 0.5.17
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
-  '@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.21.1
-      '@rspack/binding': 1.6.0-beta.1
-      '@rspack/lite-tapable': 1.0.1
-    optionalDependencies:
-      '@swc/helpers': 0.5.17
-
-  '@rspack/core@1.6.8(@swc/helpers@0.5.23)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.21.6
-      '@rspack/binding': 1.6.8
-      '@rspack/lite-tapable': 1.1.0
-    optionalDependencies:
-      '@swc/helpers': 0.5.23
+    optional: true
 
   '@rspack/core@1.7.9(@swc/helpers@0.5.17)':
     dependencies:
@@ -39067,37 +37743,7 @@ snapshots:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
       '@swc/helpers': 0.5.19
-
-  '@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.2.2(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.19)':
-    dependencies:
-      '@rspack/binding': 2.0.0-beta.0
-      '@rspack/lite-tapable': 1.1.0
-    optionalDependencies:
-      '@module-federation/runtime-tools': 2.2.2(node-fetch@2.7.0(encoding@0.1.13))
-      '@swc/helpers': 0.5.19
-
-  '@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.19)':
-    dependencies:
-      '@rspack/binding': 2.0.0-beta.0
-      '@rspack/lite-tapable': 1.1.0
-    optionalDependencies:
-      '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.0)
-      '@swc/helpers': 0.5.19
-
-  '@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.19)':
-    dependencies:
-      '@rspack/binding': 2.0.0-beta.0
-      '@rspack/lite-tapable': 1.1.0
-    optionalDependencies:
-      '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.2)
-      '@swc/helpers': 0.5.19
-
-  '@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)':
-    dependencies:
-      '@rspack/binding': 2.0.6
-    optionalDependencies:
-      '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.0)
-      '@swc/helpers': 0.5.17
+    optional: true
 
   '@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)':
     dependencies:
@@ -39105,10 +37751,11 @@ snapshots:
     optionalDependencies:
       '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.2)
       '@swc/helpers': 0.5.23
+    optional: true
 
-  '@rspack/dev-server@1.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)':
+  '@rspack/dev-server@1.1.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.104.1)':
     dependencies:
-      '@rspack/core': 1.3.9(@swc/helpers@0.5.13)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
       chokidar: 3.6.0
       express: 4.22.1
       http-proxy-middleware: 2.0.9(@types/express@4.17.21)
@@ -39257,21 +37904,25 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rstest/core@0.6.9(jsdom@20.0.3)':
+  '@rstest/core@0.6.9(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(jsdom@20.0.3)':
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.1
+      '@rsbuild/core': 1.6.0-beta.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@types/chai': 5.2.3
       tinypool: 1.1.1
     optionalDependencies:
       jsdom: 20.0.3
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
 
-  '@rstest/core@0.8.5(jsdom@20.0.3)':
+  '@rstest/core@0.8.5(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(jsdom@20.0.3)':
     dependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@types/chai': 5.2.3
       tinypool: 1.1.1
     optionalDependencies:
       jsdom: 20.0.3
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
 
   '@rtsao/scc@1.1.0': {}
 
@@ -39542,15 +38193,15 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-webpack5@9.0.9(@rspack/core@1.3.9(@swc/helpers@0.5.13))(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(storybook@8.6.17(prettier@3.8.1))(typescript@5.9.3)(webpack-cli@5.1.4)':
+  '@storybook/builder-webpack5@9.0.9(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(storybook@8.6.17(prettier@3.8.1))(typescript@5.9.3)(webpack-cli@5.1.4)':
     dependencies:
       '@storybook/core-webpack': 9.0.9(storybook@8.6.17(prettier@3.8.1))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.3.1
-      css-loader: 6.11.0(@rspack/core@1.3.9(@swc/helpers@0.5.13))(webpack@5.104.1)
+      css-loader: 6.11.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(webpack@5.104.1)
       es-module-lexer: 1.5.3
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.104.1)
-      html-webpack-plugin: 5.6.2(@rspack/core@1.3.9(@swc/helpers@0.5.13))(webpack@5.104.1)
+      html-webpack-plugin: 5.6.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(webpack@5.104.1)
       magic-string: 0.30.21
       storybook: 8.6.17(prettier@3.8.1)
       style-loader: 3.3.4(webpack@5.104.1)
@@ -39882,7 +38533,7 @@ snapshots:
 
   '@storybook/mdx2-csf@1.1.0': {}
 
-  '@storybook/nextjs@9.0.9(@rspack/core@1.3.9(@swc/helpers@0.5.13))(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)(webpack-cli@5.1.4))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(storybook@8.6.17(prettier@3.8.1))(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)':
+  '@storybook/nextjs@9.0.9(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.57.0)(@swc/core@1.7.26(@swc/helpers@0.5.13))(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)(webpack-cli@5.1.4))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(storybook@8.6.17(prettier@3.8.1))(type-fest@2.19.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
@@ -39898,20 +38549,20 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.28.2
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4))
-      '@storybook/builder-webpack5': 9.0.9(@rspack/core@1.3.9(@swc/helpers@0.5.13))(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(storybook@8.6.17(prettier@3.8.1))(typescript@5.9.3)(webpack-cli@5.1.4)
+      '@storybook/builder-webpack5': 9.0.9(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(storybook@8.6.17(prettier@3.8.1))(typescript@5.9.3)(webpack-cli@5.1.4)
       '@storybook/preset-react-webpack': 9.0.9(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.8.1))(typescript@5.9.3)(webpack-cli@5.1.4)
       '@storybook/react': 9.0.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.8.1))(typescript@5.9.3)
       '@types/semver': 7.5.8
       babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1)
-      css-loader: 6.11.0(@rspack/core@1.3.9(@swc/helpers@0.5.13))(webpack@5.104.1)
+      css-loader: 6.11.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(webpack@5.104.1)
       image-size: 2.0.2
       loader-utils: 3.3.1
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.104.1)
       postcss: 8.4.49
-      postcss-loader: 8.2.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(postcss@8.4.49)(typescript@5.9.3)(webpack@5.104.1)
+      postcss-loader: 8.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(postcss@8.4.49)(typescript@5.9.3)(webpack@5.104.1)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 14.2.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.104.1)
+      sass-loader: 14.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.104.1)
       semver: 7.6.3
       storybook: 8.6.17(prettier@3.8.1)
       style-loader: 3.3.4(webpack@5.104.1)
@@ -40641,6 +39292,11 @@ snapshots:
   '@tsconfig/node16@1.0.4': {}
 
   '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -45197,7 +43853,7 @@ snapshots:
     dependencies:
       postcss: 8.5.10
 
-  css-loader@6.11.0(@rspack/core@1.3.9(@swc/helpers@0.5.13))(webpack@5.104.1):
+  css-loader@6.11.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.49)
       postcss: 8.4.49
@@ -45208,22 +43864,22 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      '@rspack/core': 1.3.9(@swc/helpers@0.5.13)
-      webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
-
-  css-loader@6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.49)
-      postcss: 8.4.49
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.49)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.4.49)
-      postcss-modules-scope: 3.2.1(postcss@8.4.49)
-      postcss-modules-values: 4.0.0(postcss@8.4.49)
-      postcss-value-parser: 4.2.0
-      semver: 7.6.3
-    optionalDependencies:
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
+
+  css-loader@6.11.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(webpack@5.104.1):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.49)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.4.49)
+      postcss-modules-scope: 3.2.1(postcss@8.4.49)
+      postcss-modules-values: 4.0.0(postcss@8.4.49)
+      postcss-value-parser: 4.2.0
+      semver: 7.6.3
+    optionalDependencies:
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
+      webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
 
   css-minimizer-webpack-plugin@5.0.1(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
     dependencies:
@@ -45282,6 +43938,18 @@ snapshots:
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
+    optionalDependencies:
+      esbuild: 0.25.5
+
+  css-minimizer-webpack-plugin@7.0.2(esbuild@0.25.5)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      cssnano: 7.1.3(postcss@8.5.10)
+      jest-worker: 29.7.0
+      postcss: 8.5.10
+      schema-utils: 4.3.0
+      serialize-javascript: 6.0.2
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)
     optionalDependencies:
       esbuild: 0.25.5
 
@@ -45623,8 +44291,6 @@ snapshots:
   dayjs@1.11.20: {}
 
   de-indent@1.0.2: {}
-
-  debounce@1.2.1: {}
 
   debug@2.6.9:
     dependencies:
@@ -47352,8 +46018,6 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
-  exit-hook@4.0.0: {}
-
   exit@0.1.2: {}
 
   expand-brackets@2.1.4:
@@ -48318,10 +46982,6 @@ snapshots:
       pumpify: 1.5.1
       through2: 2.0.5
 
-  gzip-size@6.0.0:
-    dependencies:
-      duplexer: 0.1.2
-
   handle-thing@2.0.1: {}
 
   handlebars@4.7.7:
@@ -48669,9 +47329,9 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
-  html-rspack-plugin@5.7.2(@rspack/core@0.7.5(@swc/helpers@0.5.23)):
+  html-rspack-plugin@5.7.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)):
     optionalDependencies:
-      '@rspack/core': 0.7.5(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23)'
 
   html-tags@3.3.1: {}
 
@@ -48687,7 +47347,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.2(@rspack/core@1.3.9(@swc/helpers@0.5.13))(webpack@5.104.1):
+  html-webpack-plugin@5.6.2(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(webpack@5.104.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -48695,10 +47355,10 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      '@rspack/core': 1.3.9(@swc/helpers@0.5.13)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
 
-  html-webpack-plugin@5.6.6(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -48706,7 +47366,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
     optional: true
 
@@ -53103,14 +51763,14 @@ snapshots:
       semver: 7.6.3
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
 
-  postcss-loader@8.2.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(postcss@8.4.49)(typescript@5.9.3)(webpack@5.104.1):
+  postcss-loader@8.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(postcss@8.4.49)(typescript@5.9.3)(webpack@5.104.1):
     dependencies:
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.6.1
       postcss: 8.4.49
       semver: 7.6.3
     optionalDependencies:
-      '@rspack/core': 1.3.9(@swc/helpers@0.5.13)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
@@ -55702,6 +54362,15 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1))
       webpack-sources: 3.5.0
 
+  react-server-dom-webpack@19.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)):
+    dependencies:
+      acorn-loose: 8.5.2
+      neo-async: 2.6.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)
+      webpack-sources: 3.5.0
+
   react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
     dependencies:
       acorn-loose: 8.5.2
@@ -56334,7 +55003,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3)):
+  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
@@ -56345,14 +55014,14 @@ snapshots:
       dts-resolver: 2.1.3
       get-tsconfig: 4.13.6
       obug: 2.1.1
-      rolldown: 1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown: 1.0.0-rc.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optionalDependencies:
       typescript: 5.9.3
       vue-tsc: 2.2.12(typescript@5.9.3)
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  rolldown@1.0.0-rc.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     dependencies:
       '@oxc-project/types': 0.112.0
       '@rolldown/pluginutils': 1.0.0-rc.3
@@ -56367,14 +55036,14 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.3
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.3
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.3
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.3
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.3
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  rolldown@1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  rolldown@1.0.0-rc.9(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     dependencies:
       '@oxc-project/types': 0.115.0
       '@rolldown/pluginutils': 1.0.0-rc.9
@@ -56391,7 +55060,7 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
     transitivePeerDependencies:
@@ -56457,10 +55126,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.10.6(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(@rsbuild/core@1.4.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3):
+  rsbuild-plugin-dts@0.10.6(@microsoft/api-extractor@7.57.7(@types/node@20.19.5))(@rsbuild/core@1.4.16(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.4.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rsbuild/core': 1.4.16(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       magic-string: 0.30.21
       picocolors: 1.1.1
       tinyglobby: 0.2.15
@@ -56469,10 +55138,10 @@ snapshots:
       '@microsoft/api-extractor': 7.57.7(@types/node@20.19.5)
       typescript: 5.9.3
 
-  rsbuild-plugin-dts@0.12.4(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@rsbuild/core@1.5.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.6.3):
+  rsbuild-plugin-dts@0.12.4(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@rsbuild/core@1.5.17(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(typescript@5.6.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.5.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rsbuild/core': 1.5.17(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       magic-string: 0.30.21
       picocolors: 1.1.1
       tinyglobby: 0.2.15
@@ -56481,10 +55150,10 @@ snapshots:
       '@microsoft/api-extractor': 7.57.7(@types/node@22.19.15)
       typescript: 5.6.3
 
-  rsbuild-plugin-dts@0.12.4(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.5.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3):
+  rsbuild-plugin-dts@0.12.4(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.5.17(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.5.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rsbuild/core': 1.5.17(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       magic-string: 0.30.21
       picocolors: 1.1.1
       tinyglobby: 0.2.15
@@ -56493,18 +55162,18 @@ snapshots:
       '@microsoft/api-extractor': 7.57.7(@types/node@26.0.0)
       typescript: 5.9.3
 
-  rsbuild-plugin-dts@0.18.5(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.7.3)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.18.5(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0)))(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))
     optionalDependencies:
       '@microsoft/api-extractor': 7.57.7(@types/node@26.0.0)
       typescript: 5.9.3
 
-  rsbuild-plugin-dts@0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.4.0-beta.2)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@rsbuild/core@1.4.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2)))(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.2(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       magic-string: 0.30.21
       picocolors: 1.1.1
       tinyglobby: 0.2.15
@@ -56520,12 +55189,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
 
-  rsbuild-plugin-publint@0.2.1(@rsbuild/core@1.7.3):
+  rsbuild-plugin-publint@0.2.1(@rsbuild/core@1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))):
     dependencies:
       picocolors: 1.1.1
       publint: 0.2.12
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 1.7.3(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
 
   rslog@1.2.3: {}
 
@@ -56543,17 +55212,17 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 1.7.9(@swc/helpers@0.5.19)
 
-  rspack-manifest-plugin@5.2.1(@rspack/core@1.3.9(@swc/helpers@0.5.13)):
+  rspack-manifest-plugin@5.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@rspack/core': 1.3.9(@swc/helpers@0.5.13)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)'
 
-  rspack-manifest-plugin@5.2.1(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)):
+  rspack-manifest-plugin@5.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
 
   rspack-vue-loader@17.5.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
@@ -56786,20 +55455,20 @@ snapshots:
       sass-embedded-win32-arm64: 1.98.0
       sass-embedded-win32-x64: 1.98.0
 
-  sass-loader@14.2.1(@rspack/core@1.3.9(@swc/helpers@0.5.13))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.104.1):
+  sass-loader@14.2.1(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.104.1):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      '@rspack/core': 1.3.9(@swc/helpers@0.5.13)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
       sass: 1.100.0
       sass-embedded: 1.100.0
       webpack: 5.104.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.28.1)(webpack-cli@5.1.4)
 
-  sass-loader@16.0.7(@rspack/core@1.6.8(@swc/helpers@0.5.23))(sass-embedded@1.98.0)(sass@1.98.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  sass-loader@16.0.7(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(sass-embedded@1.98.0)(sass@1.98.0)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23)'
       sass: 1.98.0
       sass-embedded: 1.98.0
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
@@ -57420,10 +56089,10 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-addon-rslib@1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rslib/core@0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3))(storybook-builder-rsbuild@1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/react@18.3.28)(storybook@8.6.17(prettier@3.8.1))(tslib@2.8.1)(typescript@5.9.3))(typescript@5.9.3):
+  storybook-addon-rslib@1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rslib/core@0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3))(storybook-builder-rsbuild@1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/react@18.3.28)(storybook@8.6.17(prettier@3.8.1))(tslib@2.8.1)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@rsbuild/core': 2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0)
-      '@rslib/core': 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(typescript@5.9.3)
+      '@rslib/core': 0.9.2(@microsoft/api-extractor@7.57.7(@types/node@26.0.0))(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(typescript@5.9.3)
       storybook-builder-rsbuild: 1.0.3(@rsbuild/core@2.0.14(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(core-js@3.49.0))(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.23))(@types/react@18.3.28)(storybook@8.6.17(prettier@3.8.1))(tslib@2.8.1)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -58307,6 +56976,17 @@ snapshots:
       '@swc/core': 1.15.10(@swc/helpers@0.5.23)
       esbuild: 0.28.1
 
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.0
+      terser: 5.46.1
+      webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4)
+    optionalDependencies:
+      '@swc/core': 1.15.10(@swc/helpers@0.5.23)
+      esbuild: 0.28.1
+
   terser-webpack-plugin@5.4.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.19))(esbuild@0.18.20)(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -58551,7 +57231,19 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-checker-rspack-plugin@1.3.0(@rspack/core@1.3.9(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4):
+  ts-checker-rspack-plugin@1.3.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3):
+    dependencies:
+      '@rspack/lite-tapable': 1.1.0
+      chokidar: 3.6.0
+      memfs: 4.56.11(tslib@2.8.1)
+      picocolors: 1.1.1
+      typescript: 5.9.3
+    optionalDependencies:
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)'
+    transitivePeerDependencies:
+      - tslib
+
+  ts-checker-rspack-plugin@1.3.0(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13))(tslib@2.8.1)(typescript@5.0.4):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
@@ -58559,7 +57251,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.0.4
     optionalDependencies:
-      '@rspack/core': 1.3.9(@swc/helpers@0.5.13)
+      '@rspack/core': '@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.13)'
     transitivePeerDependencies:
       - tslib
 
@@ -58584,18 +57276,6 @@ snapshots:
       typescript: 5.9.3
     optionalDependencies:
       '@rspack/core': 1.7.9(@swc/helpers@0.5.19)
-    transitivePeerDependencies:
-      - tslib
-
-  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17))(tslib@2.8.1)(typescript@5.9.3):
-    dependencies:
-      '@rspack/lite-tapable': 1.1.0
-      chokidar: 3.6.0
-      memfs: 4.56.11(tslib@2.8.1)
-      picocolors: 1.1.1
-      typescript: 5.9.3
-    optionalDependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.0))(@swc/helpers@0.5.17)
     transitivePeerDependencies:
       - tslib
 
@@ -58980,7 +57660,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(publint@0.3.18)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3)):
+  tsdown@0.20.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(publint@0.3.18)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3)):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -58990,14 +57670,14 @@ snapshots:
       import-without-cache: 0.2.5
       obug: 2.1.1
       picomatch: 4.0.3
-      rolldown: 1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
+      rolldown: 1.0.0-rc.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       semver: 7.7.4
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
-      unrun: 0.2.32(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      unrun: 0.2.32(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optionalDependencies:
       publint: 0.3.18
       typescript: 5.9.3
@@ -59492,9 +58172,9 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
-  unrun@0.2.32(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  unrun@0.2.32(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     dependencies:
-      rolldown: 1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown: 1.0.0-rc.9(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -60209,24 +58889,6 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-bundle-analyzer@4.10.2:
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      commander: 7.2.0
-      debounce: 1.2.1
-      escape-string-regexp: 4.0.0
-      gzip-size: 6.0.0
-      html-escaper: 2.0.2
-      opener: 1.5.2
-      picocolors: 1.1.1
-      sirv: 2.0.4
-      ws: 7.5.11
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
@@ -60513,18 +59175,16 @@ snapshots:
 
   webpack-node-externals@3.0.0: {}
 
-  webpack-sources@3.2.3: {}
-
   webpack-sources@3.3.4: {}
 
   webpack-sources@3.5.0: {}
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4)
     optionalDependencies:
-      html-webpack-plugin: 5.6.6(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
+      html-webpack-plugin: 5.6.6(@rspack-canary/core@2.0.9-canary-cb6bd31a-20260617080342(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.25.5)(webpack-cli@5.1.4))
 
   webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.7.9(@swc/helpers@0.5.17))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)))(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack-cli@5.1.4)):
     dependencies:
@@ -60703,6 +59363,40 @@ snapshots:
       schema-utils: 4.3.3
       tapable: 2.3.0
       terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)))
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    optionalDependencies:
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.1
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack@5.104.1(@swc/core@1.15.10(@swc/helpers@0.5.23))(esbuild@0.28.1)(webpack-cli@5.1.4))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:

--- a/tools/scripts/probe-modern-ssr-remove-remote-gc.mjs
+++ b/tools/scripts/probe-modern-ssr-remove-remote-gc.mjs
@@ -1,0 +1,484 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { createReadStream, existsSync } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import {
+  dirname,
+  extname,
+  join,
+  normalize,
+  relative,
+  resolve,
+} from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, '../..');
+const HOST_READY_URL = 'http://127.0.0.1:3050/';
+const HOST_PROBE_URL = 'http://127.0.0.1:3050/remove-remote-cache-fast';
+const WAIT_TIMEOUT_MS = 60_000;
+const WAIT_INTERVAL_MS = 500;
+const REQUEST_DELAY_MS = 250;
+
+const args = new Set(process.argv.slice(2));
+const getArgValue = (name, fallback) => {
+  const prefix = `${name}=`;
+  const arg = process.argv.slice(2).find((item) => item.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : fallback;
+};
+
+const iterations = Number(getArgValue('--iterations', '20'));
+const warmup = Number(getArgValue('--warmup', '3'));
+const maxGrowthMb = Number(getArgValue('--max-growth-mb', '20'));
+const strict = args.has('--strict');
+
+if (!Number.isInteger(iterations) || iterations < 1) {
+  throw new Error('--iterations must be a positive integer');
+}
+if (!Number.isInteger(warmup) || warmup < 1) {
+  throw new Error('--warmup must be a positive integer');
+}
+if (!Number.isFinite(maxGrowthMb) || maxGrowthMb < 0) {
+  throw new Error('--max-growth-mb must be a non-negative number');
+}
+
+const staticApps = [
+  {
+    name: 'remote v1',
+    port: 3051,
+    root: join(REPO_ROOT, 'apps/modernjs-ssr/remote/dist'),
+    requiredPath: 'static/mf-manifest.json',
+  },
+  {
+    name: 'nested remote',
+    port: 3052,
+    root: join(REPO_ROOT, 'apps/modernjs-ssr/nested-remote/dist'),
+    requiredPath: 'mf-manifest.json',
+  },
+  {
+    name: 'remote v2',
+    port: 3055,
+    root: join(REPO_ROOT, 'apps/modernjs-ssr/remote-new-version/dist'),
+    requiredPath: 'mf-manifest.json',
+  },
+];
+
+const requiredFiles = [
+  join(REPO_ROOT, 'apps/modernjs-ssr/host/dist/mf-manifest.json'),
+  ...staticApps.map((app) => join(app.root, app.requiredPath)),
+  join(
+    REPO_ROOT,
+    'apps/modernjs-ssr/host/node_modules/@modern-js/app-tools/bin/modern.js',
+  ),
+];
+
+const contentTypes = {
+  '.css': 'text/css',
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.map': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain',
+  '.zip': 'application/zip',
+};
+
+function assertBuildOutputs() {
+  const missing = requiredFiles.filter((file) => !existsSync(file));
+  if (missing.length > 0) {
+    throw new Error(
+      [
+        'Missing Modern SSR build output:',
+        ...missing.map((file) => `  - ${relative(REPO_ROOT, file)}`),
+        'Run `pnpm run app:modern:build` before this probe.',
+      ].join('\n'),
+    );
+  }
+}
+
+async function startStaticServer({ name, port, root }) {
+  const server = createServer(async (req, res) => {
+    const urlPath = decodeURIComponent(
+      new URL(req.url || '/', HOST_READY_URL).pathname,
+    );
+    const requestPath = urlPath === '/' ? '/index.html' : urlPath;
+    const file = resolve(root, normalize(requestPath).replace(/^[/\\]+/, ''));
+
+    if (!file.startsWith(root)) {
+      res.statusCode = 403;
+      res.end('forbidden');
+      return;
+    }
+
+    try {
+      const fileStat = await stat(file);
+      if (!fileStat.isFile()) {
+        res.statusCode = 404;
+        res.end('not found');
+        return;
+      }
+    } catch {
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader(
+      'Content-Type',
+      contentTypes[extname(file)] || 'application/octet-stream',
+    );
+    createReadStream(file).pipe(res);
+  });
+
+  await new Promise((resolveListen, rejectListen) => {
+    server.once('error', rejectListen);
+    server.listen(port, () => {
+      server.off('error', rejectListen);
+      resolveListen();
+    });
+  });
+
+  console.log(`[gc-probe] ${name} static server: http://localhost:${port}`);
+  return server;
+}
+
+function startHost() {
+  const cli = join(
+    REPO_ROOT,
+    'apps/modernjs-ssr/host/node_modules/@modern-js/app-tools/bin/modern.js',
+  );
+  const child = spawn(process.execPath, ['--expose-gc', cli, 'serve'], {
+    cwd: join(REPO_ROOT, 'apps/modernjs-ssr/host'),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  child.stdout.on('data', (chunk) => {
+    process.stdout.write(prefixLines('[host]', chunk));
+  });
+  child.stderr.on('data', (chunk) => {
+    process.stderr.write(prefixLines('[host]', chunk));
+  });
+
+  return child;
+}
+
+function prefixLines(prefix, chunk) {
+  return chunk
+    .toString()
+    .split(/(\r?\n)/)
+    .map((part) =>
+      part === '\n' || part === '\r\n' || part === ''
+        ? part
+        : `${prefix} ${part}`,
+    )
+    .join('');
+}
+
+async function waitForHost(child) {
+  const startedAt = Date.now();
+  let lastError;
+
+  while (Date.now() - startedAt < WAIT_TIMEOUT_MS) {
+    if (child.exitCode !== null) {
+      throw new Error(
+        `host exited before it became ready, code ${child.exitCode}`,
+      );
+    }
+
+    try {
+      const response = await fetch(HOST_READY_URL);
+      if (response.status < 500) {
+        return;
+      }
+      lastError = new Error(`host responded with ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await delay(WAIT_INTERVAL_MS);
+  }
+
+  throw new Error(
+    `host did not become ready: ${lastError?.message || 'timeout'}`,
+  );
+}
+
+async function requestProbe() {
+  const response = await fetch(HOST_PROBE_URL);
+  const html = await response.text();
+  if (!response.ok) {
+    throw new Error(`${HOST_PROBE_URL} responded with ${response.status}`);
+  }
+
+  const match = html.match(
+    /<pre id="remove-remote-cache-result">([\s\S]*?)<\/pre>/,
+  );
+  if (!match) {
+    throw new Error('probe result was not found in host response');
+  }
+
+  return JSON.parse(decodeHtml(match[1]));
+}
+
+function decodeHtml(value) {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+function findSnapshot(result, label) {
+  const snapshot = result.snapshots.find((item) => item.label === label);
+  if (!snapshot) {
+    throw new Error(`snapshot "${label}" was not found`);
+  }
+  return snapshot;
+}
+
+function validateProbeResult(result) {
+  if (!result.gcAvailable) {
+    throw new Error(
+      'host did not expose global.gc; the host must run with --expose-gc',
+    );
+  }
+  if (result.heavyStats?.version !== 'v1') {
+    throw new Error(
+      `expected initial remote v1, got ${result.heavyStats?.version}`,
+    );
+  }
+  if (result.reloadedHeavyStats?.version !== 'v2') {
+    throw new Error(
+      `expected reloaded remote v2, got ${result.reloadedHeavyStats?.version}`,
+    );
+  }
+  if (result.removeRemoteError) {
+    throw new Error(`removeRemote failed: ${result.removeRemoteError}`);
+  }
+  if (
+    result.clearCacheCalls.length !== 1 ||
+    result.clearCacheCalls[0].result !== 'resolved'
+  ) {
+    throw new Error(
+      'removeRemote did not trigger a successful clearCache call',
+    );
+  }
+}
+
+function analyzeProbe(result) {
+  validateProbeResult(result);
+
+  const afterLoad = findSnapshot(result, 'after load');
+  const afterRemove = findSnapshot(result, 'after removeRemote');
+  const afterGc = findSnapshot(result, 'after gc');
+  const afterReload = findSnapshot(result, 'after reload');
+
+  return {
+    afterLoad,
+    afterRemove,
+    afterGc,
+    afterReload,
+    heapAfterRemoveToGc: round(afterGc.heapUsedMb - afterRemove.heapUsedMb),
+    heapAfterLoadToGc: round(afterGc.heapUsedMb - afterLoad.heapUsedMb),
+    rssAfterRemoveToGc: round(afterGc.rssMb - afterRemove.rssMb),
+    oldRemoteRemoved:
+      !afterGc.globalSnapshotKeys.includes(
+        'remote:http://127.0.0.1:3051/static/mf-manifest.json',
+      ) &&
+      !Object.values(afterGc.hostSnapshotRemotesInfo).includes(
+        'http://127.0.0.1:3051/static/mf-manifest.json',
+      ) &&
+      !afterGc.moduleCacheKeys.includes('remote'),
+    newRemoteLoaded: Object.values(
+      afterReload.hostSnapshotRemotesInfo,
+    ).includes('http://127.0.0.1:3055/mf-manifest.json'),
+  };
+}
+
+function printProbe(index, analysis) {
+  const decreased = analysis.heapAfterRemoveToGc < 0;
+  const sign = (value) => (value > 0 ? `+${value}` : String(value));
+
+  console.log(`\n[gc-probe] iteration ${index}`);
+  console.log(
+    [
+      `  after load heap/rss: ${analysis.afterLoad.heapUsedMb}/${analysis.afterLoad.rssMb} MB`,
+      `  after remove heap/rss: ${analysis.afterRemove.heapUsedMb}/${analysis.afterRemove.rssMb} MB`,
+      `  after gc heap/rss: ${analysis.afterGc.heapUsedMb}/${analysis.afterGc.rssMb} MB`,
+      `  after reload heap/rss: ${analysis.afterReload.heapUsedMb}/${analysis.afterReload.rssMb} MB`,
+      `  heap remove -> gc: ${sign(analysis.heapAfterRemoveToGc)} MB`,
+      `  heap load -> gc: ${sign(analysis.heapAfterLoadToGc)} MB`,
+      `  rss remove -> gc: ${sign(analysis.rssAfterRemoveToGc)} MB`,
+      `  old remote removed before reload: ${analysis.oldRemoteRemoved}`,
+      `  new remote loaded after reload: ${analysis.newRemoteLoaded}`,
+      `  heap decreased after gc: ${decreased}`,
+    ].join('\n'),
+  );
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function delay(ms) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
+}
+
+async function closeHost(child) {
+  if (!child || child.exitCode !== null) {
+    return;
+  }
+
+  child.kill('SIGINT');
+  await Promise.race([
+    new Promise((resolveExit) => child.once('exit', resolveExit)),
+    delay(8000).then(() => {
+      if (child.exitCode === null) {
+        child.kill('SIGKILL');
+      }
+    }),
+  ]);
+}
+
+async function main() {
+  assertBuildOutputs();
+
+  const staticServers = [];
+  let host;
+  let failed = false;
+
+  const cleanup = async () => {
+    await closeHost(host);
+    await Promise.all(
+      staticServers.map(
+        (server) => new Promise((resolveClose) => server.close(resolveClose)),
+      ),
+    );
+  };
+
+  process.once('SIGINT', () => {
+    cleanup().finally(() => process.exit(130));
+  });
+
+  try {
+    for (const app of staticApps) {
+      staticServers.push(await startStaticServer(app));
+    }
+
+    host = startHost();
+    await waitForHost(host);
+    console.log('[gc-probe] host ready with --expose-gc');
+    console.log(
+      `[gc-probe] probing ${HOST_PROBE_URL} for ${iterations} iteration(s)`,
+    );
+
+    const analyses = [];
+    for (let index = 1; index <= iterations; index += 1) {
+      const result = await requestProbe();
+      const analysis = analyzeProbe(result);
+      analyses.push(analysis);
+      printProbe(index, analysis);
+
+      if (index < iterations) {
+        await delay(REQUEST_DELAY_MS);
+      }
+    }
+
+    const decreasedCount = analyses.filter(
+      (analysis) => analysis.heapAfterRemoveToGc < 0,
+    ).length;
+    const oldRemoteRemoved = analyses.every(
+      (analysis) => analysis.oldRemoteRemoved,
+    );
+    const newRemoteLoaded = analyses.every(
+      (analysis) => analysis.newRemoteLoaded,
+    );
+
+    console.log(
+      `\n[gc-probe] heap decreased after gc in ${decreasedCount}/${iterations} iteration(s)`,
+    );
+    console.log(
+      `[gc-probe] old remote removed before reload: ${oldRemoteRemoved}`,
+    );
+    console.log(
+      `[gc-probe] new remote loaded after reload: ${newRemoteLoaded}`,
+    );
+
+    const baselineIndex = Math.min(warmup, analyses.length) - 1;
+    const baseline = analyses[baselineIndex];
+    const final = analyses[analyses.length - 1];
+    const afterWarmup = analyses.slice(baselineIndex);
+    const heapAfterGcGrowth = round(
+      final.afterGc.heapUsedMb - baseline.afterGc.heapUsedMb,
+    );
+    const heapAfterReloadGrowth = round(
+      final.afterReload.heapUsedMb - baseline.afterReload.heapUsedMb,
+    );
+    const maxHeapAfterGcGrowth = round(
+      Math.max(
+        ...afterWarmup.map(
+          (analysis) =>
+            analysis.afterGc.heapUsedMb - baseline.afterGc.heapUsedMb,
+        ),
+      ),
+    );
+    const maxHeapAfterReloadGrowth = round(
+      Math.max(
+        ...afterWarmup.map(
+          (analysis) =>
+            analysis.afterReload.heapUsedMb - baseline.afterReload.heapUsedMb,
+        ),
+      ),
+    );
+
+    console.log(
+      `[gc-probe] baseline iteration: ${baselineIndex + 1} (warmup=${warmup})`,
+    );
+    console.log(
+      `[gc-probe] final after-gc heap growth: ${heapAfterGcGrowth} MB (limit ${maxGrowthMb} MB)`,
+    );
+    console.log(
+      `[gc-probe] final after-reload heap growth: ${heapAfterReloadGrowth} MB (limit ${maxGrowthMb} MB)`,
+    );
+    console.log(
+      `[gc-probe] max after-gc heap growth after warmup: ${maxHeapAfterGcGrowth} MB`,
+    );
+    console.log(
+      `[gc-probe] max after-reload heap growth after warmup: ${maxHeapAfterReloadGrowth} MB`,
+    );
+
+    if (
+      heapAfterGcGrowth > maxGrowthMb ||
+      heapAfterReloadGrowth > maxGrowthMb
+    ) {
+      failed = true;
+      console.error(
+        '[gc-probe] memory growth check failed: heap did not stabilize after warmup',
+      );
+    }
+
+    if (!oldRemoteRemoved || !newRemoteLoaded) {
+      failed = true;
+    }
+
+    if (strict && decreasedCount !== iterations) {
+      failed = true;
+      console.error(
+        '[gc-probe] strict mode failed: heap did not decrease after gc in every iteration',
+      );
+    }
+  } finally {
+    await cleanup();
+  }
+
+  if (failed) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('[gc-probe] Error:', error);
+  process.exitCode = 1;
+});

--- a/tools/scripts/probe-modern-ssr-remove-remote-gc.mjs
+++ b/tools/scripts/probe-modern-ssr-remove-remote-gc.mjs
@@ -223,11 +223,16 @@ async function requestProbe() {
 }
 
 function decodeHtml(value) {
-  return value
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>');
+  const entities = {
+    '&quot;': '"',
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+  };
+  return value.replace(
+    /&(quot|amp|lt|gt);/g,
+    (entity) => entities[entity] || entity,
+  );
 }
 
 function findSnapshot(result, label) {

--- a/tools/scripts/run-modern-e2e.mjs
+++ b/tools/scripts/run-modern-e2e.mjs
@@ -60,6 +60,23 @@ const SCENARIOS = {
     serveCmd: MODERN_SERVE_CMD,
     waitTargets: MODERN_WAIT_TARGETS,
     verifyManifest: true,
+    e2eCmd: [
+      'pnpm',
+      '--dir',
+      'apps/modernjs-ssr/host',
+      'exec',
+      'cypress',
+      'run',
+      '--project',
+      '.',
+      '--e2e',
+      '--config',
+      'baseUrl=http://localhost:3050,responseTimeout=120000,pageLoadTimeout=120000,defaultCommandTimeout=120000',
+      '--browser',
+      'chrome',
+      '--spec',
+      'cypress/e2e/remove-remote-cache.cy.ts',
+    ],
   },
 };
 
@@ -188,18 +205,41 @@ function buildManifestValidationScript(urls) {
   return `
     (async () => {
       const urls = ${JSON.stringify(urls)};
+      const timeoutMs = 60000;
+      const retryIntervalMs = 500;
+      const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+      async function validateManifest(url) {
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(\`\${url} responded with status \${response.status}\`);
+        }
+        const payload = await response.text();
+        try {
+          JSON.parse(payload);
+        } catch (error) {
+          throw new Error(\`\${url} did not return valid JSON\`);
+        }
+      }
+
       await Promise.all(
         urls.map(async (url) => {
-          const response = await fetch(url);
-          if (!response.ok) {
-            throw new Error(\`\${url} responded with status \${response.status}\`);
+          const startedAt = Date.now();
+          let lastError;
+
+          while (Date.now() - startedAt < timeoutMs) {
+            try {
+              await validateManifest(url);
+              return;
+            } catch (error) {
+              lastError = error;
+              await sleep(retryIntervalMs);
+            }
           }
-          const payload = await response.text();
-          try {
-            JSON.parse(payload);
-          } catch (error) {
-            throw new Error(\`\${url} did not return valid JSON\`);
-          }
+
+          throw new Error(
+            \`\${url} did not return valid JSON within \${timeoutMs}ms: \${lastError?.message || 'unknown error'}\`,
+          );
         }),
       );
     })().catch((error) => {


### PR DESCRIPTION
## Summary

- add `removeRemote` as a public runtime API and lifecycle hook
- install webpack bundler runtime cache clearing through a runtime plugin
- clear stale remote, chunk, entry, shared, and runtime caches so the next SSR load can use the current remote
- add focused runtime and bundler runtime tests

## Validation

- `pnpm --filter @module-federation/runtime-core test -- register-remotes.spec.ts`
- `pnpm --filter @module-federation/runtime test -- api.spec.ts`
- `pnpm --filter @module-federation/webpack-bundler-runtime test -- clearCache.spec.ts`
- `pnpm --filter @module-federation/runtime-core build`
- `pnpm --filter @module-federation/runtime build`
- `pnpm --filter @module-federation/webpack-bundler-runtime build`

Note: these commands were run with Node v22.22.2; the repo warns that it expects Node ^20.

## Memory validation

Local SSR memory repro:

1. Start the four apps from the repo root:

```bash
pnpm --dir apps/modernjs-ssr/nested-remote dev
pnpm --dir apps/modernjs-ssr/remote dev
pnpm --dir apps/modernjs-ssr/remote-new-version dev
pnpm --dir apps/modernjs-ssr/host dev
```

The host `dev` script starts Node with `--expose-gc`, so the page can trigger GC before collecting memory rows.

2. Open the full flow:

```text
http://localhost:3050/remove-remote-cache
```

Expected checks:

- `heavy version` is `v1`
- `reloaded heavy version` is `v2`
- `after load` `heap MB` is higher than `before load`
- `after gc` or one delayed GC row is lower than `after removeRemote`
- `after reload` rises again after loading remote v2

3. If heap snapshots are needed, start the host with snapshots enabled while the remotes above are still running:

```bash
MF_SSR_HEAP_SNAPSHOT=all \
MF_SSR_HEAP_SNAPSHOT_DIR=/tmp/mf-ssr-cache-probe \
pnpm --dir apps/modernjs-ssr/host dev
```

Then open the same route and load the generated `.heapsnapshot` files in Chrome DevTools Memory. Compare later snapshots against `before load`, and search for `remote-heavy`, `remote-heavy-v2`, `Heavy`, or `remote/Heavy` to inspect retained objects and retainers.

4. If the full route is too heavy while snapshots are enabled, use the split routes in order from the same host process:

```text
http://localhost:3050/remove-remote-cache/load-remote
http://localhost:3050/remove-remote-cache/remove-remote
http://localhost:3050/remove-remote-cache/register-new-remote
```

5. Automated checks:

```bash
node tools/scripts/run-modern-e2e.mjs --mode=manifest
pnpm run probe:modern:ssr-gc -- --iterations=20 --max-growth-mb=20
```