### PR TITLE
 feat(bridge): add lifecycle observability

### DIFF
--- a/.changeset/calm-bridges-observe.md
+++ b/.changeset/calm-bridges-observe.md
@@ -1,0 +1,10 @@
+---
+'@module-federation/runtime-core': patch
+'@module-federation/runtime': patch
+'@module-federation/bridge-shared': patch
+'@module-federation/bridge-react': patch
+'@module-federation/bridge-vue3': patch
+'@module-federation/observability-plugin': patch
+---
+
+Add safe Bridge render, commit, failure, destroy, and route synchronization signals for React and Vue applications, together with correlated runtime observability reports.

--- a/packages/bridge/bridge-react/__tests__/bridge-lifecycle.spec.tsx
+++ b/packages/bridge/bridge-react/__tests__/bridge-lifecycle.spec.tsx
@@ -1,0 +1,262 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
+import {
+  createBridgeComponent as createLegacyBridgeComponent,
+  createRemoteAppComponent,
+} from '../src';
+import { createBridgeComponent as createReact18BridgeComponent } from '../src/v18';
+import { createBridgeComponent as createReact19BridgeComponent } from '../src/v19';
+import { federationRuntime } from '../src/provider/plugin';
+import { createContainer } from './util';
+
+const createLifecycleFixture = () => {
+  const events: Array<{ lifecycle: string; payload: Record<string, any> }> = [];
+  const eventHook = (lifecycle: string) => ({
+    emit: jest.fn((payload: Record<string, any>) => {
+      events.push({ lifecycle, payload });
+    }),
+  });
+  const lifecycle = {
+    beforeBridgeRender: { emit: jest.fn(() => ({})) },
+    afterBridgeRender: { emit: jest.fn() },
+    beforeBridgeDestroy: { emit: jest.fn() },
+    afterBridgeDestroy: { emit: jest.fn() },
+    beforeBridgeOperation: eventHook('beforeBridgeOperation'),
+    bridgeRenderInvoked: eventHook('bridgeRenderInvoked'),
+    afterBridgeOperation: eventHook('afterBridgeOperation'),
+    afterBridgeCommit: eventHook('afterBridgeCommit'),
+  };
+  federationRuntime.instance = { bridgeHook: { lifecycle } } as any;
+  return { events, lifecycle };
+};
+
+describe('React Bridge operation lifecycle', () => {
+  afterEach(() => {
+    federationRuntime.instance = null;
+    document.body.innerHTML = '';
+  });
+
+  it.each([
+    ['legacy', createLegacyBridgeComponent],
+    ['react18', createReact18BridgeComponent],
+    ['react19', createReact19BridgeComponent],
+  ])('confirms a real commit for the %s provider path', async (_, factory) => {
+    const { events } = createLifecycleFixture();
+    const containerInfo = createContainer();
+    const bridge = factory({
+      rootComponent: () => <div>committed</div>,
+    })();
+
+    await act(async () => {
+      await bridge.render({
+        dom: containerInfo.container,
+        moduleName: 'remote/App',
+        basename: '/safe?token=private#hash',
+        businessValue: 'must-not-leak',
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        events.some((event) => event.lifecycle === 'afterBridgeCommit'),
+      ).toBe(true);
+    });
+    const renderEvents = events.filter(
+      (event) => event.payload.operation === 'render',
+    );
+    expect(renderEvents.map((event) => event.lifecycle)).toEqual(
+      expect.arrayContaining([
+        'beforeBridgeOperation',
+        'bridgeRenderInvoked',
+        'afterBridgeOperation',
+        'afterBridgeCommit',
+      ]),
+    );
+    expect(
+      new Set(renderEvents.map((event) => event.payload.operationId)).size,
+    ).toBe(1);
+    expect(JSON.stringify(events)).not.toContain('must-not-leak');
+    expect(JSON.stringify(events)).not.toContain('token=private');
+    expect(JSON.stringify(events)).not.toContain('HTMLDivElement');
+
+    bridge.destroy({ dom: containerInfo.container, moduleName: 'remote/App' });
+    bridge.destroy({ dom: containerInfo.container, moduleName: 'remote/App' });
+    const destroyResults = events.filter(
+      (event) =>
+        event.lifecycle === 'afterBridgeOperation' &&
+        event.payload.operation === 'destroy',
+    );
+    expect(destroyResults.map((event) => event.payload.outcome)).toEqual([
+      'success',
+      'skipped',
+    ]);
+    containerInfo.clean();
+  });
+
+  it('distinguishes updates and correlates consumer and producer operations', async () => {
+    const { events } = createLifecycleFixture();
+    const BridgeProvider = createReact18BridgeComponent({
+      rootComponent: ({ value }: { value?: string }) => <div>{value}</div>,
+    });
+    const remoteModule: Record<PropertyKey, unknown> = {
+      default: BridgeProvider,
+    };
+    remoteModule[Symbol.for('mf_module_id')] = 'remote/App';
+    const RemoteComponent = createRemoteAppComponent({
+      loader: async () => remoteModule,
+      fallback: () => null,
+      loading: null,
+    });
+    const result = render(<RemoteComponent value="first" />);
+
+    await waitFor(() =>
+      expect(result.container.textContent).toContain('first'),
+    );
+    const firstStarts = events.filter(
+      (event) =>
+        event.lifecycle === 'beforeBridgeOperation' &&
+        event.payload.operation === 'render',
+    );
+    expect(firstStarts.map((event) => event.payload.side).sort()).toEqual([
+      'consumer',
+      'producer',
+    ]);
+    expect(
+      new Set(firstStarts.map((event) => event.payload.operationId)).size,
+    ).toBe(1);
+
+    result.rerender(<RemoteComponent value="second" />);
+    await waitFor(() =>
+      expect(result.container.textContent).toContain('second'),
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.lifecycle === 'beforeBridgeOperation' &&
+          event.payload.operation === 'update' &&
+          event.payload.reason === 'props-update',
+      ),
+    ).toBe(true);
+    result.unmount();
+  });
+
+  it.each([
+    [
+      'throw',
+      () => {
+        throw new Error('sync render failed token=secret');
+      },
+    ],
+    [
+      'reject',
+      () => Promise.reject(new Error('async render failed token=secret')),
+    ],
+  ])(
+    'records a custom render %s and preserves the error',
+    async (_, customRender) => {
+      const { events } = createLifecycleFixture();
+      const containerInfo = createContainer();
+      const bridge = createLegacyBridgeComponent({
+        rootComponent: () => <div />,
+        render: customRender as any,
+      })();
+
+      await expect(
+        bridge.render({
+          dom: containerInfo.container,
+          moduleName: 'remote/App',
+        }),
+      ).rejects.toThrow('render failed');
+      const result = events.find(
+        (event) =>
+          event.lifecycle === 'afterBridgeOperation' &&
+          event.payload.operation === 'render',
+      );
+      expect(result?.payload.outcome).toBe('error');
+      expect(result?.payload.error.message).not.toContain('token=secret');
+      containerInfo.clean();
+    },
+  );
+
+  it('records destroy errors without swallowing them', async () => {
+    const { events } = createLifecycleFixture();
+    const containerInfo = createContainer();
+    const bridge = createLegacyBridgeComponent({
+      rootComponent: () => <div />,
+      createRoot: () => ({
+        render: jest.fn(),
+        unmount: () => {
+          throw new Error('destroy failed');
+        },
+      }),
+    })();
+    await bridge.render({
+      dom: containerInfo.container,
+      moduleName: 'remote/App',
+    });
+    expect(
+      events.some((event) => event.lifecycle === 'afterBridgeCommit'),
+    ).toBe(false);
+
+    expect(() =>
+      bridge.destroy({
+        dom: containerInfo.container,
+        moduleName: 'remote/App',
+      }),
+    ).toThrow('destroy failed');
+    expect(
+      events.find(
+        (event) =>
+          event.lifecycle === 'afterBridgeOperation' &&
+          event.payload.operation === 'destroy',
+      )?.payload.outcome,
+    ).toBe('error');
+    containerInfo.clean();
+  });
+
+  it('records host-to-remote popstate route synchronization', async () => {
+    const { events } = createLifecycleFixture();
+    const BridgeProvider = createReact18BridgeComponent({
+      rootComponent: () => <div>remote</div>,
+    });
+    const remoteModule: Record<PropertyKey, unknown> = {
+      default: BridgeProvider,
+    };
+    remoteModule[Symbol.for('mf_module_id')] = 'remote/App';
+    const RemoteComponent = createRemoteAppComponent({
+      loader: async () => remoteModule,
+      fallback: () => null,
+      loading: null,
+    });
+    let navigate!: ReturnType<typeof useNavigate>;
+    const Host = () => {
+      navigate = useNavigate();
+      return <RemoteComponent />;
+    };
+    const result = render(
+      <MemoryRouter initialEntries={['/first']}>
+        <Host />
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(result.container.textContent).toContain('remote'),
+    );
+
+    act(() => navigate('/second'));
+    await waitFor(() => {
+      expect(
+        events.some(
+          (event) =>
+            event.lifecycle === 'afterBridgeOperation' &&
+            event.payload.operation === 'route-sync' &&
+            event.payload.side === 'consumer' &&
+            event.payload.route.action === 'host-to-remote' &&
+            event.payload.route.mechanism === 'popstate' &&
+            event.payload.outcome === 'success',
+        ),
+      ).toBe(true);
+    });
+    result.unmount();
+  });
+});

--- a/packages/bridge/bridge-react/src/provider/versions/bridge-base.tsx
+++ b/packages/bridge/bridge-react/src/provider/versions/bridge-base.tsx
@@ -16,6 +16,31 @@ import { ErrorBoundary } from '../../error-boundary';
 import { RouterContext } from '../context';
 import { LoggerInstance } from '../../utils';
 import { federationRuntime } from '../plugin';
