### PR TITLE
test(cypress): drop redundant uncaught:exception suppression in memory-router spec

### DIFF
--- a/apps/router-demo/router-host-2000/cypress/e2e/memory-router.cy.ts
+++ b/apps/router-demo/router-host-2000/cypress/e2e/memory-router.cy.ts
@@ -15,8 +15,6 @@ describe('router-host-2000/memory-router', () => {
   });
 
   describe('memory-router', () => {
-    Cypress.on('uncaught:exception', () => false);
-
     it('remote1', () => {
       cy.verifyContent('Remote1 home page');
       cy.clickByClass('.self-remote1-detail-link');


### PR DESCRIPTION
## Description

Removes the per-spec `Cypress.on('uncaught:exception', () => false)` in `apps/router-demo/router-host-2000/cypress/e2e/memory-router.cy.ts`.

The global handler in `cypress/support/e2e.ts` already allow-lists the only errors this happy-path navigation flow can legitimately emit (the React-bridge `Failed to construct 'HTMLElement'` / `Illegal constructor` and the `react-dom/client` module-not-found cases) and returns `true` (fails the test) for everything else. The per-spec handler was strictly weaker: it swallowed every uncaught exception unconditionally, so a genuine regression in this flow would be silently hidden instead of failing. The sibling happy-path specs (`remote1.cy.ts`, `remote2.cy.ts`, `remote3.cy.ts`, `host.cy.ts`) already run the same federated-remote flow with no per-spec handler, relying on the global allow-list. This brings `memory-router.cy.ts` in line with them and restores real-error visibility.

The dedicated error specs (`remote-render-error.cy.ts`, `remote-resource-error.cy.ts`), which deliberately trigger errors, keep their handlers and are intentionally untouched.

## Related Issue

No separate tracking issue. This is a small test-suite hardening with no behavior change to shipped packages. Happy to open an issue first if you prefer that for traceability.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (could not run the Cypress suite locally without the demo dev server; the change only removes an error-suppression handler).
- [ ] I have updated the documentation.

Found while reviewing the test suite with [e2e-skills/e2e-reviewer](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).
