### PR TITLE
fix(runtime-core): refetch manifest after forced remote registration

### DIFF
--- a/.changeset/strong-remotes-refetch.md
+++ b/.changeset/strong-remotes-refetch.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/runtime-core": patch
+---
+
+Refetch manifest snapshots after force-registering remotes.

--- a/packages/runtime-core/__tests__/register-remotes.spec.ts
+++ b/packages/runtime-core/__tests__/register-remotes.spec.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it, expect } from 'vitest';
+import { assert, describe, it, expect, vi } from 'vitest';
 import { ModuleFederation } from '../src/index';
 
 describe('ModuleFederation', () => {
@@ -101,5 +101,112 @@ describe('ModuleFederation', () => {
     const newApp1Res = await newApp1Module();
     // Value is different from the registered remote
     expect(newApp1Res).toBe('hello app1 entry2');
+  });
+  it('reloads manifest snapshots when a manifest remote is force registered with the same entry', async () => {
+    const manifestUrl =
+      'http://localhost:1111/resources/register-remotes/manifest/federation-manifest.json';
+    const manifests = [
+      {
+        id: '@register-remotes/manifest',
+        name: '@register-remotes/manifest',
+        metaData: {
+          name: '@register-remotes/manifest',
+          publicPath: 'http://localhost:1111/',
+          type: 'app',
+          globalName: '@snapshot/remote1',
+          buildInfo: {
+            buildVersion: 'first',
+          },
+          remoteEntry: {
+            name: 'federation-remote-entry.js',
+            path: 'resources/snapshot/remote1',
+          },
+          types: {
+            name: 'index.d.ts',
+            path: './',
+          },
+        },
+        remotes: [],
+        shared: [],
+        exposes: [],
+      },
+      {
+        id: '@register-remotes/manifest',
+        name: '@register-remotes/manifest',
+        metaData: {
+          name: '@register-remotes/manifest',
+          publicPath: 'http://localhost:1111/',
+          type: 'app',
+          globalName: '@snapshot/remote2',
+          buildInfo: {
+            buildVersion: 'second',
+          },
+          remoteEntry: {
+            name: 'federation-remote-entry.js',
+            path: 'resources/snapshot/remote2',
+          },
+          types: {
+            name: 'index.d.ts',
+            path: './',
+          },
+        },
+        remotes: [],
+        shared: [],
+        exposes: [],
+      },
+    ];
+    const manifestFetch = vi.fn((url: string) => {
+      if (url === manifestUrl) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(manifests[manifestFetch.mock.calls.length - 1]),
+            {
+              status: 200,
+              statusText: 'OK',
+              headers: { 'Content-Type': 'application/json' },
+            },
+          ),
+        );
+      }
+    });
+    const FM = new ModuleFederation({
+      name: '@federation/instance',
+      version: '1.0.1',
+      remotes: [
+        {
+          name: '@register-remotes/manifest',
+          entry: manifestUrl,
+        },
+      ],
+      plugins: [
+        {
+          name: 'manifest-fetch',
+          fetch: manifestFetch,
+        },
+      ],
+    });
+
+    const appModule = await FM.loadRemote<Promise<() => string>>(
+      '@register-remotes/manifest/say',
+    );
+    assert(appModule);
+    expect(await appModule()).toBe('hello world "@snapshot/remote1"');
+
+    FM.registerRemotes(
+      [
+        {
+          name: '@register-remotes/manifest',
+          entry: manifestUrl,
+        },
+      ],
+      { force: true },
+    );
+
+    const nextAppModule = await FM.loadRemote<Promise<() => string>>(
+      '@register-remotes/manifest/say',
+    );
+    assert(nextAppModule);
+    expect(await nextAppModule()).toBe('hello world "@snapshot/remote2"');
+    expect(manifestFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -37,6 +37,7 @@ import {
   error,
   getRemoteInfo,
   getRemoteEntryUniqueKey,
+  getFMId,
   composeRemoteRequestId,
   matchRemoteWithNameAndExpose,
   optionsToMFContext,
@@ -688,6 +689,29 @@ export class RemoteHandler {
       if (remoteIndex !== -1) {
         host.options.remotes.splice(remoteIndex, 1);
       }
+      const globalSnapshotKey = getInfoWithoutType(
+        CurrentGlobal.__FEDERATION__.moduleInfo,
+        getFMId(remote),
+      ).key;
+      delete CurrentGlobal.__FEDERATION__.moduleInfo[globalSnapshotKey];
+
+      if ('entry' in remote) {
+        host.snapshotHandler.manifestCache.delete(remote.entry);
+        delete Global.__FEDERATION__.__MANIFEST_LOADING__[remote.entry];
+      }
+
+      const { hostGlobalSnapshot } = getGlobalRemoteInfo(remote, host);
+      if (hostGlobalSnapshot) {
+        const remoteKey =
+          hostGlobalSnapshot &&
+          'remotesInfo' in hostGlobalSnapshot &&
+          hostGlobalSnapshot.remotesInfo &&
+          getInfoWithoutType(hostGlobalSnapshot.remotesInfo, remote.name).key;
+        if (remoteKey) {
+          delete hostGlobalSnapshot.remotesInfo[remoteKey];
+        }
+      }
+
       const loadedModule = host.moduleCache.get(remote.name);
       if (loadedModule) {
         const remoteInfo = loadedModule.remoteInfo;
@@ -710,8 +734,6 @@ export class RemoteHandler {
         if (globalLoading[remoteEntryUniqueKey]) {
           delete globalLoading[remoteEntryUniqueKey];
         }
-
-        host.snapshotHandler.manifestCache.delete(remoteInfo.entry);
 
         // delete unloaded shared and instance
         let remoteInsId = remoteInfo.buildVersion
@@ -790,24 +812,6 @@ export class RemoteHandler {
             },
           );
           CurrentGlobal.__FEDERATION__.__INSTANCES__.splice(remoteInsIndex, 1);
-        }
-
-        const { hostGlobalSnapshot } = getGlobalRemoteInfo(remote, host);
-        if (hostGlobalSnapshot) {
-          const remoteKey =
-            hostGlobalSnapshot &&
-            'remotesInfo' in hostGlobalSnapshot &&
-            hostGlobalSnapshot.remotesInfo &&
-            getInfoWithoutType(hostGlobalSnapshot.remotesInfo, remote.name).key;
-          if (remoteKey) {
-            delete hostGlobalSnapshot.remotesInfo[remoteKey];
-            if (
-              //eslint-disable-next-line no-extra-boolean-cast
-              Boolean(Global.__FEDERATION__.__MANIFEST_LOADING__[remoteKey])
-            ) {
-              delete Global.__FEDERATION__.__MANIFEST_LOADING__[remoteKey];
-            }
-          }
         }
 
         host.moduleCache.delete(remote.name);


### PR DESCRIPTION
## What changed

Fixes #4807.

When a remote is re-registered with `force: true`, the runtime now clears the old manifest snapshot state tied to the previously registered remote. This makes the next `loadRemote` refetch the manifest instead of reusing stale snapshot data.

A regression test covers re-registering a manifest remote with the same entry URL and receiving the updated remote entry on the next load.

## Validation

- `pnpm --filter @module-federation/runtime-core test -- register-remotes.spec.ts`
- `pnpm exec prettier --check packages/runtime-core/src/remote/index.ts packages/runtime-core/__tests__/register-remotes.spec.ts .changeset/strong-remotes-refetch.md`
- `pnpm --filter @module-federation/runtime-core run build`
- `pnpm --filter @module-federation/runtime-core run lint`
- `/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 .codex/skills/changeset-pr/scripts/inspect_changeset_scope.py --base origin/main --file .changeset/strong-remotes-refetch.md`
- `python3 .codex/skills/changeset-pr/scripts/run_changeset_status.py --verbose`

## Notes

- The first run of the new regression test failed before the fix, then passed after the cache invalidation change.
- The system `python3` is 3.9 and cannot run the scope helper, so the scope helper was run with the bundled Python 3.12 path listed above.