### PR TITLE
fix(modern-js-v3): load config in esm build

### DIFF
--- a/.changeset/smooth-modern-jiti-filename.md
+++ b/.changeset/smooth-modern-jiti-filename.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/modern-js-v3": patch
+---
+
+Fix loading Modern.js v3 federation config files from the ESM config plugin build.

--- a/packages/modernjs-v3/src/cli/configPlugin.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.ts
@@ -96,10 +96,10 @@ export const getMFConfig = async (
   if (config) {
     return config;
   }
-  const mfConfigPath = configPath ? configPath : defaultPath;
+  const mfConfigPath = path.resolve(configPath || defaultPath);
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { createJiti } = require('jiti');
-  const jit = createJiti(__filename, {
+  const jit = createJiti(mfConfigPath, {
     interopDefault: true,
   });
   const configModule = await jit(mfConfigPath);


### PR DESCRIPTION
## Description

Fix Modern.js v3 federation config loading when the config plugin is built as ESM.

The config file path is now resolved before loading, and `jiti` is initialized from the actual federation config file path instead of the plugin build file. This keeps config resolution based on the user's config location and fixes the failure reported in #4805.

This PR also includes a patch changeset for `@module-federation/modern-js-v3`.

## Related Issue

https://github.com/module-federation/core/issues/4805

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
