### PR TITLE
perf(runtime-core): bypass range parsing in versionLt and cache satisfy ranges

### DIFF
--- a/.changeset/perf-share-semver.md
+++ b/.changeset/perf-share-semver.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime-core': patch
+---
+
+perf(runtime-core): optimize share version comparison by bypassing range parsing for versionLt and caching parsed requiredVersion ranges

--- a/packages/runtime-core/__tests__/versionLt.spec.ts
+++ b/packages/runtime-core/__tests__/versionLt.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'vitest';
+import { satisfy } from '../src/utils/semver';
+import { findVersion, versionLt } from '../src/utils/share';
+
+function transformInvalidVersion(version: string): string {
+  const isNumberVersion = !Number.isNaN(Number(version));
+  if (isNumberVersion) {
+    const splitArr = version.split('.');
+    let validVersion = version;
+    for (let i = 0; i < 3 - splitArr.length; i++) {
+      validVersion += '.0';
+    }
+    return validVersion;
+  }
+  return version;
+}
+
+function legacyVersionLt(a: string, b: string): boolean {
+  return satisfy(transformInvalidVersion(a), `<=${transformInvalidVersion(b)}`);
+}
+
+describe('versionLt', () => {
+  test('equal versions are inclusive (<=)', () => {
+    expect(versionLt('1.2.3', '1.2.3')).toBe(true);
+    expect(versionLt('18.2.0', '18.2.0')).toBe(true);
+  });
+
+  test('strict less and greater', () => {
+    expect(versionLt('1.2.2', '1.2.3')).toBe(true);
+    expect(versionLt('1.2.4', '1.2.3')).toBe(false);
+    expect(versionLt('17.0.0', '18.3.1')).toBe(true);
+    expect(versionLt('18.3.1', '17.0.0')).toBe(false);
+  });
+
+  test('prerelease ordering', () => {
+    expect(versionLt('1.2.3-beta', '1.2.3')).toBe(true);
+    expect(versionLt('1.2.3', '1.2.3-beta')).toBe(false);
+    expect(versionLt('4.0.0-alpha.56', '4.0.0-alpha.57')).toBe(true);
+    expect(versionLt('4.0.0-alpha.58', '4.0.0-alpha.57')).toBe(false);
+  });
+
+  test('transformInvalidVersion numeric strings', () => {
+    expect(versionLt('16', '16.0.0')).toBe(true);
+    expect(versionLt('16.1', '16.1.0')).toBe(true);
+    expect(versionLt('16', '17.0.0')).toBe(true);
+    expect(versionLt('17', '16.0.0')).toBe(false);
+  });
+
+  test('invalid inputs return false', () => {
+    expect(versionLt('', '1.2.3')).toBe(false);
+    expect(versionLt('1.2.3', '')).toBe(false);
+    expect(versionLt('not-a-version', '1.2.3')).toBe(false);
+    expect(versionLt('1.2.3', 'not-a-version')).toBe(false);
+  });
+
+  test('parity with legacy satisfy(a, "<=" + b) behavior', () => {
+    const pairs: Array<[string, string]> = [
+      ['1.2.3', '1.2.3'],
+      ['1.2.2', '1.2.3'],
+      ['1.2.4', '1.2.3'],
+      ['16', '16.0.0'],
+      ['16.1', '16.1.0'],
+      ['1.2.3-beta', '1.2.3'],
+      ['4.0.0-alpha.56', '4.0.0-alpha.57'],
+      ['4.0.0-alpha.58', '4.0.0-alpha.57'],
+      ['18.2.0', '18.3.1'],
+      ['', '1.0.0'],
+      ['1.0.0', ''],
+    ];
+
+    for (const [a, b] of pairs) {
+      expect(versionLt(a, b)).toBe(legacyVersionLt(a, b));
+    }
+  });
+});
+
+describe('findVersion', () => {
+  test('picks the highest semver version', () => {
+    const shareVersionMap = {
+      '17.0.0': {},
+      '18.2.0': {},
+      '18.3.1': {},
+    };
+
+    expect(findVersion(shareVersionMap)).toBe('18.3.1');
+  });
+
+  test('replaces default version 0 with a real version', () => {
+    const shareVersionMap = {
+      '0': {},
+      '18.2.0': {},
+    };
+
+    expect(findVersion(shareVersionMap)).toBe('18.2.0');
+  });
+
+  test('keeps the later key when versions compare equal', () => {
+    const shareVersionMap = {
+      '1.2.3+build': {},
+      '1.2.3': {},
+    };
+
+    expect(findVersion(shareVersionMap)).toBe('1.2.3');
+  });
+});
+
+describe('parseRangeComparators cache', () => {
+  test('repeated satisfy calls with the same range stay consistent', () => {
+    const range = '^18.2.0';
+    const versions = ['17.0.0', '18.1.0', '18.2.0', '18.3.1', '19.0.0'];
+
+    for (const version of versions) {
+      expect(satisfy(version, range)).toBe(satisfy(version, range));
+    }
+  });
+});

