### PR TITLE
Release v2.7.0

### DIFF
--- a/.changeset/bright-pots-vanish.md
+++ b/.changeset/bright-pots-vanish.md
@@ -1,5 +1,0 @@
----
-'@module-federation/retry-plugin': patch
----
-
-fix: externalize @module-federation/runtime and runtime-core from DTS bundle to prevent type incompatibility in consumers

--- a/.changeset/clean-devtools-graph.md
+++ b/.changeset/clean-devtools-graph.md
@@ -1,5 +1,0 @@
----
-"@module-federation/devtools": patch
----
-
-Fix dependency graph cards for remotes that are only known by their manifest URL.

--- a/.changeset/drop-ansi-colors-dts-plugin.md
+++ b/.changeset/drop-ansi-colors-dts-plugin.md
@@ -1,5 +1,0 @@
----
-'@module-federation/dts-plugin': patch
----
-
-chore(dts-plugin): drop `ansi-colors` dependency in favor of inline ANSI escape for the single red error message.

--- a/.changeset/drop-lodash-get.md
+++ b/.changeset/drop-lodash-get.md
@@ -1,5 +1,0 @@
----
-'@module-federation/typescript': patch
----
-
-chore(typescript): drop `lodash.get` dependency in favor of optional chaining in `normalizeOptions`.

--- a/.changeset/drop-node-fetch-sdk.md
+++ b/.changeset/drop-node-fetch-sdk.md
@@ -1,5 +1,0 @@
----
-'@module-federation/sdk': minor
----
-
-chore(sdk): drop the `node-fetch` fallback and optional peer dependency. Native `fetch` was already preferred everywhere it exists (Node 18+); the fallback only fired on EOL Node versions, where the loader-hook path was broken anyway. Removes up to ~9MB of optional install weight (`web-streams-polyfill` et al).

--- a/.changeset/drop-resolve-extractor.md
+++ b/.changeset/drop-resolve-extractor.md
@@ -1,5 +1,0 @@
----
-'@module-federation/third-party-dts-extractor': patch
----
-
-chore(third-party-dts-extractor): replace `resolve` with `exsolve` (0 transitive deps, ~100KB smaller) for the single `package.json` lookup.

--- a/.changeset/fuzzy-pears-play.md
+++ b/.changeset/fuzzy-pears-play.md
@@ -1,5 +1,0 @@
----
-"@module-federation/playground": patch
----
-
-Add a publishable Module Federation playground package for the docs site.

--- a/.changeset/modern-v3-lazy-compilation.md
+++ b/.changeset/modern-v3-lazy-compilation.md
@@ -1,5 +1,0 @@
----
-"@module-federation/modern-js-v3": patch
----
-
-Disable lazy compilation for Modern.js v3 producer apps.

--- a/.changeset/node-esm-builtin-loader.md
+++ b/.changeset/node-esm-builtin-loader.md
@@ -1,5 +1,0 @@
----
-"@module-federation/sdk": patch
----
-
-Handle Node.js built-in imports in the Node ESM remote loader.

--- a/.changeset/quiet-devtools-module-info.md
+++ b/.changeset/quiet-devtools-module-info.md
@@ -1,5 +1,0 @@
----
-'@module-federation/devtools': patch
----
-
-Guard Chrome DevTools module info sync against invalid undefined placeholder payloads.

