### PR TITLE
docs(website-new): add GA4 tracking

### DIFF
--- a/apps/website-new/i18n.json
+++ b/apps/website-new/i18n.json
@@ -66,6 +66,8 @@
     "pt-BR": "Copiar código"
   },
   "codeButtonGroupWrapButtonText": {
+    "en": "Toggle line wrap",
+    "zh": "切换自动换行",
     "pt-BR": "Alternar quebra de linha"
   },
   "notFoundText": {
@@ -75,15 +77,23 @@
     "pt-BR": "Voltar para a página inicial"
   },
   "promptCopyText": {
+    "en": "Copy prompt",
+    "zh": "复制提示词",
     "pt-BR": "Copiar prompt"
   },
   "promptCopiedText": {
+    "en": "Copied",
+    "zh": "已复制",
     "pt-BR": "Copiado"
   },
   "promptExpandText": {
+    "en": "Expand",
+    "zh": "展开",
     "pt-BR": "Expandir"
   },
   "promptCollapseText": {
+    "en": "Collapse",
+    "zh": "收起",
     "pt-BR": "Recolher"
   }
 }

--- a/apps/website-new/rspress.config.ts
+++ b/apps/website-new/rspress.config.ts
@@ -14,6 +14,7 @@ const siteOrigin = (
 const siteIcon = '/svg.svg';
 const socialImageUrl = `${siteOrigin}/module-federation-social.svg`;
 const socialImageAlt = 'Module Federation icon';
+const googleAnalyticsMeasurementId = 'G-DRPXW0EEVT';
 
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
@@ -88,6 +89,28 @@ export default defineConfig({
     pluginModuleFederation(mfConfig),
   ],
   builderConfig: {
+    html: {
+      tags: [
+        {
+          tag: 'script',
+          attrs: {
+            async: true,
+            src: `https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsMeasurementId}`,
+          },
+          append: false,
+        },
+        {
+          tag: 'script',
+          children: `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${googleAnalyticsMeasurementId}');
+`,
+          append: false,
+        },
+      ],
+    },
     plugins: [moduleFederationPluginOverview, pluginSass()],
     output: {
       assetPrefix:


### PR DESCRIPTION
## Summary
- add GA4 tracking for module-federation.io using measurement ID G-DRPXW0EEVT
- inject the Google tag through Rspress/Rsbuild html.tags
- add missing en/zh i18n fallbacks required by the current Rspress build

## Validation
- pnpm --filter website-new build
- rg -n 'G-DRPXW0EEVT|googletagmanager.com/gtag' apps/website-new/doc_build -g '*.html' -g '*.js'
- git diff --check