### PR TITLE
fix(devtools): show manifest-only remotes in dependency graph

### DIFF
--- a/.changeset/clean-devtools-graph.md
+++ b/.changeset/clean-devtools-graph.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/devtools": patch
+---
+
+Fix dependency graph cards for remotes that are only known by their manifest URL.

--- a/packages/chrome-devtools/__tests__/dependency-graph.spec.ts
+++ b/packages/chrome-devtools/__tests__/dependency-graph.spec.ts
@@ -1,0 +1,68 @@
+import { expect, describe, it } from 'vitest';
+
+import { DependencyGraph } from '../src/utils/sdk/graph';
+
+describe('DependencyGraph', () => {
+  it('keeps the matched remote entry when the provider snapshot is missing', () => {
+    const remoteEntry =
+      'https://ad.oceanengine.com/copilot/vmok/ocean_copilot_sdk/vmok-manifest.json';
+    const snapshot = {
+      '@qianchuan-vmok/qc-copilot:https://qianchuan.jinritemai.com/vmok-modules/qc-copilot/manifest/vmok-manifest.json':
+        {
+          version:
+            'https://qianchuan.jinritemai.com/vmok-modules/qc-copilot/manifest/vmok-manifest.json',
+          remotesInfo: {
+            '@ocean-copilot/sdk': {
+              matchedVersion: remoteEntry,
+            },
+          },
+        },
+    } as any;
+    const consumer =
+      '@qianchuan-vmok/qc-copilot:https://qianchuan.jinritemai.com/vmok-modules/qc-copilot/manifest/vmok-manifest.json';
+    const moduleGraph = new DependencyGraph(snapshot, consumer);
+
+    moduleGraph.createGraph();
+    moduleGraph.run(moduleGraph.graph, consumer, 'graphItem');
+
+    const remoteNode = moduleGraph.node.find((node) =>
+      node.data.info.startsWith('@ocean-copilot/sdk:'),
+    );
+
+    expect(remoteNode?.data.info).toBe(`@ocean-copilot/sdk:${remoteEntry}`);
+  });
+
+  it('keeps remote entry query parameters in node info', () => {
+    const remoteEntry =
+      'https://qianchuan.jinritemai.com/vmok-modules/qc-runtime/manifest/vmok-manifest.json?aavid=1689373886941197&from_qc_login=1';
+    const snapshot = {
+      '@qianchuan-vmok/qc-main-mono-home': {
+        version: '0.0.4302',
+        remotesInfo: {
+          '@qianchuan-vmok/runtime-module': {
+            matchedVersion: remoteEntry,
+          },
+        },
+      },
+    } as any;
+    const moduleGraph = new DependencyGraph(
+      snapshot,
+      '@qianchuan-vmok/qc-main-mono-home',
+    );
+
+    moduleGraph.createGraph();
+    moduleGraph.run(
+      moduleGraph.graph,
+      '@qianchuan-vmok/qc-main-mono-home',
+      'graphItem',
+    );
+
+    const remoteNode = moduleGraph.node.find((node) =>
+      node.data.info.startsWith('@qianchuan-vmok/runtime-module:'),
+    );
+
+    expect(remoteNode?.data.info).toBe(
+      `@qianchuan-vmok/runtime-module:${remoteEntry}`,
+    );
+  });
+});

--- a/packages/chrome-devtools/src/component/DependencyGraphItem/index.tsx
+++ b/packages/chrome-devtools/src/component/DependencyGraphItem/index.tsx
@@ -6,6 +6,26 @@ import { useTranslation } from 'react-i18next';
 import styles from './index.module.scss';
 import 'reactflow/dist/style.css';
 
+const parseInfo = (info: string) => {
+  const array = info.split(':');
+  const [fallbackName, fallbackVersion = ''] = array;
+  const idx = array.findIndex((item, index) => {
+    return index > 0 && (item.startsWith('http') || item.startsWith('//'));
+  });
+
+  if (idx > 0) {
+    return {
+      name: array.slice(0, idx).join(':'),
+      version: array.slice(idx).join(':'),
+    };
+  }
+
+  return {
+    name: fallbackName,
+    version: fallbackVersion,
+  };
+};
+
 const GraphItem = (props: {
   data: { info?: string; color?: string; remote?: any };
 }) => {
@@ -16,13 +36,7 @@ const GraphItem = (props: {
   let name: string;
   let version: string;
   const { info = '', color, remote } = props.data;
-  const infoArray = info.split(':');
-  if (info.endsWith('.json') || info.endsWith('.js')) {
-    name = infoArray.shift() as string;
-    version = infoArray.join(':');
-  } else {
-    [name, version] = infoArray;
-  }
+  ({ name, version } = parseInfo(info));
 
   const isEntryType = version?.startsWith('http') || version?.startsWith('//');
 

--- a/packages/chrome-devtools/src/utils/sdk/graph.ts
+++ b/packages/chrome-devtools/src/utils/sdk/graph.ts
@@ -41,35 +41,50 @@ export const validateSemver = (schema: string) => {
 
 export const validatePort = (schema: string) => !isNaN(Number(schema));
 
-const splitModuleId = (target: string) => {
+const isEntrySegment = (segment: string) =>
+  segment.startsWith('http') || segment.startsWith('//');
+
+const parseModuleId = (target: string) => {
   const array = target.split(':');
   const { length } = array;
+  const result = {
+    name: target,
+    version: '',
+  };
+
   if (length === 1) {
-    return target;
+    return result;
   } else if (length >= 3) {
-    // @xxx:https://xxx.xxx.json
-    if (
-      array[length - 1].endsWith('.json') ||
-      array[length - 1].endsWith('.js')
-    ) {
-      const idx = array.findIndex((t) => t.startsWith('http'));
-      return array[idx - 1];
-    } else {
-      // type:@xxx:https://xxx.xxx.json
-      return array[1];
+    const idx = array.findIndex(isEntrySegment);
+    if (idx > 0) {
+      result.name = array[idx - 1];
+      result.version = array.slice(idx).join(':');
+      return result;
     }
+    // type:@xxx:1.0.0
+    result.name = array[1];
+    result.version = array.slice(2).join(':');
+    return result;
   } else {
     const nameOrVersion = array[length - 1];
     if (
       nameOrVersion === '*' ||
       nameOrVersion === 'latest' ||
-      validateSemver(nameOrVersion)
+      validateSemver(nameOrVersion) ||
+      isEntrySegment(nameOrVersion) ||
+      nameOrVersion.endsWith('.json') ||
+      nameOrVersion.endsWith('.js')
     ) {
-      return array[0];
+      result.name = array[0];
+      result.version = nameOrVersion;
+      return result;
     } else {
-      return nameOrVersion;
+      result.name = nameOrVersion;
+      return result;
     }
   }
+
+  return result;
 };
 
 export class DependencyGraph {
@@ -182,7 +197,7 @@ export class DependencyGraph {
     if (!targetGraph || !Object.keys(targetGraph)?.length) {
       return;
     }
-    const name = splitModuleId(target);
+    const { name, version } = parseModuleId(target);
     const targetWithoutType = name;
     let info = name;
 
@@ -190,6 +205,8 @@ export class DependencyGraph {
     if (remote && ('version' in remote || 'remoteEntry' in remote)) {
       // @ts-expect-error
       info += `:${remote.version || remote.remoteEntry}`;
+    } else if (version) {
+      info += `:${version}`;
     }
 
     if (!this.identifyMap.has(targetWithoutType)) {


### PR DESCRIPTION
## Description
fix(devtools): show manifest-only remotes in dependency graph
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
