### PR TITLE
fix(ci): support current Rslib bundle API

### DIFF
--- a/scripts/bundle-size-report.mjs
+++ b/scripts/bundle-size-report.mjs
@@ -876,7 +876,10 @@ function compare(baseData, currentData) {
   );
 
   const buildTable = (title, metrics, rowsData) => {
-    if (rowsData.length === 0) return [];
+    const changedRows = rowsData.filter(({ base, current }) =>
+      hasMetricChange(base, current, metrics),
+    );
+    if (changedRows.length === 0) return [];
     const rows = [];
     rows.push(`### ${title}`);
     rows.push('');
@@ -888,7 +891,7 @@ function compare(baseData, currentData) {
     rows.push(`| ${headers.join(' | ')} |`);
     rows.push(`| ${headers.map(() => '---').join(' | ')} |`);
 
-    for (const { name, base, current } of rowsData) {
+    for (const { name, base, current } of changedRows) {
       const cells = [`\`${name}\``];
       for (const metric of metrics) {
         const currentValue = current[metric.key];

--- a/scripts/bundle-size-report.mjs
+++ b/scripts/bundle-size-report.mjs
@@ -102,7 +102,9 @@ async function runRslibBuild(config) {
   }
   if (typeof rslib.createRslib === 'function') {
     const instance = await rslib.createRslib({ config });
-    return instance.build();
+    const result = await instance.build();
+    await result.close();
+    return result;
   }
   throw new Error('Unsupported @rslib/core API: no build function available');
 }

--- a/scripts/bundle-size-report.mjs
+++ b/scripts/bundle-size-report.mjs
@@ -95,6 +95,18 @@ async function loadRslib() {
   return rslibPromise;
 }
 
+async function runRslibBuild(config) {
+  const rslib = await loadRslib();
+  if (typeof rslib.build === 'function') {
+    return rslib.build(config);
+  }
+  if (typeof rslib.createRslib === 'function') {
+    const instance = await rslib.createRslib({ config });
+    return instance.build();
+  }
+  throw new Error('Unsupported @rslib/core API: no build function available');
+}
+
 async function loadWebpack() {
   if (!webpackPromise) {
     webpackPromise = Promise.resolve(require('webpack'));
@@ -291,14 +303,13 @@ async function bundleEntry(entryPath, options) {
   }
 
   try {
-    const { build } = await loadRslib();
     const entryName = options.entryName || 'bundle';
     const distRoot = createTempDir(
       options.packageName || 'pkg',
       options.target,
     );
 
-    await build(
+    await runRslibBuild(
       {
         lib: [
           {
@@ -667,6 +678,17 @@ async function measure(packagesDir) {
       bundleErrors: rootMetrics.bundleErrors,
       entrypoints,
     };
+  }
+
+  const hasSuccessfulBundle = Object.values(results).some((pkg) =>
+    Object.values(pkg.entrypoints).some(
+      (entry) =>
+        typeof entry.webBundleGzip === 'number' ||
+        typeof entry.nodeBundleGzip === 'number',
+    ),
+  );
+  if (packages.length > 0 && !hasSuccessfulBundle) {
+    throw new Error('Bundle size measurement failed for every package');
   }
 
   return {


### PR DESCRIPTION
The bundle-size report still called the removed top-level `build(config)` API after `@rslib/core` moved to `createRslib({ config }).build()`. As a result, every package reported `build is not a function`, while the workflow remained green.

This change supports both Rslib API generations and fails measurement when every package bundle fails, preventing false-green reports.

Validation:
- `pnpm run ci:local --only=bundle-size`
- `pnpm exec prettier --check scripts/bundle-size-report.mjs`

No changeset: CI-only tooling change.