### PR TITLE
ci(release): show release type in approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Release ${{ inputs.version }} from ${{ inputs.branch }}
 on:
   workflow_dispatch:
     inputs:
@@ -20,7 +21,7 @@ permissions:
 
 jobs:
   release:
-    name: Release
+    name: Release ${{ inputs.version }}
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
     environment: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   release:
-    name: Release ${{ inputs.version }}
+    name: Release ${{ inputs.version }} from ${{ inputs.branch }}
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
     environment: npm


### PR DESCRIPTION
The release workflow currently displays the generic `Release` label while waiting for approval, so reviewers cannot tell whether they are approving a `latest` or `next` publication.

This adds the selected release version and branch to both the workflow run name and the protected release job name. The existing `npm` environment and its approval policy remain unchanged. Reviewers will now see labels such as `Release latest from main` before approving.

Validation:
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @changesets/assemble-release-plan run build`
- `pnpm exec prettier --check .github/workflows/release.yml`
- `git diff --check`
- Pre-commit `lint-fix` and commit message validation

Skipped checks:
- Full package tests and lint were not run because this only changes GitHub Actions display names and does not affect package code.
- No publish command was run.