### PR TITLE
fix(metro): resolve Windows hoisted split bundles

### DIFF
--- a/.changeset/fix-windows-hoisted-bundles.md
+++ b/.changeset/fix-windows-hoisted-bundles.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/metro": patch
+---
+
+fix(metro): normalize Windows separators before encoding parent directory segments in split-bundle URLs.

--- a/packages/metro-core/__tests__/modules/asyncRequire.spec.ts
+++ b/packages/metro-core/__tests__/modules/asyncRequire.spec.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { runInNewContext } from 'node:vm';
+import { describe, expect, it } from '@rstest/core';
+import ts from 'typescript';
+
+const source = readFileSync(
+  path.resolve('src/modules/asyncRequire.ts'),
+  'utf8',
+);
+const module = {
+  exports: {} as { encodeBundlePath: (bundlePath: string) => string },
+};
+const context: Record<string, unknown> = {
+  __METRO_GLOBAL_PREFIX__: 'test',
+  module,
+  exports: module.exports,
+  process: { env: { EXPO_OS: 'android' } },
+  require: () => ({}),
+  test__loadBundleAsync: () => undefined,
+};
+context.global = context;
+context.globalThis = context;
+
+runInNewContext(
+  ts.transpileModule(`${source}\nmodule.exports = { encodeBundlePath };`, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2021,
+    },
+  }).outputText,
+  context,
+);
+
+const { encodeBundlePath } = module.exports;
+
+describe('encodeBundlePath', () => {
+  it('preserves POSIX parent segments in bundle URLs', () => {
+    expect(
+      encodeBundlePath(
+        '/../../node_modules/@repro/hoisted/dist/module/index.bundle',
+      ),
+    ).toBe('/..%2F..%2Fnode_modules/@repro/hoisted/dist/module/index.bundle');
+  });
+
+  it('preserves Windows parent segments in bundle URLs', () => {
+    expect(
+      encodeBundlePath(
+        '/..\\..\\node_modules\\@repro\\hoisted\\dist\\module\\index.bundle',
+      ),
+    ).toBe('/..%2F..%2Fnode_modules/@repro/hoisted/dist/module/index.bundle');
+  });
+});

--- a/packages/metro-core/src/modules/asyncRequire.ts
+++ b/packages/metro-core/src/modules/asyncRequire.ts
@@ -1,3 +1,6 @@
+// This file is injected as a self-contained Metro runtime module. Keep all
+// runtime logic in this file and do not add imports.
+
 // join two paths
 // e.g. /a/b/ + /c/d -> /a/b/c/d
 function joinComponents(prefix: string, suffix: string) {
@@ -12,6 +15,13 @@ function getPublicPath(url?: string) {
 
 function isUrl(url: string) {
   return url.match(/^https?:\/\//);
+}
+
+// normalize Windows separators and encode parent segments to prevent URL sanitization
+// macOS: /../../node_modules -> /..%2F..%2Fnode_modules
+// Windows: /..\..\node_modules -> /..%2F..%2Fnode_modules
+function encodeBundlePath(bundlePath: string) {
+  return bundlePath.replaceAll('\\', '/').replaceAll('../', '..%2F');
 }
 
 // get bundle id from the bundle path
@@ -99,8 +109,7 @@ function buildLoadBundleAsyncWrapper() {
       bundlePath = joinComponents(publicPath, bundlePath);
     }
 
-    // ../../node_modules/ -> ..%2F..%2Fnode_modules/ so that it's not automatically sanitized
-    const encodedBundlePath = bundlePath.replaceAll('../', '..%2F');
+    const encodedBundlePath = encodeBundlePath(bundlePath);
 
     let result;
     if (cacheHandler) {


### PR DESCRIPTION
## Description

Metro emits lazy split-bundle paths with Windows separators. The async require
runtime encoded only POSIX parent segments, allowing URL normalization to turn
workspace-hoisted dependencies into app-local `./node_modules` requests.

Normalize separators before encoding parent segments, while preserving the
existing POSIX behavior. Add regression coverage for both path formats and a
patch changeset for `@module-federation/metro`.

Verified end to end with an Android emulator connected to Metro running in a
Windows VM. The host, direct remote, and nested remote all loaded successfully.

Testing performed:

- Ran the full `@module-federation/metro` Rstest suite: 15 files and 50 tests
  passed.
- Ran the focused POSIX and Windows path regression tests natively on both
  macOS and Windows.
- Ran Metro on the Windows UTM VM and connected the macOS Android emulator
  through SSH and ADB port forwarding. The host, direct remote, and nested
  remote rendered successfully with lodash `4.18.1`, without the previous
  app-local `node_modules` resolution error.
- Ran Prettier, the Metro package ESLint task, and Changesets status validation.

## Related Issue

Reported directly through a Windows reproduction; no linked issue.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
