### PR TITLE
feat(retry-plugin): support function-based retryDelay for exponential backoff

### DIFF
--- a/.changeset/retry-plugin-exponential-backoff.md
+++ b/.changeset/retry-plugin-exponential-backoff.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/retry-plugin": minor
+---
+
+Support function-based `retryDelay` for per-attempt delay strategies such as exponential backoff.

--- a/packages/retry-plugin/README.md
+++ b/packages/retry-plugin/README.md
@@ -93,18 +93,18 @@ export default () =>
 
 ### CommonRetryOptions
 
-| Option            | Type                  | Default     | Description                              |
-| ----------------- | --------------------- | ----------- | ---------------------------------------- |
-| `retryTimes`      | `number`              | `3`         | Number of retry attempts                 |
-| `retryDelay`      | `number`              | `1000`      | Delay between retries in milliseconds    |
-| `successTimes`    | `number`              | `0`         | Number of successful requests required   |
-| `domains`         | `string[]`            | `[]`        | Alternative domains for script resources |
-| `manifestDomains` | `string[]`            | `[]`        | Alternative domains for manifest files   |
-| `addQuery`        | `boolean \| function` | `false`     | Add query parameters for cache busting   |
-| `fetchOptions`    | `RequestInit`         | `{}`        | Additional fetch options                 |
-| `onRetry`         | `function`            | `undefined` | Callback when retry occurs               |
-| `onSuccess`       | `function`            | `undefined` | Callback when request succeeds           |
-| `onError`         | `function`            | `undefined` | Callback when all retries fail           |
+| Option            | Type                                    | Default     | Description                                                                                      |
+| ----------------- | --------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------ |
+| `retryTimes`      | `number`                                | `3`         | Number of retry attempts                                                                         |
+| `retryDelay`      | `number \| (attempt: number) => number` | `1000`      | Delay between retries in milliseconds, or a function returning delay per 1-indexed retry attempt |
+| `successTimes`    | `number`                                | `0`         | Number of successful requests required                                                           |
+| `domains`         | `string[]`                              | `[]`        | Alternative domains for script resources                                                         |
+| `manifestDomains` | `string[]`                              | `[]`        | Alternative domains for manifest files                                                           |
+| `addQuery`        | `boolean \| function`                   | `false`     | Add query parameters for cache busting                                                           |
+| `fetchOptions`    | `RequestInit`                           | `{}`        | Additional fetch options                                                                         |
+| `onRetry`         | `function`                              | `undefined` | Callback when retry occurs                                                                       |
+| `onSuccess`       | `function`                              | `undefined` | Callback when request succeeds                                                                   |
+| `onError`         | `function`                              | `undefined` | Callback when all retries fail                                                                   |
 
 ### addQuery Function
 