--- a/.changeset/replace-find-pkg-with-empathic.md
+++ b/.changeset/replace-find-pkg-with-empathic.md
@@ -1,7 +1,0 @@
----
-'@module-federation/managers': patch
-'@module-federation/third-party-dts-extractor': patch
-'@module-federation/manifest': patch
----
-
-chore: replace `find-pkg` with `empathic` (per [e18e replacements](https://e18e.dev/docs/replacements/find-pkg.html)). Removes unused `find-pkg` dependency from `@module-federation/manifest`.

--- a/.changeset/small-deps-consolidated.md
+++ b/.changeset/small-deps-consolidated.md
@@ -1,9 +1,0 @@
----
-'@module-federation/devtools': patch
-'@module-federation/treeshake-server': patch
-'@module-federation/rspress-plugin': patch
-'create-module-federation': patch
-'@module-federation/third-party-dts-extractor': patch
----
-
-Bump runtime dependencies: echarts 6.1.0 (devtools), hono 4.12.26 and @hono/node-server 1.19.13 (treeshake-server), lodash-es 4.18.1 (rspress-plugin), handlebars 4.7.9 (create-module-federation), resolve 1.22.12 (third-party-dts-extractor).

--- a/.changeset/tricky-pants-rescue.md
+++ b/.changeset/tricky-pants-rescue.md
@@ -1,5 +1,0 @@
----
-'@module-federation/treeshake-server': patch
----
-
-Bump undici to 7.28.0 to resolve known vulnerabilities (CVE-2026-12151 and related advisories).

--- a/.changeset/upgrade-rslib-rsbuild-deps.md
+++ b/.changeset/upgrade-rslib-rsbuild-deps.md
@@ -1,8 +1,0 @@
----
-'@module-federation/rsbuild-plugin': patch
-'@module-federation/esbuild': patch
-'@module-federation/metro': patch
-'@module-federation/storybook-addon': patch
----
-
-chore(deps): upgrade `@rslib/core` to 0.23.2, `@rsbuild/core` to 2.1.4, and `@rsbuild/plugin-react`/`plugin-vue`/`plugin-sass` to their 2.x latest across dev dependencies. `create-module-federation` templates are updated so newly scaffolded projects pick up the same versions. `@module-federation/modern-js-v3` is realigned to `@modern-js/* 3.5.0` (which uses `@rsbuild/core 2.1.0`) to resolve a `Rspack` type mismatch between the upgraded `@module-federation/rsbuild-plugin` and modern-js's own rsbuild embedding. Peer dependency ranges are untouched.

--- a/apps/node-dynamic-remote-new-version/CHANGELOG.md
+++ b/apps/node-dynamic-remote-new-version/CHANGELOG.md
@@ -1,5 +1,11 @@
 # node-dynamic-remote-new-version
 
+## 1.0.13
+
+### Patch Changes
+
+- @module-federation/node@2.7.46
+
 ## 1.0.12
 
 ### Patch Changes

--- a/apps/node-dynamic-remote-new-version/package.json
+++ b/apps/node-dynamic-remote-new-version/package.json
@@ -6,7 +6,7 @@
     "@module-federation/node": "workspace:*",
     "lodash": "4.18.1"
   },
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "build": "NODE_OPTIONS=--max_old_space_size=4096 pnpm exec webpack-cli --config webpack.config.js --output-path dist --mode production",
     "build:development": "NODE_OPTIONS=--max_old_space_size=4096 pnpm exec webpack-cli --config webpack.config.js --output-path dist --mode development",

--- a/apps/node-dynamic-remote/CHANGELOG.md
+++ b/apps/node-dynamic-remote/CHANGELOG.md
@@ -1,5 +1,11 @@
 # node-dynamic-remote
 
+## 1.0.13
+
+### Patch Changes
+
+- @module-federation/node@2.7.46
+
 ## 1.0.12
 
 ### Patch Changes

--- a/apps/node-dynamic-remote/package.json
+++ b/apps/node-dynamic-remote/package.json
@@ -6,7 +6,7 @@
     "@module-federation/node": "workspace:*",
     "lodash": "4.18.1"
   },
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "build": "NODE_OPTIONS=--max_old_space_size=4096 pnpm exec webpack-cli --config webpack.config.js --output-path dist --mode production",
     "build:development": "NODE_OPTIONS=--max_old_space_size=4096 pnpm exec webpack-cli --config webpack.config.js --output-path dist --mode development",

--- a/apps/router-demo/router-remote5-2005/CHANGELOG.md
+++ b/apps/router-demo/router-remote5-2005/CHANGELOG.md
@@ -1,5 +1,13 @@
 # remote5
 
+## 2.0.15
+
+### Patch Changes
+
+- Updated dependencies [61fe85d]
+  - @module-federation/rsbuild-plugin@2.7.0
+  - @module-federation/bridge-react@2.7.0
+
 ## 2.0.14
 
 ### Patch Changes

--- a/apps/router-demo/router-remote5-2005/package.json
+++ b/apps/router-demo/router-remote5-2005/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote5",
   "private": true,
-  "version": "2.0.14",
+  "version": "2.0.15",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/router-demo/router-remote6-2006/CHANGELOG.md
+++ b/apps/router-demo/router-remote6-2006/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.15
+
+### Patch Changes
+
+- Updated dependencies [61fe85d]
+  - @module-federation/rsbuild-plugin@2.7.0
+  - @module-federation/bridge-react@2.7.0
+
 ## 2.0.14
 
 ### Patch Changes

--- a/apps/router-demo/router-remote6-2006/package.json
+++ b/apps/router-demo/router-remote6-2006/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote6",
   "private": true,
-  "version": "2.0.14",
+  "version": "2.0.15",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/shared-tree-shaking/no-server/host/CHANGELOG.md
+++ b/apps/shared-tree-shaking/no-server/host/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.15
+
+### Patch Changes
+
+- @module-federation/enhanced@2.7.0
+
 ## 1.0.14
 
 ### Patch Changes

--- a/apps/shared-tree-shaking/no-server/host/package.json
+++ b/apps/shared-tree-shaking/no-server/host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-no-server-host",
   "private": true,
-  "version": "1.0.14",
+  "version": "1.0.15",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/shared-tree-shaking/no-server/provider/CHANGELOG.md
+++ b/apps/shared-tree-shaking/no-server/provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.15
+
+### Patch Changes
+
+- @module-federation/enhanced@2.7.0
+
 ## 1.0.14
 
 ### Patch Changes

