### PR TITLE
chore(dts-plugin): remove isomorphic-ws dependency

### DIFF
--- a/.changeset/dts-plugin-remove-isomorphic-ws.md
+++ b/.changeset/dts-plugin-remove-isomorphic-ws.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+chore(dts-plugin): drop the `isomorphic-ws` dependency. Node-side server code now imports `ws` directly and browser-side code uses the global `WebSocket`, preserving Node 20 compatibility.

--- a/packages/dts-plugin/package.json
+++ b/packages/dts-plugin/package.json
@@ -70,7 +70,6 @@
     "@module-federation/sdk": "workspace:*",
     "@module-federation/third-party-dts-extractor": "workspace:*",
     "adm-zip": "0.6.0",
-    "isomorphic-ws": "5.0.0",
     "undici": "7.28.0",
     "ws": "8.21.0"
   },

--- a/packages/dts-plugin/src/runtime-plugins/dynamic-remote-type-hints-plugin.ts
+++ b/packages/dts-plugin/src/runtime-plugins/dynamic-remote-type-hints-plugin.ts
@@ -10,15 +10,20 @@ declare const FEDERATION_IPV4: string | undefined;
 const PLUGIN_NAME = 'dynamic-remote-type-hints-plugin';
 
 function dynamicRemoteTypeHintsPlugin(): ModuleFederationRuntimePlugin {
-  let ws = createWebsocket();
+  // `createWebsocket` relies on the global `WebSocket`, which only exists in
+  // browsers and Node >= 22. In a Node/SSR host on older Node it is undefined,
+  // so guard construction to degrade gracefully instead of throwing at init.
+  let ws = typeof WebSocket !== 'undefined' ? createWebsocket() : undefined;
   let isConnected = false;
-  ws.onopen = () => {
-    isConnected = true;
-  };
+  if (ws) {
+    ws.onopen = () => {
+      isConnected = true;
+    };
 
-  ws.onerror = (err) => {
-    console.error(`[ ${PLUGIN_NAME} ] err: ${err}`);
-  };
+    ws.onerror = (err) => {
+      console.error(`[ ${PLUGIN_NAME} ] err: ${err}`);
+    };
+  }
 
   return {
     name: 'dynamic-remote-type-hints-plugin',
@@ -40,7 +45,7 @@ function dynamicRemoteTypeHintsPlugin(): ModuleFederationRuntimePlugin {
           alias: remote.alias || remote.name,
         };
         if (remoteIp) {
-          ws.send(
+          ws?.send(
             JSON.stringify(
               new AddDynamicRemoteAction({
                 remoteIp,
@@ -52,7 +57,7 @@ function dynamicRemoteTypeHintsPlugin(): ModuleFederationRuntimePlugin {
           );
         }
         // fetch types
-        ws.send(
+        ws?.send(
           JSON.stringify(
             new FetchTypesAction({
               name: origin.name,

--- a/packages/dts-plugin/src/server/DevServer.ts
+++ b/packages/dts-plugin/src/server/DevServer.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'isomorphic-ws';
+import WebSocket from 'ws';
 import { UpdateMode } from './constant';
 import { Broker } from './broker/Broker';
 import { fib, getIdentifier, getIPV4, fileLog } from './utils';

--- a/packages/dts-plugin/src/server/WebClient.ts
+++ b/packages/dts-plugin/src/server/WebClient.ts
@@ -1,4 +1,3 @@
-import WebSocket from 'isomorphic-ws';
 import { DEFAULT_WEB_SOCKET_PORT } from './constant';
 import { Message } from './message/Message';
 import { AddWebClientAction } from './message/Action';

--- a/packages/dts-plugin/src/server/broker/Broker.ts
+++ b/packages/dts-plugin/src/server/broker/Broker.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, createServer } from 'http';
 import { UpdateMode } from '../constant';
-import WebSocket from 'isomorphic-ws';
+import WebSocket from 'ws';
 import { parse } from 'url';
 import { Publisher } from '../Publisher';
 import { getIdentifier, fileLog, error } from '../utils';

--- a/packages/dts-plugin/src/server/createWebsocket.ts
+++ b/packages/dts-plugin/src/server/createWebsocket.ts
@@ -1,9 +1,10 @@
-import WebSocket from 'isomorphic-ws';
 import {
   DEFAULT_WEB_SOCKET_PORT,
   WEB_SOCKET_CONNECT_MAGIC_ID,
 } from './constant';
 
+// Browser-only module: uses the global `WebSocket` (always present in browsers),
+// so no `isomorphic-ws`/`ws` dependency is required here.
 export function createWebsocket() {
   return new WebSocket(
     `ws://127.0.0.1:${DEFAULT_WEB_SOCKET_PORT}?WEB_SOCKET_CONNECT_MAGIC_ID=${WEB_SOCKET_CONNECT_MAGIC_ID}`,

--- a/packages/dts-plugin/src/server/types/broker.ts
+++ b/packages/dts-plugin/src/server/types/broker.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'isomorphic-ws';
+import type WebSocket from 'ws';
 import { Subscriber } from './message';
 
 type SubscriberIdentifier = string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3240,9 +3240,6 @@ importers:
       adm-zip:
         specifier: 0.6.0
         version: 0.6.0
-      isomorphic-ws:
-        specifier: 5.0.0
-        version: 5.0.0(ws@8.21.0)
       undici:
         specifier: 7.28.0
         version: 7.28.0
@@ -51359,10 +51356,6 @@ snapshots:
   isomorphic-ws@5.0.0(ws@8.18.0):
     dependencies:
       ws: 8.18.0
-
-  isomorphic-ws@5.0.0(ws@8.21.0):
-    dependencies:
-      ws: 8.21.0
 
   isstream@0.1.2: {}
 


### PR DESCRIPTION
## Description

Drops isomorphic-ws in favor of using each runtime's native WebSocket directly:
- Node server code (DevServer, Broker, types/broker) imports ws directly — isomorphic-ws was just a passthrough to ws in Node, so this is behavior-identical (and matches Publisher.ts, which already did this).
- Browser code (createWebsocket, WebClient) uses the global WebSocket.
- Guards the dynamic-remote-type-hints runtime plugin to no-op when no global WebSocket exists (Node < 22 / SSR) instead of throwing — preserves Node 20 compatibility.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] I have updated the documentation.
