### PR TITLE
feat(runtime): expose shared diagnostics

### DIFF
--- a/.changeset/calm-shares-report.md
+++ b/.changeset/calm-shares-report.md
@@ -1,0 +1,7 @@
+---
+'@module-federation/runtime-core': patch
+'@module-federation/webpack-bundler-runtime': patch
+'@module-federation/observability-plugin': patch
+---
+
+Report safe shared registration outcomes, dependency selection reasons, and explicit load context for observability.

--- a/packages/observability-plugin/__tests__/observability.spec.ts
+++ b/packages/observability-plugin/__tests__/observability.spec.ts
@@ -70,11 +70,17 @@ type SharedHookFixturePlugin = {
     shared: SharedFixture;
     origin: EnabledOriginFixture;
   }) => unknown;
+  afterRegisterShare?: (args: {
+    pkgName: string;
+    registration: any;
+    origin: EnabledOriginFixture;
+  }) => unknown;
   beforeLoadShare?: (args: {
     pkgName: string;
     shareInfo?: SharedFixture;
     shared: Record<string, unknown>;
     origin: EnabledOriginFixture;
+    loadContext?: any;
   }) => unknown;
   afterLoadShare?: (args: {
     pkgName: string;
@@ -83,6 +89,7 @@ type SharedHookFixturePlugin = {
     shared: Record<string, unknown>;
     origin: EnabledOriginFixture;
     lifecycle: 'loadShare' | 'loadShareSync';
+    selectionResult?: any;
   }) => void;
   errorLoadShare?: (args: {
     pkgName: string;
@@ -93,6 +100,7 @@ type SharedHookFixturePlugin = {
     lifecycle: 'loadShare' | 'loadShareSync';
     error?: Error;
     recovered?: boolean;
+    selectionResult?: any;
   }) => unknown;
 };
 
@@ -5867,6 +5875,369 @@ describe('ObservabilityPlugin', () => {
     expect(JSON.stringify(report)).toContain('component:business-loaded');
     expect(JSON.stringify(report)).toContain('demo-secret');
     expect(JSON.stringify(report)).toContain('token=');
+  });
+
+  it('reports runtime-produced shared selection details without unsafe values', () => {
+    const observability = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const plugin = observability.plugin as SharedHookFixturePlugin;
+    const shared = createShared({
+      get: () => () => ({ secretFactoryValue: 'must-not-leak' }),
+    });
+    const loadContext = {
+      trigger: 'build',
+      moduleId: 42,
+      chunkId: 'shared-chunk',
+      requestId: 'consume-request',
+      operationId: 'loadShare-42',
+    };
+    const selectionResult = {
+      scope: 'default',
+      requestedVersion: '18.0.0',
+      requiredVersion: '^18.0.0',
+      singleton: true,
+      strictVersion: false,
+      eager: false,
+      strategy: 'loaded-first',
+      candidates: [
+        {
+          scope: 'default',
+          version: '17.0.2',
+          provider: 'legacy-provider',
+          loaded: false,
+          loading: false,
+          singleton: true,
+          eager: false,
+          strategy: 'loaded-first',
+          compatible: false,
+          rejectionReason: 'version-mismatch',
+        },
+        {
+          scope: 'default',
+          version: '18.3.1',
+          provider: 'host',
+          loaded: true,
+          loading: false,
+          singleton: true,
+          eager: false,
+          strategy: 'loaded-first',
+          compatible: true,
+        },
+      ],
+      selected: {
+        scope: 'default',
+        version: '18.3.1',
+        provider: 'host',
+        loaded: true,
+        loading: false,
+        singleton: true,
+        eager: false,
+        strategy: 'loaded-first',
+        compatible: true,
+      },
+      reason: 'singleton-existing',
+      loadType: 'async',
+      context: loadContext,
+    };
+
+    plugin.beforeLoadShare?.({
+      pkgName: 'react',
+      shareInfo: shared,
+      shared: {},
+      origin: enabledOrigin,
+      loadContext,
+    });
+    plugin.afterLoadShare?.({
+      pkgName: 'react',
+      shareInfo: shared,
+      selectedShared: shared,
+      shared: {},
+      lifecycle: 'loadShare',
+      origin: enabledOrigin,
+      selectionResult,
+    });
+
+    const report = observability.getLatestReport();
+    expect(report?.requestId).toBe('loadShare-42');
+    expect(report?.shared).toMatchObject({
+      name: 'react',
+      selectedVersion: '18.3.1',
+      provider: 'host',
+      selectionReason: 'singleton-existing',
+      loadType: 'async',
+      trigger: 'build',
+      moduleId: 42,
+      chunkId: 'shared-chunk',
+      requestId: 'consume-request',
+      operationId: 'loadShare-42',
+      candidates: [
+        expect.objectContaining({
+          version: '17.0.2',
+          provider: 'legacy-provider',
+          rejectionReason: 'version-mismatch',
+        }),
+        expect.objectContaining({
+          version: '18.3.1',
+          provider: 'host',
+          loaded: true,
+        }),
+      ],
+    });
+    expect(JSON.stringify(report)).not.toContain('secretFactoryValue');
+    expect(report?.shared).not.toHaveProperty('get');
+    expect(report?.shared).not.toHaveProperty('lib');
+    expect(report?.shared).not.toHaveProperty('loadingPromise');
+  });
+
+  it('uses real runtime local-fallback facts in the shared report', async () => {
+    const observability = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const localFactory = () => ({ source: 'local' });
+    const instance = new ModuleFederation({
+      name: 'fallback-observability-host',
+      remotes: [],
+      plugins: [observability.plugin],
+      shared: {
+        fallbackPackage: {
+          version: '1.0.0',
+          scope: 'local',
+          lib: localFactory,
+        },
+      },
+    });
+
+    const result = await instance.loadShare('fallbackPackage', {
+      resolver: (options) => ({ ...options[0], scope: ['missing'] }),
+    });
+
+    expect(result).toBe(localFactory);
+    expect(observability.getLatestReport()).toMatchObject({
+      status: 'success',
+      summary: {
+        outcome: 'shared-resolved',
+        flags: { fallback: true },
+      },
+      shared: {
+        name: 'fallbackPackage',
+        selectionReason: 'local-fallback',
+        fallback: true,
+        selectedVersion: '1.0.0',
+        provider: 'fallback-observability-host',
+      },
+    });
+  });
+
+  it('records safe registration history and current shared strategy', () => {
+    const observability = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const plugin = observability.plugin as SharedHookFixturePlugin;
+    const shared = createShared({ loaded: true });
+    const origin = {
+      ...enabledOrigin,
+      shareScopeMap: {
+        default: { react: { '18.3.1': shared } },
+      },
+      sharedHandler: {
+        shareScopeMap: {
+          default: { react: { '18.3.1': shared } },
+        },
+        hooks: { lifecycle: { afterRegisterShare: {} } },
+      },
+    };
+    const candidate = {
+      scope: 'default',
+      version: '18.3.1',
+      provider: 'host',
+      loaded: true,
+      loading: false,
+      singleton: false,
+      eager: false,
+      strategy: 'loaded-first',
+      compatible: true,
+    };
+
+    plugin.afterRegisterShare?.({
+      pkgName: 'react',
+      registration: {
+        registrationId: 'shared-register-1',
+        scope: 'default',
+        trigger: 'container-init',
+        candidate,
+        candidates: [candidate],
+        action: 'registered',
+        effective: candidate,
+        reason: 'container-share-registered',
+      },
+      origin,
+    });
+
+    expect(observability.getLatestReport()).toMatchObject({
+      status: 'success',
+      summary: {
+        outcome: 'shared-registered',
+        sharedRegistered: true,
+      },
+      shared: {
+        name: 'react',
+        candidates: [expect.objectContaining({ version: '18.3.1' })],
+        registration: {
+          registrationId: 'shared-register-1',
+          action: 'registered',
+          reason: 'container-share-registered',
+          trigger: 'container-init',
+        },
+      },
+    });
+    const state = observability.getRuntimeState();
+    expect(state.instances[0].shareScopes[0].shared[0].versions[0]).toEqual({
+      version: '18.3.1',
+      provider: 'host',
+      loaded: true,
+      strategy: 'loaded-first',
+    });
+    expect(JSON.stringify(state)).not.toContain('get');
+    expect(JSON.stringify(state)).not.toContain('secret');
+    expect(state.capabilities.sharedTrace).toMatchObject({
+      available: true,
+      completeness: 'complete',
+    });
+  });
+
+  it('keeps concurrent shared traces and instances independently correlated', () => {
+    const observability = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const plugin = observability.plugin as SharedHookFixturePlugin;
+    const firstOrigin = { ...enabledOrigin, options: { name: 'first-host' } };
+    const secondOrigin = { ...enabledOrigin, options: { name: 'second-host' } };
+    const shared = createShared();
+    const emitSelection = (
+      origin: EnabledOriginFixture,
+      operationId: string,
+      provider: string,
+    ) => {
+      const loadContext = { trigger: 'runtime', operationId };
+      plugin.beforeLoadShare?.({
+        pkgName: 'react',
+        shareInfo: shared,
+        shared: {},
+        origin,
+        loadContext,
+      });
+      return () =>
+        plugin.afterLoadShare?.({
+          pkgName: 'react',
+          shareInfo: shared,
+          selectedShared: shared,
+          shared: {},
+          lifecycle: 'loadShare',
+          origin,
+          selectionResult: {
+            scope: 'default',
+            requestedVersion: '18.3.1',
+            requiredVersion: '^18.0.0',
+            singleton: false,
+            strictVersion: false,
+            eager: false,
+            strategy: 'loaded-first',
+            candidates: [],
+            selected: {
+              scope: 'default',
+              version: '18.3.1',
+              provider,
+              loaded: true,
+              loading: false,
+              singleton: false,
+              eager: false,
+              strategy: 'loaded-first',
+            },
+            reason: 'loaded-first',
+            loadType: 'async',
+            context: loadContext,
+          },
+        });
+    };
+
+    const finishFirst = emitSelection(firstOrigin, 'same-operation', 'first');
+    const finishSecond = emitSelection(
+      secondOrigin,
+      'same-operation',
+      'second',
+    );
+    finishSecond();
+    finishFirst();
+
+    const reports = observability.findReports({ shared: 'react', limit: 10 });
+    expect(reports).toHaveLength(2);
+    expect(new Set(reports.map((report) => report.traceId)).size).toBe(2);
+    expect(new Set(reports.map((report) => report.instanceRef)).size).toBe(2);
+    expect(reports.map((report) => report.shared?.provider).sort()).toEqual([
+      'first',
+      'second',
+    ]);
+    reports.forEach((report) => {
+      expect(report.events).toHaveLength(2);
+      expect(
+        report.events.every((event) => event.requestId === 'same-operation'),
+      ).toBe(true);
+    });
+  });
+
+  it('degrades shared trace capability for old or incomplete runtimes', () => {
+    const oldRuntime = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const oldPlugin = oldRuntime.plugin as SharedHookFixturePlugin;
+    const shared = createShared();
+    const oldOrigin = {
+      ...enabledOrigin,
+      version: '2.4.9',
+      shareScopeMap: { default: { react: { '18.3.1': shared } } },
+    };
+    oldPlugin.beforeLoadShare?.({
+      pkgName: 'react',
+      shareInfo: shared,
+      shared: {},
+      origin: oldOrigin,
+    });
+    expect(oldRuntime.getRuntimeState().capabilities).toMatchObject({
+      sharedState: { available: true, completeness: 'complete' },
+      sharedTrace: { available: false, completeness: 'unavailable' },
+    });
+
+    const partialRuntime = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const partialPlugin = partialRuntime.plugin as SharedHookFixturePlugin;
+    partialPlugin.beforeLoadShare?.({
+      pkgName: 'react',
+      shareInfo: shared,
+      shared: {},
+      origin: enabledOrigin,
+    });
+    partialPlugin.afterLoadShare?.({
+      pkgName: 'react',
+      shareInfo: shared,
+      selectedShared: shared,
+      shared: {},
+      lifecycle: 'loadShare',
+      origin: enabledOrigin,
+    });
+    expect(
+      partialRuntime.getRuntimeState().capabilities.sharedTrace,
+    ).toMatchObject({
+      available: true,
+      completeness: 'partial',
+    });
   });
 
   it('does not let observability callbacks affect loading', async () => {

--- a/packages/observability-plugin/src/core.ts
+++ b/packages/observability-plugin/src/core.ts
@@ -23,6 +23,7 @@ export type ObservabilityReportOutcome =
   | 'pending'
   | 'runtime-loaded'
   | 'shared-resolved'
+  | 'shared-registered'
   | 'preloaded'
   | 'component-loaded'
   | 'failed'
@@ -92,6 +93,7 @@ export interface ObservabilityRuntimeStateInstance {
         loaded?: boolean;
         singleton?: boolean;
         eager?: boolean;
+        strategy?: string;
       }>;
     }>;
   }>;
@@ -272,6 +274,43 @@ export interface ObservabilitySharedInfo {
   reason?: string;
   definedBy?: 'bundler-runtime';
   conflict?: ObservabilitySharedConflictInfo;
+  candidates?: ObservabilitySharedCandidate[];
+  selectionReason?: string;
+  failureReason?: string;
+  loadType?: 'sync' | 'async';
+  trigger?: string;
+  moduleId?: string | number;
+  chunkId?: string | number;
+  remote?: string;
+  expose?: string;
+  requestId?: string;
+  operationId?: string;
+  fallback?: boolean;
+  recovered?: boolean;
+  registration?: ObservabilitySharedRegistration;
+}
+
+export interface ObservabilitySharedCandidate {
+  scope: string;
+  version: string;
+  provider?: string;
+  loaded: boolean;
+  loading: boolean;
+  singleton: boolean;
+  eager: boolean;
+  strategy?: string;
+  compatible?: boolean;
+  rejectionReason?: string;
+}
+
+export interface ObservabilitySharedRegistration {
+  registrationId: string;
+  action: 'registered' | 'replaced' | 'reused' | 'ignored';
+  reason: string;
+  trigger: string;
+  scope: string;
+  candidate: ObservabilitySharedCandidate;
+  effective?: ObservabilitySharedCandidate;
 }
 
 export interface ObservabilitySharedConflictVersion {
@@ -355,6 +394,7 @@ export interface ObservabilityReport {
     loadCompleted: boolean;
     runtimeLoaded: boolean;
     sharedResolved: boolean;
+    sharedRegistered: boolean;
     preloaded: boolean;
     componentLoaded: boolean;
     outcome: ObservabilityReportOutcome;
@@ -525,6 +565,9 @@ export interface ObservabilityRuntimeOrigin {
   shareScopeMap?: ObservabilityRuntimeShareScopeMap;
   sharedHandler?: {
     shareScopeMap?: ObservabilityRuntimeShareScopeMap;
+    hooks?: {
+      lifecycle?: Record<string, unknown>;
+    };
   };
   loadShare?: (pkgName: string) => Promise<false | (() => unknown)>;
   loadShareSync?: (pkgName: string) => false | (() => unknown);
@@ -557,6 +600,47 @@ interface ObservabilityRuntimeSharedSource {
   strategy?: string;
   shareConfig?: ObservabilityRuntimeSharedConfig;
   get?: unknown;
+}
+
+interface ObservabilityRuntimeSharedCandidate {
+  scope: string;
+  version: string;
+  provider?: string;
+  loaded: boolean;
+  loading: boolean;
+  singleton: boolean;
+  eager: boolean;
+  strategy?: string;
+  compatible?: boolean;
+  rejectionReason?: string;
+}
+
+interface ObservabilityRuntimeSharedLoadContext {
+  trigger?: string;
+  moduleId?: string | number;
+  chunkId?: string | number;
+  remote?: string;
+  expose?: string;
+  requestId?: string;
+  operationId?: string;
+}
+
+interface ObservabilityRuntimeSharedSelectionResult {
+  scope?: string;
+  requestedVersion?: string;
+  requiredVersion?: string | false;
+  singleton?: boolean;
+  strictVersion?: boolean;
+  eager?: boolean;
+  strategy?: string;
+  candidates?: ObservabilityRuntimeSharedCandidate[];
+  selected?: ObservabilityRuntimeSharedCandidate;
+  reason?: string;
+  failureReason?: string;
+  fallback?: boolean;
+  recovered?: boolean;
+  loadType?: 'sync' | 'async';
+  context?: ObservabilityRuntimeSharedLoadContext;
 }
 
 interface ObservabilityRuntimeRemoteSource {
@@ -743,6 +827,23 @@ interface ObservabilitySharedLifecycleArgs {
   origin: ObservabilityRuntimeOrigin;
   error?: unknown;
   recovered?: boolean;
+  loadContext?: ObservabilityRuntimeSharedLoadContext;
+  selectionResult?: ObservabilityRuntimeSharedSelectionResult;
+}
+
+interface ObservabilitySharedRegistrationArgs {
+  pkgName: string;
+  registration: {
+    registrationId: string;
+    scope: string;
+    trigger: string;
+    candidate: ObservabilityRuntimeSharedCandidate;
+    candidates: ObservabilityRuntimeSharedCandidate[];
+    action: ObservabilitySharedRegistration['action'];
+    effective?: ObservabilityRuntimeSharedCandidate;
+    reason: string;
+  };
+  origin: ObservabilityRuntimeOrigin;
 }
 
 export type ObservabilityRuntimePlugin = ModuleFederationRuntimePlugin;
@@ -1376,33 +1477,168 @@ function supportsRuntimeObservability(origin?: ObservabilityRuntimeOrigin) {
   });
 }
 
+function createSharedCandidate(
+  candidate: ObservabilityRuntimeSharedCandidate,
+): ObservabilitySharedCandidate {
+  return {
+    scope: candidate.scope,
+    version: candidate.version,
+    provider: candidate.provider,
+    loaded: candidate.loaded === true,
+    loading: candidate.loading === true,
+    singleton: candidate.singleton === true,
+    eager: candidate.eager === true,
+    strategy: candidate.strategy,
+    compatible: candidate.compatible,
+    rejectionReason: candidate.rejectionReason,
+  };
+}
+
 function createSharedInfo(
   args: ObservabilitySharedLifecycleArgs,
   reason?: string,
 ): ObservabilitySharedInfo {
   const shareConfig = args.shareInfo?.shareConfig;
+  const selection = args.selectionResult;
+  const selected = selection?.selected;
+  const context = selection?.context || args.loadContext;
   const handledBundlerRuntimeShared = reason === 'custom-share-info-unmatched';
-  const loaded = args.selectedShared?.loaded;
+  const loaded = selected?.loaded ?? args.selectedShared?.loaded;
+  const candidates = selection?.candidates?.map(createSharedCandidate);
 
   return {
     name: args.pkgName,
-    shareScope: getSharedScopes(args.shareInfo),
-    version: args.selectedShared?.version || args.shareInfo?.version,
-    requiredVersion: shareConfig?.requiredVersion,
-    selectedVersion: args.selectedShared?.version,
-    availableVersions: getAvailableSharedVersions(args),
-    provider: args.selectedShared?.from,
+    shareScope: selection?.scope
+      ? [selection.scope]
+      : getSharedScopes(args.shareInfo),
+    version:
+      selection?.requestedVersion ||
+      args.selectedShared?.version ||
+      args.shareInfo?.version,
+    requiredVersion: selection?.requiredVersion ?? shareConfig?.requiredVersion,
+    selectedVersion: selected?.version || args.selectedShared?.version,
+    availableVersions: candidates?.length
+      ? Array.from(new Set(candidates.map((candidate) => candidate.version)))
+      : getAvailableSharedVersions(args),
+    provider: selected?.provider || args.selectedShared?.from,
     useIn: getSharedUseIn(args),
-    singleton: shareConfig?.singleton,
-    strictVersion: shareConfig?.strictVersion,
-    eager: shareConfig?.eager,
-    strategy: args.shareInfo?.strategy,
+    singleton: selection?.singleton ?? shareConfig?.singleton,
+    strictVersion: selection?.strictVersion ?? shareConfig?.strictVersion,
+    eager: selection?.eager ?? shareConfig?.eager,
+    strategy: selection?.strategy || args.shareInfo?.strategy,
     loaded,
     loading: loaded
       ? undefined
-      : Boolean(args.selectedShared?.loading) || undefined,
+      : selected?.loading || Boolean(args.selectedShared?.loading) || undefined,
     reason,
+    selectionReason: selection?.reason,
+    failureReason: selection?.failureReason,
+    candidates,
+    loadType: selection?.loadType,
+    trigger: context?.trigger,
+    moduleId: context?.moduleId,
+    chunkId: context?.chunkId,
+    remote: context?.remote,
+    expose: context?.expose,
+    requestId: context?.requestId,
+    operationId: context?.operationId,
+    fallback: selection?.fallback,
+    recovered: selection?.recovered ?? args.recovered,
     definedBy: handledBundlerRuntimeShared ? 'bundler-runtime' : undefined,
+  };
+}
+
+function createSharedRegistrationInfo(
+  args: ObservabilitySharedRegistrationArgs,
+): ObservabilitySharedInfo {
+  const registration = args.registration;
+  const candidate = createSharedCandidate(registration.candidate);
+  const effective = registration.effective
+    ? createSharedCandidate(registration.effective)
+    : undefined;
+  return {
+    name: args.pkgName,
+    shareScope: [registration.scope],
+    version: candidate.version,
+    selectedVersion: effective?.version,
+    availableVersions: Array.from(
+      new Set(registration.candidates.map((item) => item.version)),
+    ),
+    provider: effective?.provider,
+    singleton: candidate.singleton,
+    eager: candidate.eager,
+    strategy: candidate.strategy,
+    loaded: effective?.loaded,
+    loading: effective?.loading || undefined,
+    candidates: registration.candidates.map(createSharedCandidate),
+    trigger: registration.trigger,
+    registration: {
+      registrationId: registration.registrationId,
+      action: registration.action,
+      reason: registration.reason,
+      trigger: registration.trigger,
+      scope: registration.scope,
+      candidate,
+      effective,
+    },
+  };
+}
+
+function getSharedOperationId(args: ObservabilitySharedLifecycleArgs) {
+  return (
+    args.selectionResult?.context?.operationId ||
+    args.loadContext?.operationId ||
+    `shared:${args.pkgName}`
+  );
+}
+
+function sanitizeSharedCandidate(
+  candidate: ObservabilitySharedCandidate,
+): ObservabilitySharedCandidate | undefined {
+  const scope = sanitizeText(candidate.scope, 120);
+  const version = sanitizeText(candidate.version, 120);
+  if (!scope || !version) {
+    return undefined;
+  }
+  return {
+    scope,
+    version,
+    provider: sanitizeText(candidate.provider, 160),
+    loaded: candidate.loaded === true,
+    loading: candidate.loading === true,
+    singleton: candidate.singleton === true,
+    eager: candidate.eager === true,
+    strategy: sanitizeText(candidate.strategy, 80),
+    compatible: candidate.compatible,
+    rejectionReason: sanitizeText(candidate.rejectionReason, 120),
+  };
+}
+
+function sanitizeSharedRegistration(
+  registration: ObservabilitySharedRegistration | undefined,
+): ObservabilitySharedRegistration | undefined {
+  if (!registration) {
+    return undefined;
+  }
+  const candidate = sanitizeSharedCandidate(registration.candidate);
+  const effective = registration.effective
+    ? sanitizeSharedCandidate(registration.effective)
+    : undefined;
+  const registrationId = sanitizeText(registration.registrationId, 120);
+  const scope = sanitizeText(registration.scope, 120);
+  const trigger = sanitizeText(registration.trigger, 80);
+  const reason = sanitizeText(registration.reason, 120);
+  if (!candidate || !registrationId || !scope || !trigger || !reason) {
+    return undefined;
+  }
+  return {
+    registrationId,
+    action: registration.action,
+    reason,
+    trigger,
+    scope,
+    candidate,
+    effective,
   };
 }
 
@@ -1440,6 +1676,35 @@ function sanitizeShared(
     definedBy:
       shared.definedBy === 'bundler-runtime' ? 'bundler-runtime' : undefined,
     conflict: sanitizeSharedConflict(shared.conflict),
+    candidates: (shared.candidates || [])
+      .map(sanitizeSharedCandidate)
+      .filter(
+        (candidate): candidate is ObservabilitySharedCandidate =>
+          candidate !== undefined,
+      )
+      .slice(0, 20),
+    selectionReason: sanitizeText(shared.selectionReason, 120),
+    failureReason: sanitizeText(shared.failureReason, 120),
+    loadType:
+      shared.loadType === 'sync' || shared.loadType === 'async'
+        ? shared.loadType
+        : undefined,
+    trigger: sanitizeText(shared.trigger, 80),
+    moduleId:
+      typeof shared.moduleId === 'number'
+        ? shared.moduleId
+        : sanitizeText(shared.moduleId, 160),
+    chunkId:
+      typeof shared.chunkId === 'number'
+        ? shared.chunkId
+        : sanitizeText(shared.chunkId, 160),
+    remote: sanitizeText(shared.remote, 160),
+    expose: sanitizeText(shared.expose, 240),
+    requestId: sanitizeText(shared.requestId, 240),
+    operationId: sanitizeText(shared.operationId, 160),
+    fallback: shared.fallback === true || undefined,
+    recovered: shared.recovered === true || undefined,
+    registration: sanitizeSharedRegistration(shared.registration),
   };
 }
 
@@ -2796,6 +3061,9 @@ export function createObservability(
     (event.status === 'success' ||
       (event.status === 'complete' && event.recovered));
 
+  const isSharedRegisteredEvent = (event: ObservabilityEvent) =>
+    event.phase === 'shared-registration' && event.status === 'success';
+
   const isPreloadedEvent = (event: ObservabilityEvent) =>
     event.phase === 'preload' && event.status === 'success';
 
@@ -2869,6 +3137,9 @@ export function createObservability(
       ) {
         collection.flags.fallback = true;
       }
+      if (event.shared?.fallback) {
+        collection.flags.fallback = true;
+      }
       if (event.shared?.selectedVersion || event.shared?.provider) {
         collection.shared = {
           name: event.shared.name,
@@ -2921,6 +3192,7 @@ export function createObservability(
     const loadCompleted = report.events.some(isLoadRemoteCompleteEvent);
     const runtimeLoaded = report.events.some(isRuntimeLoadedEvent);
     const sharedResolved = report.events.some(isSharedResolvedEvent);
+    const sharedRegistered = report.events.some(isSharedRegisteredEvent);
     const preloaded = report.events.some(isPreloadedEvent);
     const recovered = report.events.some((item) => item.recovered);
     const componentLoaded = report.events.some(isComponentLoadedEvent);
@@ -2937,6 +3209,8 @@ export function createObservability(
       outcome = 'runtime-loaded';
     } else if (sharedResolved) {
       outcome = 'shared-resolved';
+    } else if (sharedRegistered) {
+      outcome = 'shared-registered';
     } else if (preloaded) {
       outcome = 'preloaded';
     }
@@ -2949,6 +3223,7 @@ export function createObservability(
       loadCompleted,
       runtimeLoaded,
       sharedResolved,
+      sharedRegistered,
       preloaded,
       componentLoaded,
       outcome,
@@ -3516,6 +3791,7 @@ export function createObservability(
           loadCompleted: false,
           runtimeLoaded: false,
           sharedResolved: false,
+          sharedRegistered: false,
           preloaded: false,
           componentLoaded: false,
           outcome: 'pending',
@@ -3810,23 +4086,29 @@ export function createObservability(
 
   const getShareScopeSummaries = (origin: ObservabilityRuntimeOrigin) =>
     Object.entries(getOriginShareScopeMap(origin)).map(([name, scope]) => {
-      const sharedNames = Object.keys(scope || {}).sort();
+      const rawSharedNames = Object.keys(scope || {}).sort();
+      const sharedEntries = rawSharedNames.slice(0, 100).map((rawName) => ({
+        rawName,
+        name: sanitizeText(rawName, 160) || 'unknown',
+      }));
       return {
         name: sanitizeText(name, 120) || 'default',
-        sharedCount: sharedNames.length,
-        sharedNames,
-        shared: sharedNames.map((sharedName) => ({
-          name: sharedName,
-          versions: Object.entries(scope?.[sharedName] || {}).map(
-            ([version, shared]) =>
+        sharedCount: rawSharedNames.length,
+        sharedNames: sharedEntries.map((entry) => entry.name),
+        shared: sharedEntries.map((entry) => ({
+          name: entry.name,
+          versions: Object.entries(scope?.[entry.rawName] || {})
+            .slice(0, 20)
+            .map(([version, shared]) =>
               omitUndefinedFields({
                 version: sanitizeText(version, 120) || version,
                 provider: sanitizeText(shared.from, 160),
                 loaded: shared.loaded === true || undefined,
                 singleton: shared.shareConfig?.singleton || undefined,
                 eager: shared.shareConfig?.eager || undefined,
+                strategy: sanitizeText(shared.strategy, 80),
               }),
-          ),
+            ),
         })),
       };
     });
@@ -4052,6 +4334,16 @@ export function createObservability(
     );
     const hasRemoteSignals = events.some((event) => Boolean(event.remote));
     const hasSharedSignals = events.some((event) => Boolean(event.shared));
+    const hasDetailedSharedSignals = events.some(
+      (event) =>
+        Boolean(event.shared?.selectionReason) ||
+        Boolean(event.shared?.registration),
+    );
+    const hasDetailedSharedHooks = instanceDrafts.some((draft) =>
+      Boolean(
+        draft.origin.sharedHandler?.hooks?.lifecycle?.['afterRegisterShare'],
+      ),
+    );
     const hasBridge = instances.some((instance) => instance.bridge?.available);
     const traceCompleteness = hasIncompleteHistory ? 'partial' : 'complete';
 
@@ -4092,11 +4384,15 @@ export function createObservability(
           available: hasStableSharedRuntime && hasSharedSignals,
           completeness:
             hasStableSharedRuntime && hasSharedSignals
-              ? traceCompleteness
+              ? hasDetailedSharedHooks && hasDetailedSharedSignals
+                ? traceCompleteness
+                : 'partial'
               : 'unavailable',
           reason: hasStableSharedRuntime
             ? hasSharedSignals
-              ? undefined
+              ? hasDetailedSharedHooks && hasDetailedSharedSignals
+                ? undefined
+                : 'Shared history is available, but detailed registration or selection results are missing.'
               : 'No shared lifecycle signal has been observed yet.'
             : 'Shared tracing requires a stable runtime version of 2.5.0 or newer.',
         },
@@ -5347,6 +5643,39 @@ export function createObservability(
 
       return returnHookArgs(args);
     },
+    afterRegisterShare(args) {
+      const registrationArgs = args as ObservabilitySharedRegistrationArgs;
+      if (
+        shouldGuardSharedHooksByRuntimeVersion &&
+        !supportsRuntimeHookObservability(registrationArgs.origin)
+      ) {
+        return returnHookArgs(args);
+      }
+
+      if (!prepareRuntimeOrigin(registrationArgs.origin)) {
+        return returnHookArgs(args);
+      }
+
+      recordEvent(
+        {
+          phase: 'shared-registration',
+          status: 'success',
+          requestId: registrationArgs.registration.registrationId,
+          lifecycle: 'afterRegisterShare',
+          shared: createSharedRegistrationInfo(registrationArgs),
+          message: `shared:registration-${registrationArgs.registration.action}`,
+          metadata: {
+            scope: registrationArgs.registration.scope,
+            action: registrationArgs.registration.action,
+            reason: registrationArgs.registration.reason,
+            trigger: registrationArgs.registration.trigger,
+          },
+        },
+        registrationArgs.origin,
+      );
+
+      return returnHookArgs(args);
+    },
     beforeLoadShare(args) {
       if (
         shouldGuardSharedHooksByRuntimeVersion &&
@@ -5363,7 +5692,7 @@ export function createObservability(
         {
           phase: 'shared',
           status: 'start',
-          requestId: `shared:${args.pkgName}`,
+          requestId: getSharedOperationId(args),
           lifecycle: 'loadShare',
           shared: createSharedInfo(args),
           message: 'shared:load-start',
@@ -5389,7 +5718,7 @@ export function createObservability(
         {
           phase: 'shared',
           status: 'success',
-          requestId: `shared:${args.pkgName}`,
+          requestId: getSharedOperationId(args),
           lifecycle: args.lifecycle,
           shared: createSharedInfo(args),
           message:
@@ -5423,7 +5752,7 @@ export function createObservability(
         {
           phase: 'shared',
           status: handledCustomShareMiss ? 'complete' : 'error',
-          requestId: `shared:${args.pkgName}`,
+          requestId: getSharedOperationId(args),
           lifecycle: args.lifecycle,
           shared: createSharedInfo(args, reason),
           message: reason ? `shared:${reason}` : undefined,

--- a/packages/runtime-core/__tests__/share-format.spec.ts
+++ b/packages/runtime-core/__tests__/share-format.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { formatShareConfigs } from '../src/utils/share';
 import type { Options, ShareArgs, UserOptions } from '../src/type';
 

--- a/packages/runtime-core/__tests__/shared-diagnostics.spec.ts
+++ b/packages/runtime-core/__tests__/shared-diagnostics.spec.ts
@@ -2,7 +2,12 @@ import { beforeEach, describe, expect, it } from '@rstest/core';
 import { RUNTIME_005 } from '@module-federation/error-codes';
 import { ModuleFederation } from '../src/core';
 import { resetFederationGlobalInfo } from '../src/global';
-import type { ModuleFederationRuntimePlugin } from '../src/type';
+import type {
+  ModuleFederationRuntimePlugin,
+  Shared,
+  SharedRegistrationResult,
+  SharedSelectionResult,
+} from '../src/type';
 
 type SharedLifecycleEvent =
   | { type: 'before'; pkgName: string }
@@ -162,5 +167,526 @@ describe('shared lifecycle hooks', () => {
       availableVersions: [],
     });
     expect(errorEvent?.error).toBeInstanceOf(Error);
+  });
+});
+
+type DetailedSharedEvent =
+  | { type: 'registration'; result: SharedRegistrationResult }
+  | { type: 'selection'; result?: SharedSelectionResult }
+  | { type: 'selection-error'; result?: SharedSelectionResult };
+
+const createDetailedSharedPlugin = (
+  events: DetailedSharedEvent[],
+): ModuleFederationRuntimePlugin => ({
+  name: 'detailed-shared-lifecycle-test-plugin',
+  afterRegisterShare(args) {
+    events.push({ type: 'registration', result: args.registration });
+  },
+  afterLoadShare(args) {
+    events.push({ type: 'selection', result: args.selectionResult });
+  },
+  errorLoadShare(args) {
+    events.push({ type: 'selection-error', result: args.selectionResult });
+  },
+});
+
+const createRuntimeShared = (overrides: Partial<Shared> = {}): Shared => ({
+  version: '1.0.0',
+  get: () => () => ({ version: overrides.version || '1.0.0' }),
+  shareConfig: {
+    requiredVersion: '*',
+    singleton: false,
+    strictVersion: false,
+    eager: false,
+  },
+  scope: ['default'],
+  useIn: [],
+  from: 'provider',
+  deps: [],
+  strategy: 'version-first',
+  ...overrides,
+});
+
+describe('detailed shared diagnostics', () => {
+  beforeEach(() => {
+    resetFederationGlobalInfo();
+  });
+
+  it('reports registered, reused, replaced, and ignored registration results', () => {
+    const events: DetailedSharedEvent[] = [];
+    const mf = new ModuleFederation({
+      name: 'z-host',
+      remotes: [],
+      plugins: [createDetailedSharedPlugin(events)],
+      shared: {
+        initial: {
+          version: '1.0.0',
+          lib: () => ({ initial: true }),
+        },
+      },
+    });
+
+    expect(events[0]).toMatchObject({
+      type: 'registration',
+      result: {
+        action: 'registered',
+        reason: 'first-registration',
+        candidate: {
+          version: '1.0.0',
+          provider: 'z-host',
+        },
+      },
+    });
+
+    mf.registerShared({
+      initial: {
+        version: '1.0.0',
+        lib: () => ({ initial: true }),
+      },
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: 'registration',
+      result: {
+        action: 'reused',
+        reason: 'same-version-same-provider',
+      },
+    });
+
+    const eagerCandidate = createRuntimeShared({
+      from: 'remote-eager',
+      eager: true,
+      shareConfig: {
+        requiredVersion: '*',
+        singleton: false,
+        strictVersion: false,
+        eager: true,
+      },
+    });
+    mf.options.shared.eager = [eagerCandidate];
+    mf.shareScopeMap.default.eager = {
+      '1.0.0': createRuntimeShared({ from: 'remote-lazy' }),
+    };
+    mf.initializeSharing('default', { from: 'build' });
+    expect(events.at(-1)).toMatchObject({
+      type: 'registration',
+      result: {
+        action: 'replaced',
+        reason: 'eager-preferred',
+        effective: { provider: 'remote-eager', eager: true },
+      },
+    });
+
+    mf.options.shared.providerPriority = [
+      createRuntimeShared({ from: 'candidate-provider' }),
+    ];
+    mf.shareScopeMap.default.providerPriority = {
+      '1.0.0': createRuntimeShared({ from: 'a-provider' }),
+    };
+    mf.initializeSharing('default', { from: 'build' });
+    expect(events.at(-1)).toMatchObject({
+      type: 'registration',
+      result: {
+        action: 'replaced',
+        reason: 'provider-name-preferred',
+        effective: { provider: 'candidate-provider' },
+      },
+    });
+
+    mf.options.shared.loadedFirst = [
+      createRuntimeShared({ from: 'candidate-provider' }),
+    ];
+    mf.shareScopeMap.default.loadedFirst = {
+      '1.0.0': createRuntimeShared({
+        from: 'loaded-first-provider',
+        strategy: 'loaded-first',
+      }),
+    };
+    mf.initializeSharing('default', { from: 'build' });
+    expect(events.at(-1)).toMatchObject({
+      type: 'registration',
+      result: {
+        action: 'ignored',
+        reason: 'loaded-first-preserved',
+        effective: { provider: 'loaded-first-provider' },
+      },
+    });
+
+    const loaded = createRuntimeShared({
+      from: 'loaded-provider',
+      loaded: true,
+      lib: () => ({ loaded: true }),
+    });
+    mf.options.shared.loaded = [
+      createRuntimeShared({ from: 'replacement-provider' }),
+    ];
+    mf.shareScopeMap.default.loaded = { '1.0.0': loaded };
+    mf.initializeSharing('default', { from: 'build' });
+    expect(events.at(-1)).toMatchObject({
+      type: 'registration',
+      result: {
+        action: 'ignored',
+        reason: 'loaded-version-preserved',
+        effective: { provider: 'loaded-provider', loaded: true },
+      },
+    });
+
+    const reused = createRuntimeShared({ from: 'same-provider' });
+    mf.options.shared.reused = [reused];
+    mf.shareScopeMap.default.reused = { '1.0.0': reused };
+    mf.initializeSharing('default', { from: 'build' });
+    expect(events.at(-1)).toMatchObject({
+      type: 'registration',
+      result: {
+        action: 'reused',
+        reason: 'same-registration-reused',
+      },
+    });
+  });
+
+  it.each([
+    {
+      strategy: 'version-first' as const,
+      expectedVersion: '2.0.0',
+      expectedReason: 'version-first',
+      rejectedVersion: '1.0.0',
+      rejectionReason: 'lower-priority-version',
+    },
+    {
+      strategy: 'loaded-first' as const,
+      expectedVersion: '1.0.0',
+      expectedReason: 'loaded-first',
+      rejectedVersion: '2.0.0',
+      rejectionReason: 'not-loaded',
+    },
+  ])(
+    'reports $strategy selection from all candidates',
+    async ({
+      strategy,
+      expectedVersion,
+      expectedReason,
+      rejectedVersion,
+      rejectionReason,
+    }) => {
+      const events: DetailedSharedEvent[] = [];
+      const mf = new ModuleFederation({
+        name: `selection-${strategy}`,
+        remotes: [],
+        plugins: [createDetailedSharedPlugin(events)],
+        shared: {},
+      });
+      mf.options.shared.react = [];
+      mf.shareScopeMap.default = {
+        react: {
+          '1.0.0': createRuntimeShared({
+            version: '1.0.0',
+            from: 'loaded-provider',
+            loaded: strategy === 'loaded-first',
+            lib:
+              strategy === 'loaded-first'
+                ? () => ({ version: '1.0.0' })
+                : undefined,
+            strategy,
+          }),
+          '2.0.0': createRuntimeShared({
+            version: '2.0.0',
+            from: 'new-provider',
+            strategy,
+          }),
+        },
+      };
+
+      const factory = await mf.loadShare<{ version: string }>('react', {
+        customShareInfo: {
+          version: '0.0.0',
+          scope: ['default'],
+          strategy,
+          shareConfig: {
+            requiredVersion: '*',
+            singleton: false,
+            strictVersion: false,
+            eager: false,
+          },
+        },
+      });
+
+      expect(factory && factory()).toEqual({ version: expectedVersion });
+      expect(events.at(-1)).toMatchObject({
+        type: 'selection',
+        result: {
+          reason: expectedReason,
+          selected: { version: expectedVersion },
+          candidates: [
+            { version: '1.0.0', provider: 'loaded-provider' },
+            { version: '2.0.0', provider: 'new-provider' },
+          ],
+          loadType: 'async',
+          context: {
+            trigger: 'runtime',
+            operationId: expect.stringMatching(/^loadShare-/),
+          },
+        },
+      });
+      const selectionEvent = events.at(-1);
+      expect(
+        selectionEvent?.type === 'selection'
+          ? selectionEvent.result?.candidates.find(
+              (candidate) => candidate.version === rejectedVersion,
+            )
+          : undefined,
+      ).toMatchObject({ rejectionReason });
+    },
+  );
+
+  it('reports singleton selection and strict-version rejection', async () => {
+    const events: DetailedSharedEvent[] = [];
+    const mf = new ModuleFederation({
+      name: 'singleton-host',
+      remotes: [],
+      plugins: [createDetailedSharedPlugin(events)],
+      shared: {},
+    });
+    mf.options.shared.react = [];
+    mf.shareScopeMap.default = {
+      react: {
+        '18.3.1': createRuntimeShared({
+          version: '18.3.1',
+          from: 'react-provider',
+          loaded: true,
+          lib: () => ({ version: '18.3.1' }),
+        }),
+      },
+    };
+
+    await mf.loadShare('react', {
+      customShareInfo: {
+        version: '18.0.0',
+        scope: ['default'],
+        shareConfig: {
+          requiredVersion: '^18.0.0',
+          singleton: true,
+          strictVersion: true,
+          eager: false,
+        },
+      },
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: 'selection',
+      result: {
+        reason: 'singleton-existing',
+        selected: { version: '18.3.1', provider: 'react-provider' },
+      },
+    });
+
+    await expect(
+      mf.loadShare('react', {
+        customShareInfo: {
+          version: '19.0.0',
+          scope: ['default'],
+          shareConfig: {
+            requiredVersion: '^19.0.0',
+            singleton: true,
+            strictVersion: true,
+            eager: false,
+          },
+        },
+      }),
+    ).rejects.toThrow('does not satisfy');
+    expect(events.at(-1)).toMatchObject({
+      type: 'selection-error',
+      result: {
+        reason: 'strict-version-rejected',
+        failureReason: 'strict-version-rejected',
+        selected: undefined,
+      },
+    });
+  });
+
+  it('reports custom resolver and local fallback without changing return behavior', async () => {
+    const events: DetailedSharedEvent[] = [];
+    const localFactory = () => ({ version: 'local' });
+    const mf = new ModuleFederation({
+      name: 'resolver-host',
+      remotes: [],
+      plugins: [createDetailedSharedPlugin(events)],
+      shared: {
+        custom: [
+          { version: '1.0.0', lib: () => ({ version: '1.0.0' }) },
+          { version: '2.0.0', lib: () => ({ version: '2.0.0' }) },
+        ],
+        fallback: {
+          version: '1.0.0',
+          scope: 'local',
+          lib: localFactory,
+        },
+      },
+    });
+
+    const customFactory = await mf.loadShare<{ version: string }>('custom', {
+      resolver: (options) => options[0],
+    });
+    expect(customFactory && customFactory()).toEqual({ version: '1.0.0' });
+    expect(events.at(-1)).toMatchObject({
+      type: 'selection',
+      result: { reason: 'custom-resolver' },
+    });
+
+    const fallbackFactory = await mf.loadShare<{ version: string }>(
+      'fallback',
+      {
+        resolver: (options) => ({ ...options[0], scope: ['missing'] }),
+      },
+    );
+    expect(fallbackFactory).toBe(localFactory);
+    expect(events.at(-1)).toMatchObject({
+      type: 'selection',
+      result: {
+        reason: 'local-fallback',
+        fallback: true,
+        selected: { version: '1.0.0', provider: 'resolver-host' },
+      },
+    });
+  });
+
+  it('keeps concurrent operations and explicit build context independent', async () => {
+    const events: DetailedSharedEvent[] = [];
+    const mf = new ModuleFederation({
+      name: 'context-host',
+      remotes: [],
+      plugins: [createDetailedSharedPlugin(events)],
+      shared: {
+        slow: {
+          version: '1.0.0',
+          get: async () => {
+            await Promise.resolve();
+            return () => ({ slow: true });
+          },
+        },
+      },
+    });
+
+    await Promise.all([
+      mf.loadShare('slow', {
+        from: 'build',
+        context: { moduleId: 10, chunkId: 'chunk-a' },
+      }),
+      mf.loadShare('slow', {
+        context: { requestId: 'runtime-request' },
+      }),
+    ]);
+
+    const selections = events.filter(
+      (event): event is Extract<DetailedSharedEvent, { type: 'selection' }> =>
+        event.type === 'selection',
+    );
+    expect(selections).toHaveLength(2);
+    expect(selections[0].result?.context).toMatchObject({
+      trigger: 'build',
+      moduleId: 10,
+      chunkId: 'chunk-a',
+    });
+    expect(selections[1].result?.context).toMatchObject({
+      trigger: 'runtime',
+      requestId: 'runtime-request',
+    });
+    expect(selections[0].result?.context.operationId).not.toBe(
+      selections[1].result?.context.operationId,
+    );
+  });
+
+  it('reports the original asynchronous load failure with its selection', async () => {
+    const events: DetailedSharedEvent[] = [];
+    const originalError = new Error('shared factory failed');
+    const mf = new ModuleFederation({
+      name: 'async-error-host',
+      remotes: [],
+      plugins: [createDetailedSharedPlugin(events)],
+      shared: {
+        broken: {
+          version: '1.0.0',
+          get: async () => {
+            throw originalError;
+          },
+        },
+      },
+    });
+
+    await expect(mf.loadShare('broken')).rejects.toBe(originalError);
+    expect(events.at(-1)).toMatchObject({
+      type: 'selection-error',
+      result: {
+        selected: { version: '1.0.0', provider: 'async-error-host' },
+        failureReason: 'load-error',
+        loadType: 'async',
+      },
+    });
+  });
+
+  it('reports synchronous success and keeps its factory return unchanged', () => {
+    const events: DetailedSharedEvent[] = [];
+    const factory = () => ({ sync: true });
+    const mf = new ModuleFederation({
+      name: 'sync-success-host',
+      remotes: [],
+      plugins: [createDetailedSharedPlugin(events)],
+      shared: {
+        eagerShared: {
+          version: '1.0.0',
+          eager: true,
+          lib: factory,
+        },
+      },
+    });
+
+    const result = mf.loadShareSync<{ sync: boolean }>('eagerShared', {
+      from: 'build',
+      context: { moduleId: 'sync-module' },
+    });
+    expect(result).toBe(factory);
+    expect(result()).toEqual({ sync: true });
+    expect(events.at(-1)).toMatchObject({
+      type: 'selection',
+      result: {
+        loadType: 'sync',
+        context: {
+          trigger: 'build',
+          moduleId: 'sync-module',
+          operationId: expect.stringMatching(/^loadShareSync-/),
+        },
+      },
+    });
+  });
+
+  it('reports container share-scope registration with safe summaries', () => {
+    const events: DetailedSharedEvent[] = [];
+    const mf = new ModuleFederation({
+      name: 'container-host',
+      remotes: [],
+      plugins: [createDetailedSharedPlugin(events)],
+      shared: {},
+    });
+    const remoteShared = createRuntimeShared({
+      version: '3.0.0',
+      from: 'remote-provider',
+    });
+
+    mf.initShareScopeMap('remote-scope', {
+      remotePackage: { '3.0.0': remoteShared },
+    });
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'registration',
+      result: {
+        trigger: 'container-init',
+        action: 'registered',
+        candidate: {
+          scope: 'remote-scope',
+          version: '3.0.0',
+          provider: 'remote-provider',
+        },
+      },
+    });
+    expect(events.at(-1)).not.toHaveProperty('result.candidate.get');
+    expect(events.at(-1)).not.toHaveProperty('result.candidate.lib');
+    expect(events.at(-1)).not.toHaveProperty('result.candidate.loadingPromise');
   });
 });

--- a/packages/runtime-core/src/core.ts
+++ b/packages/runtime-core/src/core.ts
@@ -19,6 +19,8 @@ import {
   RemoteEntryInitOptions,
   CallFrom,
   ResourceLoadContext,
+  LoadShareExtraOptions,
+  SharedLoadContext,
 } from './type';
 import { getBuilderId, registerPlugins, getRemoteEntry, error } from './utils';
 import {
@@ -344,10 +346,7 @@ export class ModuleFederation {
 
   async loadShare<T>(
     pkgName: string,
-    extraOptions?: {
-      customShareInfo?: Partial<Shared>;
-      resolver?: (sharedOptions: ShareInfos[string]) => Shared;
-    },
+    extraOptions?: LoadShareExtraOptions,
   ): Promise<false | (() => T | undefined)> {
     return this.sharedHandler.loadShare(pkgName, extraOptions);
   }
@@ -358,11 +357,7 @@ export class ModuleFederation {
   // 3. If the local get returns something other than Promise, then it will be used directly
   loadShareSync<T>(
     pkgName: string,
-    extraOptions?: {
-      customShareInfo?: Partial<Shared>;
-      from?: 'build' | 'runtime';
-      resolver?: (sharedOptions: ShareInfos[string]) => Shared;
-    },
+    extraOptions?: LoadShareExtraOptions,
   ): () => T | never {
     return this.sharedHandler.loadShareSync(pkgName, extraOptions);
   }
@@ -373,6 +368,7 @@ export class ModuleFederation {
       initScope?: InitScope;
       from?: CallFrom;
       strategy?: Shared['strategy'];
+      context?: SharedLoadContext;
     },
   ): Array<Promise<void>> {
     return this.sharedHandler.initializeSharing(shareScopeName, extraOptions);

--- a/packages/runtime-core/src/shared/index.ts
+++ b/packages/runtime-core/src/shared/index.ts
@@ -16,6 +16,12 @@ import {
   InitTokens,
   CallFrom,
   TreeShakingArgs,
+  LoadShareExtraOptions,
+  SharedLoadContext,
+  SharedLoadTrigger,
+  SharedRegistrationResult,
+  SharedSelectionDecision,
+  SharedSelectionResult,
 } from '../type';
 import { ModuleFederation } from '../core';
 import {
@@ -33,6 +39,7 @@ import {
   directShare,
   shouldUseTreeShaking,
   addUseIn,
+  getSharedCandidateInfo,
 } from '../utils/share';
 import {
   assert,
@@ -54,12 +61,23 @@ export class SharedHandler {
       shared: Shared;
       origin: ModuleFederation;
     }>('beforeRegisterShare'),
+    afterRegisterShare: new SyncHook<
+      [
+        {
+          pkgName: string;
+          registration: SharedRegistrationResult;
+          origin: ModuleFederation;
+        },
+      ],
+      void
+    >('afterRegisterShare'),
     afterResolve: new AsyncWaterfallHook<LoadRemoteMatch>('afterResolve'),
     beforeLoadShare: new AsyncWaterfallHook<{
       pkgName: string;
       shareInfo?: Shared;
       shared: Options['shared'];
       origin: ModuleFederation;
+      loadContext: SharedSelectionResult['context'];
     }>('beforeLoadShare'),
     // not used yet
     loadShare: new AsyncHook<[ModuleFederation, string, ShareInfos]>(),
@@ -72,6 +90,7 @@ export class SharedHandler {
           shared: Options['shared'];
           shareScopeMap: ShareScopeMap;
           lifecycle: 'loadShare' | 'loadShareSync';
+          selectionResult?: SharedSelectionResult;
           origin: ModuleFederation;
         },
       ],
@@ -88,6 +107,7 @@ export class SharedHandler {
           origin: ModuleFederation;
           error?: unknown;
           recovered?: boolean;
+          selectionResult?: SharedSelectionResult;
         },
       ],
       void
@@ -111,6 +131,8 @@ export class SharedHandler {
     }>('initContainerShareScopeMap'),
   });
   initTokens: InitTokens;
+  private operationCounter = 0;
+  private registrationCounter = 0;
   constructor(host: ModuleFederation) {
     this.host = host;
     this.shareScopeMap = {};
@@ -118,16 +140,96 @@ export class SharedHandler {
     this._setGlobalShareScopeMap(host.options);
   }
 
+  private createLoadContext(
+    lifecycle: 'loadShare' | 'loadShareSync',
+    extraOptions?: LoadShareExtraOptions,
+  ): SharedSelectionResult['context'] {
+    this.operationCounter += 1;
+    const context = extraOptions?.context || {};
+    return {
+      ...context,
+      operationId:
+        context.operationId || `${lifecycle}-${this.operationCounter}`,
+      trigger: context.trigger || extraOptions?.from || 'runtime',
+    };
+  }
+
+  private createSelectionResult(
+    decision: SharedSelectionDecision,
+    loadType: SharedSelectionResult['loadType'],
+    context: SharedSelectionResult['context'],
+    overrides: Partial<SharedSelectionDecision> = {},
+  ): SharedSelectionResult {
+    return {
+      ...decision,
+      ...overrides,
+      loadType,
+      context,
+    };
+  }
+
+  private createSelectionDecision(
+    pkgName: string,
+    shareInfo: Partial<Shared> | undefined,
+    reason: SharedSelectionDecision['reason'],
+  ): SharedSelectionDecision {
+    const scopes = shareInfo?.scope?.length ? shareInfo.scope : [DEFAULT_SCOPE];
+    const candidates = scopes.flatMap((scope) =>
+      Object.entries(this.shareScopeMap[scope]?.[pkgName] || {}).map(
+        ([version, shared]) =>
+          getSharedCandidateInfo(
+            scope,
+            version,
+            shared,
+            shareInfo?.shareConfig?.requiredVersion,
+          ),
+      ),
+    );
+    return {
+      scope: scopes[0],
+      requestedVersion: shareInfo?.version,
+      requiredVersion: shareInfo?.shareConfig?.requiredVersion,
+      singleton: Boolean(shareInfo?.shareConfig?.singleton),
+      strictVersion: Boolean(shareInfo?.shareConfig?.strictVersion),
+      eager: Boolean(shareInfo?.shareConfig?.eager),
+      strategy: shareInfo?.strategy || 'version-first',
+      candidates,
+      reason,
+      failureReason: reason,
+    };
+  }
+
+  private emitAfterRegisterShare(
+    pkgName: string,
+    registration: Omit<SharedRegistrationResult, 'registrationId'>,
+  ): void {
+    this.registrationCounter += 1;
+    try {
+      this.hooks.lifecycle.afterRegisterShare.emit({
+        pkgName,
+        registration: {
+          ...registration,
+          registrationId: `shared-register-${this.registrationCounter}`,
+        },
+        origin: this.host,
+      });
+    } catch (hookError) {
+      warn(hookError);
+    }
+  }
+
   private emitAfterLoadShare({
     lifecycle,
     pkgName,
     shareInfo,
     selectedShared,
+    selectionResult,
   }: {
     lifecycle: 'loadShare' | 'loadShareSync';
     pkgName: string;
     shareInfo?: Partial<Shared>;
     selectedShared?: Partial<Shared>;
+    selectionResult?: SharedSelectionResult;
   }): void {
     try {
       this.hooks.lifecycle.afterLoadShare.emit({
@@ -137,6 +239,7 @@ export class SharedHandler {
         shared: this.host.options.shared,
         shareScopeMap: this.shareScopeMap,
         lifecycle,
+        selectionResult,
         origin: this.host,
       });
     } catch (error) {
@@ -150,12 +253,14 @@ export class SharedHandler {
     shareInfo,
     error,
     recovered,
+    selectionResult,
   }: {
     lifecycle: 'loadShare' | 'loadShareSync';
     pkgName: string;
     shareInfo?: Partial<Shared>;
     error?: unknown;
     recovered?: boolean;
+    selectionResult?: SharedSelectionResult;
   }): void {
     try {
       this.hooks.lifecycle.errorLoadShare.emit({
@@ -167,6 +272,7 @@ export class SharedHandler {
         origin: this.host,
         error,
         recovered,
+        selectionResult,
       });
     } catch (hookError) {
       warn(hookError);
@@ -191,6 +297,9 @@ export class SharedHandler {
             shared: sharedVal,
           });
           const registeredShared = this.shareScopeMap[sc]?.[sharedKey];
+          const previousAtVersion = registeredShared?.[sharedVal.version];
+          let action: SharedRegistrationResult['action'];
+          let reason: string;
           if (!registeredShared) {
             this.setShared({
               pkgName: sharedKey,
@@ -200,7 +309,55 @@ export class SharedHandler {
               shared: sharedVal,
               from: userOptions.name,
             });
+            action = 'registered';
+            reason = 'first-registration';
+          } else if (
+            previousAtVersion === sharedVal ||
+            previousAtVersion?.from === sharedVal.from
+          ) {
+            action = 'reused';
+            reason = 'same-version-same-provider';
+          } else {
+            action = 'ignored';
+            reason = previousAtVersion
+              ? 'existing-version-preserved'
+              : 'scope-already-registered';
           }
+
+          const candidates = Object.entries(
+            this.shareScopeMap[sc]?.[sharedKey] || {},
+          ).map(([version, shared]) =>
+            getSharedCandidateInfo(
+              sc,
+              version,
+              shared,
+              sharedVal.shareConfig?.requiredVersion,
+            ),
+          );
+          const effectiveShared =
+            this.shareScopeMap[sc]?.[sharedKey]?.[sharedVal.version] ||
+            Object.values(this.shareScopeMap[sc]?.[sharedKey] || {})[0];
+          this.emitAfterRegisterShare(sharedKey, {
+            scope: sc,
+            trigger: 'runtime',
+            candidate: getSharedCandidateInfo(
+              sc,
+              sharedVal.version,
+              sharedVal,
+              sharedVal.shareConfig?.requiredVersion,
+            ),
+            candidates,
+            action,
+            effective: effectiveShared
+              ? getSharedCandidateInfo(
+                  sc,
+                  effectiveShared.version,
+                  effectiveShared,
+                  sharedVal.shareConfig?.requiredVersion,
+                )
+              : undefined,
+            reason,
+          });
         });
       });
     });
@@ -213,12 +370,10 @@ export class SharedHandler {
 
   async loadShare<T>(
     pkgName: string,
-    extraOptions?: {
-      customShareInfo?: Partial<Shared>;
-      resolver?: (sharedOptions: ShareInfos[string]) => Shared;
-    },
+    extraOptions?: LoadShareExtraOptions,
   ): Promise<false | (() => T | undefined)> {
     const { host } = this;
+    const loadContext = this.createLoadContext('loadShare', extraOptions);
     // This function performs the following steps:
     // 1. Checks if the currently loaded share already exists, if not, it throws an error
     // 2. Searches globally for a matching share, if found, it uses it directly
@@ -230,6 +385,7 @@ export class SharedHandler {
       shareInfos: host.options.shared,
     });
     let shareOptionsRes: Shared | undefined = shareOptions;
+    let selectionDecision: SharedSelectionDecision | undefined;
 
     try {
       if (shareOptions?.scope) {
@@ -238,6 +394,8 @@ export class SharedHandler {
             await Promise.all(
               this.initializeSharing(shareScope, {
                 strategy: shareOptions.strategy,
+                from: extraOptions?.from,
+                context: loadContext,
               }),
             );
             return;
@@ -249,6 +407,7 @@ export class SharedHandler {
         shareInfo: shareOptions,
         shared: host.options.shared,
         origin: host,
+        loadContext,
       });
 
       shareOptionsRes = loadShareRes.shareInfo;
@@ -266,7 +425,44 @@ export class SharedHandler {
           pkgName,
           shareOptionsRes,
           this.hooks.lifecycle.resolveShare,
+          (decision) => {
+            selectionDecision = decision;
+          },
         ) || {};
+
+      if (selectionDecision && extraOptions?.resolver && registeredShared) {
+        selectionDecision = {
+          ...selectionDecision,
+          reason: 'custom-resolver',
+          failureReason: undefined,
+        };
+      }
+
+      const registeredSelectionResult = registeredShared
+        ? this.createSelectionResult(
+            selectionDecision ||
+              this.createSelectionDecision(
+                pkgName,
+                resolvedShareOptions,
+                'exact-match',
+              ),
+            'async',
+            loadContext,
+            {
+              selected:
+                selectionDecision?.selected ||
+                getSharedCandidateInfo(
+                  selectionDecision?.scope ||
+                    resolvedShareOptions.scope?.[0] ||
+                    DEFAULT_SCOPE,
+                  registeredShared.version,
+                  registeredShared,
+                  resolvedShareOptions.shareConfig?.requiredVersion,
+                ),
+              failureReason: undefined,
+            },
+          )
+        : undefined;
 
       if (registeredShared) {
         const targetShared = directShare(registeredShared, useTreesShaking);
@@ -277,6 +473,7 @@ export class SharedHandler {
             pkgName,
             shareInfo: resolvedShareOptions,
             selectedShared: registeredShared,
+            selectionResult: registeredSelectionResult,
           });
           return targetShared.lib as () => T;
         } else if (targetShared.loading && !targetShared.loaded) {
@@ -291,6 +488,7 @@ export class SharedHandler {
             pkgName,
             shareInfo: resolvedShareOptions,
             selectedShared: registeredShared,
+            selectionResult: registeredSelectionResult,
           });
           return factory;
         } else {
@@ -319,6 +517,7 @@ export class SharedHandler {
             pkgName,
             shareInfo: resolvedShareOptions,
             selectedShared: registeredShared,
+            selectionResult: registeredSelectionResult,
           });
           return factory;
         }
@@ -329,6 +528,17 @@ export class SharedHandler {
             pkgName,
             shareInfo: resolvedShareOptions,
             recovered: true,
+            selectionResult: this.createSelectionResult(
+              selectionDecision ||
+                this.createSelectionDecision(
+                  pkgName,
+                  resolvedShareOptions,
+                  'version-mismatch',
+                ),
+              'async',
+              loadContext,
+              { recovered: true },
+            ),
           });
           return false;
         }
@@ -375,6 +585,27 @@ export class SharedHandler {
           pkgName,
           shareInfo: resolvedShareOptions,
           selectedShared: resolvedShareOptions,
+          selectionResult: this.createSelectionResult(
+            selectionDecision ||
+              this.createSelectionDecision(
+                pkgName,
+                resolvedShareOptions,
+                'local-fallback',
+              ),
+            'async',
+            loadContext,
+            {
+              reason: 'local-fallback',
+              failureReason: undefined,
+              fallback: true,
+              selected: getSharedCandidateInfo(
+                resolvedShareOptions.scope?.[0] || DEFAULT_SCOPE,
+                resolvedShareOptions.version,
+                resolvedShareOptions,
+                resolvedShareOptions.shareConfig?.requiredVersion,
+              ),
+            },
+          ),
         });
         return factory;
       }
@@ -384,6 +615,21 @@ export class SharedHandler {
         pkgName,
         shareInfo: shareOptionsRes,
         error: shareError,
+        selectionResult: this.createSelectionResult(
+          selectionDecision ||
+            this.createSelectionDecision(
+              pkgName,
+              shareOptionsRes,
+              shareOptionsRes ? 'load-error' : 'missing-config',
+            ),
+          'async',
+          loadContext,
+          {
+            failureReason:
+              selectionDecision?.failureReason ||
+              (shareOptionsRes ? 'load-error' : 'missing-config'),
+          },
+        ),
       });
       throw shareError;
     }
@@ -401,11 +647,14 @@ export class SharedHandler {
       initScope?: InitScope;
       from?: CallFrom;
       strategy?: ShareStrategy;
+      context?: SharedLoadContext;
     },
   ): Array<Promise<void>> {
     const { host } = this;
     const from = extraOptions?.from;
     const strategy = extraOptions?.strategy;
+    const trigger: SharedLoadTrigger =
+      extraOptions?.context?.trigger || from || 'runtime';
     let initScope = extraOptions?.initScope;
     const promises: Promise<any>[] = [];
     if (from !== 'build') {
@@ -430,23 +679,78 @@ export class SharedHandler {
       const { version, eager } = shared;
       scope[name] = scope[name] || {};
       const versions = scope[name];
+      const existingShared = versions[version];
       const activeVersion: Shared =
-        versions[version] && (directShare(versions[version]) as Shared);
+        existingShared && (directShare(existingShared) as Shared);
       const activeVersionEager = Boolean(
         activeVersion &&
         (('eager' in activeVersion && activeVersion.eager) ||
           ('shareConfig' in activeVersion && activeVersion.shareConfig?.eager)),
       );
-      if (
+      const shouldReplace = Boolean(
         !activeVersion ||
         (activeVersion.strategy !== 'loaded-first' &&
           !activeVersion.loaded &&
           (Boolean(!eager) !== !activeVersionEager
             ? eager
-            : hostName > versions[version].from))
-      ) {
+            : hostName > versions[version].from)),
+      );
+      let action: SharedRegistrationResult['action'];
+      let reason: string;
+      if (existingShared === shared) {
+        action = 'reused';
+        reason = 'same-registration-reused';
+      } else if (shouldReplace) {
         versions[version] = shared;
+        action = activeVersion ? 'replaced' : 'registered';
+        reason = !activeVersion
+          ? 'first-registration'
+          : eager && !activeVersionEager
+            ? 'eager-preferred'
+            : 'provider-name-preferred';
+      } else {
+        action = 'ignored';
+        reason =
+          activeVersion.strategy === 'loaded-first'
+            ? 'loaded-first-preserved'
+            : activeVersion.loaded
+              ? 'loaded-version-preserved'
+              : activeVersionEager && !eager
+                ? 'eager-provider-preserved'
+                : 'provider-name-preserved';
       }
+
+      const candidate = getSharedCandidateInfo(
+        shareScopeName,
+        version,
+        shared,
+        shared.shareConfig?.requiredVersion,
+      );
+      const effectiveShared = versions[version];
+      this.emitAfterRegisterShare(name, {
+        scope: shareScopeName,
+        trigger,
+        candidate,
+        candidates: Object.entries(versions).map(
+          ([candidateVersion, candidateShared]) =>
+            getSharedCandidateInfo(
+              shareScopeName,
+              candidateVersion,
+              candidateShared,
+              shared.shareConfig?.requiredVersion,
+            ),
+        ),
+        action,
+        effective: effectiveShared
+          ? getSharedCandidateInfo(
+              shareScopeName,
+              effectiveShared.version,
+              effectiveShared,
+              shared.shareConfig?.requiredVersion,
+            )
+          : undefined,
+        reason,
+      });
     };
 
     const initRemoteModule = async (key: string): Promise<void> => {
@@ -506,13 +810,11 @@ export class SharedHandler {
   // 3. If the local get returns something other than Promise, then it will be used directly
   loadShareSync<T>(
     pkgName: string,
-    extraOptions?: {
-      from?: 'build' | 'runtime';
-      customShareInfo?: Partial<Shared>;
-      resolver?: (sharedOptions: ShareInfos[string]) => Shared;
-    },
+    extraOptions?: LoadShareExtraOptions,
   ): () => T | never {
     const { host } = this;
+    const loadContext = this.createLoadContext('loadShareSync', extraOptions);
+    let selectionDecision: SharedSelectionDecision | undefined;
     const shareOptions = getTargetSharedOptions({
       pkgName,
       extraOptions,
@@ -524,6 +826,8 @@ export class SharedHandler {
         shareOptions.scope.forEach((shareScope) => {
           this.initializeSharing(shareScope, {
             strategy: shareOptions.strategy,
+            from: extraOptions?.from,
+            context: loadContext,
           });
         });
       }
@@ -533,7 +837,44 @@ export class SharedHandler {
           pkgName,
           shareOptions,
           this.hooks.lifecycle.resolveShare,
+          (decision) => {
+            selectionDecision = decision;
+          },
         ) || {};
+
+      if (selectionDecision && extraOptions?.resolver && registeredShared) {
+        selectionDecision = {
+          ...selectionDecision,
+          reason: 'custom-resolver',
+          failureReason: undefined,
+        };
+      }
+
+      const registeredSelectionResult = registeredShared
+        ? this.createSelectionResult(
+            selectionDecision ||
+              this.createSelectionDecision(
+                pkgName,
+                shareOptions,
+                'exact-match',
+              ),
+            'sync',
+            loadContext,
+            {
+              selected:
+                selectionDecision?.selected ||
+                getSharedCandidateInfo(
+                  selectionDecision?.scope ||
+                    shareOptions.scope?.[0] ||
+                    DEFAULT_SCOPE,
+                  registeredShared.version,
+                  registeredShared,
+                  shareOptions.shareConfig?.requiredVersion,
+                ),
+              failureReason: undefined,
+            },
+          )
+        : undefined;
 
       if (registeredShared) {
         if (typeof registeredShared.lib === 'function') {
@@ -549,6 +890,7 @@ export class SharedHandler {
             pkgName,
             shareInfo: shareOptions,
             selectedShared: registeredShared,
+            selectionResult: registeredSelectionResult,
           });
           return registeredShared.lib as () => T;
         }
@@ -568,6 +910,7 @@ export class SharedHandler {
               pkgName,
               shareInfo: shareOptions,
               selectedShared: registeredShared,
+              selectionResult: registeredSelectionResult,
             });
             return module;
           }
@@ -583,6 +926,27 @@ export class SharedHandler {
           pkgName,
           shareInfo: shareOptions,
           selectedShared: shareOptions,
+          selectionResult: this.createSelectionResult(
+            selectionDecision ||
+              this.createSelectionDecision(
+                pkgName,
+                shareOptions,
+                'local-fallback',
+              ),
+            'sync',
+            loadContext,
+            {
+              reason: 'local-fallback',
+              failureReason: undefined,
+              fallback: true,
+              selected: getSharedCandidateInfo(
+                shareOptions.scope?.[0] || DEFAULT_SCOPE,
+                shareOptions.version,
+                shareOptions,
+                shareOptions.shareConfig?.requiredVersion,
+              ),
+            },
+          ),
         });
         return shareOptions.lib as () => T;
       }
@@ -619,6 +983,27 @@ export class SharedHandler {
           pkgName,
           shareInfo: shareOptions,
           selectedShared: shareOptions,
+          selectionResult: this.createSelectionResult(
+            selectionDecision ||
+              this.createSelectionDecision(
+                pkgName,
+                shareOptions,
+                'local-fallback',
+              ),
+            'sync',
+            loadContext,
+            {
+              reason: 'local-fallback',
+              failureReason: undefined,
+              fallback: true,
+              selected: getSharedCandidateInfo(
+                shareOptions.scope?.[0] || DEFAULT_SCOPE,
+                shareOptions.version,
+                shareOptions,
+                shareOptions.shareConfig?.requiredVersion,
+              ),
+            },
+          ),
         });
         return shareOptions.lib as () => T;
       }
@@ -639,6 +1024,15 @@ export class SharedHandler {
         pkgName,
         shareInfo: shareOptions,
         error: shareError,
+        selectionResult: this.createSelectionResult(
+          selectionDecision ||
+            this.createSelectionDecision(pkgName, shareOptions, 'load-error'),
+          'sync',
+          loadContext,
+          {
+            failureReason: selectionDecision?.failureReason || 'load-error',
+          },
+        ),
       });
       throw shareError;
     }
@@ -650,7 +1044,50 @@ export class SharedHandler {
     extraOptions: { hostShareScopeMap?: ShareScopeMap } = {},
   ): void {
     const { host } = this;
+    const previousScope = this.shareScopeMap[scopeName];
     this.shareScopeMap[scopeName] = shareScope;
+    Object.entries(shareScope).forEach(([pkgName, versions]) => {
+      Object.entries(versions).forEach(([version, shared]) => {
+        const previousShared = previousScope?.[pkgName]?.[version];
+        const action: SharedRegistrationResult['action'] = !previousShared
+          ? 'registered'
+          : previousShared === shared
+            ? 'reused'
+            : 'replaced';
+        this.emitAfterRegisterShare(pkgName, {
+          scope: scopeName,
+          trigger: 'container-init',
+          candidate: getSharedCandidateInfo(
+            scopeName,
+            version,
+            shared,
+            shared.shareConfig?.requiredVersion,
+          ),
+          candidates: Object.entries(versions).map(
+            ([candidateVersion, candidateShared]) =>
+              getSharedCandidateInfo(
+                scopeName,
+                candidateVersion,
+                candidateShared,
+                shared.shareConfig?.requiredVersion,
+              ),
+          ),
+          action,
+          effective: getSharedCandidateInfo(
+            scopeName,
+            version,
+            shared,
+            shared.shareConfig?.requiredVersion,
+          ),
+          reason:
+            action === 'registered'
+              ? 'container-share-registered'
+              : action === 'reused'
+                ? 'container-share-reused'
+                : 'container-share-replaced',
+        });
+      });
+    });
     this.hooks.lifecycle.initContainerShareScopeMap.emit({
       shareScope,
       options: host.options,

--- a/packages/runtime-core/src/type/config.ts
+++ b/packages/runtime-core/src/type/config.ts
@@ -27,9 +27,23 @@ export type RemoteInfoOptionalVersion = {
 export type Remote = (RemoteWithEntry | RemoteWithVersion) & RemoteInfoCommon;
 
 export type LoadShareExtraOptions = {
+  from?: CallFrom;
   customShareInfo?: Partial<Shared>;
   resolver?: (sharedOptions: ShareInfos[string]) => Shared;
+  context?: SharedLoadContext;
 };
+
+export type SharedLoadTrigger = CallFrom | 'container-init' | 'remote-load';
+
+export interface SharedLoadContext {
+  trigger?: SharedLoadTrigger;
+  moduleId?: string | number;
+  chunkId?: string | number;
+  remote?: string;
+  expose?: string;
+  requestId?: string;
+  operationId?: string;
+}
 
 export interface RemoteInfo {
   alias?: string;
@@ -105,6 +119,75 @@ export type Shared = {
   treeShaking?: TreeShakingArgs;
   // _noMatchedUsedExports?: NoMatchedUsedExportsItem[];
 };
+
+export interface SharedCandidateInfo {
+  scope: string;
+  version: string;
+  provider?: string;
+  loaded: boolean;
+  loading: boolean;
+  singleton: boolean;
+  eager: boolean;
+  strategy: ShareStrategy;
+  compatible?: boolean;
+  rejectionReason?: string;
+}
+
+export type SharedSelectionReason =
+  | 'exact-match'
+  | 'compatible-highest-version'
+  | 'compatible-version'
+  | 'loaded-first'
+  | 'version-first'
+  | 'singleton-existing'
+  | 'custom-resolver'
+  | 'local-fallback'
+  | 'version-mismatch'
+  | 'strict-version-rejected'
+  | 'missing-provider'
+  | 'missing-config'
+  | 'load-error';
+
+export interface SharedSelectionDecision {
+  scope?: string;
+  requestedVersion?: string;
+  requiredVersion?: string | false;
+  singleton: boolean;
+  strictVersion: boolean;
+  eager: boolean;
+  strategy: ShareStrategy;
+  candidates: SharedCandidateInfo[];
+  selected?: SharedCandidateInfo;
+  reason: SharedSelectionReason;
+  failureReason?: SharedSelectionReason;
+  fallback?: boolean;
+  recovered?: boolean;
+}
+
+export interface SharedSelectionResult extends SharedSelectionDecision {
+  loadType: 'sync' | 'async';
+  context: SharedLoadContext & {
+    operationId: string;
+    trigger: SharedLoadTrigger;
+  };
+}
+
+export type SharedRegistrationAction =
+  | 'registered'
+  | 'replaced'
+  | 'reused'
+  | 'ignored';
+
+export interface SharedRegistrationResult {
+  registrationId: string;
+  scope: string;
+  trigger: SharedLoadTrigger;
+  candidate: SharedCandidateInfo;
+  candidates: SharedCandidateInfo[];
+  action: SharedRegistrationAction;
+  effective?: SharedCandidateInfo;
+  reason: string;
+}
 
 export type ShareScopeMap = {
   [scope: string]: {

--- a/packages/runtime-core/src/utils/share.ts
+++ b/packages/runtime-core/src/utils/share.ts
@@ -13,6 +13,8 @@ import {
   ShareStrategy,
   TreeShakingArgs,
   SharedGetter,
+  SharedCandidateInfo,
+  SharedSelectionDecision,
 } from '../type';
 import { warn, error } from './logger';
 import { satisfy } from './semver';
@@ -208,6 +210,65 @@ const isLoading = (shared: {
   return Boolean(shared.loading);
 };
 
+const isVersionCompatible = (
+  version: string,
+  requiredVersion?: string | false,
+): boolean | undefined => {
+  if (requiredVersion === undefined) {
+    return undefined;
+  }
+  if (requiredVersion === false || requiredVersion === '*') {
+    return true;
+  }
+  try {
+    return satisfy(version, requiredVersion);
+  } catch {
+    return false;
+  }
+};
+
+export function getSharedCandidateInfo(
+  scope: string,
+  version: string,
+  shared: Shared,
+  requiredVersion?: string | false,
+): SharedCandidateInfo {
+  const compatible = isVersionCompatible(version, requiredVersion);
+  const treeShakingShared = shared.treeShaking;
+  const loaded =
+    isLoaded(shared) ||
+    Boolean(treeShakingShared && isLoaded(treeShakingShared));
+  const loading =
+    !loaded &&
+    (isLoading(shared) ||
+      Boolean(treeShakingShared && isLoading(treeShakingShared)));
+
+  return {
+    scope,
+    version,
+    provider: shared.from,
+    loaded,
+    loading,
+    singleton: Boolean(shared.shareConfig?.singleton),
+    eager: Boolean(shared.shareConfig?.eager ?? shared.eager),
+    strategy: shared.strategy || 'version-first',
+    compatible,
+    rejectionReason: compatible === false ? 'version-mismatch' : undefined,
+  };
+}
+
+function getSharedCandidates(
+  shareScopeMap: ShareScopeMap,
+  scope: string,
+  pkgName: string,
+  requiredVersion?: string | false,
+): SharedCandidateInfo[] {
+  return Object.entries(shareScopeMap[scope]?.[pkgName] || {}).map(
+    ([version, shared]) =>
+      getSharedCandidateInfo(scope, version, shared, requiredVersion),
+  );
+}
+
 const isMatchUsedExports = (
   treeShaking?: TreeShakingArgs,
   usedExports?: string[],
@@ -364,6 +425,7 @@ export function getRegisteredShare(
     GlobalFederation: Federation;
     resolver: () => { shared: Shared; useTreesShaking: boolean } | undefined;
   }>,
+  onSelection?: (selection: SharedSelectionDecision) => void,
 ): { shared: Shared; useTreesShaking: boolean } | void {
   if (!localShareScopeMap) {
     return;
@@ -375,6 +437,62 @@ export function getRegisteredShare(
     treeShaking,
   } = shareInfo;
   const scopes = Array.isArray(scope) ? scope : [scope];
+  const createDecision = (
+    sc: string | undefined,
+    candidates: SharedCandidateInfo[],
+    reason: SharedSelectionDecision['reason'],
+    selected?: SharedCandidateInfo,
+    failureReason?: SharedSelectionDecision['failureReason'],
+  ): SharedSelectionDecision => {
+    const selectedCandidate = selected
+      ? { ...selected, rejectionReason: undefined }
+      : undefined;
+    const candidatesWithReasons = candidates.map((candidate) => {
+      const isSelected = Boolean(
+        selectedCandidate &&
+        candidate.scope === selectedCandidate.scope &&
+        candidate.version === selectedCandidate.version &&
+        candidate.provider === selectedCandidate.provider,
+      );
+      if (isSelected) {
+        return selectedCandidate!;
+      }
+      if (candidate.rejectionReason) {
+        return candidate;
+      }
+
+      let rejectionReason: string | undefined;
+      if (reason === 'custom-resolver') {
+        rejectionReason = 'custom-resolver';
+      } else if (reason === 'singleton-existing') {
+        rejectionReason = 'singleton-existing';
+      } else if (
+        reason === 'loaded-first' &&
+        !candidate.loaded &&
+        !candidate.loading
+      ) {
+        rejectionReason = 'not-loaded';
+      } else if (selectedCandidate) {
+        rejectionReason = 'lower-priority-version';
+      }
+      return rejectionReason ? { ...candidate, rejectionReason } : candidate;
+    });
+
+    return {
+      scope: sc,
+      requestedVersion: shareInfo.version,
+      requiredVersion: shareConfig?.requiredVersion,
+      singleton: Boolean(shareConfig?.singleton),
+      strictVersion: Boolean(shareConfig?.strictVersion),
+      eager: Boolean(shareConfig?.eager),
+      strategy: strategy || 'version-first',
+      candidates: candidatesWithReasons,
+      selected: selectedCandidate,
+      reason,
+      failureReason,
+    };
+  };
+
   for (const sc of scopes) {
     if (
       shareConfig &&
@@ -382,6 +500,12 @@ export function getRegisteredShare(
       localShareScopeMap[sc][pkgName]
     ) {
       const { requiredVersion } = shareConfig;
+      const candidates = getSharedCandidates(
+        localShareScopeMap,
+        sc,
+        pkgName,
+        requiredVersion,
+      );
       const findShareFunction = getFindShareFunction(strategy);
       const { version: maxOrSingletonVersion, useTreesShaking } =
         findShareFunction(localShareScopeMap, sc, pkgName, treeShaking);
@@ -468,9 +592,91 @@ export function getRegisteredShare(
         resolver: defaultResolver,
       };
       const resolveShared = resolveShare.emit(params) || params;
-      return resolveShared.resolver();
+      const usedCustomResolver = resolveShared.resolver !== defaultResolver;
+      try {
+        const resolved = resolveShared.resolver();
+        if (!resolved) {
+          onSelection?.(
+            createDecision(
+              sc,
+              candidates,
+              'version-mismatch',
+              undefined,
+              'version-mismatch',
+            ),
+          );
+          return;
+        }
+
+        const selected = getSharedCandidateInfo(
+          sc,
+          resolved.shared.version,
+          resolved.shared,
+          requiredVersion,
+        );
+        let reason: SharedSelectionDecision['reason'];
+        if (usedCustomResolver) {
+          reason = 'custom-resolver';
+        } else if (shareConfig.singleton) {
+          reason = 'singleton-existing';
+        } else if (
+          strategy === 'loaded-first' &&
+          isLoadingOrLoaded(resolved.shared)
+        ) {
+          reason = 'loaded-first';
+        } else if (resolved.shared.version === shareInfo.version) {
+          reason = 'exact-match';
+        } else if (requiredVersion === false || requiredVersion === '*') {
+          reason =
+            strategy === 'loaded-first' ? 'loaded-first' : 'version-first';
+        } else if (resolved.shared.version === maxOrSingletonVersion) {
+          reason = 'compatible-highest-version';
+        } else {
+          reason = 'compatible-version';
+        }
+        onSelection?.(createDecision(sc, candidates, reason, selected));
+        return resolved;
+      } catch (selectionError) {
+        const strictVersionRejected =
+          !usedCustomResolver &&
+          Boolean(shareConfig.singleton && shareConfig.strictVersion) &&
+          typeof requiredVersion === 'string' &&
+          isVersionCompatible(maxOrSingletonVersion, requiredVersion) === false;
+        const failureReason = strictVersionRejected
+          ? 'strict-version-rejected'
+          : 'load-error';
+        onSelection?.(
+          createDecision(
+            sc,
+            candidates,
+            failureReason,
+            undefined,
+            failureReason,
+          ),
+        );
+        throw selectionError;
+      }
     }
   }
+
+  const candidates = scopes.flatMap((sc) =>
+    getSharedCandidates(
+      localShareScopeMap,
+      sc,
+      pkgName,
+      shareConfig?.requiredVersion,
+    ),
+  );
+  const failureReason = shareConfig ? 'missing-provider' : 'missing-config';
+  onSelection?.(
+    createDecision(
+      scopes[0],
+      candidates,
+      failureReason,
+      undefined,
+      failureReason,
+    ),
+  );
 }
 
 export function getGlobalShareScope(): GlobalShareScopeMap {

--- a/packages/webpack-bundler-runtime/__tests__/consumes.spec.ts
+++ b/packages/webpack-bundler-runtime/__tests__/consumes.spec.ts
@@ -161,7 +161,15 @@ describe('consumes', () => {
     expect(mockPromises.length).toBe(1);
     expect(mockFederationInstance.loadShare).toHaveBeenCalledWith(
       mockShareKey,
-      { customShareInfo: mockShareInfo },
+      {
+        customShareInfo: mockShareInfo,
+        from: 'build',
+        context: {
+          trigger: 'build',
+          moduleId: mockModuleId,
+          chunkId: 'testChunkId',
+        },
+      },
     );
 
     // Wait for promise to resolve

--- a/packages/webpack-bundler-runtime/__tests__/installInitialConsumes.spec.ts
+++ b/packages/webpack-bundler-runtime/__tests__/installInitialConsumes.spec.ts
@@ -183,4 +183,49 @@ describe('installInitialConsumes', () => {
     // Verify
     expect(mockWebpackRequire.m[mockModuleId]).toBeDefined();
   });
+
+  test('should pass build and module context to the real sync loader', () => {
+    const actualInstallInitialConsumes = jest.requireActual(
+      '../src/installInitialConsumes',
+    ).installInitialConsumes as typeof installInitialConsumes;
+    const moduleId = 'context-module';
+    const factory = jest.fn(() => ({ loaded: true }));
+    const loadShareSync = jest.fn(() => factory);
+    const webpackRequire = {
+      m: {},
+      c: {},
+      federation: {
+        instance: { loadShareSync },
+      },
+    };
+    const options: InstallInitialConsumesOptions = {
+      moduleToHandlerMapping: {
+        [moduleId]: {
+          shareKey: 'context-share',
+          getter: jest.fn(),
+          shareInfo: {
+            scope: ['default'],
+            shareConfig: { singleton: true, requiredVersion: '*' },
+          },
+        },
+      },
+      webpackRequire: webpackRequire as any,
+      installedModules: {},
+      initialConsumes: [moduleId],
+    };
+
+    actualInstallInitialConsumes(options);
+    const module = { exports: undefined };
+    webpackRequire.m[moduleId](module);
+
+    expect(loadShareSync).toHaveBeenCalledWith('context-share', {
+      customShareInfo: options.moduleToHandlerMapping[moduleId].shareInfo,
+      from: 'build',
+      context: {
+        trigger: 'build',
+        moduleId,
+      },
+    });
+    expect(module.exports).toEqual({ loaded: true });
+  });
 });

--- a/packages/webpack-bundler-runtime/src/consumes.ts
+++ b/packages/webpack-bundler-runtime/src/consumes.ts
@@ -82,6 +82,12 @@ export function consumes(options: ConsumesOptions) {
         const promise = federationInstance
           .loadShare(shareKey, {
             customShareInfo,
+            from: 'build',
+            context: {
+              trigger: 'build',
+              moduleId: id,
+              chunkId,
+            },
           })
           .then((factory: any) => {
             if (factory === false) {

--- a/packages/webpack-bundler-runtime/src/installInitialConsumes.ts
+++ b/packages/webpack-bundler-runtime/src/installInitialConsumes.ts
@@ -29,10 +29,20 @@ function handleInitialConsumes(options: HandleInitialConsumesOptions) {
     if (asyncLoad) {
       return federationInstance.loadShare(shareKey, {
         customShareInfo,
+        from: 'build',
+        context: {
+          trigger: 'build',
+          moduleId,
+        },
       });
     }
     return federationInstance.loadShareSync(shareKey, {
       customShareInfo,
+      from: 'build',
+      context: {
+        trigger: 'build',
+        moduleId,
+      },
     });
   } catch (err) {
     console.error(


### PR DESCRIPTION

## Description

Add safe and structured diagnostics for shared dependency registration and selection.

Runtime Core now reports:

- The final registration outcome: registered, replaced, reused, or ignored.
- The selected shared candidate and the reason behind the decision.
- Rejected candidates and failure reasons.
- Local fallback and recovery outcomes.
- Explicit per-operation context for runtime and build-triggered loads.

Webpack Bundler Runtime supplies module and chunk context when it is genuinely available.

The Observability plugin exposes this information through shared state and traces while preserving instance isolation, redacting sensitive text, limiting report size, and avoiding factories, promises, or complete share-scope objects.

Older runtimes continue to expose current shared state when available. Shared history is marked partial or unavailable when detailed runtime signals are missing.

This change does not add or modify OpenRuntime commands and does not alter existing shared loading behavior.

## Related Issue

MF-Shared-01

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Validation

- Runtime Core: 111 tests passed.
- Webpack Bundler Runtime: 102 tests passed.
- Observability Plugin: 101 tests passed.
- Local CI `build-and-test`: 76 tasks passed.
- All three affected packages built successfully.
- Repository-wide formatting check passed.
- Package lint checks passed during commit.

Commands:

- `pnpm --filter @module-federation/runtime-core test`
- `pnpm --filter @module-federation/runtime-core build`
- `pnpm --filter @module-federation/webpack-bundler-runtime test`
- `pnpm --filter @module-federation/webpack-bundler-runtime build`
- `pnpm --filter @module-federation/observability-plugin test`
- `pnpm --filter @module-federation/observability-plugin build`
- `pnpm exec prettier --check .`
- `pnpm run ci:local --only=build-and-test`

## Skipped checks

Metro, application E2E, DevTools, and bundle-size jobs were not run because this change does not affect those areas. GitHub-only checks remain for CI.

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.