--- a/apps/shared-tree-shaking/no-server/provider/package.json
+++ b/apps/shared-tree-shaking/no-server/provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-no-server-provider",
   "private": true,
-  "version": "1.0.14",
+  "version": "1.0.15",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/shared-tree-shaking/with-server/host/CHANGELOG.md
+++ b/apps/shared-tree-shaking/with-server/host/CHANGELOG.md
@@ -1,5 +1,12 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.15
+
+### Patch Changes
+
+- Updated dependencies [d13cafa]
+  - @module-federation/modern-js-v3@2.7.0
+
 ## 1.0.14
 
 ### Patch Changes

--- a/apps/shared-tree-shaking/with-server/host/package.json
+++ b/apps/shared-tree-shaking/with-server/host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-with-server-host",
   "private": true,
-  "version": "1.0.14",
+  "version": "1.0.15",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/shared-tree-shaking/with-server/provider/CHANGELOG.md
+++ b/apps/shared-tree-shaking/with-server/provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.15
+
+### Patch Changes
+
+- Updated dependencies [d13cafa]
+  - @module-federation/modern-js-v3@2.7.0
+
 ## 1.0.14
 
 ### Patch Changes

--- a/apps/shared-tree-shaking/with-server/provider/package.json
+++ b/apps/shared-tree-shaking/with-server/provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-with-server-provider",
   "private": true,
-  "version": "1.0.14",
+  "version": "1.0.15",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "modern dev",

--- a/apps/website-new/CHANGELOG.md
+++ b/apps/website-new/CHANGELOG.md
@@ -1,5 +1,14 @@
 # website-new
 
+## 1.3.27
+
+### Patch Changes
+
+- Updated dependencies [8ec950c]
+  - @module-federation/rspress-plugin@2.7.0
+  - @module-federation/runtime@2.7.0
+  - @module-federation/error-codes@2.7.0
+
 ## 1.3.26
 
 ### Patch Changes

--- a/apps/website-new/package.json
+++ b/apps/website-new/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website-new",
-  "version": "1.3.26",
+  "version": "1.3.27",
   "private": true,
   "description": "Federation example for website-new",
   "scripts": {

--- a/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
+++ b/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/bridge-react-webpack-plugin
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/bridge/bridge-react-webpack-plugin/package.json
+++ b/packages/bridge/bridge-react-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react-webpack-plugin",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/bridge-react/CHANGELOG.md
+++ b/packages/bridge/bridge-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/bridge-react
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/bridge/bridge-react/package.json
+++ b/packages/bridge/bridge-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/bridge/bridge-shared/CHANGELOG.md
+++ b/packages/bridge/bridge-shared/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/bridge-shared
 
+## 2.7.0
+
 ## 2.6.0
 
 ## 2.5.1

--- a/packages/bridge/bridge-shared/package.json
+++ b/packages/bridge/bridge-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-shared",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/vue3-bridge/CHANGELOG.md
+++ b/packages/bridge/vue3-bridge/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/bridge-vue3
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/runtime@2.7.0
+  - @module-federation/bridge-shared@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/bridge/vue3-bridge/package.json
+++ b/packages/bridge/vue3-bridge/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/module-federation/core.git",
     "directory": "packages/bridge/vue3-bridge"
   },
-  "version": "2.6.0",
+  "version": "2.7.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/chrome-devtools/CHANGELOG.md
+++ b/packages/chrome-devtools/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @module-federation/devtools
 
+## 2.7.0
+
+### Patch Changes
+
+- 8e3d5cb: Fix dependency graph cards for remotes that are only known by their manifest URL.
+- 538e38b: Guard Chrome DevTools module info sync against invalid undefined placeholder payloads.
+- 8ec950c: Bump runtime dependencies: echarts 6.1.0 (devtools), hono 4.12.26 and @hono/node-server 1.19.13 (treeshake-server), lodash-es 4.18.1 (rspress-plugin), handlebars 4.7.9 (create-module-federation), resolve 1.22.12 (third-party-dts-extractor).
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/observability-plugin@2.5.3
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/chrome-devtools/package.json
+++ b/packages/chrome-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/devtools",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/cli
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [a7351f3]
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/dts-plugin@2.7.0
+  - @module-federation/sdk@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/cli",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "commonjs",
   "description": "Module Federation CLI",
   "homepage": "https://module-federation.io",

--- a/packages/create-module-federation/CHANGELOG.md
+++ b/packages/create-module-federation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-module-federation
 
+## 2.7.0
+
+### Patch Changes
+
+- 8ec950c: Bump runtime dependencies: echarts 6.1.0 (devtools), hono 4.12.26 and @hono/node-server 1.19.13 (treeshake-server), lodash-es 4.18.1 (rspress-plugin), handlebars 4.7.9 (create-module-federation), resolve 1.22.12 (third-party-dts-extractor).
+
 ## 2.6.0
 
 ## 2.5.1