@@ -142,7 +142,7 @@ onError: ({ domains, url, tagName }) => {
 ```ts
 RetryPlugin({
   retryTimes: 5,
-  retryDelay: (attempt) => Math.pow(2, attempt) * 1000, // Exponential backoff
+  retryDelay: (attempt) => 1000 * 2 ** (attempt - 1), // Exponential backoff: 1s, 2s, 4s, ...
   domains: ['https://cdn1.example.com', 'https://cdn2.example.com', 'https://cdn3.example.com'],
   manifestDomains: ['https://api1.example.com', 'https://api2.example.com'],
   addQuery: ({ times, originalQuery }) => {

--- a/packages/retry-plugin/__tests__/retry.spec.ts
+++ b/packages/retry-plugin/__tests__/retry.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { fetchRetry } from '../src/fetch-retry';
 import { scriptRetry } from '../src/script-retry';
 import { ERROR_ABANDONED, RUNTIME_008 } from '../src/constant';
@@ -18,6 +18,7 @@ describe('Retry Plugin', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetch.mockClear();
+    vi.useRealTimers();
   });
 
   describe('fetchRetry', () => {
@@ -381,6 +382,64 @@ describe('Retry Plugin', () => {
       );
       expect(sequence[2]).not.toContain('retry=1');
       expect(sequence[2]).not.toContain('retry=2');
+    });
+  });
+
+  describe('exponential backoff', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should apply exponential backoff when retryDelay is a function for fetchRetry', async () => {
+      vi.useFakeTimers();
+      const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+      mockFetch.mockRejectedValue(new Error('fail'));
+
+      const backoff = (attempt: number) => 1000 * 2 ** (attempt - 1);
+
+      const fetchPromise = fetchRetry({
+        url: 'https://example.com/api',
+        retryTimes: 3,
+        retryDelay: backoff,
+      });
+
+      const assertion = expect(fetchPromise).rejects.toThrow();
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      const delays = setTimeoutSpy.mock.calls.map(([, ms]) => ms);
+      expect(delays).toEqual([1000, 2000, 4000]);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('should apply exponential backoff when retryDelay is a function for scriptRetry', async () => {
+      vi.useFakeTimers();
+      const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+      const mockRetryFn = vi
+        .fn()
+        .mockRejectedValue(new Error('Script load error'));
+
+      const backoff = (attempt: number) => 1000 * 2 ** (attempt - 1);
+
+      const retryFunction = scriptRetry({
+        retryOptions: {
+          retryTimes: 3,
+          retryDelay: backoff,
+        },
+        retryFn: mockRetryFn,
+      });
+
+      const retryPromise = retryFunction({
+        url: 'https://example.com/script.js',
+      });
+
+      const assertion = expect(retryPromise).rejects.toThrow(ERROR_ABANDONED);
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      const delays = setTimeoutSpy.mock.calls.map(([, ms]) => ms);
+      expect(delays).toEqual([1000, 2000, 4000]);
+      setTimeoutSpy.mockRestore();
     });
   });
 });

--- a/packages/retry-plugin/src/fetch-retry.ts
+++ b/packages/retry-plugin/src/fetch-retry.ts
@@ -69,8 +69,15 @@ async function fetchRetry(
     });
   }
   try {
-    if (!isFirstAttempt && retryDelay > 0) {
-      await new Promise((resolve) => setTimeout(resolve, retryDelay));
+    if (!isFirstAttempt) {
+      const attemptIndex = total - retryTimes;
+      const delay =
+        typeof retryDelay === 'function'
+          ? retryDelay(attemptIndex)
+          : retryDelay;
+      if (delay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
     }
     const response = await fetch(requestUrl, fetchOptions);
     const responseClone = response.clone();

--- a/packages/retry-plugin/src/script-retry.ts
+++ b/packages/retry-plugin/src/script-retry.ts
@@ -34,8 +34,12 @@ export function scriptRetry<T extends Record<string, any>>({
     while (attempts < maxAttempts) {
       try {
         beforeExecuteRetry();
-        if (retryDelay > 0) {
-          await new Promise((resolve) => setTimeout(resolve, retryDelay));
+        const delay =
+          typeof retryDelay === 'function'
+            ? retryDelay(attempts + 1)
+            : retryDelay;
+        if (delay > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
         }
         const retryIndex = attempts + 1;
         retryWrapper = await (retryFn as any)({

--- a/packages/retry-plugin/src/types.d.ts
+++ b/packages/retry-plugin/src/types.d.ts
@@ -12,9 +12,10 @@ export type CommonRetryOptions = {
    */
   successTimes?: number;
   /**
-   * retry delay
+   * retry delay in milliseconds, or a function that returns delay per attempt.
+   * When a function, `attempt` is 1-indexed (the nth retry, not the initial call).
    */
-  retryDelay?: number;
+  retryDelay?: number | ((attempt: number) => number);
   /**
    * retry path
    */


### PR DESCRIPTION
## Description

This PR extends `@module-federation/retry-plugin` so `retryDelay` can be either a fixed number or a callback of the form `(attempt: number) => number`, enabling per-attempt delay strategies such as exponential backoff.

Previously, only a numeric `retryDelay` was supported at runtime.

### Changes

- Update `retryDelay` type to `number | ((attempt: number) => number)` (`attempt` is 1-indexed, matching `onRetry.times`)
- Resolve function-based delays in `fetch-retry.ts` (fetch/chunk retries) and `script-retry.ts` (loadEntryError / remoteEntry script retries)
- Add Vitest coverage verifying exponential backoff delays using fake timers
- Update README configuration documentation and advanced examples
- Add a minor changeset

### Example

```ts
RetryPlugin({
  retryTimes: 5,
  retryDelay: (attempt) => 1000 * 2 ** (attempt - 1), // 1s, 2s, 4s, 8s, 16s
});
```

## Related Issue

N/A — enhancement to support per-attempt retry delays (e.g. exponential backoff). The README advanced example previously showed a function-based retryDelay, but the runtime only accepted a number.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation.