+import {
+  completeBridgeOperation,
+  attachBridgeOperationContext,
+  createBridgeId,
+  createBridgeOperationContext,
+  emitBridgeLifecycle,
+  getAttachedBridgeOperationContext,
+} from '@module-federation/bridge-shared';
+
+class BridgeCommitObserver extends React.Component<{
+  children: React.ReactNode;
+  onCommit: () => void;
+}> {
+  componentDidMount() {
+    this.props.onCommit();
+  }
+
+  componentDidUpdate() {
+    this.props.onCommit();
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
 
 export function createBaseBridgeComponent<T>({
   createRoot,
@@ -24,6 +49,7 @@ export function createBaseBridgeComponent<T>({
 }: ProviderFnParams<T>) {
   return () => {
     const rootMap = new Map<any, RootType>();
+    const bridgeIds = new WeakMap<object, string>();
     const instance = federationRuntime.instance;
     LoggerInstance.debug(
       `createBridgeComponent instance from props >>>`,
@@ -85,6 +111,31 @@ export function createBaseBridgeComponent<T>({
     return {
       async render(info: RenderParams) {
         LoggerInstance.debug(`createBridgeComponent render Info`, info);
+        const parentContext = getAttachedBridgeOperationContext(info);
+        const bridgeId =
+          parentContext?.bridgeId ||
+          bridgeIds.get(info.dom) ||
+          createBridgeId();
+        bridgeIds.set(info.dom, bridgeId);
+        const operation =
+          parentContext?.operation ||
+          (rootMap.has(info.dom) ? 'update' : 'render');
+        const operationContext = createBridgeOperationContext({
+          side: 'producer',
+          framework: 'react',
+          operation,
+          bridgeId,
+          moduleName: info.moduleName,
+          parent: parentContext,
+          reason: parentContext?.reason || 'direct',
+        });
+        emitBridgeLifecycle(
+          instance,
+          'beforeBridgeOperation',
+          operationContext,
+        );
+        attachBridgeOperationContext(info, operationContext);
+
         const {
           moduleName,
           dom,
@@ -99,56 +150,160 @@ export function createBaseBridgeComponent<T>({
           ...(rootOptions as CreateRootOptions),
         };
 
-        const beforeBridgeRenderRes =
-          instance?.bridgeHook?.lifecycle?.beforeBridgeRender?.emit(info) || {};
-
-        const rootComponentWithErrorBoundary = (
-          <BridgeWrapper
-            basename={basename}
-            moduleName={moduleName}
-            memoryRoute={memoryRoute}
-            propsInfo={
-              {
-                ...omitHostFallback(propsInfo as Record<string, unknown>),
-                basename,
-                ...(beforeBridgeRenderRes as any)?.extraProps,
-              } as T
-            }
-          />
-        );
-
-        if (bridgeInfo.render) {
-          await Promise.resolve(
-            bridgeInfo.render(rootComponentWithErrorBoundary, dom),
-          ).then((root: RootType) => rootMap.set(dom, root));
-        } else {
-          let root = rootMap.get(dom);
-          // Do not call createRoot multiple times
-          if (!root && createRoot) {
-            root = createRoot(dom, mergedRootOptions);
-            rootMap.set(dom, root as any);
-          }
-
-          if (root && 'render' in root) {
-            root.render(rootComponentWithErrorBoundary);
-          }
+        let routeContext:
+          | ReturnType<typeof createBridgeOperationContext>
+          | undefined;
+        if (memoryRoute?.entryPath || basename) {
+          routeContext = createBridgeOperationContext({
+            side: 'producer',
+            framework: 'react',
+            operation: 'route-sync',
+            bridgeId,
+            moduleName,
+            route: memoryRoute?.entryPath
+              ? {
+                  action: 'memory-route-init',
+                  to: memoryRoute.entryPath,
+                  basename,
+                }
+              : { action: 'basename-init', to: basename, basename },
+          });
+          emitBridgeLifecycle(instance, 'beforeBridgeOperation', routeContext);
         }
-        instance?.bridgeHook?.lifecycle?.afterBridgeRender?.emit(info) || {};
+
+        let commitEmitted = false;
+        const emitCommit = () => {
+          if (commitEmitted) {
+            return;
+          }
+          commitEmitted = true;
+          emitBridgeLifecycle(
+            instance,
+            'afterBridgeCommit',
+            completeBridgeOperation(operationContext, 'success'),
+          );
+          if (routeContext) {
+            emitBridgeLifecycle(
+              instance,
+              'afterBridgeOperation',
+              completeBridgeOperation(routeContext, 'success'),
+            );
+          }
+        };
+
+        try {
+          const beforeBridgeRenderRes =
+            instance?.bridgeHook?.lifecycle?.beforeBridgeRender?.emit(info) ||
+            {};
+
+          const rootComponentWithErrorBoundary = (
+            <BridgeCommitObserver onCommit={emitCommit}>
+              <BridgeWrapper
+                basename={basename}
+                moduleName={moduleName}
+                memoryRoute={memoryRoute}
+                propsInfo={
+                  {
+                    ...omitHostFallback(propsInfo as Record<string, unknown>),
+                    basename,
+                    ...(beforeBridgeRenderRes as any)?.extraProps,
+                  } as T
+                }
+              />
+            </BridgeCommitObserver>
+          );
+
+          emitBridgeLifecycle(
+            instance,
+            'bridgeRenderInvoked',
+            operationContext,
+          );
+          if (bridgeInfo.render) {
+            await Promise.resolve(
+              bridgeInfo.render(rootComponentWithErrorBoundary, dom),
+            ).then((root: RootType) => rootMap.set(dom, root));
+          } else {
+            let root = rootMap.get(dom);
+            // Do not call createRoot multiple times
+            if (!root && createRoot) {
+              root = createRoot(dom, mergedRootOptions);
+              rootMap.set(dom, root as any);
+            }
+
+            if (root && 'render' in root) {
+              root.render(rootComponentWithErrorBoundary);
+            }
+          }
+          instance?.bridgeHook?.lifecycle?.afterBridgeRender?.emit(info) || {};
+          emitBridgeLifecycle(
+            instance,
+            'afterBridgeOperation',
+            completeBridgeOperation(operationContext, 'success'),
+          );
+        } catch (error) {
+          if (routeContext) {
+            emitBridgeLifecycle(
+              instance,
+              'afterBridgeOperation',
+              completeBridgeOperation(routeContext, 'error', error),
+            );
+          }
+          emitBridgeLifecycle(
+            instance,
+            'afterBridgeOperation',
+            completeBridgeOperation(operationContext, 'error', error),
+          );
+          throw error;
+        }
       },
 
       destroy(info: DestroyParams) {
         const { dom } = info;
         LoggerInstance.debug(`createBridgeComponent destroy Info`, info);
         const root = rootMap.get(dom);
-        if (root) {
-          if ('unmount' in root) {
-            root.unmount();
-          } else {
-            LoggerInstance.warn('Root does not have unmount method');
+        const parentContext = getAttachedBridgeOperationContext(info);
+        const operationContext = createBridgeOperationContext({
+          side: 'producer',
+          framework: 'react',
+          operation: 'destroy',
+          bridgeId:
+            parentContext?.bridgeId || bridgeIds.get(dom) || createBridgeId(),
+          moduleName: info.moduleName,
+          parent: parentContext,
+          reason: parentContext?.reason || 'direct',
+        });
+        emitBridgeLifecycle(
+          instance,
+          'beforeBridgeOperation',
+          operationContext,
+        );
+        attachBridgeOperationContext(info, operationContext);
+        try {
+          instance?.bridgeHook?.lifecycle?.beforeBridgeDestroy?.emit(info);
+          let outcome: 'success' | 'skipped' = 'skipped';
+          if (root) {
+            if ('unmount' in root) {
+              root.unmount();
+              outcome = 'success';
+            } else {
+              LoggerInstance.warn('Root does not have unmount method');
+            }
+            rootMap.delete(dom);
           }
-          rootMap.delete(dom);
+          instance?.bridgeHook?.lifecycle?.afterBridgeDestroy?.emit(info);
+          emitBridgeLifecycle(
+            instance,
+            'afterBridgeOperation',
+            completeBridgeOperation(operationContext, outcome),
+          );
+        } catch (error) {
+          emitBridgeLifecycle(
+            instance,
+            'afterBridgeOperation',
+            completeBridgeOperation(operationContext, 'error', error),
+          );
+          throw error;
         }
-        instance?.bridgeHook?.lifecycle?.afterBridgeDestroy?.emit(info);
       },
     };
   };

--- a/packages/bridge/bridge-react/src/remote/RemoteAppWrapper.tsx
+++ b/packages/bridge/bridge-react/src/remote/RemoteAppWrapper.tsx
@@ -6,6 +6,13 @@ import React, { useEffect, useRef, useState, forwardRef } from 'react';
 import { LoggerInstance, getRootDomDefaultClassName } from '../utils';
 import { federationRuntime } from '../provider/plugin';
 import { RemoteComponentProps, RemoteAppParams } from '../types';
+import {
+  attachBridgeOperationContext,
+  completeBridgeOperation,
+  createBridgeId,
+  createBridgeOperationContext,
+  emitBridgeLifecycle,
+} from '@module-federation/bridge-shared';
 
 export const RemoteAppWrapper = forwardRef(function (
   props: RemoteAppParams & RemoteComponentProps,
@@ -31,6 +38,8 @@ export const RemoteAppWrapper = forwardRef(function (
 
   const renderDom: React.MutableRefObject<HTMLElement | null> = useRef(null);
   const providerInfoRef = useRef<any>(null);
+  const [bridgeId] = useState(createBridgeId);
+  const hasRenderedRef = useRef(false);
   const [initialized, setInitialized] = useState(false);
 
   LoggerInstance.debug(`RemoteAppWrapper instance from props >>>`, instance);
@@ -49,28 +58,71 @@ export const RemoteAppWrapper = forwardRef(function (
           { moduleName, basename, dom: renderDom.current },
         );
 
-        instance?.bridgeHook?.lifecycle?.beforeBridgeDestroy?.emit({
+        const destroyInfo = {
           moduleName,
           dom: renderDom.current,
           basename,
           memoryRoute,
           fallback,
           ...resProps,
-        });
-
-        providerInfoRef.current?.destroy({
+        };
+        const operationContext = createBridgeOperationContext({
+          side: 'consumer',
+          framework: 'react',
+          operation: 'destroy',
+          bridgeId,
           moduleName,
-          dom: renderDom.current,
+          reason: 'unmount',
         });
+        attachBridgeOperationContext(destroyInfo, operationContext);
+        emitBridgeLifecycle(
+          instance,
+          'beforeBridgeOperation',
+          operationContext,
+        );
 
-        instance?.bridgeHook?.lifecycle?.afterBridgeDestroy?.emit({
-          moduleName,
-          dom: renderDom.current,
-          basename,
-          memoryRoute,
-          fallback,
-          ...resProps,
-        });
+        try {
+          instance?.bridgeHook?.lifecycle?.beforeBridgeDestroy?.emit(
+            destroyInfo,
+          );
+          const result = providerInfoRef.current?.destroy(destroyInfo);
+          instance?.bridgeHook?.lifecycle?.afterBridgeDestroy?.emit(
+            destroyInfo,
+          );
+          if (result && typeof result.then === 'function') {
+            void result.then(
+              () =>
+                emitBridgeLifecycle(
+                  instance,
+                  'afterBridgeOperation',
+                  completeBridgeOperation(operationContext, 'success'),
+                ),
+              (error: unknown) => {
+                emitBridgeLifecycle(
+                  instance,
+                  'afterBridgeOperation',
+                  completeBridgeOperation(operationContext, 'error', error),
+                );
+                throw error;
+              },
+            );
+          } else {
+            emitBridgeLifecycle(
+              instance,
+              'afterBridgeOperation',
+              completeBridgeOperation(operationContext, 'success'),
+            );
+          }
+        } catch (error) {
+          emitBridgeLifecycle(
+            instance,
+            'afterBridgeOperation',
+            completeBridgeOperation(operationContext, 'error', error),
+          );
+          throw error;
+        }
+
+        hasRenderedRef.current = false;
       }
     };
   }, [moduleName]);
@@ -88,14 +140,61 @@ export const RemoteAppWrapper = forwardRef(function (
       ...resProps,
     };
     renderDom.current = rootRef.current;
+    const operationContext = createBridgeOperationContext({
+      side: 'consumer',
+      framework: 'react',
+      operation: hasRenderedRef.current ? 'update' : 'render',
+      bridgeId,
+      moduleName,
+      reason: hasRenderedRef.current ? 'props-update' : 'mount',
+    });
+    attachBridgeOperationContext(renderProps, operationContext);
+    emitBridgeLifecycle(instance, 'beforeBridgeOperation', operationContext);
 
-    const beforeBridgeRenderRes =
-      instance?.bridgeHook?.lifecycle?.beforeBridgeRender?.emit(renderProps) ||
-      {};
-    // @ts-ignore
-    renderProps = { ...renderProps, ...beforeBridgeRenderRes.extraProps };
-    providerInfoRef.current.render(renderProps);
-    instance?.bridgeHook?.lifecycle?.afterBridgeRender?.emit(renderProps);
+    try {
+      const beforeBridgeRenderRes =
+        instance?.bridgeHook?.lifecycle?.beforeBridgeRender?.emit(
+          renderProps,
+        ) || {};
+      // @ts-ignore
+      renderProps = { ...renderProps, ...beforeBridgeRenderRes.extraProps };
+      attachBridgeOperationContext(renderProps, operationContext);
+      emitBridgeLifecycle(instance, 'bridgeRenderInvoked', operationContext);
+      const result = providerInfoRef.current.render(renderProps);
+      hasRenderedRef.current = true;
+      instance?.bridgeHook?.lifecycle?.afterBridgeRender?.emit(renderProps);
+      if (result && typeof result.then === 'function') {
+        void result.then(
+          () =>
+            emitBridgeLifecycle(
+              instance,
+              'afterBridgeOperation',
+              completeBridgeOperation(operationContext, 'success'),
+            ),
+          (error: unknown) => {
+            emitBridgeLifecycle(
+              instance,
+              'afterBridgeOperation',
+              completeBridgeOperation(operationContext, 'error', error),
+            );
+            throw error;
+          },
+        );
+      } else {
+        emitBridgeLifecycle(
+          instance,
+          'afterBridgeOperation',
+          completeBridgeOperation(operationContext, 'success'),
+        );
+      }
+    } catch (error) {
+      emitBridgeLifecycle(
+        instance,
+        'afterBridgeOperation',
+        completeBridgeOperation(operationContext, 'error', error),
+      );
+      throw error;
+    }
   }, [initialized, ...Object.values(props)]);
 
   // bridge-remote-root

--- a/packages/bridge/bridge-react/src/remote/router-component/component.tsx
+++ b/packages/bridge/bridge-react/src/remote/router-component/component.tsx
@@ -1,8 +1,15 @@
 import React, { useContext, useEffect, useState, forwardRef } from 'react';
 import * as ReactRouterDOM from 'react-router-dom';
-import { dispatchPopstateEnv } from '@module-federation/bridge-shared';
+import {
+  completeBridgeOperation,
+  createBridgeId,
+  createBridgeOperationContext,
+  dispatchPopstateEnv,
+  emitBridgeLifecycle,
+} from '@module-federation/bridge-shared';
 import { LoggerInstance, pathJoin } from '../../utils';
 import { RemoteAppWrapper } from '../RemoteAppWrapper';
+import { federationRuntime } from '../../provider/plugin';
 
 interface ExtraDataProps {
   basename?: string;
@@ -14,6 +21,7 @@ export function withRouterData<
   WrappedComponent: React.ComponentType<P & ExtraDataProps>,
 ): React.FC<Omit<P, keyof ExtraDataProps>> {
   const Component = forwardRef(function (props: any, ref) {
+    const [routeBridgeId] = useState(createBridgeId);
     if (props?.basename) {
       return (
         <WrappedComponent {...props} basename={props.basename} ref={ref} />
@@ -87,7 +95,40 @@ export function withRouterData<
               pathname: location.pathname,
             },
           );
-          dispatchPopstateEnv();
+          const operationContext = createBridgeOperationContext({
+            side: 'consumer',
+            framework: 'react',
+            operation: 'route-sync',
+            bridgeId: routeBridgeId,
+            moduleName: props.moduleName,
+            route: {
+              action: 'host-to-remote',
+              mechanism: 'popstate',
+              from: pathname,
+              to: location.pathname,
+              basename,
+            },
+          });
+          emitBridgeLifecycle(
+            federationRuntime.instance,
+            'beforeBridgeOperation',
+            operationContext,
+          );
+          try {
+            dispatchPopstateEnv();
+            emitBridgeLifecycle(
+              federationRuntime.instance,
+              'afterBridgeOperation',
+              completeBridgeOperation(operationContext, 'success'),
+            );
+          } catch (error) {
+            emitBridgeLifecycle(
+              federationRuntime.instance,
+              'afterBridgeOperation',
+              completeBridgeOperation(operationContext, 'error', error),
+            );
+            throw error;
+          }
         }
         setPathname(location.pathname);
       }, [location]);

--- a/packages/bridge/bridge-react/src/types.ts
+++ b/packages/bridge/bridge-react/src/types.ts
@@ -135,8 +135,8 @@ export interface RemoteComponentParams<
  */
 export interface RemoteModule {
   provider: () => {
-    render: (info: RenderFnParams) => void;
-    destroy: (info: { dom: any }) => void;
+    render: (info: RenderFnParams) => unknown | Promise<unknown>;
+    destroy: (info: { dom: any }) => unknown | Promise<unknown>;
   };
 }
 

--- a/packages/bridge/bridge-shared/src/index.ts
+++ b/packages/bridge/bridge-shared/src/index.ts
@@ -1,2 +1,21 @@
-export type { RenderFnParams, ProviderParams } from './type';
+export type {
+  RenderFnParams,
+  ProviderParams,
+  BridgeFramework,
+  BridgeOperation,
+  BridgeOperationContext,
+  BridgeOperationOutcome,
+  BridgeOperationResult,
+  BridgeOperationSide,
+  BridgeRouteSummary,
+} from './type';
 export { dispatchPopstateEnv } from './env';
+export {
+  attachBridgeOperationContext,
+  completeBridgeOperation,
+  createBridgeId,
+  createBridgeOperationContext,
+  emitBridgeLifecycle,
+  getAttachedBridgeOperationContext,
+  sanitizeBridgePath,
+} from './lifecycle';

--- a/packages/bridge/bridge-shared/src/lifecycle.ts
+++ b/packages/bridge/bridge-shared/src/lifecycle.ts
@@ -1,0 +1,176 @@
+import type {
+  BridgeFramework,
+  BridgeOperation,
+  BridgeOperationContext,
+  BridgeOperationOutcome,
+  BridgeOperationResult,
+  BridgeOperationSide,
+  BridgeRouteSummary,
+} from './type';
+
+const OPERATION_CONTEXT_SYMBOL = Symbol.for(
+  'module-federation.bridge.operation-context',
+);
+
+let bridgeCounter = 0;
+let operationCounter = 0;
+
+const sanitizeText = (value: unknown, maxLength = 240) => {
+  if (typeof value !== 'string' || !value) {
+    return undefined;
+  }
+
+  const sanitized = value
+    .replace(
+      /\b(token|key|secret|password|auth|code)\s*[:=]\s*[^&#\s]+/gi,
+      '$1=[redacted]',
+    )
+    .replace(/#.*$/g, '')
+    .trim();
+  return sanitized ? sanitized.slice(0, maxLength) : undefined;
+};
+
+export const sanitizeBridgePath = (value: unknown) => {
+  const sanitized = sanitizeText(value);
+  if (!sanitized) {
+    return undefined;
+  }
+
+  return sanitized.split(/[?#]/, 1)[0] || '/';
+};
+
+const getModuleInfo = (moduleName: unknown) => {
+  const safeModuleName = sanitizeText(moduleName, 160);
+  if (!safeModuleName) {
+    return {};
+  }
+
+  const slashIndex = safeModuleName.indexOf('/');
+  if (slashIndex <= 0) {
+    return { moduleName: safeModuleName, remote: safeModuleName };
+  }
+
+  const remote = safeModuleName.slice(0, slashIndex);
+  const rawExpose = safeModuleName.slice(slashIndex + 1);
+  return {
+    moduleName: safeModuleName,
+    remote,
+    expose: rawExpose ? `./${rawExpose.replace(/^\.\//, '')}` : undefined,
+  };
+};
+
+export const createBridgeId = () => {
+  bridgeCounter += 1;
+  return `bridge-${Date.now().toString(36)}-${bridgeCounter.toString(36)}`;
+};
+
+const createOperationId = () => {
+  operationCounter += 1;
+  return `bridge-op-${Date.now().toString(36)}-${operationCounter.toString(36)}`;
+};
+
+export function createBridgeOperationContext(options: {
+  side: BridgeOperationSide;
+  framework: BridgeFramework;
+  operation: BridgeOperation;
+  bridgeId?: string;
+  moduleName?: string;
+  route?: BridgeRouteSummary;
+  parent?: BridgeOperationContext;
+  reason?: BridgeOperationContext['reason'];
+}): BridgeOperationContext {
+  const moduleInfo = getModuleInfo(
+    options.moduleName || options.parent?.moduleName,
+  );
+  const route = options.route
+    ? {
+        action: options.route.action,
+        from: sanitizeBridgePath(options.route.from),
+        to: sanitizeBridgePath(options.route.to),
+        basename: sanitizeBridgePath(options.route.basename),
+        mechanism: options.route.mechanism,
+      }
+    : undefined;
+
+  return {
+    operationId: options.parent?.operationId || createOperationId(),
+    bridgeId: options.bridgeId || options.parent?.bridgeId || createBridgeId(),
+    side: options.side,
+    framework: options.framework,
+    operation: options.operation,
+    ...moduleInfo,
+    route,
+    reason: options.reason || options.parent?.reason,
+    startedAt: Date.now(),
+  };
+}
+
+export function completeBridgeOperation(
+  context: BridgeOperationContext,
+  outcome: BridgeOperationOutcome,
+  error?: unknown,
+): BridgeOperationResult {
+  const endedAt = Date.now();
+  let errorSummary: BridgeOperationResult['error'];
+  if (error instanceof Error) {
+    errorSummary = {
+      name: sanitizeText(error.name, 80),
+      message: sanitizeText(error.message, 240),
+    };
+  } else if (error !== undefined) {
+    errorSummary = { message: sanitizeText(error, 240) };
+  }
+
+  return {
+    ...context,
+    endedAt,
+    duration: Math.max(0, endedAt - context.startedAt),
+    outcome,
+    error: errorSummary,
+  };
+}
+
+export function attachBridgeOperationContext(
+  target: object,
+  context: BridgeOperationContext,
+) {
+  Object.defineProperty(target, OPERATION_CONTEXT_SYMBOL, {
+    configurable: true,
+    enumerable: false,
+    value: context,
+  });
+  return target;
+}
+
+export function getAttachedBridgeOperationContext(
+  target: unknown,
+): BridgeOperationContext | undefined {
+  if (!target || (typeof target !== 'object' && typeof target !== 'function')) {
+    return undefined;
+  }
+  return (target as Record<PropertyKey, unknown>)[OPERATION_CONTEXT_SYMBOL] as
+    | BridgeOperationContext
+    | undefined;
+}
+
+type BridgeLifecycle = Partial<
+  Record<
+    | 'beforeBridgeOperation'
+    | 'bridgeRenderInvoked'
+    | 'afterBridgeOperation'
+    | 'afterBridgeCommit',
+    { emit(payload: BridgeOperationContext | BridgeOperationResult): unknown }
+  >
+>;
+
+export function emitBridgeLifecycle(
+  instance: { bridgeHook?: { lifecycle?: BridgeLifecycle } } | null | undefined,
+  lifecycle: keyof BridgeLifecycle,
+  payload: BridgeOperationContext | BridgeOperationResult,
+) {
+  try {
+    instance?.bridgeHook?.lifecycle?.[lifecycle]?.emit(payload);
+  } catch {
+    // Observability signals must not affect Bridge behavior.
+  }
+}

--- a/packages/bridge/vue3-bridge/__tests__/bridgeLifecycle.test.ts
+++ b/packages/bridge/vue3-bridge/__tests__/bridgeLifecycle.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+import { h, nextTick } from 'vue';
+import { createMemoryHistory, createRouter } from 'vue-router';
+import { createBridgeComponent } from '../src/provider';
+
+const { lifecycleEvents, bridgeLifecycle } = rs.hoisted(() => {
+  const lifecycleEvents: Array<{
+    lifecycle: string;
+    payload: Record<string, any>;
+  }> = [];
+  const eventHook = (lifecycle: string) => ({
+    emit: rs.fn((payload: Record<string, any>) => {
+      lifecycleEvents.push({ lifecycle, payload });
+    }),
+  });
+  return {
+    lifecycleEvents,
+    bridgeLifecycle: {
+      beforeBridgeRender: { emit: rs.fn(async () => ({})) },
+      afterBridgeRender: { emit: rs.fn() },
+      beforeBridgeDestroy: { emit: rs.fn() },
+      afterBridgeDestroy: { emit: rs.fn() },
+      beforeBridgeOperation: eventHook('beforeBridgeOperation'),
+      bridgeRenderInvoked: eventHook('bridgeRenderInvoked'),
+      afterBridgeOperation: eventHook('afterBridgeOperation'),
+      afterBridgeCommit: eventHook('afterBridgeCommit'),
+    },
+  };
+});
+
+rs.mock('@module-federation/runtime', () => ({
+  getInstance: () => ({ bridgeHook: { lifecycle: bridgeLifecycle } }),
+}));
+
+describe('Vue Bridge operation lifecycle', () => {
+  beforeEach(() => {
+    rs.stubGlobal('__APP_VERSION__', '2.8.0-test');
+    lifecycleEvents.length = 0;
+    document.body.innerHTML = '';
+  });
+
+  it('records render invocation, real commit, safe payloads, and repeated destroy', async () => {
+    const dom = document.createElement('div');
+    document.body.appendChild(dom);
+    const bridge = createBridgeComponent({
+      rootComponent: { render: () => h('div', 'committed') },
+      appOptions: () => undefined,
+    })();
+
+    await bridge.render({
+      dom,
+      moduleName: 'remote/App',
+      basename: '/safe?token=private#hash',
+      secretData: 'must-not-leak',
+    } as any);
+    await nextTick();
+
+    const renderEvents = lifecycleEvents.filter(
+      (event) => event.payload.operation === 'render',
+    );
+    expect(renderEvents.map((event) => event.lifecycle)).toEqual(
+      expect.arrayContaining([
+        'beforeBridgeOperation',
+        'bridgeRenderInvoked',
+        'afterBridgeOperation',
+        'afterBridgeCommit',
+      ]),
+    );
+    expect(
+      new Set(renderEvents.map((event) => event.payload.operationId)).size,
+    ).toBe(1);
+    expect(JSON.stringify(lifecycleEvents)).not.toContain('must-not-leak');
+    expect(JSON.stringify(lifecycleEvents)).not.toContain('token=private');
+
+    bridge.destroy({ dom });
+    bridge.destroy({ dom });
+    expect(
+      lifecycleEvents
+        .filter(
+          (event) =>
+            event.lifecycle === 'afterBridgeOperation' &&
+            event.payload.operation === 'destroy',
+        )
+        .map((event) => event.payload.outcome),
+    ).toEqual(['success', 'skipped']);
+  });
+
+  it('records render and destroy errors without swallowing them', async () => {
+    const renderDom = document.createElement('div');
+    const renderBridge = createBridgeComponent({
+      rootComponent: { render: () => h('div') },
+      appOptions: () => {
+        throw new Error('vue render failed token=secret');
+      },
+    })();
+    await expect(
+      renderBridge.render({ dom: renderDom, moduleName: 'remote/App' }),
+    ).rejects.toThrow('vue render failed');
+    expect(
+      lifecycleEvents.find(
+        (event) =>
+          event.lifecycle === 'afterBridgeOperation' &&
+          event.payload.operation === 'render',
+      )?.payload,
+    ).toMatchObject({ outcome: 'error' });
+    expect(JSON.stringify(lifecycleEvents)).not.toContain('token=secret');
+
+    lifecycleEvents.length = 0;
+    const destroyDom = document.createElement('div');
+    const destroyBridge = createBridgeComponent({
+      rootComponent: { render: () => h('div') },
+      appOptions: ({ app }) => {
+        app.unmount = () => {
+          throw new Error('vue destroy failed');
+        };
+      },
+    })();
+    await destroyBridge.render({
+      dom: destroyDom,
+      moduleName: 'remote/App',
+    });
+    expect(() => destroyBridge.destroy({ dom: destroyDom })).toThrow(
+      'vue destroy failed',
+    );
+    expect(
+      lifecycleEvents.find(
+        (event) =>
+          event.lifecycle === 'afterBridgeOperation' &&
+          event.payload.operation === 'destroy',
+      )?.payload.outcome,
+    ).toBe('error');
+  });
+
+  it('records basename, memory-route, and remote-to-host navigation results', async () => {
+    const dom = document.createElement('div');
+    let bridgeRouter: ReturnType<typeof createRouter> | undefined;
+    const sourceRouter = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/start', component: { render: () => h('div', 'start') } },
+        { path: '/next', component: { render: () => h('div', 'next') } },
+      ],
+    });
+    const bridge = createBridgeComponent({
+      rootComponent: { render: () => h('div') },
+      appOptions: () => ({
+        router: sourceRouter,
+        afterRouterCreate(router) {
+          bridgeRouter = router;
+        },
+      }),
+    })();
+
+    await bridge.render({
+      dom,
+      moduleName: 'remote/App',
+      basename: '/remote',
+      memoryRoute: { entryPath: '/start?token=private#hash' },
+    });
+    expect(bridgeRouter).toBeDefined();
+    await bridgeRouter?.push('/next?token=private#hash');
+    await bridgeRouter?.push('/next?token=private#hash');
+
+    const routeResults = lifecycleEvents.filter(
+      (event) =>
+        event.lifecycle === 'afterBridgeOperation' &&
+        event.payload.operation === 'route-sync',
+    );
+    expect(routeResults.map((event) => event.payload.route.action)).toEqual(
+      expect.arrayContaining(['memory-route-init', 'remote-to-host']),
+    );
+    expect(routeResults.map((event) => event.payload.outcome)).toEqual(
+      expect.arrayContaining(['success', 'skipped']),
+    );
+    expect(JSON.stringify(routeResults)).not.toContain('token=private');
+    bridge.destroy({ dom });
+  });
+});

--- a/packages/bridge/vue3-bridge/__tests__/remoteApp.test.ts
+++ b/packages/bridge/vue3-bridge/__tests__/remoteApp.test.ts
@@ -3,23 +3,35 @@ import { createApp, defineComponent, h, KeepAlive, nextTick } from 'vue';
 import { createMemoryHistory, createRouter, RouterView } from 'vue-router';
 import RemoteApp from '../src/remoteApp';
 
-const { dispatchPopstateEnv } = rs.hoisted(() => ({
-  dispatchPopstateEnv: rs.fn(),
-}));
-
-rs.mock('@module-federation/bridge-shared', () => ({
-  dispatchPopstateEnv,
-}));
+const { lifecycleEvents, bridgeLifecycle } = rs.hoisted(() => {
+  const lifecycleEvents: Array<{
+    lifecycle: string;
+    payload: Record<string, any>;
+  }> = [];
+  const eventHook = (lifecycle: string) => ({
+    emit: rs.fn((payload: Record<string, any>) => {
+      lifecycleEvents.push({ lifecycle, payload });
+    }),
+  });
+  return {
+    lifecycleEvents,
+    bridgeLifecycle: {
+      beforeBridgeRender: { emit: rs.fn(async () => ({})) },
+      afterBridgeRender: { emit: rs.fn() },
+      beforeBridgeDestroy: { emit: rs.fn() },
+      afterBridgeDestroy: { emit: rs.fn() },
+      beforeBridgeOperation: eventHook('beforeBridgeOperation'),
+      bridgeRenderInvoked: eventHook('bridgeRenderInvoked'),
+      afterBridgeOperation: eventHook('afterBridgeOperation'),
+      afterBridgeCommit: eventHook('afterBridgeCommit'),
+    },
+  };
+});
 
 rs.mock('@module-federation/runtime', () => ({
   getInstance: () => ({
     bridgeHook: {
-      lifecycle: {
-        beforeBridgeRender: { emit: rs.fn(async () => ({})) },
-        afterBridgeRender: { emit: rs.fn() },
-        beforeBridgeDestroy: { emit: rs.fn() },
-        afterBridgeDestroy: { emit: rs.fn() },
-      },
+      lifecycle: bridgeLifecycle,
     },
   }),
 }));
@@ -36,7 +48,7 @@ describe('RemoteApp', () => {
   beforeEach(() => {
     root = document.createElement('div');
     document.body.appendChild(root);
-    dispatchPopstateEnv.mockClear();
+    lifecycleEvents.length = 0;
   });
 
   afterEach(() => {
@@ -85,14 +97,36 @@ describe('RemoteApp', () => {
     app.mount(root);
     await flushBridgeRender();
     expect(providerReturn.render).toHaveBeenCalledTimes(1);
+    expect(
+      lifecycleEvents.some(
+        (event) =>
+          event.lifecycle === 'beforeBridgeOperation' &&
+          event.payload.operation === 'render' &&
+          event.payload.reason === 'mount',
+      ),
+    ).toBe(true);
 
     await router.push('/');
     await flushBridgeRender();
     expect(providerReturn.destroy).toHaveBeenCalledTimes(1);
+    expect(
+      lifecycleEvents.some(
+        (event) =>
+          event.payload.operation === 'destroy' &&
+          event.payload.reason === 'keep-alive-deactivate',
+      ),
+    ).toBe(true);
 
     await router.push('/ec');
     await flushBridgeRender();
     expect(providerReturn.render).toHaveBeenCalledTimes(2);
+    expect(
+      lifecycleEvents.some(
+        (event) =>
+          event.payload.operation === 'update' &&
+          event.payload.reason === 'keep-alive-activate',
+      ),
+    ).toBe(true);
 
     app.unmount();
   });

--- a/packages/bridge/vue3-bridge/src/provider.ts
+++ b/packages/bridge/vue3-bridge/src/provider.ts
@@ -1,9 +1,18 @@
 import * as Vue from 'vue';
 import * as VueRouter from 'vue-router';
-import { RenderFnParams } from '@module-federation/bridge-shared';
 import { LoggerInstance } from './utils';
 import { getInstance } from '@module-federation/runtime';
 import { processRoutes } from './routeUtils';
+import {
+  attachBridgeOperationContext,
+  completeBridgeOperation,
+  createBridgeId,
+  createBridgeOperationContext,
+  emitBridgeLifecycle,
+  getAttachedBridgeOperationContext,
+  type RenderFnParams,
+  sanitizeBridgePath,
+} from '@module-federation/bridge-shared';
 
 declare const __APP_VERSION__: string;
 
@@ -27,12 +36,37 @@ export type ProviderFnParams = {
 
 export function createBridgeComponent(bridgeInfo: ProviderFnParams) {
   const rootMap = new Map();
+  const bridgeIds = new WeakMap<object, string>();
+  const destroyedRoots = new WeakSet<object>();
   const instance = getInstance();
   return () => {
     return {
       __APP_VERSION__,
       async render(info: RenderFnParams) {
         LoggerInstance.debug(`createBridgeComponent render Info`, info);
+        const parentContext = getAttachedBridgeOperationContext(info);
+        const bridgeId =
+          parentContext?.bridgeId ||
+          bridgeIds.get(info.dom) ||
+          createBridgeId();
+        bridgeIds.set(info.dom, bridgeId);
+        const operationContext = createBridgeOperationContext({
+          side: 'producer',
+          framework: 'vue',
+          operation:
+            parentContext?.operation ||
+            (rootMap.has(info.dom) ? 'update' : 'render'),
+          bridgeId,
+          moduleName: info.moduleName,
+          parent: parentContext,
+          reason: parentContext?.reason || 'direct',
+        });
+        emitBridgeLifecycle(
+          instance,
+          'beforeBridgeOperation',
+          operationContext,
+        );
+        attachBridgeOperationContext(info, operationContext);
         const {
           moduleName,
           dom,
@@ -41,71 +75,259 @@ export function createBridgeComponent(bridgeInfo: ProviderFnParams) {
           hashRoute,
           ...propsInfo
         } = info;
-        const app = Vue.createApp(bridgeInfo.rootComponent, propsInfo);
-        rootMap.set(dom, app);
+        let routeContext:
+          | ReturnType<typeof createBridgeOperationContext>
+          | undefined;
+        let routeCompleted = false;
 
-        const beforeBridgeRenderRes =
-          await instance?.bridgeHook?.lifecycle?.beforeBridgeRender?.emit(info);
+        try {
+          const app = Vue.createApp(bridgeInfo.rootComponent, propsInfo);
+          rootMap.set(dom, app);
+          destroyedRoots.delete(app);
 
-        const extraProps =
-          beforeBridgeRenderRes &&
-          typeof beforeBridgeRenderRes === 'object' &&
-          beforeBridgeRenderRes?.extraProps
-            ? beforeBridgeRenderRes?.extraProps
-            : {};
+          const beforeBridgeRenderRes =
+            await instance?.bridgeHook?.lifecycle?.beforeBridgeRender?.emit(
+              info,
+            );
 
-        const bridgeOptions = bridgeInfo.appOptions({
-          app,
-          basename,
-          memoryRoute,
-          hashRoute,
-          ...propsInfo,
-          ...extraProps,
-        });
-        if (bridgeOptions?.router) {
-          const { history, routes, patchRouter } = processRoutes({
-            router: bridgeOptions.router,
-            basename: info.basename,
-            memoryRoute: info.memoryRoute,
-            hashRoute: info.hashRoute,
+          const extraProps =
+            beforeBridgeRenderRes &&
+            typeof beforeBridgeRenderRes === 'object' &&
+            beforeBridgeRenderRes?.extraProps
+              ? beforeBridgeRenderRes?.extraProps
+              : {};
+
+          const bridgeOptions = bridgeInfo.appOptions({
+            app,
+            basename,
+            memoryRoute,
+            hashRoute,
+            ...propsInfo,
+            ...extraProps,
           });
+          if (bridgeOptions?.router) {
+            routeContext = createBridgeOperationContext({
+              side: 'producer',
+              framework: 'vue',
+              operation: 'route-sync',
+              bridgeId,
+              moduleName,
+              route: memoryRoute?.entryPath
+                ? {
+                    action: 'memory-route-init',
+                    to: memoryRoute.entryPath,
+                    basename,
+                  }
+                : { action: 'basename-init', to: basename, basename },
+            });
+            emitBridgeLifecycle(
+              instance,
+              'beforeBridgeOperation',
+              routeContext,
+            );
+            const { history, routes, patchRouter } = processRoutes({
+              router: bridgeOptions.router,
+              basename: info.basename,
+              memoryRoute: info.memoryRoute,
+              hashRoute: info.hashRoute,
+            });
 
-          const router = VueRouter.createRouter({
-            ...bridgeOptions.router.options,
-            history,
-            routes,
-          });
+            const router = VueRouter.createRouter({
+              ...bridgeOptions.router.options,
+              history,
+              routes,
+            });
 
-          if (patchRouter) {
-            patchRouter(router);
+            if (patchRouter) {
+              patchRouter(router);
+            }
+
+            if (bridgeOptions.afterRouterCreate) {
+              bridgeOptions.afterRouterCreate(router);
+            }
+
+            LoggerInstance.debug(
+              `createBridgeComponent render router info>>>`,
+              {
+                moduleName,
+                router,
+              },
+            );
+            // memory route Initializes the route
+            if (memoryRoute) {
+              const navigationResult = await router.push(memoryRoute.entryPath);
+              if (VueRouter.isNavigationFailure(navigationResult)) {
+                emitBridgeLifecycle(
+                  instance,
+                  'afterBridgeOperation',
+                  completeBridgeOperation(routeContext, 'skipped'),
+                );
+                routeCompleted = true;
+              }
+            }
+
+            const observeNavigation = (method: 'push' | 'replace') => {
+              const original = router[method].bind(router);
+              router[method] = ((to: VueRouter.RouteLocationRaw) => {
+                const navigationContext = createBridgeOperationContext({
+                  side: 'producer',
+                  framework: 'vue',
+                  operation: 'route-sync',
+                  bridgeId,
+                  moduleName,
+                  route: {
+                    action: 'remote-to-host',
+                    from: router.currentRoute.value.path,
+                    to: sanitizeBridgePath(
+                      typeof to === 'string'
+                        ? to
+                        : 'path' in to
+                          ? to.path
+                          : undefined,
+                    ),
+                    basename,
+                  },
+                });
+                emitBridgeLifecycle(
+                  instance,
+                  'beforeBridgeOperation',
+                  navigationContext,
+                );
+                try {
+                  const navigation = original(to);
+                  return navigation.then(
+                    (result) => {
+                      emitBridgeLifecycle(
+                        instance,
+                        'afterBridgeOperation',
+                        completeBridgeOperation(
+                          navigationContext,
+                          VueRouter.isNavigationFailure(result)
+                            ? 'skipped'
+                            : 'success',
+                        ),
+                      );
+                      return result;
+                    },
+                    (error) => {
+                      emitBridgeLifecycle(
+                        instance,
+                        'afterBridgeOperation',
+                        completeBridgeOperation(
+                          navigationContext,
+                          'error',
+                          error,
+                        ),
+                      );
+                      throw error;
+                    },
+                  );
+                } catch (error) {
+                  emitBridgeLifecycle(
+                    instance,
+                    'afterBridgeOperation',
+                    completeBridgeOperation(navigationContext, 'error', error),
+                  );
+                  throw error;
+                }
+              }) as (typeof router)[typeof method];
+            };
+            observeNavigation('push');
+            observeNavigation('replace');
+
+            app.use(router);
+            if (!routeCompleted) {
+              emitBridgeLifecycle(
+                instance,
+                'afterBridgeOperation',
+                completeBridgeOperation(routeContext, 'success'),
+              );
+              routeCompleted = true;
+            }
           }
 
-          if (bridgeOptions.afterRouterCreate) {
-            bridgeOptions.afterRouterCreate(router);
-          }
-
-          LoggerInstance.debug(`createBridgeComponent render router info>>>`, {
-            moduleName,
-            router,
+          emitBridgeLifecycle(
+            instance,
+            'bridgeRenderInvoked',
+            operationContext,
+          );
+          app.mount(dom);
+          instance?.bridgeHook?.lifecycle?.afterBridgeRender?.emit(info);
+          emitBridgeLifecycle(
+            instance,
+            'afterBridgeOperation',
+            completeBridgeOperation(operationContext, 'success'),
+          );
+          void Vue.nextTick().then(() => {
+            emitBridgeLifecycle(
+              instance,
+              'afterBridgeCommit',
+              completeBridgeOperation(operationContext, 'success'),
+            );
           });
-          // memory route Initializes the route
-          if (memoryRoute) {
-            await router.push(memoryRoute.entryPath);
+        } catch (error) {
+          if (routeContext && !routeCompleted) {
+            emitBridgeLifecycle(
+              instance,
+              'afterBridgeOperation',
+              completeBridgeOperation(routeContext, 'error', error),
+            );
           }
-
-          app.use(router);
+          emitBridgeLifecycle(
+            instance,
+            'afterBridgeOperation',
+            completeBridgeOperation(operationContext, 'error', error),
+          );
+          throw error;
         }
-
-        app.mount(dom);
-        instance?.bridgeHook?.lifecycle?.afterBridgeRender?.emit(info);
       },
       destroy(info: { dom: HTMLElement }) {
         LoggerInstance.debug(`createBridgeComponent destroy Info`, info);
         const root = rootMap.get(info?.dom);
 
-        instance?.bridgeHook?.lifecycle?.beforeBridgeDestroy?.emit(info);
-        root?.unmount();
-        instance?.bridgeHook?.lifecycle?.afterBridgeDestroy?.emit(info);
+        const parentContext = getAttachedBridgeOperationContext(info);
+        const operationContext = createBridgeOperationContext({
+          side: 'producer',
+          framework: 'vue',
+          operation: 'destroy',
+          bridgeId:
+            parentContext?.bridgeId ||
+            bridgeIds.get(info.dom) ||
+            createBridgeId(),
+          moduleName: parentContext?.moduleName,
+          parent: parentContext,
+          reason: parentContext?.reason || 'direct',
+        });
+        emitBridgeLifecycle(
+          instance,
+          'beforeBridgeOperation',
+          operationContext,
+        );
+        attachBridgeOperationContext(info, operationContext);
+        try {
+          instance?.bridgeHook?.lifecycle?.beforeBridgeDestroy?.emit(info);
+          const alreadyDestroyed = root && destroyedRoots.has(root);
+          if (root && !alreadyDestroyed) {
+            root.unmount();
+            destroyedRoots.add(root);
+          }
+          instance?.bridgeHook?.lifecycle?.afterBridgeDestroy?.emit(info);
+          emitBridgeLifecycle(
+            instance,
+            'afterBridgeOperation',
+            completeBridgeOperation(
+              operationContext,
+              root && !alreadyDestroyed ? 'success' : 'skipped',
+            ),
+          );
+        } catch (error) {
+          emitBridgeLifecycle(
+            instance,
+            'afterBridgeOperation',
+            completeBridgeOperation(operationContext, 'error', error),
+          );
+          throw error;
+        }
       },
     };
   };

--- a/packages/bridge/vue3-bridge/src/remoteApp.tsx
+++ b/packages/bridge/vue3-bridge/src/remoteApp.tsx
@@ -9,7 +9,14 @@ import {
   useAttrs,
   nextTick,
 } from 'vue';
-import { dispatchPopstateEnv } from '@module-federation/bridge-shared';
+import {
+  attachBridgeOperationContext,
+  completeBridgeOperation,
+  createBridgeId,
+  createBridgeOperationContext,
+  dispatchPopstateEnv,
+  emitBridgeLifecycle,
+} from '@module-federation/bridge-shared';
 import { useRoute } from 'vue-router';
 import { LoggerInstance } from './utils';
 import { getInstance } from '@module-federation/runtime';
@@ -32,6 +39,8 @@ export default defineComponent({
     const isRendered = ref(false);
     const isActive = ref(false);
     const wasDeactivated = ref(false);
+    const hasEverRendered = ref(false);
+    const bridgeId = createBridgeId();
     const route = useRoute();
     const hostInstance = getInstance();
     const componentAttrs = useAttrs();
@@ -44,7 +53,9 @@ export default defineComponent({
       hashRoute: props.hashRoute,
     });
 
-    const renderComponent = async () => {
+    const renderComponent = async (
+      reason: 'mount' | 'keep-alive-activate' = 'mount',
+    ) => {
       if (!rootRef.value || isRendered.value) {
         return;
       }
@@ -63,19 +74,59 @@ export default defineComponent({
         `createRemoteAppComponent LazyComponent render >>>`,
         renderProps,
       );
+      const operationContext = createBridgeOperationContext({
+        side: 'consumer',
+        framework: 'vue',
+        operation: hasEverRendered.value ? 'update' : 'render',
+        bridgeId,
+        moduleName: props.moduleName,
+        reason,
+      });
+      attachBridgeOperationContext(renderProps, operationContext);
+      emitBridgeLifecycle(
+        hostInstance,
+        'beforeBridgeOperation',
+        operationContext,
+      );
 
-      const beforeBridgeRenderRes =
-        (await hostInstance?.bridgeHook?.lifecycle?.beforeBridgeRender?.emit(
+      try {
+        const beforeBridgeRenderRes =
+          (await hostInstance?.bridgeHook?.lifecycle?.beforeBridgeRender?.emit(
+            renderProps,
+          )) || {};
+
+        renderProps = { ...renderProps, ...beforeBridgeRenderRes.extraProps };
+        attachBridgeOperationContext(renderProps, operationContext);
+        emitBridgeLifecycle(
+          hostInstance,
+          'bridgeRenderInvoked',
+          operationContext,
+        );
+        const result = providerReturn.render(renderProps);
+        isRendered.value = true;
+        hasEverRendered.value = true;
+        hostInstance?.bridgeHook?.lifecycle?.afterBridgeRender?.emit(
           renderProps,
-        )) || {};
-
-      renderProps = { ...renderProps, ...beforeBridgeRenderRes.extraProps };
-      providerReturn.render(renderProps);
-      isRendered.value = true;
-      hostInstance?.bridgeHook?.lifecycle?.afterBridgeRender?.emit(renderProps);
+        );
+        await result;
+        emitBridgeLifecycle(
+          hostInstance,
+          'afterBridgeOperation',
+          completeBridgeOperation(operationContext, 'success'),
+        );
+      } catch (error) {
+        emitBridgeLifecycle(
+          hostInstance,
+          'afterBridgeOperation',
+          completeBridgeOperation(operationContext, 'error', error),
+        );
+        throw error;
+      }
     };
 
-    const destroyComponent = () => {
+    const destroyComponent = (
+      reason: 'keep-alive-deactivate' | 'unmount' = 'unmount',
+    ) => {
       const providerReturn = providerInfoRef.value as any;
       if (!providerReturn || !isRendered.value) {
         return;
@@ -88,17 +139,64 @@ export default defineComponent({
       );
 
       const bridgeRenderProps = getBridgeRenderProps();
-      hostInstance?.bridgeHook?.lifecycle?.beforeBridgeDestroy?.emit(
-        bridgeRenderProps,
+      const operationContext = createBridgeOperationContext({
+        side: 'consumer',
+        framework: 'vue',
+        operation: 'destroy',
+        bridgeId,
+        moduleName: props.moduleName,
+        reason,
+      });
+      attachBridgeOperationContext(bridgeRenderProps, operationContext);
+      emitBridgeLifecycle(
+        hostInstance,
+        'beforeBridgeOperation',
+        operationContext,
       );
+      try {
+        hostInstance?.bridgeHook?.lifecycle?.beforeBridgeDestroy?.emit(
+          bridgeRenderProps,
+        );
 
-      providerReturn.destroy({ dom: rootRef.value });
-      providerInfoRef.value = null;
-      isRendered.value = false;
+        const result = providerReturn.destroy(bridgeRenderProps);
+        providerInfoRef.value = null;
+        isRendered.value = false;
 
-      hostInstance?.bridgeHook?.lifecycle?.afterBridgeDestroy?.emit(
-        bridgeRenderProps,
-      );
+        hostInstance?.bridgeHook?.lifecycle?.afterBridgeDestroy?.emit(
+          bridgeRenderProps,
+        );
+        if (result && typeof result.then === 'function') {
+          void result.then(
+            () =>
+              emitBridgeLifecycle(
+                hostInstance,
+                'afterBridgeOperation',
+                completeBridgeOperation(operationContext, 'success'),
+              ),
+            (error: unknown) => {
+              emitBridgeLifecycle(
+                hostInstance,
+                'afterBridgeOperation',
+                completeBridgeOperation(operationContext, 'error', error),
+              );
+              throw error;
+            },
+          );
+        } else {
+          emitBridgeLifecycle(
+            hostInstance,
+            'afterBridgeOperation',
+            completeBridgeOperation(operationContext, 'success'),
+          );
+        }
+      } catch (error) {
+        emitBridgeLifecycle(
+          hostInstance,
+          'afterBridgeOperation',
+          completeBridgeOperation(operationContext, 'error', error),
+        );
+        throw error;
+      }
     };
 
     const watchStopHandle = watch(
@@ -117,7 +215,40 @@ export default defineComponent({
               pathname: route.path,
             },
           );
-          dispatchPopstateEnv();
+          const operationContext = createBridgeOperationContext({
+            side: 'consumer',
+            framework: 'vue',
+            operation: 'route-sync',
+            bridgeId,
+            moduleName: props.moduleName,
+            route: {
+              action: 'host-to-remote',
+              mechanism: 'popstate',
+              from: pathname.value,
+              to: newPath,
+              basename: props.basename,
+            },
+          });
+          emitBridgeLifecycle(
+            hostInstance,
+            'beforeBridgeOperation',
+            operationContext,
+          );
+          try {
+            dispatchPopstateEnv();
+            emitBridgeLifecycle(
+              hostInstance,
+              'afterBridgeOperation',
+              completeBridgeOperation(operationContext, 'success'),
+            );
+          } catch (error) {
+            emitBridgeLifecycle(
+              hostInstance,
+              'afterBridgeOperation',
+              completeBridgeOperation(operationContext, 'error', error),
+            );
+            throw error;
+          }
         }
         pathname.value = newPath;
       },
@@ -125,7 +256,7 @@ export default defineComponent({
 
     onMounted(() => {
       isActive.value = true;
-      renderComponent();
+      void renderComponent('mount');
     });
 
     onActivated(async () => {
@@ -135,18 +266,18 @@ export default defineComponent({
       }
       wasDeactivated.value = false;
       await nextTick();
-      renderComponent();
+      void renderComponent('keep-alive-activate');
     });
 
     onDeactivated(() => {
       isActive.value = false;
       wasDeactivated.value = true;
-      destroyComponent();
+      destroyComponent('keep-alive-deactivate');
     });
 
     onBeforeUnmount(() => {
       watchStopHandle();
-      destroyComponent();
+      destroyComponent('unmount');
     });
 
     return () => <div {...(props.rootAttrs || {})} ref={rootRef}></div>;

--- a/packages/observability-plugin/__tests__/observability.spec.ts
+++ b/packages/observability-plugin/__tests__/observability.spec.ts
@@ -53,6 +53,27 @@ const createShared = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const createBridgeOperation = (overrides: Record<string, unknown> = {}) => ({
+  operationId: 'bridge-op-1',
+  bridgeId: 'bridge-1',
+  side: 'consumer',
+  framework: 'react',
+  operation: 'render',
+  moduleName: 'remote/App',
+  remote: 'remote',
+  expose: './App',
+  reason: 'mount',
+  startedAt: 1,
+  ...overrides,
+});
+
+const bridgeLifecycleFixture = {
+  beforeBridgeOperation: {},
+  bridgeRenderInvoked: {},
+  afterBridgeOperation: {},
+  afterBridgeCommit: {},
+};
+
 type SharedFixture = ReturnType<typeof createShared>;
 type ShareScopeMapFixture = Record<
   string,
@@ -1085,6 +1106,7 @@ describe('ObservabilityPlugin', () => {
     const globalObject = globalThis as any;
     const previousFederation = globalObject.__FEDERATION__;
     const instance = createRuntimeInstance({
+      bridgeHook: { lifecycle: bridgeLifecycleFixture },
       options: {
         name: 'late-host',
         remotes: [
@@ -1113,7 +1135,29 @@ describe('ObservabilityPlugin', () => {
         console: false,
         browser: { enabled: true, scope: 'multi-instance' },
       });
-      observability.plugin.apply?.(instance as any);
+      const hooks = observability.plugin.apply?.(instance as any) as any;
+      const commit = createBridgeOperation({
+        endedAt: 2,
+        duration: 1,
+        outcome: 'success',
+      });
+      hooks.beforeBridgeOperation(createBridgeOperation());
+      hooks.afterBridgeOperation(commit);
+      hooks.afterBridgeCommit(commit);
+      hooks.afterBridgeOperation(
+        createBridgeOperation({
+          operationId: 'bridge-op-route',
+          operation: 'route-sync',
+          route: {
+            action: 'host-to-remote',
+            to: '/safe?token=secret#private',
+            mechanism: 'popstate',
+          },
+          endedAt: 3,
+          duration: 1,
+          outcome: 'success',
+        }),
+      );
       const reader =
         globalObject.__FEDERATION__.__OBSERVABILITY__['multi-instance'];
       const state = reader.getRuntimeState();
@@ -1124,6 +1168,11 @@ describe('ObservabilityPlugin', () => {
       });
       expect(JSON.stringify(state)).not.toContain('token=secret');
       expect(JSON.stringify(state)).not.toContain('private');
+      expect(state.capabilities.bridgeTrace).toMatchObject({
+        available: true,
+        completeness: 'partial',
+        reason: expect.stringContaining('runtime history is incomplete'),
+      });
       state.instances[0].name = 'mutated';
       expect(reader.getRuntimeState().instances[0].name).not.toBe('mutated');
     } finally {
@@ -1196,6 +1245,241 @@ describe('ObservabilityPlugin', () => {
     expect(
       runtime.getSnapshot().targets['mf:instance:mf-2:remote:remote'],
     ).toBeDefined();
+  });
+
+  it('correlates Bridge render, commit, route, and destroy signals without treating commit as business readiness', async () => {
+    const observability = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const instance = createRuntimeInstance({
+      bridgeHook: { lifecycle: bridgeLifecycleFixture },
+    });
+    const hooks = observability.plugin.apply?.(instance as any) as any;
+
+    hooks.beforeRequest({
+      id: 'remote/App',
+      options: {},
+      origin: undefined,
+    });
+    await hooks.onLoad({
+      id: 'remote/App',
+      expose: './App',
+      remote: { name: 'remote' },
+      exposeModule: {},
+      origin: undefined,
+    });
+
+    const consumerRender = createBridgeOperation({
+      unsafeDom: { secret: 'must-not-leak' },
+      props: { password: 'must-not-leak' },
+    });
+    const consumerRenderResult = {
+      ...consumerRender,
+      endedAt: 2,
+      duration: 1,
+      outcome: 'success',
+    };
+    hooks.beforeBridgeOperation(consumerRender);
+    hooks.bridgeRenderInvoked(consumerRender);
+    hooks.afterBridgeOperation(consumerRenderResult);
+    hooks.afterBridgeCommit(consumerRenderResult);
+
+    const producerRender = createBridgeOperation({ side: 'producer' });
+    const producerRenderResult = {
+      ...producerRender,
+      endedAt: 2,
+      duration: 1,
+      outcome: 'success',
+    };
+    hooks.beforeBridgeOperation(producerRender);
+    hooks.bridgeRenderInvoked(producerRender);
+    hooks.afterBridgeOperation(producerRenderResult);
+    hooks.afterBridgeCommit(producerRenderResult);
+
+    const route = createBridgeOperation({
+      operationId: 'bridge-op-route',
+      operation: 'route-sync',
+      route: {
+        action: 'host-to-remote',
+        from: '/before?token=secret#private',
+        to: '/after?token=secret#private',
+        mechanism: 'popstate',
+      },
+    });
+    hooks.beforeBridgeOperation(route);
+    hooks.afterBridgeOperation({
+      ...route,
+      endedAt: 3,
+      duration: 1,
+      outcome: 'success',
+    });
+
+    const destroy = createBridgeOperation({
+      operationId: 'bridge-op-destroy',
+      side: 'producer',
+      operation: 'destroy',
+      reason: 'unmount',
+    });
+    hooks.beforeBridgeOperation(destroy);
+    hooks.afterBridgeOperation({
+      ...destroy,
+      endedAt: 4,
+      duration: 1,
+      outcome: 'success',
+    });
+
+    const report = observability.getLatestReport();
+    expect(report?.events.map((event) => event.message)).toEqual(
+      expect.arrayContaining([
+        'bridge:provider-acquired',
+        'bridge:render-start',
+        'bridge:render-invoked',
+        'bridge:render-success',
+        'bridge:render-committed',
+        'bridge:route-sync-success',
+        'bridge:destroy-success',
+      ]),
+    );
+    expect(report?.summary.componentLoaded).toBe(false);
+    expect(
+      new Set(
+        report?.events
+          .filter((event) => event.bridge?.operationId === 'bridge-op-1')
+          .map((event) => event.traceId),
+      ).size,
+    ).toBe(1);
+    expect(observability.getRuntimeState()).toMatchObject({
+      capabilities: {
+        bridgeTrace: {
+          available: true,
+          completeness: 'complete',
+        },
+      },
+      instances: [
+        expect.objectContaining({
+          bridge: expect.objectContaining({
+            status: 'destroyed',
+            commitObserved: true,
+            routeSyncObserved: true,
+            states: expect.arrayContaining([
+              expect.objectContaining({ side: 'consumer' }),
+              expect.objectContaining({
+                side: 'producer',
+                status: 'destroyed',
+              }),
+            ]),
+          }),
+        }),
+      ],
+    });
+    expect(JSON.stringify(report)).not.toContain('must-not-leak');
+    expect(JSON.stringify(report)).not.toContain('token=secret');
+    expect(JSON.stringify(report)).not.toContain('#private');
+  });
+
+  it('keeps identical Bridge identifiers isolated between runtime instances', () => {
+    const observability = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const first = createRuntimeInstance({
+      bridgeHook: { lifecycle: bridgeLifecycleFixture },
+    });
+    const second = createRuntimeInstance({
+      bridgeHook: { lifecycle: bridgeLifecycleFixture },
+    });
+    const firstHooks = observability.plugin.apply?.(first as any) as any;
+    const secondHooks = observability.plugin.apply?.(second as any) as any;
+    const start = createBridgeOperation();
+    const result = {
+      ...start,
+      endedAt: 2,
+      duration: 1,
+      outcome: 'success',
+    };
+
+    firstHooks.beforeBridgeOperation(start);
+    firstHooks.afterBridgeOperation(result);
+    secondHooks.beforeBridgeOperation(start);
+    secondHooks.afterBridgeOperation(result);
+
+    const firstReports = observability.findReports({ instanceRef: 'mf-1' });
+    const secondReports = observability.findReports({ instanceRef: 'mf-2' });
+    expect(firstReports).toHaveLength(1);
+    expect(secondReports).toHaveLength(1);
+    expect(firstReports[0].traceId).not.toBe(secondReports[0].traceId);
+    expect(
+      firstReports[0].events.every((event) => event.instanceRef === 'mf-1'),
+    ).toBe(true);
+    expect(
+      secondReports[0].events.every((event) => event.instanceRef === 'mf-2'),
+    ).toBe(true);
+    expect(
+      observability
+        .getRuntimeState()
+        .instances.map((item) => item.bridge?.states),
+    ).toEqual([
+      [expect.objectContaining({ bridgeId: 'bridge-1' })],
+      [expect.objectContaining({ bridgeId: 'bridge-1' })],
+    ]);
+  });
+
+  it('keeps concurrent Bridge states isolated and records safe failures', () => {
+    const observability = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const instance = createRuntimeInstance({
+      bridgeHook: { lifecycle: bridgeLifecycleFixture },
+    });
+    const hooks = observability.plugin.apply?.(instance as any) as any;
+    const first = createBridgeOperation({
+      operationId: 'bridge-op-first',
+      bridgeId: 'bridge-first',
+      remote: undefined,
+    });
+    const second = createBridgeOperation({
+      operationId: 'bridge-op-second',
+      bridgeId: 'bridge-second',
+      remote: undefined,
+    });
+
+    hooks.beforeBridgeOperation(first);
+    hooks.beforeBridgeOperation(second);
+    hooks.afterBridgeOperation({
+      ...first,
+      endedAt: 2,
+      duration: 1,
+      outcome: 'success',
+    });
+    hooks.afterBridgeOperation({
+      ...second,
+      endedAt: 3,
+      duration: 2,
+      outcome: 'error',
+      error: {
+        name: 'Error',
+        message: 'render failed token=must-not-leak',
+      },
+    });
+
+    expect(observability.findReports()).toHaveLength(2);
+    expect(observability.getRuntimeState().instances[0].bridge?.states).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          bridgeId: 'bridge-first',
+          status: 'rendered',
+        }),
+        expect.objectContaining({
+          bridgeId: 'bridge-second',
+          status: 'error',
+        }),
+      ]),
+    );
+    expect(JSON.stringify(observability.findReports())).not.toContain(
+      'must-not-leak',
+    );
   });
 
   it('reports conservative trace capabilities for late and old runtimes', () => {

--- a/packages/observability-plugin/src/core.ts
+++ b/packages/observability-plugin/src/core.ts
@@ -2,6 +2,8 @@ import type {
   ModuleFederation,
   ModuleFederationRuntimePlugin,
   RuntimePluginHooks,
+  BridgeOperationContext,
+  BridgeOperationResult,
 } from '@module-federation/runtime';
 import { createLogger, isDebugMode } from '@module-federation/sdk';
 
@@ -100,8 +102,69 @@ export interface ObservabilityRuntimeStateInstance {
   bridge?: {
     available: boolean;
     lifecycleCount?: number;
+    framework?: 'react' | 'vue';
+    moduleName?: string;
+    remote?: string;
+    expose?: string;
+    status?: ObservabilityBridgeStatus;
+    lastOperationAt?: number;
+    commitObserved?: boolean;
+    routeSyncObserved?: boolean;
+    states: ObservabilityBridgeState[];
   };
   active: boolean;
+}
+
+export type ObservabilityBridgeStatus =
+  | 'idle'
+  | 'rendering'
+  | 'rendered'
+  | 'destroying'
+  | 'destroyed'
+  | 'error';
+
+export interface ObservabilityBridgeRouteSummary {
+  action: string;
+  from?: string;
+  to?: string;
+  basename?: string;
+  mechanism?: 'popstate';
+}
+
+export interface ObservabilityBridgeInfo {
+  operationId: string;
+  bridgeId: string;
+  side: 'consumer' | 'producer';
+  framework: 'react' | 'vue';
+  operation: 'render' | 'update' | 'destroy' | 'route-sync';
+  moduleName?: string;
+  remote?: string;
+  expose?: string;
+  route?: ObservabilityBridgeRouteSummary;
+  reason?: string;
+  startedAt: number;
+  endedAt?: number;
+  duration?: number;
+  outcome?: 'success' | 'error' | 'skipped';
+  error?: {
+    name?: string;
+    message?: string;
+  };
+}
+
+export interface ObservabilityBridgeState {
+  bridgeId: string;
+  side: 'consumer' | 'producer';
+  framework: 'react' | 'vue';
+  moduleName?: string;
+  remote?: string;
+  expose?: string;
+  status: ObservabilityBridgeStatus;
+  lastOperation?: ObservabilityBridgeInfo['operation'];
+  lastOperationId?: string;
+  lastOperationAt?: number;
+  commitObserved: boolean;
+  routeSyncObserved: boolean;
 }
 
 export interface ObservabilityRuntimeRelationship {
@@ -360,6 +423,7 @@ export interface ObservabilityEvent {
   componentName?: string;
   metadata?: ObservabilityMetadata;
   loadedBefore?: ObservabilityLoadedBeforeInfo;
+  bridge?: ObservabilityBridgeInfo;
 }
 
 export interface ObservabilityReport {
@@ -387,6 +451,7 @@ export interface ObservabilityReport {
   errorContext?: ObservabilityMetadata;
   moduleInfo?: ObservabilityModuleInfoSummary;
   loadedBefore?: ObservabilityLoadedBeforeInfo;
+  bridge?: ObservabilityBridgeInfo;
   events: ObservabilityEvent[];
   summary: {
     eventCount: number;
@@ -546,6 +611,7 @@ export interface ObservabilityRuntimeEventInput {
   componentName?: string;
   metadata?: Record<string, unknown>;
   loadedBefore?: ObservabilityLoadedBeforeInfo;
+  bridge?: ObservabilityBridgeInfo;
 }
 
 export interface ObservabilityRuntimeOrigin {
@@ -665,6 +731,13 @@ interface ObservabilityRemoteLoadArgs {
   exposeModule?: unknown;
   exposeModuleFactory?: unknown;
 }
+
+type ObservabilityBridgeHookArgs = (
+  | BridgeOperationContext
+  | BridgeOperationResult
+) & {
+  origin?: ObservabilityRuntimeOrigin;
+};
 
 interface ObservabilityRemoteBeforeRequestArgs {
   id: string;
@@ -1199,6 +1272,50 @@ function sanitizeRemote(
     entryGlobalName: sanitizeText(remote.entryGlobalName, 120),
     type: sanitizeText(remote.type, 80),
   };
+}
+
+function normalizeBridgeInfo(
+  bridge: BridgeOperationContext | BridgeOperationResult | undefined,
+): ObservabilityBridgeInfo | undefined {
+  if (!bridge?.operationId || !bridge.bridgeId) {
+    return undefined;
+  }
+
+  const result = bridge as BridgeOperationResult;
+  return omitUndefinedFields({
+    operationId: sanitizeText(bridge.operationId, 120) || bridge.operationId,
+    bridgeId: sanitizeText(bridge.bridgeId, 120) || bridge.bridgeId,
+    side: bridge.side,
+    framework: bridge.framework,
+    operation: bridge.operation,
+    moduleName: sanitizeText(bridge.moduleName, 160),
+    remote: sanitizeText(bridge.remote, 120),
+    expose: sanitizeText(bridge.expose, 240),
+    route: bridge.route
+      ? {
+          action: sanitizeText(bridge.route.action, 80) || 'route-update',
+          from: sanitizeUrl(bridge.route.from),
+          to: sanitizeUrl(bridge.route.to),
+          basename: sanitizeUrl(bridge.route.basename),
+          mechanism: bridge.route.mechanism,
+        }
+      : undefined,
+    reason: sanitizeText(bridge.reason, 80),
+    startedAt: Number.isFinite(bridge.startedAt)
+      ? bridge.startedAt
+      : Date.now(),
+    endedAt: Number.isFinite(result.endedAt) ? result.endedAt : undefined,
+    duration: Number.isFinite(result.duration)
+      ? Math.max(0, result.duration)
+      : undefined,
+    outcome: result.outcome,
+    error: result.error
+      ? {
+          name: sanitizeText(result.error.name, 80),
+          message: sanitizeText(result.error.message, 240),
+        }
+      : undefined,
+  });
 }
 
 function createRemoteInfo(
@@ -2014,6 +2131,21 @@ function copyEvent(event: ObservabilityEvent): ObservabilityEvent {
     errorContext: event.errorContext ? { ...event.errorContext } : undefined,
     metadata: event.metadata ? { ...event.metadata } : undefined,
     loadedBefore: copyLoadedBeforeInfo(event.loadedBefore),
+    bridge: copyBridgeInfo(event.bridge),
+  });
+}
+
+function copyBridgeInfo(
+  bridge: ObservabilityBridgeInfo | undefined,
+): ObservabilityBridgeInfo | undefined {
+  if (!bridge) {
+    return undefined;
+  }
+
+  return omitUndefinedFields({
+    ...bridge,
+    route: bridge.route ? { ...bridge.route } : undefined,
+    error: bridge.error ? { ...bridge.error } : undefined,
   });
 }
 
@@ -2131,6 +2263,7 @@ function copyReport(report: ObservabilityReport): ObservabilityReport {
     errorContext: report.errorContext ? { ...report.errorContext } : undefined,
     moduleInfo: copyModuleInfoSummary(report.moduleInfo),
     loadedBefore: copyLoadedBeforeInfo(report.loadedBefore),
+    bridge: copyBridgeInfo(report.bridge),
     events: report.events.map(copyEvent),
     summary: copySummary(report.summary),
     diagnosis: copyFactReport(report.diagnosis),
@@ -2787,13 +2920,19 @@ export function createObservability(
   const latestTraceByInstance = new Map<string, string>();
   const traceByRequest = new Map<string, string>();
   const traceByRemote = new Map<string, string>();
+  const traceByBridgeOperation = new Map<string, string>();
   const instanceRefs = new WeakMap<object, string>();
   const instancesByRef = new Map<string, ObservabilityRuntimeOrigin>();
+  const bridgeStatesByInstance = new Map<
+    string,
+    Map<string, ObservabilityBridgeState>
+  >();
   const lateBoundInstanceRefs = new Set<string>();
   const boundInstanceRefs = new Set<string>();
   const attachedInstanceApis = new WeakMap<object, ObservabilityInstanceAPI>();
   const phaseStartTimes = new Map<string, number>();
   const reportedSharedConflictKeys = new Set<string>();
+  const reportedBridgeProviderKeys = new Set<string>();
   const collectorOptions = normalizeCollectorOptions(options.collector);
   const devtoolsOptions = normalizeDevtoolsOptions(options.devtools);
   const seenManifestUrls = new Set<string>();
@@ -2889,6 +3028,15 @@ export function createObservability(
       }
     }
 
+    if (event.bridge?.operationId) {
+      const traceId = traceByBridgeOperation.get(
+        getTraceMapKey(instanceRef, event.bridge.operationId),
+      );
+      if (traceId) {
+        return traceId;
+      }
+    }
+
     if (event.remote?.name) {
       const traceId = traceByRemote.get(
         getTraceMapKey(instanceRef, event.remote.name),
@@ -2897,7 +3045,6 @@ export function createObservability(
         return traceId;
       }
     }
-
     return event.traceId || createTraceId(event);
   };
 
@@ -2950,6 +3097,7 @@ export function createObservability(
       componentName: sanitizeText(event.componentName, 160),
       metadata: clipObservabilityMetadata(event.metadata),
       loadedBefore: copyLoadedBeforeInfo(event.loadedBefore),
+      bridge: copyBridgeInfo(event.bridge),
     };
 
     if (normalizedEvent.status === 'error' || event.error) {
@@ -3011,6 +3159,12 @@ export function createObservability(
     if (event.remote?.name) {
       traceByRemote.set(
         getTraceMapKey(event.instanceRef, event.remote.name),
+        event.traceId,
+      );
+    }
+    if (event.bridge?.operationId) {
+      traceByBridgeOperation.set(
+        getTraceMapKey(event.instanceRef, event.bridge.operationId),
         event.traceId,
       );
     }
@@ -3784,6 +3938,7 @@ export function createObservability(
           ? { ...event.errorContext }
           : undefined,
         loadedBefore: copyLoadedBeforeInfo(event.loadedBefore),
+        bridge: copyBridgeInfo(event.bridge),
         events: [],
         summary: {
           eventCount: 0,
@@ -3856,6 +4011,9 @@ export function createObservability(
     }
     if (event.loadedBefore) {
       report.loadedBefore = copyLoadedBeforeInfo(event.loadedBefore);
+    }
+    if (event.bridge) {
+      report.bridge = copyBridgeInfo(event.bridge);
     }
 
     report.events.push(event);
@@ -4113,18 +4271,96 @@ export function createObservability(
       };
     });
 
+  const updateBridgeState = (
+    origin: ObservabilityRuntimeOrigin,
+    bridge: ObservabilityBridgeInfo,
+    signal: 'start' | 'invoked' | 'result' | 'commit',
+  ) => {
+    const instanceRef = getInstanceRef(origin);
+    if (!instanceRef) {
+      return;
+    }
+    let states = bridgeStatesByInstance.get(instanceRef);
+    if (!states) {
+      states = new Map();
+      bridgeStatesByInstance.set(instanceRef, states);
+    }
+    const key = `${bridge.bridgeId}\u0000${bridge.side}`;
+    const previous = states.get(key);
+    let status = previous?.status || 'idle';
+    if (signal === 'start') {
+      if (bridge.operation === 'destroy') {
+        status = 'destroying';
+      } else if (
+        bridge.operation === 'render' ||
+        bridge.operation === 'update'
+      ) {
+        status = 'rendering';
+      }
+    } else if (signal === 'result') {
+      if (bridge.outcome === 'error') {
+        status = 'error';
+      } else if (bridge.operation === 'destroy') {
+        status = 'destroyed';
+      } else if (
+        bridge.operation === 'render' ||
+        bridge.operation === 'update'
+      ) {
+        status = 'rendered';
+      }
+    } else if (signal === 'commit') {
+      status = 'rendered';
+    }
+
+    states.set(key, {
+      bridgeId: bridge.bridgeId,
+      side: bridge.side,
+      framework: bridge.framework,
+      moduleName: bridge.moduleName || previous?.moduleName,
+      remote: bridge.remote || previous?.remote,
+      expose: bridge.expose || previous?.expose,
+      status,
+      lastOperation: bridge.operation,
+      lastOperationId: bridge.operationId,
+      lastOperationAt: bridge.endedAt || bridge.startedAt,
+      commitObserved: signal === 'commit' || previous?.commitObserved === true,
+      routeSyncObserved:
+        bridge.operation === 'route-sync' ||
+        previous?.routeSyncObserved === true,
+    });
+  };
+
   const getBridgeSummary = (
     origin: ObservabilityRuntimeOrigin,
+    instanceRef: string,
   ): ObservabilityRuntimeStateInstance['bridge'] => {
     if (!isRecord(origin.bridgeHook)) {
       return undefined;
     }
     const lifecycle = getObjectValue(origin.bridgeHook, 'lifecycle');
+    const states = Array.from(
+      bridgeStatesByInstance.get(instanceRef)?.values() || [],
+    )
+      .sort(
+        (left, right) =>
+          (right.lastOperationAt || 0) - (left.lastOperationAt || 0),
+      )
+      .map((state) => ({ ...state }));
+    const latest = states[0];
     return {
       available: true,
       lifecycleCount: isRecord(lifecycle)
         ? Object.keys(lifecycle).length
         : undefined,
+      framework: latest?.framework,
+      moduleName: latest?.moduleName,
+      remote: latest?.remote,
+      expose: latest?.expose,
+      status: latest?.status || 'idle',
+      lastOperationAt: latest?.lastOperationAt,
+      commitObserved: states.some((state) => state.commitObserved),
+      routeSyncObserved: states.some((state) => state.routeSyncObserved),
+      states,
     };
   };
 
@@ -4317,7 +4553,7 @@ export function createObservability(
           remotes: draft.remotes,
           loadedProducers: draft.loadedProducers,
           shareScopes: getShareScopeSummaries(draft.origin),
-          bridge: getBridgeSummary(draft.origin),
+          bridge: getBridgeSummary(draft.origin, draft.instanceRef),
           active: activeInstances.includes(
             draft.origin as ObservabilityRuntimeInstanceLike,
           ),
@@ -4345,6 +4581,14 @@ export function createObservability(
       ),
     );
     const hasBridge = instances.some((instance) => instance.bridge?.available);
+    const bridgeEvents = events.filter((event) => Boolean(event.bridge));
+    const hasBridgeSignals = bridgeEvents.length > 0;
+    const hasBridgeCommit = bridgeEvents.some(
+      (event) => event.phase === 'bridge-commit',
+    );
+    const hasBridgeRoute = bridgeEvents.some(
+      (event) => event.bridge?.operation === 'route-sync',
+    );
     const traceCompleteness = hasIncompleteHistory ? 'partial' : 'complete';
 
     return omitUndefinedFields({
@@ -4397,11 +4641,25 @@ export function createObservability(
             : 'Shared tracing requires a stable runtime version of 2.5.0 or newer.',
         },
         bridgeTrace: {
-          available: false,
-          completeness: 'unavailable',
-          reason: hasBridge
-            ? 'Bridge is present, but no complete Bridge trace signal is available.'
-            : 'Bridge is not present on an observed instance.',
+          available: hasBridgeSignals,
+          completeness: !hasBridgeSignals
+            ? 'unavailable'
+            : hasIncompleteHistory || !hasBridgeCommit || !hasBridgeRoute
+              ? 'partial'
+              : 'complete',
+          reason: !hasBridgeSignals
+            ? hasBridge
+              ? 'Bridge is present, but no Bridge lifecycle signal has been observed.'
+              : 'Bridge is not present on an observed instance.'
+            : [
+                hasIncompleteHistory ? 'runtime history is incomplete' : '',
+                !hasBridgeCommit
+                  ? 'no framework commit signal was observed'
+                  : '',
+                !hasBridgeRoute ? 'no route sync signal was observed' : '',
+              ]
+                .filter(Boolean)
+                .join('; ') || undefined,
         },
       },
       instances,
@@ -5071,7 +5329,120 @@ export function createObservability(
     };
   };
 
+  const recordBridgeSignal = (
+    args: ObservabilityBridgeHookArgs,
+    signal: 'start' | 'invoked' | 'result' | 'commit',
+  ) => {
+    const origin = args.origin || lastRuntimeOrigin;
+    if (!origin || !prepareRuntimeOrigin(origin)) {
+      return;
+    }
+    const bridge = normalizeBridgeInfo(args);
+    if (!bridge) {
+      return;
+    }
+    updateBridgeState(origin, bridge, signal);
+    const remote = bridge.remote ? { name: bridge.remote } : undefined;
+    const status: ObservabilityEventStatus =
+      signal === 'start'
+        ? 'start'
+        : bridge.outcome === 'error'
+          ? 'error'
+          : bridge.outcome === 'skipped'
+            ? 'complete'
+            : 'success';
+    const phase =
+      signal === 'commit'
+        ? 'bridge-commit'
+        : bridge.operation === 'destroy'
+          ? 'bridge-destroy'
+          : bridge.operation === 'route-sync'
+            ? 'bridge-route'
+            : 'bridge-render';
+    const operationLabel =
+      bridge.operation === 'update' ? 'update' : bridge.operation;
+    const message =
+      signal === 'start'
+        ? `bridge:${operationLabel}-start`
+        : signal === 'invoked'
+          ? `bridge:${operationLabel}-invoked`
+          : signal === 'commit'
+            ? 'bridge:render-committed'
+            : `bridge:${operationLabel}-${bridge.outcome || 'success'}`;
+    const instanceRef = getInstanceRef(origin);
+
+    if (
+      signal === 'start' &&
+      bridge.side === 'consumer' &&
+      bridge.operation === 'render' &&
+      instanceRef
+    ) {
+      const providerKey = `${instanceRef}\u0000${bridge.bridgeId}`;
+      if (!reportedBridgeProviderKeys.has(providerKey)) {
+        reportedBridgeProviderKeys.add(providerKey);
+        recordEvent(
+          {
+            phase: 'bridge-provider',
+            status: 'success',
+            remote,
+            expose: bridge.expose,
+            bridge,
+            lifecycle: 'beforeBridgeOperation',
+            message: 'bridge:provider-acquired',
+            source: 'runtime',
+          },
+          origin,
+        );
+      }
+    }
+
+    recordEvent(
+      {
+        phase,
+        status,
+        remote,
+        expose: bridge.expose,
+        bridge,
+        duration: bridge.duration,
+        lifecycle:
+          signal === 'start'
+            ? 'beforeBridgeOperation'
+            : signal === 'invoked'
+              ? 'bridgeRenderInvoked'
+              : signal === 'commit'
+                ? 'afterBridgeCommit'
+                : 'afterBridgeOperation',
+        message,
+        error: bridge.outcome === 'error' ? bridge.error?.message : undefined,
+        errorContext:
+          bridge.outcome === 'error'
+            ? {
+                operationId: bridge.operationId,
+                bridgeId: bridge.bridgeId,
+                side: bridge.side,
+                framework: bridge.framework,
+                errorName: bridge.error?.name,
+              }
+            : undefined,
+        source: 'runtime',
+      },
+      origin,
+    );
+  };
+
   const legacyHooks: RuntimePluginHooks = {
+    beforeBridgeOperation(args) {
+      recordBridgeSignal(args as ObservabilityBridgeHookArgs, 'start');
+    },
+    bridgeRenderInvoked(args) {
+      recordBridgeSignal(args as ObservabilityBridgeHookArgs, 'invoked');
+    },
+    afterBridgeOperation(args) {
+      recordBridgeSignal(args as ObservabilityBridgeHookArgs, 'result');
+    },
+    afterBridgeCommit(args) {
+      recordBridgeSignal(args as ObservabilityBridgeHookArgs, 'commit');
+    },
     beforeRequest(args) {
       const requestArgs = args as ObservabilityRemoteBeforeRequestArgs;
       if (!prepareRuntimeOrigin(requestArgs.origin)) {
@@ -5969,10 +6340,12 @@ export function createObservability(
       reports.clear();
       traceByRequest.clear();
       traceByRemote.clear();
+      traceByBridgeOperation.clear();
       latestTraceByInstance.clear();
       phaseStartTimes.clear();
       seenManifestUrls.clear();
       seenRemoteEntryKeys.clear();
+      reportedBridgeProviderKeys.clear();
       consoleReportedTraceIds.clear();
       consoleReportedStartKeys.clear();
       latestTraceId = undefined;

--- a/packages/runtime-core/__tests__/plugin.spec.ts
+++ b/packages/runtime-core/__tests__/plugin.spec.ts
@@ -197,6 +197,56 @@ describe('runtime plugins', () => {
     expect(instanceBeforeInit).toHaveBeenCalledTimes(1);
     expect(sharedBeforeInit).not.toHaveBeenCalled();
   });
+
+  it('registers safe Bridge lifecycle handlers on each runtime instance', () => {
+    const beforeBridgeOperation = rs.fn();
+    const bridgeRenderInvoked = rs.fn();
+    const afterBridgeOperation = rs.fn();
+    const afterBridgeCommit = rs.fn();
+    const instance = new ModuleFederation({
+      name: 'bridge-lifecycle-host',
+      plugins: [
+        {
+          name: 'bridge-lifecycle-plugin',
+          apply: () => ({
+            beforeBridgeOperation,
+            bridgeRenderInvoked,
+            afterBridgeOperation,
+            afterBridgeCommit,
+          }),
+        },
+      ],
+    });
+    const context = {
+      operationId: 'bridge-op-1',
+      bridgeId: 'bridge-1',
+      side: 'consumer' as const,
+      framework: 'react' as const,
+      operation: 'render' as const,
+      moduleName: 'remote/App',
+      remote: 'remote',
+      expose: './App',
+      reason: 'mount' as const,
+      startedAt: 1,
+    };
+    const result = {
+      ...context,
+      endedAt: 2,
+      duration: 1,
+      outcome: 'success' as const,
+    };
+
+    instance.bridgeHook.lifecycle.beforeBridgeOperation.emit(context);
+    instance.bridgeHook.lifecycle.bridgeRenderInvoked.emit(context);
+    instance.bridgeHook.lifecycle.afterBridgeOperation.emit(result);
+    instance.bridgeHook.lifecycle.afterBridgeCommit.emit(result);
+
+    expect(beforeBridgeOperation).toHaveBeenCalledWith(context);
+    expect(bridgeRenderInvoked).toHaveBeenCalledWith(context);
+    expect(afterBridgeOperation).toHaveBeenCalledWith(result);
+    expect(afterBridgeCommit).toHaveBeenCalledWith(result);
+    expect(JSON.stringify(context)).not.toMatch(/dom|props|router|component/);
+  });
 });
 
 describe('global runtime plugins', () => {

--- a/packages/runtime-core/src/core.ts
+++ b/packages/runtime-core/src/core.ts
@@ -21,6 +21,8 @@ import {
   ResourceLoadContext,
   LoadShareExtraOptions,
   SharedLoadContext,
+  BridgeOperationContext,
+  BridgeOperationResult,
 } from './type';
 import { getBuilderId, registerPlugins, getRemoteEntry, error } from './utils';
 import {
@@ -294,6 +296,10 @@ export class ModuleFederation {
       [Record<string, any>],
       void | Record<string, any>
     >(),
+    beforeBridgeOperation: new SyncHook<[BridgeOperationContext], void>(),
+    bridgeRenderInvoked: new SyncHook<[BridgeOperationContext], void>(),
+    afterBridgeOperation: new SyncHook<[BridgeOperationResult], void>(),
+    afterBridgeCommit: new SyncHook<[BridgeOperationResult], void>(),
   });
   moduleInfo?: GlobalModuleInfo[string];
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -27,6 +27,8 @@ export {
 } from './global';
 export type {
   UserOptions,
+  BridgeOperationContext,
+  BridgeOperationResult,
   ModuleFederationRuntimePlugin,
   RuntimePluginHooks,
 } from './type';

--- a/packages/runtime-core/src/type/bridge.ts
+++ b/packages/runtime-core/src/type/bridge.ts
@@ -1,18 +1,3 @@
-import type { CSSProperties } from 'react';
-
-export interface ProviderParams {
-  moduleName?: string;
-  basename?: string;
-  memoryRoute?: { entryPath: string };
-  hashRoute?: boolean;
-  style?: CSSProperties;
-  className?: string;
-}
-
-export interface RenderFnParams extends ProviderParams {
-  dom: HTMLElement;
-}
-
 export type BridgeOperationSide = 'consumer' | 'producer';
 
 export type BridgeFramework = 'react' | 'vue';

--- a/packages/runtime-core/src/type/index.ts
+++ b/packages/runtime-core/src/type/index.ts
@@ -1,3 +1,4 @@
 export * from './config';
+export * from './bridge';
 export * from './plugin';
 export * from './preload';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -19,6 +19,8 @@ export {
   registerGlobalPlugins,
   type ModuleFederationRuntimePlugin,
   type RuntimePluginHooks,
+  type BridgeOperationContext,
+  type BridgeOperationResult,
   type Federation,
 } from '@module-federation/runtime-core';
 


### PR DESCRIPTION

## What changed

This PR adds safe, correlated lifecycle observability for React and Vue Bridge applications.

- Records render, update, commit, route sync, destroy, and failure events.
- Correlates consumer and producer events without treating them as duplicate renders.
- Confirms commits from real React and Vue lifecycle points.
- Keeps the existing Bridge hooks and their behavior unchanged.
- Preserves original render and destroy errors.
- Tracks each Bridge instance independently, including concurrent and same-name instances.
- Reports complete, partial, or unavailable Bridge trace capability.
- Removes DOM elements, props, components, router instances, query strings, hashes, and other sensitive values from reported data.
- Covers React legacy, React 18/19, Vue KeepAlive, custom render/createRoot, repeated destroy, updates, route sync, late plugin injection, and failures.
- Adds the required release changeset.

## Why

The existing `afterBridgeRender` signal only confirms that the render call returned. It does not prove that React or Vue committed the result.

This change adds reliable commit and route synchronization signals while preserving the meaning and compatibility of the existing hooks.

## Impact

Bridge applications can now expose a safe lifecycle trace through the observability plugin.

The trace can reliably identify:

- operation and Bridge IDs
- consumer or producer side
- React or Vue framework
- render, update, destroy, or route-sync operation
- related module, remote, and expose
- safe route summary
- start and end times
- duration
- success, error, or skipped result
- safe error summary
- whether commit and route-sync signals were observed

A framework commit is not treated as business readiness. Late plugin injection or missing commit and route signals remain explicitly marked as partial.

This PR does not add OpenRuntime commands and does not change the OpenRuntime repository.

## Validation

Passed on Node.js 24:

- `pnpm --filter @module-federation/runtime-core test` — 103 tests passed
- `pnpm --filter @module-federation/bridge-react test` — 37 tests passed
- `pnpm --filter @module-federation/bridge-vue3 test` — 53 tests passed
- `pnpm --filter @module-federation/observability-plugin test` — 99 tests passed
- Builds passed for runtime-core, runtime, bridge-shared, bridge-react, bridge-vue3, and observability-plugin
- `pnpm exec prettier --check .`
- `pnpm exec changeset status --verbose`
- `git diff --check`
- `pnpm run ci:local --only=build-and-test` — 43 builds and 76 tasks passed
- The repository’s commit-time formatting, lint, and commit-message checks passed

## Skipped checks

Browser E2E, Metro, devtools, and bundle-size jobs were not run because this change is limited to the browser Bridge and runtime packages. The affected package tests, builds, and the repository-wide build-and-test job all passed.

No publish, push, or PR creation command was run.