### PR TITLE
fix(runtime): propagate share scopes to nested remotes

### DIFF
--- a/.changeset/fix-nested-remote-share-scopes.md
+++ b/.changeset/fix-nested-remote-share-scopes.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/runtime-core": patch
+---
+
+Preserve inherited share scopes when initializing nested remotes so loaded singleton dependencies can be reused.

--- a/packages/runtime-core/__tests__/instance.spec.ts
+++ b/packages/runtime-core/__tests__/instance.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, rs } from '@rstest/core';
 import { ModuleFederation, Module } from '../src/index';
 import type { ModuleFederationRuntimePlugin } from '../src/type/plugin';
+import type { ShareScopeMap } from '../src/type';
 
 describe('ModuleFederation', () => {
   it('should initialize with provided arguments', () => {
@@ -65,5 +66,88 @@ describe('ModuleFederation', () => {
     expect(module.inited).toBe(true);
     expect(module.initing).toBe(false);
     expect((module as any).initPromise).toBeUndefined();
+  });
+
+  it('preserves inherited share scopes for nested remotes', async () => {
+    const react19Scope = {
+      react: {
+        '19.0.0': {
+          version: '19.0.0',
+          from: 'host-a',
+        },
+      },
+    } as ShareScopeMap[string];
+    const react18Scope = {
+      react: {
+        '18.0.0': {
+          version: '18.0.0',
+          from: 'host-a',
+        },
+      },
+    } as ShareScopeMap[string];
+    const hostA = new ModuleFederation({
+      name: '@federation/host-a',
+      remotes: [],
+    });
+    const containerB = new ModuleFederation({
+      name: '@federation/container-b',
+      remotes: [],
+    });
+
+    hostA.initShareScopeMap('react18-share-scope', react18Scope);
+    hostA.initShareScopeMap('react19-share-scope', react19Scope);
+
+    const remoteB = new Module({
+      remoteInfo: {
+        name: '@federation/remote-b',
+        entry: 'http://localhost:3002/remoteEntry.js',
+        type: 'global',
+        entryGlobalName: '__remote_b__',
+        shareScope: 'react18-share-scope',
+      },
+      host: hostA,
+    });
+    remoteB.remoteEntryExports = {
+      init: rs.fn((shareScope, _initScope, remoteEntryInitOptions) => {
+        containerB.initShareScopeMap('react18-share-scope', shareScope, {
+          hostShareScopeMap: remoteEntryInitOptions.shareScopeMap,
+        });
+      }),
+      get: rs.fn(),
+    } as any;
+
+    await remoteB.init();
+
+    const initRemoteC = rs.fn(
+      (shareScope, _initScope, remoteEntryInitOptions) => {
+        expect(shareScope).toBe(react19Scope);
+        expect(
+          remoteEntryInitOptions.shareScopeMap['react18-share-scope'],
+        ).toBe(react18Scope);
+        expect(
+          remoteEntryInitOptions.shareScopeMap['react19-share-scope'],
+        ).toBe(react19Scope);
+      },
+    );
+    const remoteC = new Module({
+      remoteInfo: {
+        name: '@federation/remote-c',
+        entry: 'http://localhost:3003/remoteEntry.js',
+        type: 'global',
+        entryGlobalName: '__remote_c__',
+        shareScope: 'react19-share-scope',
+      },
+      host: containerB,
+    });
+    remoteC.remoteEntryExports = {
+      init: initRemoteC,
+      get: rs.fn(),
+    } as any;
+
+    await remoteC.init();
+
+    expect(initRemoteC).toHaveBeenCalledTimes(1);
+    expect(containerB.shareScopeMap['react18-share-scope']).toBe(react18Scope);
+    expect(containerB.shareScopeMap['react19-share-scope']).toBe(react19Scope);
   });
 });

--- a/packages/runtime-core/src/shared/index.ts
+++ b/packages/runtime-core/src/shared/index.ts
@@ -650,6 +650,7 @@ export class SharedHandler {
     extraOptions: { hostShareScopeMap?: ShareScopeMap } = {},
   ): void {
     const { host } = this;
+    Object.assign(this.shareScopeMap, extraOptions.hostShareScopeMap);
     this.shareScopeMap[scopeName] = shareScope;
     this.hooks.lifecycle.initContainerShareScopeMap.emit({
       shareScope,


### PR DESCRIPTION
## Description

Propagate the complete host share scope map when initializing a remote container.

Previously, only the share scope selected for the current remote was added to the remote container's runtime state. When that remote loaded another nested remote using a different share scope, the nested remote could not access shared dependencies from the upstream host. This could cause singleton dependencies such as React to be loaded more than once.

This change:

- Copies the inherited host share scope map into the remote container while preserving the explicitly initialized scope.
- Allows nested remotes to reuse shared dependencies already provided by the upstream host.
- Adds a regression test covering the `Host A → Remote B → Remote C` initialization path with separate React 18 and React 19 share scopes.
- Adds a patch changeset for `@module-federation/runtime-core`.

### Validation

- `pnpm --filter @module-federation/runtime-core test -- instance.spec.ts`
  - Passed all 93 tests across 12 runtime-core test files.
- `pnpm --filter @module-federation/runtime-core lint`
  - Passed.
- `pnpm --filter @module-federation/runtime-core build`
  - Passed.
- `pnpm exec prettier --check packages/runtime-core/__tests__/instance.spec.ts packages/runtime-core/src/shared/index.ts .changeset/fix-nested-remote-share-scopes.md`
  - Passed.
- Confirmed that the regression test fails when the share scope map propagation is removed and passes with the fix applied.
- Manually verified the original reproduction: the nested React component renders successfully without loading a duplicate React instance.

## Related Issue

Fixes #4723

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.