### PR TITLE
fix: support Rspack module identifiers

### DIFF
--- a/.changeset/tidy-rspack-identifiers.md
+++ b/.changeset/tidy-rspack-identifiers.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/manifest': patch
+'@module-federation/utilities': patch
+---
+
+Support Rspack container reference identifiers when collecting remote and delegate modules.

--- a/packages/manifest/__tests__/ModuleHandler.spec.ts
+++ b/packages/manifest/__tests__/ModuleHandler.spec.ts
@@ -84,7 +84,21 @@ jest.mock(
     },
     RemoteManager: class {
       statsRemoteWithEmptyUsedIn: unknown[] = [];
-      init() {}
+      normalizedOptions: Record<
+        string,
+        { alias: string; name: string; entry: string }
+      > = {};
+
+      init(options: { remotes?: Record<string, string> }) {
+        this.normalizedOptions = Object.entries(options.remotes || {}).reduce(
+          (normalizedOptions, [alias, remote]) => {
+            const [name, entry] = remote.split('@');
+            normalizedOptions[alias] = { alias, name, entry };
+            return normalizedOptions;
+          },
+          {} as Record<string, { alias: string; name: string; entry: string }>,
+        );
+      }
     },
     SharedManager: class {
       normalizedOptions: Record<string, { requiredVersion?: string }> = {};
@@ -175,4 +189,38 @@ describe('ModuleHandler', () => {
     expect(exposesMap['./src/Button']?.path).toBe('./Button');
     expect(exposesMap['./src/Card']?.path).toBe('./Card');
   });
+
+  it.each(['webpack', 'rspack'] as const)(
+    'parses %s remote reference identifiers',
+    (bundler) => {
+      const modules: StatsModule[] = [
+        {
+          identifier: `remote (default) ${bundler}/container/reference/app2 ./Button`,
+          nameForCondition: './src/App.tsx',
+        } as StatsModule,
+      ];
+
+      const moduleHandler = new ModuleHandler(
+        {
+          name: 'host',
+          remotes: {
+            app2: 'app2@http://localhost:3002/remoteEntry.js',
+          },
+        },
+        modules,
+        { bundler },
+      );
+
+      const { remotes } = moduleHandler.collect();
+
+      expect(remotes).toHaveLength(1);
+      expect(remotes[0]).toMatchObject({
+        alias: 'app2',
+        consumingFederationContainerName: 'host',
+        federationContainerName: 'app2',
+        moduleName: 'Button',
+        entry: 'http://localhost:3002/remoteEntry.js',
+      });
+    },
+  );
 });

--- a/packages/manifest/src/ModuleHandler.ts
+++ b/packages/manifest/src/ModuleHandler.ts
@@ -25,6 +25,8 @@ type ContainerExposeEntry = [
   { import: string[]; name?: string },
 ];
 
+const REMOTE_REFERENCE_PREFIX = /^(?:webpack|rspack)\/container\/reference\//;
+
 const isNonEmptyString = (value: unknown): value is string => {
   return typeof value === 'string' && value.trim().length > 0;
 };
@@ -378,12 +380,12 @@ class ModuleHandler {
     }
     const remoteManagerNormalizedOptions =
       this._remoteManager.normalizedOptions;
-    // identifier = remote (default) webpack/container/reference/app2 ./Button
+    // identifier = remote (default) [webpack|rspack]/container/reference/app2 ./Button
     const data = identifier.split(' ');
 
     if (data.length === 4) {
       const moduleName = data[3].replace('./', '');
-      const remoteAlias = data[2].replace('webpack/container/reference/', '');
+      const remoteAlias = data[2].replace(REMOTE_REFERENCE_PREFIX, '');
       const normalizedRemote = remoteManagerNormalizedOptions[remoteAlias];
       const basicRemote: StatsRemoteVal = {
         alias: normalizedRemote.alias,

--- a/packages/utilities/src/plugins/DelegateModulesPlugin.test.ts
+++ b/packages/utilities/src/plugins/DelegateModulesPlugin.test.ts
@@ -1,0 +1,41 @@
+import DelegateModulesPlugin from './DelegateModulesPlugin';
+
+describe('DelegateModulesPlugin', () => {
+  it.each(['webpack', 'rspack'])(
+    'collects %s container reference modules as delegates',
+    (bundler) => {
+      const remoteModule = {
+        identifier: () => `${bundler}/container/reference/app2`,
+        userRequest: `${bundler}/container/reference/app2`,
+      };
+      const finishModules = {
+        tapAsync: jest.fn(
+          (
+            _name,
+            handler: (modules: unknown[], callback: () => void) => void,
+          ) => handler([remoteModule], jest.fn()),
+        ),
+      };
+      const compilation = {
+        hooks: {
+          finishModules,
+          optimizeChunks: { tap: jest.fn() },
+        },
+      };
+      const compiler = {
+        hooks: {
+          thisCompilation: {
+            tap: jest.fn((_name, handler) => handler(compilation)),
+          },
+        },
+      };
+      const plugin = new DelegateModulesPlugin({});
+
+      plugin.apply(compiler as never);
+
+      expect(plugin._delegateModules.get(remoteModule.identifier())).toBe(
+        remoteModule,
+      );
+    },
+  );
+});

--- a/packages/utilities/src/plugins/DelegateModulesPlugin.ts
+++ b/packages/utilities/src/plugins/DelegateModulesPlugin.ts
@@ -6,6 +6,8 @@ import type {
   Module,
 } from 'webpack';
 
+const REMOTE_REFERENCE_PREFIX = /^(?:webpack|rspack)\/container\/reference/;
+
 class DelegateModulesPlugin {
   options: { debug: boolean; [key: string]: any };
   _delegateModules: Map<string, NormalModule>;
@@ -88,9 +90,8 @@ class DelegateModulesPlugin {
               if (normalModule) {
                 const mid = normalModule.identifier();
                 if (
-                  normalModule?.userRequest?.startsWith(
-                    'webpack/container/reference',
-                  )
+                  normalModule?.userRequest &&
+                  REMOTE_REFERENCE_PREFIX.test(normalModule.userRequest)
                 ) {
                   this._delegateModules.set(mid, normalModule);
                 }


### PR DESCRIPTION
## Description

Accept both `webpack/container/reference/` and `rspack/container/reference/` identifiers when:

- extracting remote aliases for manifest stats
- collecting delegated remote modules

This keeps the existing webpack behavior while supporting Rspack's bundler-specific module identifiers.

## Related Issue

- Related to web-infra-dev/rspack#14761

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.

## Validation

- `pnpm --filter @module-federation/manifest test`
- `pnpm --filter @module-federation/utilities test`
- package lint for manifest and utilities
- Turbo build for manifest and utilities, including workspace dependencies