--- a/packages/create-module-federation/package.json
+++ b/packages/create-module-federation/package.json
@@ -3,7 +3,7 @@
   "description": "Create a new Module Federation project",
   "public": true,
   "sideEffects": false,
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/dts-plugin/CHANGELOG.md
+++ b/packages/dts-plugin/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @module-federation/dts-plugin
 
+## 2.7.0
+
+### Patch Changes
+
+- a7351f3: chore(dts-plugin): drop `ansi-colors` dependency in favor of inline ANSI escape for the single red error message.
+- Updated dependencies [dcc640b]
+- Updated dependencies [2add9ef]
+- Updated dependencies [9958086]
+- Updated dependencies [a5f123a]
+- Updated dependencies [8ec950c]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/third-party-dts-extractor@2.7.0
+  - @module-federation/managers@2.7.0
+  - @module-federation/error-codes@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/dts-plugin/package.json
+++ b/packages/dts-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/dts-plugin",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "author": "hanric <hanric.zhang@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/esm/index.mjs",

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @module-federation/enhanced
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [a7351f3]
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+- Updated dependencies [a5f123a]
+  - @module-federation/dts-plugin@2.7.0
+  - @module-federation/sdk@2.7.0
+  - @module-federation/managers@2.7.0
+  - @module-federation/manifest@2.7.0
+  - @module-federation/cli@2.7.0
+  - @module-federation/rspack@2.7.0
+  - @module-federation/bridge-react-webpack-plugin@2.7.0
+  - @module-federation/webpack-bundler-runtime@2.7.0
+  - @module-federation/runtime-tools@2.7.0
+  - @module-federation/inject-external-runtime-core-plugin@2.7.0
+  - @module-federation/error-codes@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/enhanced",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "repository": {

--- a/packages/error-codes/CHANGELOG.md
+++ b/packages/error-codes/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/error-codes
 
+## 2.7.0
+
 ## 2.6.0
 
 ## 2.5.1

--- a/packages/error-codes/package.json
+++ b/packages/error-codes/package.json
@@ -4,7 +4,7 @@
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "public": true,
   "sideEffects": false,
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/esbuild/CHANGELOG.md
+++ b/packages/esbuild/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @module-federation/esbuild
 
+## 0.0.110
+
+### Patch Changes
+
+- 61fe85d: chore(deps): upgrade `@rslib/core` to 0.23.2, `@rsbuild/core` to 2.1.4, and `@rsbuild/plugin-react`/`plugin-vue`/`plugin-sass` to their 2.x latest across dev dependencies. `create-module-federation` templates are updated so newly scaffolded projects pick up the same versions. `@module-federation/modern-js-v3` is realigned to `@modern-js/* 3.5.0` (which uses `@rsbuild/core 2.1.0`) to resolve a `Rspack` type mismatch between the upgraded `@module-federation/rsbuild-plugin` and modern-js's own rsbuild embedding. Peer dependency ranges are untouched.
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/runtime@2.7.0
+  - @module-federation/webpack-bundler-runtime@2.7.0
+
 ## 0.0.109
 
 ### Patch Changes

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/esbuild",
-  "version": "0.0.109",
+  "version": "0.0.110",
   "author": "Zack Jackson (@ScriptedAlchemy)",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/managers/CHANGELOG.md
+++ b/packages/managers/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/managers
 
