### PR TITLE
fix(modern-js): set optimization target from ssr config

### DIFF
--- a/.changeset/tidy-cats-optimize.md
+++ b/.changeset/tidy-cats-optimize.md
@@ -3,4 +3,5 @@
 "@module-federation/modern-js-v3": patch
 ---
 
-Default federation optimizations to the active Modern.js browser or SSR target.
+Automatically select federation optimization targets for Modern.js browser and
+SSR builds, with an option to disable this behavior.

--- a/.changeset/tidy-cats-optimize.md
+++ b/.changeset/tidy-cats-optimize.md
@@ -1,0 +1,6 @@
+---
+"@module-federation/modern-js": patch
+"@module-federation/modern-js-v3": patch
+---
+
+Default federation optimizations to the active Modern.js browser or SSR target.

--- a/packages/modernjs-v3/src/cli/configPlugin.spec.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.spec.ts
@@ -155,6 +155,14 @@ describe('setDefaultOptimizationTarget', () => {
 
     expect(config.experiments.optimization.target).toBe('web');
   });
+
+  it('does not set a target when autoOptimization is disabled', () => {
+    const config = { name: 'host' };
+
+    setDefaultOptimizationTarget(config, true, true, false);
+
+    expect(config).toStrictEqual({ name: 'host' });
+  });
 });
 
 describe('moduleFederationConfigPlugin', async () => {

--- a/packages/modernjs-v3/src/cli/configPlugin.spec.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.spec.ts
@@ -1,5 +1,9 @@
 import { it, expect, describe, rs, afterEach } from '@rstest/core';
-import { moduleFederationConfigPlugin, patchMFConfig } from './configPlugin';
+import {
+  moduleFederationConfigPlugin,
+  patchMFConfig,
+  setDefaultOptimizationTarget,
+} from './configPlugin';
 import logger from '../logger';
 
 const mfConfig = {
@@ -107,6 +111,49 @@ describe('patchMFConfig', async () => {
         },
       },
     });
+  });
+});
+
+describe('setDefaultOptimizationTarget', () => {
+  it('defaults to web when SSR is disabled', () => {
+    const config = { name: 'host' };
+
+    setDefaultOptimizationTarget(config, false, false);
+
+    expect(config).toMatchObject({
+      experiments: { optimization: { target: 'web' } },
+    });
+  });
+
+  it('defaults to web for the browser target when SSR is enabled', () => {
+    const config = { name: 'host' };
+
+    setDefaultOptimizationTarget(config, true, false);
+
+    expect(config).toMatchObject({
+      experiments: { optimization: { target: 'web' } },
+    });
+  });
+
+  it('defaults to node for the server target when SSR is enabled', () => {
+    const config = { name: 'host' };
+
+    setDefaultOptimizationTarget(config, true, true);
+
+    expect(config).toMatchObject({
+      experiments: { optimization: { target: 'node' } },
+    });
+  });
+
+  it('preserves an explicitly configured target', () => {
+    const config = {
+      name: 'host',
+      experiments: { optimization: { target: 'web' as const } },
+    };
+
+    setDefaultOptimizationTarget(config, true, true);
+
+    expect(config.experiments.optimization.target).toBe('web');
   });
 });
 