--- a/packages/runtime-core/__tests__/versionLt.spec.ts
+++ b/packages/runtime-core/__tests__/versionLt.spec.ts
@@ -102,6 +102,23 @@ describe('findVersion', () => {
 
     expect(findVersion(shareVersionMap)).toBe('1.2.3');
   });
+
+  test('prefers wildcard versions over concrete versions', () => {
+    const shareVersionMap = {
+      '1.0.0': {},
+      '*': {},
+    };
+
+    expect(findVersion(shareVersionMap)).toBe('*');
+  });
+});
+
+describe('versionLt wildcard parity', () => {
+  test('wildcard upper bound matches legacy satisfy behavior', () => {
+    expect(versionLt('1.0.0', '*')).toBe(legacyVersionLt('1.0.0', '*'));
+    expect(versionLt('1.0.0', 'x')).toBe(legacyVersionLt('1.0.0', 'x'));
+    expect(versionLt('1.0.0', '1.x')).toBe(legacyVersionLt('1.0.0', '1.x'));
+  });
 });
 
 describe('parseRangeComparators cache', () => {

--- a/packages/runtime-core/src/utils/semver/index.ts
+++ b/packages/runtime-core/src/utils/semver/index.ts
@@ -64,16 +64,10 @@ function parseRange(range: string) {
     .join(' ');
 }
 
-export function satisfy(version: string, range: string): boolean {
-  if (!version) {
-    return false;
-  }
-
-  // Extract version details once
+export function toCompareAtom(version: string): CompareAtom | null {
   const extractedVersion = extractComparator(version);
   if (!extractedVersion) {
-    // If the version string is invalid, it can't satisfy any range
-    return false;
+    return null;
   }
   const [
     ,
@@ -84,126 +78,159 @@ export function satisfy(version: string, range: string): boolean {
     versionPatch,
     versionPreRelease,
   ] = extractedVersion;
-  const versionAtom: CompareAtom = {
+  return {
     operator: versionOperator,
     version: combineVersion(
       versionMajor,
       versionMinor,
       versionPatch,
       versionPreRelease,
-    ), // exclude build atom
+    ),
     major: versionMajor,
     minor: versionMinor,
     patch: versionPatch,
     preRelease: versionPreRelease?.split('.'),
   };
+}
 
-  // Split the range by || to handle OR conditions
+type OrRangeResult =
+  | { type: 'wildcard' }
+  | { type: 'comparators'; comparators: CompareAtom[] };
+
+const parsedRangeCache = new Map<string, OrRangeResult[]>();
+
+function comparatorStringToAtom(comparator: string): CompareAtom | null {
+  const extractedComparator = extractComparator(comparator);
+  if (!extractedComparator) {
+    return null;
+  }
+  const [
+    ,
+    rangeOperator,
+    ,
+    rangeMajor,
+    rangeMinor,
+    rangePatch,
+    rangePreRelease,
+  ] = extractedComparator;
+  return {
+    operator: rangeOperator,
+    version: combineVersion(
+      rangeMajor,
+      rangeMinor,
+      rangePatch,
+      rangePreRelease,
+    ),
+    major: rangeMajor,
+    minor: rangeMinor,
+    patch: rangePatch,
+    preRelease: rangePreRelease?.split('.'),
+  };
+}
+
+function parseOrRange(trimmedOrRange: string): OrRangeResult | null {
+  if (!trimmedOrRange) {
+    return { type: 'wildcard' };
+  }
+
+  if (trimmedOrRange === '*' || trimmedOrRange === 'x') {
+    return { type: 'wildcard' };
+  }
+
+  try {
+    const parsedSubRange = parseRange(trimmedOrRange);
+
+    if (!parsedSubRange.trim()) {
+      return { type: 'wildcard' };
+    }
+
+    const parsedComparatorString = parsedSubRange
+      .split(' ')
+      .map((rangeVersion) => parseComparatorString(rangeVersion))
+      .join(' ');
+
+    if (!parsedComparatorString.trim()) {
+      return { type: 'wildcard' };
+    }
+
+    const comparatorStrings = parsedComparatorString
+      .split(/\s+/)
+      .map((comparator) => parseGTE0(comparator))
+      .filter(Boolean);
+
+    if (comparatorStrings.length === 0) {
+      return null;
+    }
+
+    const comparators: CompareAtom[] = [];
+    for (const comparator of comparatorStrings) {
+      const rangeAtom = comparatorStringToAtom(comparator);
+      if (!rangeAtom) {
+        return null;
+      }
+      comparators.push(rangeAtom);
+    }
+
+    return { type: 'comparators', comparators };
+  } catch (e) {
+    console.error(
+      `[semver] Error processing range part "${trimmedOrRange}":`,
+      e,
+    );
+    return null;
+  }
+}
+
+export function parseRangeComparators(range: string): OrRangeResult[] {
+  const cached = parsedRangeCache.get(range);
+  if (cached) {
+    return cached;
+  }
+
   const orRanges = range.split('||');
+  const result: OrRangeResult[] = [];
 
   for (const orRange of orRanges) {
-    const trimmedOrRange = orRange.trim();
-    if (!trimmedOrRange) {
-      // An empty range string signifies wildcard *, satisfy any valid version
-      // (We already checked if the version itself is valid)
-      return true;
-    }
-
-    // Handle simple wildcards explicitly before complex parsing
-    if (trimmedOrRange === '*' || trimmedOrRange === 'x') {
-      return true;
-    }
-
-    try {
-      // Apply existing parsing logic to the current OR sub-range
-      const parsedSubRange = parseRange(trimmedOrRange); // Handles hyphens, trims etc.
-
-      // Check if the result of initial parsing is empty, which can happen
-      // for some wildcard cases handled by parseRange/parseComparatorString.
-      // E.g. `parseStar` used in `parseComparatorString` returns ''.
-      if (!parsedSubRange.trim()) {
-        // If parsing results in empty string, treat as wildcard match
-        return true;
-      }
-
-      const parsedComparatorString = parsedSubRange
-        .split(' ')
-        .map((rangeVersion) => parseComparatorString(rangeVersion)) // Expands ^, ~
-        .join(' ');
-
-      // Check again if the comparator string became empty after specific parsing like ^ or ~
-      if (!parsedComparatorString.trim()) {
-        return true;
-      }
-
-      // Split the sub-range by space for implicit AND conditions
-      const comparators = parsedComparatorString
-        .split(/\s+/)
-        .map((comparator) => parseGTE0(comparator))
-        // Filter out empty strings that might result from multiple spaces
-        .filter(Boolean);
-
-      // If a sub-range becomes empty after parsing (e.g., invalid characters),
-      // it cannot be satisfied. This check might be redundant now but kept for safety.
-      if (comparators.length === 0) {
-        continue;
-      }
-
-      let subRangeSatisfied = true;
-      for (const comparator of comparators) {
-        const extractedComparator = extractComparator(comparator);
-
-        // If any part of the AND sub-range is invalid, the sub-range is not satisfied
-        if (!extractedComparator) {
-          subRangeSatisfied = false;
-          break;
-        }
-
-        const [
-          ,
-          rangeOperator,
-          ,
-          rangeMajor,
-          rangeMinor,
-          rangePatch,
-          rangePreRelease,
-        ] = extractedComparator;
-        const rangeAtom: CompareAtom = {
-          operator: rangeOperator,
-          version: combineVersion(
-            rangeMajor,
-            rangeMinor,
-            rangePatch,
-            rangePreRelease,
-          ),
-          major: rangeMajor,
-          minor: rangeMinor,
-          patch: rangePatch,
-          preRelease: rangePreRelease?.split('.'),
-        };
-
-        // Check if the version satisfies this specific comparator in the AND chain
-        if (!compare(rangeAtom, versionAtom)) {
-          subRangeSatisfied = false; // This part of the AND condition failed
-          break; // No need to check further comparators in this sub-range
-        }
-      }
-
-      // If all AND conditions within this OR sub-range were met, the overall range is satisfied
-      if (subRangeSatisfied) {
-        return true;
-      }
-    } catch (e) {
-      // Log error and treat this sub-range as unsatisfied
-      console.error(
-        `[semver] Error processing range part "${trimmedOrRange}":`,
-        e,
-      );
-      continue;
+    const parsed = parseOrRange(orRange.trim());
+    if (parsed) {
+      result.push(parsed);
     }
   }
 
-  // If none of the OR sub-ranges were satisfied
+  parsedRangeCache.set(range, result);
+  return result;
+}
+
+export function satisfy(version: string, range: string): boolean {
+  if (!version) {
+    return false;
+  }
+
+  const versionAtom = toCompareAtom(version);
+  if (!versionAtom) {
+    return false;
+  }
+
+  const orRanges = parseRangeComparators(range);
+
+  for (const orRange of orRanges) {
+    if (orRange.type === 'wildcard') {
+      return true;
+    }
+
+    let subRangeSatisfied = true;
+    for (const rangeAtom of orRange.comparators) {
+      if (!compare(rangeAtom, versionAtom)) {
+        subRangeSatisfied = false;
+        break;
+      }
+    }
+
+    if (subRangeSatisfied) {
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/packages/runtime-core/src/utils/share.ts
+++ b/packages/runtime-core/src/utils/share.ts
@@ -160,12 +160,14 @@ function transformInvalidVersion(version: string): string {
  * compare version a and b, return true if a is less than or equal to b
  */
 export function versionLt(a: string, b: string): boolean {
-  const aAtom = toCompareAtom(transformInvalidVersion(a));
-  const bAtom = toCompareAtom(transformInvalidVersion(b));
-  if (!aAtom || !bAtom) {
-    return false;
+  const normalizedA = transformInvalidVersion(a);
+  const normalizedB = transformInvalidVersion(b);
+  const aAtom = toCompareAtom(normalizedA);
+  const bAtom = toCompareAtom(normalizedB);
+  if (aAtom && bAtom) {
+    return compare({ ...bAtom, operator: '<=' }, aAtom);
   }
-  return compare({ ...bAtom, operator: '<=' }, aAtom);
+  return satisfy(normalizedA, `<=${normalizedB}`);
 }
 
 export const findVersion = (

--- a/packages/runtime-core/src/utils/share.ts
+++ b/packages/runtime-core/src/utils/share.ts
@@ -15,7 +15,8 @@ import {
   SharedGetter,
 } from '../type';
 import { warn, error } from './logger';
-import { satisfy } from './semver';
+import { satisfy, toCompareAtom } from './semver';
+import { compare } from './semver/compare';
 import { SyncWaterfallHook } from './hooks';
 import { addUniqueItem, arrayOptions } from './tool';
 
@@ -142,27 +143,29 @@ export function shouldUseTreeShaking(
   return false;
 }
 
+function transformInvalidVersion(version: string): string {
+  const isNumberVersion = !Number.isNaN(Number(version));
+  if (isNumberVersion) {
+    const splitArr = version.split('.');
+    let validVersion = version;
+    for (let i = 0; i < 3 - splitArr.length; i++) {
+      validVersion += '.0';
+    }
+    return validVersion;
+  }
+  return version;
+}
+
 /**
- * compare version a and b, return true if a is less than b
+ * compare version a and b, return true if a is less than or equal to b
  */
 export function versionLt(a: string, b: string): boolean {
-  const transformInvalidVersion = (version: string) => {
-    const isNumberVersion = !Number.isNaN(Number(version));
-    if (isNumberVersion) {
-      const splitArr = version.split('.');
-      let validVersion = version;
-      for (let i = 0; i < 3 - splitArr.length; i++) {
-        validVersion += '.0';
-      }
-      return validVersion;
-    }
-    return version;
-  };
-  if (satisfy(transformInvalidVersion(a), `<=${transformInvalidVersion(b)}`)) {
-    return true;
-  } else {
+  const aAtom = toCompareAtom(transformInvalidVersion(a));
+  const bAtom = toCompareAtom(transformInvalidVersion(b));
+  if (!aAtom || !bAtom) {
     return false;
   }
+  return compare({ ...bAtom, operator: '<=' }, aAtom);
 }
 
 export const findVersion = (


### PR DESCRIPTION
## Description

Optimizes the share-resolution semver hot path in `@module-federation/runtime-core` without changing public API or behavior.

versionLt (used by findVersion on every loadShare / loadShareSync) previously implemented a <= b via satisfy(a, '<=' + b), running the full range parser for a simple point comparison. satisfy(versionKey, requiredVersion) in getRegisteredShare also re-parsed the same requiredVersion on every loop iteration.

This PR rewrites versionLt to use toCompareAtom() + compare() directly, extracts shared semver helpers in semver/index.ts, and caches parsed range comparators in satisfy(). Adds versionLt.spec.ts for parity and findVersion coverage, plus a patch changeset.

## Related Issue

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] I have updated the documentation.
