### PR TITLE
fix(manifest): preserve ESM remote entry type

### DIFF
--- a/.changeset/clean-dodos-federate.md
+++ b/.changeset/clean-dodos-federate.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/manifest': patch
+---
+
+Preserve the configured Module Federation library type when reconciling
+Rspack-pre-emitted stats and manifests, including ESM `module` remote entries.

--- a/packages/manifest/__tests__/StatsManager.spec.ts
+++ b/packages/manifest/__tests__/StatsManager.spec.ts
@@ -1,0 +1,73 @@
+import type { Stats, moduleFederationPlugin } from '@module-federation/sdk';
+import type { Compiler } from 'webpack';
+
+jest.mock(
+  '@module-federation/dts-plugin/core',
+  () => ({
+    isTSProject: () => false,
+    retrieveTypesAssetsInfo: () => ({}) as const,
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  '@module-federation/managers',
+  () => ({
+    ContainerManager: class {
+      init() {}
+    },
+    RemoteManager: class {
+      init() {}
+    },
+    SharedManager: class {
+      init() {}
+    },
+    PKGJsonManager: class {},
+    UNKNOWN_MODULE_NAME: 'unknown',
+    utils: {},
+  }),
+  { virtual: true },
+);
+
+import { StatsManager } from '../src/StatsManager';
+
+describe('StatsManager', () => {
+  it('reconciles pre-emitted Rspack metadata to the configured ESM library type', () => {
+    const manager = new StatsManager();
+    manager.init(
+      {
+        name: 'esm_remote',
+        library: { type: 'module' },
+        exposes: { './App': './src/App' },
+      } as moduleFederationPlugin.ModuleFederationPluginOptions,
+      { pluginVersion: 'test', bundler: 'rspack' },
+    );
+    const stats = {
+      id: 'esm_remote',
+      name: 'esm_remote',
+      metaData: {
+        name: 'esm_remote',
+        globalName: 'esm_remote',
+        buildInfo: { buildVersion: '1.0.0', buildName: 'esm_remote' },
+        remoteEntry: {
+          name: 'remoteEntry.mjs',
+          path: '',
+          type: 'global',
+        },
+        types: { path: '', name: '', api: '', zip: '' },
+        pluginVersion: 'test',
+      },
+      exposes: [],
+      shared: [],
+      remotes: [],
+    } as unknown as Stats;
+    const compiler = {
+      context: process.cwd(),
+      options: { output: { publicPath: 'auto' } },
+    } as unknown as Compiler;
+
+    const updated = manager.updateStats(stats, compiler);
+
+    expect(updated.metaData.remoteEntry.type).toBe('module');
+  });
+});

--- a/packages/manifest/__tests__/StatsManager.spec.ts
+++ b/packages/manifest/__tests__/StatsManager.spec.ts
@@ -32,12 +32,27 @@ jest.mock(
 import { StatsManager } from '../src/StatsManager';
 
 describe('StatsManager', () => {
-  it('reconciles pre-emitted Rspack metadata to the configured ESM library type', () => {
+  it.each([
+    {
+      description:
+        'reconciles pre-emitted Rspack metadata to the configured ESM library type',
+      library: { type: 'module' },
+      emittedType: 'global',
+      expectedType: 'module',
+    },
+    {
+      description:
+        'preserves pre-emitted Rspack metadata without a configured library type',
+      library: undefined,
+      emittedType: 'system',
+      expectedType: 'system',
+    },
+  ] as const)('$description', ({ library, emittedType, expectedType }) => {
     const manager = new StatsManager();
     manager.init(
       {
         name: 'esm_remote',
-        library: { type: 'module' },
+        library,
         exposes: { './App': './src/App' },
       } as moduleFederationPlugin.ModuleFederationPluginOptions,
       { pluginVersion: 'test', bundler: 'rspack' },
@@ -52,7 +67,7 @@ describe('StatsManager', () => {
         remoteEntry: {
           name: 'remoteEntry.mjs',
           path: '',
-          type: 'global',
+          type: emittedType,
         },
         types: { path: '', name: '', api: '', zip: '' },
         pluginVersion: 'test',
@@ -68,6 +83,6 @@ describe('StatsManager', () => {
 
     const updated = manager.updateStats(stats, compiler);
 
-    expect(updated.metaData.remoteEntry.type).toBe('module');
+    expect(updated.metaData.remoteEntry.type).toBe(expectedType);
   });
 });

--- a/packages/manifest/src/StatsManager.ts
+++ b/packages/manifest/src/StatsManager.ts
@@ -173,7 +173,7 @@ class StatsManager {
       remoteEntry: {
         name: getRemoteEntryName(),
         path: '',
-        // same as the types supported by runtime, currently only global/var/script is supported
+        // The runtime loader type follows the configured container library type.
         type:
           (this._options?.library?.type as RemoteEntryType | undefined) ||
           'global',

--- a/packages/manifest/src/StatsManager.ts
+++ b/packages/manifest/src/StatsManager.ts
@@ -598,6 +598,13 @@ class StatsManager {
 
   updateStats(stats: Stats, compiler: Compiler): Stats {
     const { metaData } = stats;
+    const configuredRemoteEntryType = this._options.library?.type;
+    if (configuredRemoteEntryType && metaData.remoteEntry) {
+      // Rspack may pre-emit stats with the default `global` type even when
+      // the configured container library and emitted remote entry are ESM.
+      // The configured library is authoritative for runtime loader selection.
+      metaData.remoteEntry.type = configuredRemoteEntryType;
+    }
     if (!metaData.types) {
       metaData.types = getTypesMetaInfo(this._options, compiler.context);
     }


### PR DESCRIPTION
## Description

Preserves the configured `library.type: "module"` when Rspack pre-emits remote-entry metadata as `global`. The manifest now selects the correct ESM remote-entry loader, with a focused regression test.

This is intentionally isolated from the application-lifecycle work discussed in #4891 so it can be reviewed and merged independently.

## Related Issue

Split from #4891 in response to review feedback; no separate issue.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.