+## 2.7.0
+
+### Patch Changes
+
+- a5f123a: chore: replace `find-pkg` with `empathic` (per [e18e replacements](https://e18e.dev/docs/replacements/find-pkg.html)). Removes unused `find-pkg` dependency from `@module-federation/manifest`.
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/managers/package.json
+++ b/packages/managers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/managers",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "description": "Provide managers for helping handle mf data .",
   "keywords": [

--- a/packages/manifest/CHANGELOG.md
+++ b/packages/manifest/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @module-federation/manifest
 
+## 2.7.0
+
+### Patch Changes
+
+- a5f123a: chore: replace `find-pkg` with `empathic` (per [e18e replacements](https://e18e.dev/docs/replacements/find-pkg.html)). Removes unused `find-pkg` dependency from `@module-federation/manifest`.
+- Updated dependencies [a7351f3]
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+- Updated dependencies [a5f123a]
+  - @module-federation/dts-plugin@2.7.0
+  - @module-federation/sdk@2.7.0
+  - @module-federation/managers@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/manifest",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "description": "Provide manifest/stats for webpack/rspack MF project .",
   "keywords": [

--- a/packages/metro-core/CHANGELOG.md
+++ b/packages/metro-core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @module-federation/metro
 
+## 2.7.0
+
+### Patch Changes
+
+- 61fe85d: chore(deps): upgrade `@rslib/core` to 0.23.2, `@rsbuild/core` to 2.1.4, and `@rsbuild/plugin-react`/`plugin-vue`/`plugin-sass` to their 2.x latest across dev dependencies. `create-module-federation` templates are updated so newly scaffolded projects pick up the same versions. `@module-federation/modern-js-v3` is realigned to `@modern-js/* 3.5.0` (which uses `@rsbuild/core 2.1.0`) to resolve a `Rspack` type mismatch between the upgraded `@module-federation/rsbuild-plugin` and modern-js's own rsbuild embedding. Peer dependency ranges are untouched.
+- Updated dependencies [a7351f3]
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/dts-plugin@2.7.0
+  - @module-federation/sdk@2.7.0
+  - @module-federation/runtime@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/metro-core/package.json
+++ b/packages/metro-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Module Federation for Metro bundler",
   "keywords": [
     "module-federation",

--- a/packages/metro-plugin-rnc-cli/CHANGELOG.md
+++ b/packages/metro-plugin-rnc-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/metro-plugin-rnc-cli
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [61fe85d]
+  - @module-federation/metro@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/metro-plugin-rnc-cli/package.json
+++ b/packages/metro-plugin-rnc-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro-plugin-rnc-cli",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Metro Module Federation plugin for React Native Enterprise Framework (RNEF)",
   "keywords": [
     "rnc",

--- a/packages/metro-plugin-rnef/CHANGELOG.md
+++ b/packages/metro-plugin-rnef/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/metro-plugin-rnef
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [61fe85d]
+  - @module-federation/metro@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/metro-plugin-rnef/package.json
+++ b/packages/metro-plugin-rnef/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro-plugin-rnef",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Metro Module Federation plugin for React Native Enterprise Framework (RNEF). Deprecated: use @module-federation/metro-plugin-rock instead.",
   "keywords": [
     "rnef",

--- a/packages/metro-plugin-rock/CHANGELOG.md
+++ b/packages/metro-plugin-rock/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/metro-plugin-rock
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [61fe85d]
+  - @module-federation/metro@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/metro-plugin-rock/package.json
+++ b/packages/metro-plugin-rock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro-plugin-rock",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Metro Module Federation plugin for Rock",
   "keywords": [
     "rock",

--- a/packages/modernjs-v3/CHANGELOG.md
+++ b/packages/modernjs-v3/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @module-federation/modern-js-v3
 
+## 2.7.0
+
+### Patch Changes
+
+- d13cafa: Disable lazy compilation for Modern.js v3 producer apps.
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+- Updated dependencies [61fe85d]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/rsbuild-plugin@2.7.0
+  - @module-federation/cli@2.7.0
+  - @module-federation/enhanced@2.7.0
+  - @module-federation/bridge-react@2.7.0
+  - @module-federation/node@2.7.46
+  - @module-federation/runtime@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/modernjs-v3/package.json
+++ b/packages/modernjs-v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/modern-js-v3",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "files": [
     "dist/",
     "types.d.ts",

--- a/packages/modernjs/CHANGELOG.md
+++ b/packages/modernjs/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @module-federation/modern-js
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+- Updated dependencies [61fe85d]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/rsbuild-plugin@2.7.0
+  - @module-federation/cli@2.7.0
+  - @module-federation/enhanced@2.7.0
+  - @module-federation/bridge-react@2.7.0
+  - @module-federation/node@2.7.46
+  - @module-federation/runtime@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/modernjs/package.json
+++ b/packages/modernjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/modern-js",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "files": [
     "dist/",
     "types.d.ts",

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @module-federation/nextjs-mf
 
+## 8.8.70
+
+### Patch Changes
+
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/enhanced@2.7.0
+  - @module-federation/node@2.7.46
+  - @module-federation/runtime@2.7.0
+  - @module-federation/runtime-core@2.7.0
+  - @module-federation/webpack-bundler-runtime@2.7.0
+
 ## 8.8.69
 
 ### Patch Changes

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "8.8.69",
+  "version": "8.8.70",
   "license": "MIT",
   "main": "dist/src/index.js",
   "module": "dist/src/index.mjs",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/node
 
+## 2.7.46
+
+### Patch Changes
+
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/enhanced@2.7.0
+  - @module-federation/runtime@2.7.0
+
 ## 2.7.45
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "2.7.45",
+  "version": "2.7.46",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "module": "./dist/src/index.mjs",

--- a/packages/observability-plugin/CHANGELOG.md
+++ b/packages/observability-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/observability-plugin
 
+## 2.5.3
+
+### Patch Changes
+
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+
 ## 2.5.2
 
 ### Patch Changes

--- a/packages/observability-plugin/package.json
+++ b/packages/observability-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/observability-plugin",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "author": "module-federation",
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/playground/CHANGELOG.md
+++ b/packages/playground/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @module-federation/playground
+
+## 0.0.2
+
+### Patch Changes
+
+- f8b9b32: Add a publishable Module Federation playground package for the docs site.
+  - @module-federation/bridge-react@2.7.0
+  - @module-federation/runtime@2.7.0

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/playground",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Module Federation Playground",
   "homepage": "https://module-federation.io",
   "repository": {

--- a/packages/retry-plugin/CHANGELOG.md
+++ b/packages/retry-plugin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/retry-plugin
 
+## 2.7.0
+
+### Patch Changes
+
+- c103676: fix: externalize @module-federation/runtime and runtime-core from DTS bundle to prevent type incompatibility in consumers
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/runtime@2.7.0
+
 ## 2.6.0
 
 ### Minor Changes

--- a/packages/retry-plugin/package.json
+++ b/packages/retry-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/retry-plugin",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "author": "danpeen <dapeen.feng@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/rsbuild-plugin/CHANGELOG.md
+++ b/packages/rsbuild-plugin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @module-federation/rsbuild-plugin
 
+## 2.7.0
+
+### Patch Changes
+
+- 61fe85d: chore(deps): upgrade `@rslib/core` to 0.23.2, `@rsbuild/core` to 2.1.4, and `@rsbuild/plugin-react`/`plugin-vue`/`plugin-sass` to their 2.x latest across dev dependencies. `create-module-federation` templates are updated so newly scaffolded projects pick up the same versions. `@module-federation/modern-js-v3` is realigned to `@modern-js/* 3.5.0` (which uses `@rsbuild/core 2.1.0`) to resolve a `Rspack` type mismatch between the upgraded `@module-federation/rsbuild-plugin` and modern-js's own rsbuild embedding. Peer dependency ranges are untouched.
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/enhanced@2.7.0
+  - @module-federation/node@2.7.46
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/rsbuild-plugin/package.json
+++ b/packages/rsbuild-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rsbuild-plugin",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Module Federation plugin for Rsbuild",
   "homepage": "https://module-federation.io",
   "bugs": {

--- a/packages/rspack/CHANGELOG.md
+++ b/packages/rspack/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @module-federation/rspack
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [a7351f3]
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+- Updated dependencies [a5f123a]
+  - @module-federation/dts-plugin@2.7.0
+  - @module-federation/sdk@2.7.0
+  - @module-federation/managers@2.7.0
+  - @module-federation/manifest@2.7.0
+  - @module-federation/bridge-react-webpack-plugin@2.7.0
+  - @module-federation/runtime-tools@2.7.0
+  - @module-federation/inject-external-runtime-core-plugin@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rspack",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "keywords": [
     "Module Federation",

--- a/packages/rspress-plugin/CHANGELOG.md
+++ b/packages/rspress-plugin/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @module-federation/rspress-plugin
 
+## 2.7.0
+
+### Patch Changes
+
+- 8ec950c: Bump runtime dependencies: echarts 6.1.0 (devtools), hono 4.12.26 and @hono/node-server 1.19.13 (treeshake-server), lodash-es 4.18.1 (rspress-plugin), handlebars 4.7.9 (create-module-federation), resolve 1.22.12 (third-party-dts-extractor).
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+- Updated dependencies [61fe85d]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/rsbuild-plugin@2.7.0
+  - @module-federation/enhanced@2.7.0
+  - @module-federation/error-codes@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/rspress-plugin/package.json
+++ b/packages/rspress-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rspress-plugin",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "description": "Module Federation plugin for Rspress",
   "keywords": [

--- a/packages/runtime-core/CHANGELOG.md
+++ b/packages/runtime-core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/runtime
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/error-codes@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-core",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs",

--- a/packages/runtime-plugins/inject-external-runtime-core-plugin/CHANGELOG.md
+++ b/packages/runtime-plugins/inject-external-runtime-core-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/inject-external-runtime-core-plugin
 
+## 2.7.0
+
+### Patch Changes
+
+- @module-federation/runtime-tools@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/runtime-plugins/inject-external-runtime-core-plugin/package.json
+++ b/packages/runtime-plugins/inject-external-runtime-core-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/inject-external-runtime-core-plugin",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "license": "MIT",
   "description": "A sdk for support module federation",

--- a/packages/runtime-tools/CHANGELOG.md
+++ b/packages/runtime-tools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/runtime-tools
 
+## 2.7.0
+
+### Patch Changes
+
+- @module-federation/runtime@2.7.0
+- @module-federation/webpack-bundler-runtime@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/runtime-tools/package.json
+++ b/packages/runtime-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-tools",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "main": "./dist/index.cjs",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/runtime
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/runtime-core@2.7.0
+  - @module-federation/error-codes@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/sdk
 
+## 2.7.0
+
+### Minor Changes
+
+- dcc640b: chore(sdk): drop the `node-fetch` fallback and optional peer dependency. Native `fetch` was already preferred everywhere it exists (Node 18+); the fallback only fired on EOL Node versions, where the loader-hook path was broken anyway. Removes up to ~9MB of optional install weight (`web-streams-polyfill` et al).
+
+### Patch Changes
+
+- 9958086: Handle Node.js built-in imports in the Node ESM remote loader.
+
 ## 2.6.0
 
 ## 2.5.1

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/sdk",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "license": "MIT",
   "description": "A sdk for support module federation",

--- a/packages/storybook-addon/CHANGELOG.md
+++ b/packages/storybook-addon/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/storybook-addon
 
+## 6.0.15
+
+### Patch Changes
+
+- 61fe85d: chore(deps): upgrade `@rslib/core` to 0.23.2, `@rsbuild/core` to 2.1.4, and `@rsbuild/plugin-react`/`plugin-vue`/`plugin-sass` to their 2.x latest across dev dependencies. `create-module-federation` templates are updated so newly scaffolded projects pick up the same versions. `@module-federation/modern-js-v3` is realigned to `@modern-js/* 3.5.0` (which uses `@rsbuild/core 2.1.0`) to resolve a `Rspack` type mismatch between the upgraded `@module-federation/rsbuild-plugin` and modern-js's own rsbuild embedding. Peer dependency ranges are untouched.
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/enhanced@2.7.0
+
 ## 6.0.14
 
 ### Patch Changes

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/storybook-addon",
-  "version": "6.0.14",
+  "version": "6.0.15",
   "description": "Storybook addon to consume remote module federated apps/components",
   "type": "module",
   "license": "MIT",
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@rsbuild/core": "^1.0.1 || ^2.0.0-0",
-    "@module-federation/sdk": "^2.6.0",
+    "@module-federation/sdk": "^2.7.0",
     "@nx/react": ">= 16.0.0",
     "@nx/webpack": ">= 16.0.0",
     "@nx/module-federation": ">= 16.0.0",

--- a/packages/third-party-dts-extractor/CHANGELOG.md
+++ b/packages/third-party-dts-extractor/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/third-party-dts-extractor
 
+## 2.7.0
+
+### Patch Changes
+
+- 2add9ef: chore(third-party-dts-extractor): replace `resolve` with `exsolve` (0 transitive deps, ~100KB smaller) for the single `package.json` lookup.
+- a5f123a: chore: replace `find-pkg` with `empathic` (per [e18e replacements](https://e18e.dev/docs/replacements/find-pkg.html)). Removes unused `find-pkg` dependency from `@module-federation/manifest`.
+- 8ec950c: Bump runtime dependencies: echarts 6.1.0 (devtools), hono 4.12.26 and @hono/node-server 1.19.13 (treeshake-server), lodash-es 4.18.1 (rspress-plugin), handlebars 4.7.9 (create-module-federation), resolve 1.22.12 (third-party-dts-extractor).
+
 ## 2.6.0
 
 ## 2.5.1

--- a/packages/third-party-dts-extractor/package.json
+++ b/packages/third-party-dts-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/third-party-dts-extractor",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "files": [
     "dist/",
     "README.md"

--- a/packages/treeshake-frontend/CHANGELOG.md
+++ b/packages/treeshake-frontend/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/treeshake-frontend
 
+## 2.7.0
+
 ## 2.6.0
 
 ## 2.5.1

--- a/packages/treeshake-frontend/package.json
+++ b/packages/treeshake-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/treeshake-frontend",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build && rslib build",

--- a/packages/treeshake-server/CHANGELOG.md
+++ b/packages/treeshake-server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/treeshake-server
 
+## 2.7.0
+
+### Patch Changes
+
+- 8ec950c: Bump runtime dependencies: echarts 6.1.0 (devtools), hono 4.12.26 and @hono/node-server 1.19.13 (treeshake-server), lodash-es 4.18.1 (rspress-plugin), handlebars 4.7.9 (create-module-federation), resolve 1.22.12 (third-party-dts-extractor).
+- db81375: Bump undici to 7.28.0 to resolve known vulnerabilities (CVE-2026-12151 and related advisories).
+
 ## 2.6.0
 
 ## 2.5.1

--- a/packages/treeshake-server/package.json
+++ b/packages/treeshake-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/treeshake-server",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Build service powered by Hono that installs dependencies, builds with Rspack, and uploads artifacts.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/typescript
 
+## 3.1.9
+
+### Patch Changes
+
+- 6b22938: chore(typescript): drop `lodash.get` dependency in favor of optional chaining in `normalizeOptions`.
+
 ## 3.1.8
 
 ### Patch Changes

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/typescript",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Webpack plugin to stream typescript for module federation apps/components",
   "license": "MIT",
   "type": "commonjs",

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/utilities
 
+## 3.1.98
+
+### Patch Changes
+
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+
 ## 3.1.97
 
 ### Patch Changes

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/utilities",
-  "version": "3.1.97",
+  "version": "3.1.98",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/webpack-bundler-runtime/CHANGELOG.md
+++ b/packages/webpack-bundler-runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/webpack-bundler-runtime
 
+## 2.7.0
+
+### Patch Changes
+
+- Updated dependencies [dcc640b]
+- Updated dependencies [9958086]
+  - @module-federation/sdk@2.7.0
+  - @module-federation/runtime@2.7.0
+  - @module-federation/error-codes@2.7.0
+
 ## 2.6.0
 
 ### Patch Changes

--- a/packages/webpack-bundler-runtime/package.json
+++ b/packages/webpack-bundler-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/webpack-bundler-runtime",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "license": "MIT",
   "description": "Module Federation Runtime for webpack",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at release-v2.7.0 -->

## What's Changed
### New Features 🎉
* feat(playground): add docs playground by @2heal1 in https://github.com/module-federation/core/pull/4846
* feat(i18n): add Brazilian Portuguese localization and documentation by @DevJoaoLopes in https://github.com/module-federation/core/pull/4850
* feat(website): deploy Rspress docs with Zephyr by @Nsttt in https://github.com/module-federation/core/pull/4855
### Bug Fixes 🐞
* fix(modern-js-v3): disable lazy compilation for producers by @2heal1 in https://github.com/module-federation/core/pull/4845
* fix(devtools): show manifest-only remotes in dependency graph by @2heal1 in https://github.com/module-federation/core/pull/4848
* fix(website): add social icon meta by @2heal1 in https://github.com/module-federation/core/pull/4847
* fix(retry-plugin): externalize runtime types from DTS bundle by @shashank-u03 in https://github.com/module-federation/core/pull/4853
* fix(treeshake-server): bump undici to 7.28.0 for CVE-2026-12151 by @ScriptedAlchemy in https://github.com/module-federation/core/pull/4863
* fix(sdk): handle node builtins in ESM remote loader by @dmchoi77 in https://github.com/module-federation/core/pull/4816
* fix(devtools): guard invalid module info payloads by @dmchoi77 in https://github.com/module-federation/core/pull/4787
### Document 📖
* docs: restructure architecture docs by @ScriptedAlchemy in https://github.com/module-federation/core/pull/4859
* docs: correct factual inaccuracies in architecture docs by @ScriptedAlchemy in https://github.com/module-federation/core/pull/4861
* docs(website-new): add GA4 tracking by @ScriptedAlchemy in https://github.com/module-federation/core/pull/4874
### Other Changes
* chore(deps): bump js-yaml from 3.14.2 to 5.2.0 by @dependabot[bot] in https://github.com/module-federation/core/pull/4860
* chore(deps): bump react-router from 6.30.3 to 6.30.4 in /packages/bridge/bridge-react-webpack-plugin/__tests__/mockRouterDir/router-v6/react-router-dom by @dependabot[bot] in https://github.com/module-federation/core/pull/4795
* chore(typescript): drop `lodash.get` dependency by @gu-stav in https://github.com/module-federation/core/pull/4705
* chore(managers,manifest,third-party-dts-extractor): replace `find-pkg` by @gu-stav in https://github.com/module-federation/core/pull/4707
* chore(dts-plugin): drop `ansi-colors` dependency by @gu-stav in https://github.com/module-federation/core/pull/4704
* chore(deps): bump echarts from 6.0.0 to 6.1.0 by @dependabot[bot] in https://github.com/module-federation/core/pull/4858
* chore(deps): bump @hono/node-server from 1.19.10 to 1.19.13 by @dependabot[bot] in https://github.com/module-federation/core/pull/4635
* chore(deps): bump handlebars from 4.7.7 to 4.7.9 by @dependabot[bot] in https://github.com/module-federation/core/pull/4597
* chore(third-party-dts-extractor): replace `resolve` with `exsolve` by @gu-stav in https://github.com/module-federation/core/pull/4775
* chore(deps): apply small dependabot bumps across packages and example apps by @ScriptedAlchemy in https://github.com/module-federation/core/pull/4865
* test(cypress): drop redundant uncaught:exception suppression in memory-router spec by @voidmatcha in https://github.com/module-federation/core/pull/4826
* test: migrate to Rstest by @chenjiahan in https://github.com/module-federation/core/pull/4871
* chore(sdk): drop node-fetch fallback and optional peer dependency by @gu-stav in https://github.com/module-federation/core/pull/4866
* chore: upgrade typescript to 6.0.3 by @eduard-jacko in https://github.com/module-federation/core/pull/4737
* chore(deps): upgrade Rslib, Rsbuild and Rsbuild plugins to latest by @elecmonkey in https://github.com/module-federation/core/pull/4872
* chore: remove unused jest config by @2heal1 in https://github.com/module-federation/core/pull/4875

## New Contributors
* @voidmatcha made their first contribution in https://github.com/module-federation/core/pull/4826
* @dmchoi77 made their first contribution in https://github.com/module-federation/core/pull/4816
* @DevJoaoLopes made their first contribution in https://github.com/module-federation/core/pull/4850
* @eduard-jacko made their first contribution in https://github.com/module-federation/core/pull/4737
* @elecmonkey made their first contribution in https://github.com/module-federation/core/pull/4872

**Full Changelog**: https://github.com/module-federation/core/compare/v2.6.0...v2.7.0