### PR TITLE
fix(modern-js-v3): disable lazy compilation for producers

### DIFF
--- a/.changeset/modern-v3-lazy-compilation.md
+++ b/.changeset/modern-v3-lazy-compilation.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/modern-js-v3": patch
+---
+
+Disable lazy compilation for Modern.js v3 producer apps.

--- a/packages/modernjs-v3/src/cli/configPlugin.spec.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.spec.ts
@@ -1,5 +1,6 @@
-import { it, expect, describe, vi } from 'vitest';
+import { it, expect, describe, vi, afterEach } from 'vitest';
 import { moduleFederationConfigPlugin, patchMFConfig } from './configPlugin';
+import logger from '../logger';
 
 const mfConfig = {
   name: 'host',
@@ -35,6 +36,10 @@ const getModernJsConfig = async (
 
   return configCallbacks[0]();
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('patchMFConfig', async () => {
   it('patchMFConfig: server', async () => {
@@ -107,6 +112,7 @@ describe('patchMFConfig', async () => {
 
 describe('moduleFederationConfigPlugin', async () => {
   it('disables lazyCompilation when the project is a producer', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const modernJsConfig = await getModernJsConfig(
       {
         name: 'remote',
@@ -129,9 +135,13 @@ describe('moduleFederationConfigPlugin', async () => {
         lazyCompilation: false,
       },
     });
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Detected exposes in the Module Federation config. The Modern.js v3 Module Federation plugin will set dev.lazyCompilation to false for producer apps.',
+    );
   });
 
   it('keeps lazyCompilation unchanged when the project is not a producer', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const modernJsConfig = await getModernJsConfig(
       {
         name: 'host',
@@ -153,5 +163,6 @@ describe('moduleFederationConfigPlugin', async () => {
         lazyCompilation: true,
       },
     });
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/modernjs-v3/src/cli/configPlugin.spec.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.spec.ts
@@ -1,6 +1,5 @@
-import { it, expect, describe } from 'vitest';
-import { patchMFConfig } from './configPlugin';
-import { getIPV4 } from './utils';
+import { it, expect, describe, vi } from 'vitest';
+import { moduleFederationConfigPlugin, patchMFConfig } from './configPlugin';
 
 const mfConfig = {
   name: 'host',
@@ -13,6 +12,30 @@ const mfConfig = {
     'react-dom': { singleton: true, eager: true },
   },
 };
+
+const getModernJsConfig = async (
+  moduleFederationConfig: Record<string, unknown>,
+  modernjsConfig: Record<string, unknown> = {},
+) => {
+  const configCallbacks: Array<() => unknown> = [];
+  const plugin = moduleFederationConfigPlugin({
+    originPluginOptions: {
+      config: moduleFederationConfig,
+    },
+    userConfig: {},
+  } as any);
+
+  await plugin.setup!({
+    config: vi.fn((callback) => {
+      configCallbacks.push(callback);
+    }),
+    getConfig: vi.fn(() => modernjsConfig),
+    modifyBundlerChain: vi.fn(),
+  } as any);
+
+  return configCallbacks[0]();
+};
+
 describe('patchMFConfig', async () => {
   it('patchMFConfig: server', async () => {
     const patchedConfig = JSON.parse(JSON.stringify(mfConfig));
@@ -77,6 +100,57 @@ describe('patchMFConfig', async () => {
         consumeTypes: {
           runtimePkgs: ['@module-federation/modern-js-v3/runtime'],
         },
+      },
+    });
+  });
+});
+
+describe('moduleFederationConfigPlugin', async () => {
+  it('disables lazyCompilation when the project is a producer', async () => {
+    const modernJsConfig = await getModernJsConfig(
+      {
+        name: 'remote',
+        exposes: {
+          './Button': './src/Button',
+        },
+      },
+      {
+        tools: {
+          devServer: {
+            headers: {},
+          },
+        },
+      },
+    );
+
+    expect(modernJsConfig).toMatchObject({
+      dev: {
+        assetPrefix: 'auto',
+        lazyCompilation: false,
+      },
+    });
+  });
+
+  it('keeps lazyCompilation unchanged when the project is not a producer', async () => {
+    const modernJsConfig = await getModernJsConfig(
+      {
+        name: 'host',
+        remotes: {
+          remote: 'http://localhost:3000/remoteEntry.js',
+        },
+      },
+      {
+        dev: {
+          assetPrefix: 'http://localhost:3001/',
+          lazyCompilation: true,
+        },
+      },
+    );
+
+    expect(modernJsConfig).toMatchObject({
+      dev: {
+        assetPrefix: 'http://localhost:3001/',
+        lazyCompilation: true,
       },
     });
   });

--- a/packages/modernjs-v3/src/cli/configPlugin.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.ts
@@ -450,8 +450,8 @@ export const moduleFederationConfigPlugin = (
       const exposes = userConfig.csrConfig?.exposes;
       const hasExposes =
         exposes && Array.isArray(exposes)
-          ? exposes.length
-          : Object.keys(exposes ?? {}).length;
+          ? exposes.length > 0
+          : Object.keys(exposes ?? {}).length > 0;
 
       if (corsWarnMsgs.length > 1 && hasExposes) {
         logger.warn(corsWarnMsgs.join('\n'));
@@ -486,6 +486,9 @@ export const moduleFederationConfigPlugin = (
           assetPrefix: modernjsConfig?.dev?.assetPrefix
             ? modernjsConfig.dev.assetPrefix
             : 'auto',
+          lazyCompilation: hasExposes
+            ? false
+            : modernjsConfig?.dev?.lazyCompilation,
         },
       };
     });

--- a/packages/modernjs-v3/src/cli/configPlugin.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.ts
@@ -452,9 +452,16 @@ export const moduleFederationConfigPlugin = (
         exposes && Array.isArray(exposes)
           ? exposes.length > 0
           : Object.keys(exposes ?? {}).length > 0;
+      const lazyCompilationDisabledByPlugin =
+        hasExposes && modernjsConfig?.dev?.lazyCompilation !== false;
 
       if (corsWarnMsgs.length > 1 && hasExposes) {
         logger.warn(corsWarnMsgs.join('\n'));
+      }
+      if (lazyCompilationDisabledByPlugin) {
+        logger.warn(
+          'Detected exposes in the Module Federation config. The Modern.js v3 Module Federation plugin will set dev.lazyCompilation to false for producer apps.',
+        );
       }
 
       const corsHeaders = hasExposes


### PR DESCRIPTION
## Summary

Disable lazy compilation automatically when the Modern.js v3 Module Federation plugin detects a producer app, and emit a warning when the plugin applies that override.

## Why

Producer apps expose remote modules that consumers need to load directly during development. Keeping lazy compilation enabled can leave those exposed modules behind a lazy trigger path instead of making them immediately available to consumers.

## Impact

Modern.js v3 producer apps now get `dev.lazyCompilation: false` from the plugin. Non-producer apps keep their existing `dev.lazyCompilation` setting. Producer apps also get a clear warning when the plugin disables lazy compilation for them.

## Validation

- `pnpm exec prettier --check .`
- `git diff --check`
- `pnpm exec turbo run test --filter=@module-federation/modern-js-v3 --force`
- `python3.12 .codex/skills/changeset-pr/scripts/run_changeset_status.py --verbose`

## Skipped

- Full `ci:local build-and-test` was not run; this change is scoped to `@module-federation/modern-js-v3`, and the targeted package build/test path passed.