### PR TITLE
fix: set optimization.usedExports to global to prevent tree shaking i…

### DIFF
--- a/.changeset/short-eyes-punch.md
+++ b/.changeset/short-eyes-punch.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/modern-js-v3': patch
+'@module-federation/modern-js': patch
+---
+
+fix(modernjs-v3): set optimization.usedExports to "global" to prevent tree shaking issues in micro frontend mode

--- a/packages/modernjs-v3/src/cli/configPlugin.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.ts
@@ -369,7 +369,10 @@ export function patchBundlerConfig(options: {
     modernjsConfig.deploy?.microFrontend &&
     Object.keys(mfConfig.exposes || {}).length
   ) {
-    chain.optimization.usedExports(false);
+    logger.info(
+      'optimization.usedExports is set to "global" to avoid tree shaking issues in micro frontend mode.',
+    );
+    chain.optimization.usedExports('global');
   }
 }
 

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -377,7 +377,10 @@ export function patchBundlerConfig(options: {
     modernjsConfig.deploy?.microFrontend &&
     Object.keys(mfConfig.exposes || {}).length
   ) {
-    chain.optimization.usedExports(false);
+    logger.info(
+      'optimization.usedExports is set to "global" to avoid tree shaking issues in micro frontend mode.',
+    );
+    chain.optimization.usedExports('global');
   }
 }
 


### PR DESCRIPTION

## Description
set optimization.usedExports to global to prevent tree shaking issues in micro frontend mode

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
