### PR TITLE
fix(treeshake-server): bump undici to 7.28.0 for CVE-2026-12151

### DIFF
--- a/.changeset/tricky-pants-rescue.md
+++ b/.changeset/tricky-pants-rescue.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/treeshake-server': patch
+---
+
+Bump undici to 7.28.0 to resolve known vulnerabilities (CVE-2026-12151 and related advisories).

--- a/packages/treeshake-server/package.json
+++ b/packages/treeshake-server/package.json
@@ -40,7 +40,7 @@
     "nanoid": "5.1.6",
     "p-limit": "7.2.0",
     "pino": "10.1.0",
-    "undici": "6.23.0",
+    "undici": "7.28.0",
     "zod": "4.1.12"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4428,8 +4428,8 @@ importers:
         specifier: 10.1.0
         version: 10.1.0
       undici:
-        specifier: 6.23.0
-        version: 6.23.0
+        specifier: 7.28.0
+        version: 7.28.0
       zod:
         specifier: 4.1.12
         version: 4.1.12
@@ -26543,10 +26543,6 @@ packages:
   undici@5.26.5:
     resolution: {integrity: sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==}
     engines: {node: '>=14.0'}
-
-  undici@6.23.0:
-    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
-    engines: {node: '>=18.17'}
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
@@ -60448,8 +60444,6 @@ snapshots:
   undici@5.26.5:
     dependencies:
       '@fastify/busboy': 2.1.1
-
-  undici@6.23.0: {}
 
   undici@7.28.0: {}
 


### PR DESCRIPTION
## Description

Bumps the last remaining outdated `undici` in the workspace — `@module-federation/treeshake-server` was pinned to `6.23.0` — to `7.28.0`, the version the issue proposes and the version already used by the workspace root and `@module-federation/dts-plugin` since #4835. The lockfile change is surgical: only the undici specifier/resolution entries changed. A patch changeset for `@module-federation/treeshake-server` is included.

`undici` is not imported anywhere in `treeshake-server` source (it is only declared as a dependency), so no code changes are required; build and tests confirm no behavioral impact.

Note: the open Dependabot PR #4838 predates #4835 and would now *downgrade* the root and dts-plugin undici from 7.28.0 to 6.27.0, so it should be closed in favor of this PR.

## Related Issue

Closes #4831

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.

## Validation

- `pnpm install --frozen-lockfile --lockfile-only` passes with the updated lockfile
- `pnpm exec turbo run build --filter=@module-federation/treeshake-server` — success
- `pnpm exec turbo run test --filter=@module-federation/treeshake-server` — 13 files, 28 tests passed
- `pnpm exec prettier --check` on changed files — clean