--- a/packages/modernjs-v3/src/cli/configPlugin.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.ts
@@ -236,7 +236,12 @@ export const setDefaultOptimizationTarget = (
   mfConfig: moduleFederationPlugin.ModuleFederationPluginOptions,
   enableSSR: boolean,
   isServer: boolean,
+  autoOptimization = true,
 ) => {
+  if (!autoOptimization) {
+    return;
+  }
+
   mfConfig.experiments ||= {};
   mfConfig.experiments.optimization ||= {};
   mfConfig.experiments.optimization.target ??=
@@ -415,7 +420,12 @@ export const moduleFederationConfigPlugin = (
       addMyTypes2Ignored(chain, !isWeb ? ssrConfig : csrConfig);
 
       const targetMFConfig = !isWeb ? ssrConfig : csrConfig;
-      setDefaultOptimizationTarget(targetMFConfig, enableSSR, !isWeb);
+      setDefaultOptimizationTarget(
+        targetMFConfig,
+        enableSSR,
+        !isWeb,
+        userConfig.originPluginOptions.autoOptimization,
+      );
       patchMFConfig(targetMFConfig, !isWeb);
 
       if (

--- a/packages/modernjs-v3/src/cli/configPlugin.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.ts
@@ -232,6 +232,17 @@ export const patchMFConfig = (
   return mfConfig;
 };
 
+export const setDefaultOptimizationTarget = (
+  mfConfig: moduleFederationPlugin.ModuleFederationPluginOptions,
+  enableSSR: boolean,
+  isServer: boolean,
+) => {
+  mfConfig.experiments ||= {};
+  mfConfig.experiments.optimization ||= {};
+  mfConfig.experiments.optimization.target ??=
+    enableSSR && isServer ? 'node' : 'web';
+};
+
 function patchIgnoreWarning(chain: BundlerChainConfig) {
   const ignoreWarnings = chain.get('ignoreWarnings') || [];
   const ignoredMsgs = [
@@ -404,6 +415,7 @@ export const moduleFederationConfigPlugin = (
       addMyTypes2Ignored(chain, !isWeb ? ssrConfig : csrConfig);
 
       const targetMFConfig = !isWeb ? ssrConfig : csrConfig;
+      setDefaultOptimizationTarget(targetMFConfig, enableSSR, !isWeb);
       patchMFConfig(targetMFConfig, !isWeb);
 
       if (

--- a/packages/modernjs-v3/src/types/index.ts
+++ b/packages/modernjs-v3/src/types/index.ts
@@ -4,6 +4,12 @@ import type { StatsAssetResource } from '@module-federation/rsbuild-plugin/utils
 export interface PluginOptions {
   config?: moduleFederationPlugin.ModuleFederationPluginOptions;
   configPath?: string;
+  /**
+   * Automatically set the federation optimization target from the Modern.js
+   * SSR and bundler target configuration.
+   * @default true
+   */
+  autoOptimization?: boolean;
   ssr?:
     | {
         distOutputDir?: string;

--- a/packages/modernjs/src/cli/configPlugin.spec.ts
+++ b/packages/modernjs/src/cli/configPlugin.spec.ts
@@ -1,5 +1,5 @@
 import { it, expect, describe } from '@rstest/core';
-import { patchMFConfig } from './configPlugin';
+import { patchMFConfig, setDefaultOptimizationTarget } from './configPlugin';
 import { getIPV4 } from './utils';
 
 const mfConfig = {
@@ -78,5 +78,48 @@ describe('patchMFConfig', async () => {
         },
       },
     });
+  });
+});
+
+describe('setDefaultOptimizationTarget', () => {
+  it('defaults to web when SSR is disabled', () => {
+    const config = { name: 'host' };
+
+    setDefaultOptimizationTarget(config, false, false);
+
+    expect(config).toMatchObject({
+      experiments: { optimization: { target: 'web' } },
+    });
+  });
+
+  it('defaults to web for the browser target when SSR is enabled', () => {
+    const config = { name: 'host' };
+
+    setDefaultOptimizationTarget(config, true, false);
+
+    expect(config).toMatchObject({
+      experiments: { optimization: { target: 'web' } },
+    });
+  });
+
+  it('defaults to node for the server target when SSR is enabled', () => {
+    const config = { name: 'host' };
+
+    setDefaultOptimizationTarget(config, true, true);
+
+    expect(config).toMatchObject({
+      experiments: { optimization: { target: 'node' } },
+    });
+  });
+
+  it('preserves an explicitly configured target', () => {
+    const config = {
+      name: 'host',
+      experiments: { optimization: { target: 'web' as const } },
+    };
+
+    setDefaultOptimizationTarget(config, true, true);
+
+    expect(config.experiments.optimization.target).toBe('web');
   });
 });

--- a/packages/modernjs/src/cli/configPlugin.spec.ts
+++ b/packages/modernjs/src/cli/configPlugin.spec.ts
@@ -122,4 +122,12 @@ describe('setDefaultOptimizationTarget', () => {
 
     expect(config.experiments.optimization.target).toBe('web');
   });
+
+  it('does not set a target when autoOptimization is disabled', () => {
+    const config = { name: 'host' };
+
+    setDefaultOptimizationTarget(config, true, true, false);
+
+    expect(config).toStrictEqual({ name: 'host' });
+  });
 });

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -242,7 +242,12 @@ export const setDefaultOptimizationTarget = (
   mfConfig: moduleFederationPlugin.ModuleFederationPluginOptions,
   enableSSR: boolean,
   isServer: boolean,
+  autoOptimization = true,
 ) => {
+  if (!autoOptimization) {
+    return;
+  }
+
   mfConfig.experiments ||= {};
   mfConfig.experiments.optimization ||= {};
   mfConfig.experiments.optimization.target ??=
@@ -425,7 +430,12 @@ export const moduleFederationConfigPlugin = (
       addMyTypes2Ignored(chain, !isWeb ? ssrConfig : csrConfig);
 
       const targetMFConfig = !isWeb ? ssrConfig : csrConfig;
-      setDefaultOptimizationTarget(targetMFConfig, enableSSR, !isWeb);
+      setDefaultOptimizationTarget(
+        targetMFConfig,
+        enableSSR,
+        !isWeb,
+        userConfig.originPluginOptions.autoOptimization,
+      );
       patchMFConfig(targetMFConfig, !isWeb);
 
       if (

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -238,6 +238,17 @@ export const patchMFConfig = (
   return mfConfig;
 };
 
+export const setDefaultOptimizationTarget = (
+  mfConfig: moduleFederationPlugin.ModuleFederationPluginOptions,
+  enableSSR: boolean,
+  isServer: boolean,
+) => {
+  mfConfig.experiments ||= {};
+  mfConfig.experiments.optimization ||= {};
+  mfConfig.experiments.optimization.target ??=
+    enableSSR && isServer ? 'node' : 'web';
+};
+
 function patchIgnoreWarning(chain: BundlerChainConfig) {
   const ignoreWarnings = chain.get('ignoreWarnings') || [];
   const ignoredMsgs = [
@@ -414,6 +425,7 @@ export const moduleFederationConfigPlugin = (
       addMyTypes2Ignored(chain, !isWeb ? ssrConfig : csrConfig);
 
       const targetMFConfig = !isWeb ? ssrConfig : csrConfig;
+      setDefaultOptimizationTarget(targetMFConfig, enableSSR, !isWeb);
       patchMFConfig(targetMFConfig, !isWeb);
 
       if (

--- a/packages/modernjs/src/types/index.ts
+++ b/packages/modernjs/src/types/index.ts
@@ -4,6 +4,12 @@ import type { StatsAssetResource } from '@module-federation/rsbuild-plugin/utils
 export interface PluginOptions {
   config?: moduleFederationPlugin.ModuleFederationPluginOptions;
   configPath?: string;
+  /**
+   * Automatically set the federation optimization target from the Modern.js
+   * SSR and bundler target configuration.
+   * @default true
+   */
+  autoOptimization?: boolean;
   ssr?:
     | {
         distOutputDir?: string;


### PR DESCRIPTION
## Description

Update the Modern.js and Modern.js v3 integrations to automatically select the federation optimization target based on the application configuration.

- Default to `web` for browser builds and projects without SSR.
- Default to `node` for Node builds when SSR is enabled.
- Preserve an explicitly configured optimization target.
- Add the `autoOptimization` plugin option, which defaults to `true`.
- Allow automatic target selection to be disabled with `autoOptimization: false`.

## Related Issue

<!-- Add the related issue link here -->

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.