### PR TITLE
feat(runtime): trace remote resource loading

### DIFF
--- a/.changeset/trace-real-remote-resources.md
+++ b/.changeset/trace-real-remote-resources.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/runtime-core': patch
+'@module-federation/observability-plugin': patch
+---
+
+Report real manifest, remote entry, and preload resource outcomes, including cache reuse, timeouts, failures, and recovery.

--- a/packages/observability-plugin/__tests__/observability.spec.ts
+++ b/packages/observability-plugin/__tests__/observability.spec.ts
@@ -3265,6 +3265,239 @@ describe('ObservabilityPlugin', () => {
     );
   });
 
+  it('records safe resource results in the remote timeline without duplicate legacy phases', () => {
+    const observability = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const origin = {
+      ...enabledOrigin,
+      loaderHook: {
+        lifecycle: {
+          beforeLoadResource: {},
+          afterLoadResource: {},
+        },
+      },
+    };
+    const remote = {
+      name: 'remote',
+      entry: 'http://localhost:3001/mf-manifest.json',
+    };
+
+    emitRemoteStart(observability, { origin });
+    emitRemoteMatch(observability, { origin, remoteInfo: remote });
+    observability.plugin.beforeLoadResource?.({
+      id: 'remote/Button',
+      initiator: 'loadRemote',
+      resourceType: 'manifest',
+      url: 'http://localhost:3001/mf-manifest.json?token=secret',
+      remote,
+      expose: './Button',
+      startedAt: 100,
+      origin,
+    } as any);
+    observability.plugin.afterLoadResource?.({
+      id: 'remote/Button',
+      initiator: 'loadRemote',
+      resourceType: 'manifest',
+      url: 'http://localhost:3001/mf-manifest.json?token=secret',
+      remote,
+      expose: './Button',
+      startedAt: 100,
+      endedAt: 125,
+      duration: 25,
+      outcome: 'success',
+      httpStatus: 200,
+      mimeType: 'application/json',
+      redirected: false,
+      origin,
+    } as any);
+
+    const report = observability.getLatestReport();
+    const manifestEvents = report?.events.filter(
+      (event) => event.phase === 'manifest',
+    );
+
+    expect(manifestEvents).toHaveLength(2);
+    expect(manifestEvents?.[1]).toMatchObject({
+      status: 'success',
+      lifecycle: 'afterLoadResource',
+      sanitizedUrl: 'http://localhost:3001/mf-manifest.json',
+      duration: 25,
+      resource: {
+        type: 'manifest',
+        initiator: 'loadRemote',
+        outcome: 'success',
+        url: 'http://localhost:3001/mf-manifest.json',
+        startedAt: 100,
+        endedAt: 125,
+        duration: 25,
+        httpStatus: 200,
+        mimeType: 'application/json',
+        redirected: false,
+      },
+    });
+    expect(JSON.stringify(manifestEvents)).not.toContain('token=secret');
+    expect(manifestEvents?.[1].resource).not.toHaveProperty('cacheSource');
+  });
+
+  it('keeps original resource failure evidence after recovery succeeds', () => {
+    const observability = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const origin = {
+      ...enabledOrigin,
+      loaderHook: {
+        lifecycle: {
+          beforeLoadResource: {},
+          afterLoadResource: {},
+        },
+      },
+    };
+    const remoteInfo = {
+      name: 'remote',
+      entry: 'http://localhost:3001/remoteEntry.js',
+    };
+    const resourceBase = {
+      id: 'remote/Button',
+      initiator: 'loadRemote',
+      resourceType: 'remoteEntry',
+      url: remoteInfo.entry,
+      remote: remoteInfo,
+      expose: './Button',
+      origin,
+    };
+
+    emitRemoteStart(observability, { origin });
+    observability.plugin.beforeLoadResource?.({
+      ...resourceBase,
+      startedAt: 200,
+    } as any);
+    observability.plugin.afterLoadResource?.({
+      ...resourceBase,
+      startedAt: 200,
+      endedAt: 210,
+      duration: 10,
+      outcome: 'error',
+      errorType: 'execution',
+      error: new Error('token=secret ScriptExecutionError: boom'),
+    } as any);
+    observability.plugin.beforeLoadResource?.({
+      ...resourceBase,
+      startedAt: 211,
+    } as any);
+    observability.plugin.afterLoadResource?.({
+      ...resourceBase,
+      startedAt: 211,
+      endedAt: 220,
+      duration: 9,
+      outcome: 'success',
+    } as any);
+    observability.plugin.afterLoadEntry?.({
+      remoteInfo,
+      origin,
+      recovered: true,
+    } as any);
+    emitRemoteComplete(observability, {
+      origin,
+      error: new Error('original execution failed'),
+      recovered: true,
+    });
+
+    const report = observability.getLatestReport();
+    const resourceResults = report?.events.filter(
+      (event) => event.lifecycle === 'afterLoadResource',
+    );
+
+    expect(resourceResults?.map((event) => event.resource?.outcome)).toEqual([
+      'error',
+      'success',
+    ]);
+    expect(resourceResults?.[0]).toMatchObject({
+      status: 'error',
+      errorName: 'Error',
+      errorMessage: '[redacted] ScriptExecutionError: boom',
+      ownerHint: 'remote',
+      retryable: false,
+      resource: {
+        errorType: 'execution',
+      },
+    });
+    expect(report?.status).toBe('success');
+    expect(report?.summary.outcome).toBe('recovered');
+    expect(report?.summary.error).toMatchObject({
+      failedPhase: 'remoteEntry',
+      errorName: 'Error',
+    });
+  });
+
+  it('attributes same-name resource events to their bound MF instances', async () => {
+    const observability = createObservability({
+      level: 'verbose',
+      console: false,
+    });
+    const first = new ModuleFederation({
+      name: 'same-resource-host',
+      plugins: [observability.plugin],
+    });
+    const second = new ModuleFederation({
+      name: 'same-resource-host',
+      plugins: [observability.plugin],
+    });
+
+    const emitFor = async (instance: ModuleFederation, id: string) => {
+      const startedAt = Date.now();
+      await instance.loaderHook.lifecycle.beforeLoadResource.emit({
+        id,
+        initiator: 'preloadRemote',
+        resourceType: 'css',
+        url: `https://remote.test/${id}.css`,
+        remote: {
+          name: 'same-remote',
+          entry: 'https://remote.test/remoteEntry.js',
+          entryGlobalName: 'same_remote',
+          type: 'global',
+          shareScope: 'default',
+        },
+        startedAt,
+      });
+      await instance.loaderHook.lifecycle.afterLoadResource.emit({
+        id,
+        initiator: 'preloadRemote',
+        resourceType: 'css',
+        url: `https://remote.test/${id}.css`,
+        remote: {
+          name: 'same-remote',
+          entry: 'https://remote.test/remoteEntry.js',
+          entryGlobalName: 'same_remote',
+          type: 'global',
+          shareScope: 'default',
+        },
+        startedAt,
+        endedAt: startedAt + 1,
+        duration: 1,
+        outcome: 'success',
+      });
+    };
+
+    await emitFor(first, 'first/resource');
+    await emitFor(second, 'second/resource');
+
+    const reports = observability.getReports();
+    expect(reports).toHaveLength(2);
+    expect(reports.map((report) => report.instanceRef).sort()).toEqual([
+      'mf-1',
+      'mf-2',
+    ]);
+    expect(
+      observability.getRuntimeState().capabilities.remoteTrace,
+    ).toMatchObject({
+      available: true,
+      completeness: 'complete',
+    });
+  });
+
   it('records repeated manifest snapshot loads as cached success', () => {
     const observability = createObservability({
       level: 'verbose',

--- a/packages/observability-plugin/src/core.ts
+++ b/packages/observability-plugin/src/core.ts
@@ -319,6 +319,21 @@ export interface ObservabilityRemoteInfo {
   type?: string;
 }
 
+export interface ObservabilityResourceInfo {
+  type: string;
+  initiator: 'loadRemote' | 'preloadRemote';
+  outcome?: 'success' | 'error' | 'timeout' | 'cached' | 'recovered';
+  url?: string;
+  startedAt: number;
+  endedAt?: number;
+  duration?: number;
+  httpStatus?: number;
+  mimeType?: string;
+  redirected?: boolean;
+  cacheSource?: string;
+  errorType?: string;
+}
+
 export interface ObservabilitySharedInfo {
   name: string;
   shareScope?: string[];
@@ -403,6 +418,7 @@ export interface ObservabilityEvent {
   hostName?: string;
   runtimeVersion?: string;
   remote?: ObservabilityRemoteInfo;
+  resource?: ObservabilityResourceInfo;
   shared?: ObservabilitySharedInfo;
   expose?: string;
   sanitizedUrl?: string;
@@ -594,6 +610,7 @@ export interface ObservabilityRuntimeEventInput {
   requestAlias?: string;
   hostName?: string;
   remote?: ObservabilityRemoteInfo;
+  resource?: ObservabilityResourceInfo;
   shared?: ObservabilitySharedInfo;
   expose?: string;
   url?: string;
@@ -627,6 +644,12 @@ export interface ObservabilityRuntimeOrigin {
   };
   moduleCache?: ObservabilityRuntimeInstanceLike['moduleCache'];
   remoteHandler?: ObservabilityRuntimeRemoteHandlerLike;
+  loaderHook?: {
+    lifecycle?: {
+      beforeLoadResource?: unknown;
+      afterLoadResource?: unknown;
+    };
+  };
   bridgeHook?: unknown;
   shareScopeMap?: ObservabilityRuntimeShareScopeMap;
   sharedHandler?: {
@@ -858,6 +881,29 @@ interface ObservabilityRemoteEntryAfterLoadArgs {
   error?: unknown;
   recovered?: boolean;
   cached?: boolean;
+}
+
+interface ObservabilityResourceLoadArgs {
+  origin: ObservabilityRuntimeOrigin;
+  id: string;
+  initiator: 'loadRemote' | 'preloadRemote';
+  resourceType: string;
+  url: string;
+  remote?: ObservabilityRuntimeRemoteSource;
+  expose?: string;
+  startedAt: number;
+}
+
+interface ObservabilityResourceLoadResultArgs extends ObservabilityResourceLoadArgs {
+  endedAt: number;
+  duration: number;
+  outcome: 'success' | 'error' | 'timeout' | 'cached' | 'recovered';
+  httpStatus?: number;
+  mimeType?: string;
+  redirected?: boolean;
+  cacheSource?: string;
+  errorType?: string;
+  error?: unknown;
 }
 
 interface ObservabilityRemoteInitArgs {
@@ -1315,6 +1361,48 @@ function normalizeBridgeInfo(
           message: sanitizeText(result.error.message, 240),
         }
       : undefined,
+  });
+}
+
+function sanitizeResource(
+  resource: ObservabilityResourceInfo | undefined,
+): ObservabilityResourceInfo | undefined {
+  if (!resource) {
+    return undefined;
+  }
+
+  const type = sanitizeText(resource.type, 80);
+  if (!type) {
+    return undefined;
+  }
+
+  return omitUndefinedFields({
+    type,
+    initiator: resource.initiator,
+    outcome: resource.outcome,
+    url: sanitizeUrl(resource.url),
+    startedAt: Number.isFinite(resource.startedAt)
+      ? resource.startedAt
+      : Date.now(),
+    endedAt:
+      resource.endedAt !== undefined && Number.isFinite(resource.endedAt)
+        ? resource.endedAt
+        : undefined,
+    duration:
+      resource.duration !== undefined && Number.isFinite(resource.duration)
+        ? Math.max(0, resource.duration)
+        : undefined,
+    httpStatus:
+      resource.httpStatus !== undefined && Number.isFinite(resource.httpStatus)
+        ? resource.httpStatus
+        : undefined,
+    mimeType: sanitizeText(resource.mimeType, 160),
+    redirected:
+      typeof resource.redirected === 'boolean'
+        ? resource.redirected
+        : undefined,
+    cacheSource: sanitizeText(resource.cacheSource, 80),
+    errorType: sanitizeText(resource.errorType, 80),
   });
 }
 
@@ -2084,6 +2172,15 @@ function getErrorInfo(
     };
   }
 
+  if (isRecord(error) && typeof error.message === 'string') {
+    return {
+      errorCode: extractErrorCode(error.message),
+      errorName:
+        typeof error.name === 'string' ? getRawText(error.name) : undefined,
+      errorMessage: getRawText(error.message),
+    };
+  }
+
   return {
     errorCode: extractErrorCode(error),
     errorMessage: getRawText(error),
@@ -2116,6 +2213,7 @@ function copyEvent(event: ObservabilityEvent): ObservabilityEvent {
   return omitUndefinedFields({
     ...event,
     remote: event.remote ? { ...event.remote } : undefined,
+    resource: event.resource ? { ...event.resource } : undefined,
     shared: event.shared
       ? {
           ...event.shared,
@@ -2706,9 +2804,12 @@ function createModuleInfoSummary(
 function getResourceErrorType(
   event: Pick<
     ObservabilityEvent,
-    'errorCode' | 'errorMessage' | 'message' | 'lifecycle'
+    'errorCode' | 'errorMessage' | 'message' | 'lifecycle' | 'resource'
   >,
 ): string | undefined {
+  if (event.resource?.errorType) {
+    return event.resource.errorType;
+  }
   const text = `${event.errorMessage || ''}\n${event.message || ''}`;
 
   if (!event.errorCode && !text) {
@@ -2744,9 +2845,23 @@ function getOwnerHint(
     | 'errorMessage'
     | 'message'
     | 'lifecycle'
+    | 'resource'
   >,
 ): ObservabilityOwnerHint | undefined {
   const resourceErrorType = getResourceErrorType(event);
+
+  if (event.resource?.errorType) {
+    if (
+      resourceErrorType === 'network' ||
+      resourceErrorType === 'timeout' ||
+      resourceErrorType === 'http'
+    ) {
+      return 'network';
+    }
+    if (resourceErrorType === 'execution' || resourceErrorType === 'content') {
+      return 'remote';
+    }
+  }
 
   switch (event.errorCode) {
     case 'RUNTIME-001':
@@ -2785,10 +2900,17 @@ function getOwnerHint(
 function getRetryable(
   event: Pick<
     ObservabilityEvent,
-    'errorCode' | 'errorMessage' | 'message' | 'lifecycle'
+    'errorCode' | 'errorMessage' | 'message' | 'lifecycle' | 'resource'
   >,
 ): boolean | undefined {
   const resourceErrorType = getResourceErrorType(event);
+
+  if (resourceErrorType === 'network' || resourceErrorType === 'timeout') {
+    return true;
+  }
+  if (resourceErrorType === 'execution' || resourceErrorType === 'content') {
+    return false;
+  }
 
   if (event.errorCode === 'RUNTIME-008') {
     return resourceErrorType === 'network' || resourceErrorType === 'timeout';
@@ -3055,6 +3177,7 @@ export function createObservability(
   ): ObservabilityEvent => {
     const errorInfo = getErrorInfo(event.error, options.stackTrace);
     const sanitizedRemote = sanitizeRemote(event.remote);
+    const sanitizedResource = sanitizeResource(event.resource);
     const sanitizedShared = sanitizeShared(event.shared);
     const requestAlias =
       sanitizeRequestId(event.requestAlias) ||
@@ -3064,7 +3187,15 @@ export function createObservability(
       sanitizeText(origin?.options?.name, 120);
     const runtimeVersion =
       sanitizeText(origin?.version, 80) || appliedRuntimeVersion;
-    const message = getRawText(event.message) || errorInfo.errorMessage;
+    const message = sanitizedResource
+      ? sanitizeText(event.message) || sanitizeText(errorInfo.errorMessage)
+      : getRawText(event.message) || errorInfo.errorMessage;
+    const normalizedErrorMessage = sanitizedResource
+      ? sanitizeText(errorInfo.errorMessage)
+      : errorInfo.errorMessage;
+    const normalizedErrorStack = sanitizedResource
+      ? sanitizeText(errorInfo.errorStack, 4000)
+      : errorInfo.errorStack;
 
     const normalizedEvent: ObservabilityEvent = {
       traceId,
@@ -3077,14 +3208,17 @@ export function createObservability(
       hostName,
       runtimeVersion,
       remote: sanitizedRemote,
+      resource: sanitizedResource,
       shared: sanitizedShared,
       expose: sanitizeText(event.expose, 240),
-      sanitizedUrl: clipText(event.url || event.remote?.entry, 320),
+      sanitizedUrl:
+        sanitizedResource?.url ||
+        clipText(event.url || event.remote?.entry, 320),
       message,
       errorCode: errorInfo.errorCode,
       errorName: errorInfo.errorName,
-      errorMessage: errorInfo.errorMessage,
-      errorStack: errorInfo.errorStack,
+      errorMessage: normalizedErrorMessage,
+      errorStack: normalizedErrorStack,
       duration:
         typeof event.duration === 'number' && Number.isFinite(event.duration)
           ? Math.max(0, event.duration)
@@ -3126,6 +3260,14 @@ export function createObservability(
   const shouldSkipRuntimeHook = (origin?: ObservabilityRuntimeOrigin) =>
     shouldGuardRuntimeHooksByRuntimeVersion &&
     !supportsRuntimeHookObservability(origin);
+
+  const supportsResourceLifecycle = (
+    origin?: ObservabilityRuntimeOrigin,
+  ): boolean =>
+    Boolean(
+      origin?.loaderHook?.lifecycle?.beforeLoadResource &&
+      origin.loaderHook.lifecycle.afterLoadResource,
+    );
 
   const applyPhaseDuration = (event: ObservabilityEvent) => {
     const key = getPhaseDurationKey(event);
@@ -4590,6 +4732,11 @@ export function createObservability(
       (event) => event.bridge?.operation === 'route-sync',
     );
     const traceCompleteness = hasIncompleteHistory ? 'partial' : 'complete';
+    const hasResourceLifecycle = instanceDrafts.some((draft) =>
+      supportsResourceLifecycle(draft.origin),
+    );
+    const remoteTraceCompleteness =
+      hasIncompleteHistory || !hasResourceLifecycle ? 'partial' : 'complete';
 
     return omitUndefinedFields({
       schemaVersion: 1,
@@ -4615,10 +4762,12 @@ export function createObservability(
         },
         remoteTrace: {
           available: hasRemoteSignals || boundInstanceRefs.size > 0,
-          completeness: traceCompleteness,
-          reason: hasRemoteSignals
-            ? undefined
-            : 'No remote lifecycle signal has been observed yet.',
+          completeness: remoteTraceCompleteness,
+          reason: !hasResourceLifecycle
+            ? 'Runtime resource completion hooks are unavailable; remote resource history may be incomplete.'
+            : hasRemoteSignals
+              ? undefined
+              : 'No remote lifecycle signal has been observed yet.',
         },
         sharedState: {
           available: hasSharedState,
@@ -5443,6 +5592,117 @@ export function createObservability(
     afterBridgeCommit(args) {
       recordBridgeSignal(args as ObservabilityBridgeHookArgs, 'commit');
     },
+    beforeLoadResource(args) {
+      const resourceArgs = args as ObservabilityResourceLoadArgs;
+      if (!prepareRuntimeOrigin(resourceArgs.origin)) {
+        return;
+      }
+
+      const remote = createRemoteInfo(resourceArgs.remote);
+      const phase =
+        resourceArgs.resourceType === 'manifest' ||
+        resourceArgs.resourceType === 'remoteEntry'
+          ? resourceArgs.resourceType
+          : 'preload';
+      recordEvent(
+        {
+          phase,
+          status: 'start',
+          requestId: resourceArgs.id,
+          remote,
+          expose: resourceArgs.expose,
+          url: resourceArgs.url,
+          timestamp: resourceArgs.startedAt,
+          lifecycle: 'beforeLoadResource',
+          message: `resource:${resourceArgs.resourceType}:load-start`,
+          resource: {
+            type: resourceArgs.resourceType,
+            initiator: resourceArgs.initiator,
+            url: resourceArgs.url,
+            startedAt: resourceArgs.startedAt,
+          },
+        },
+        resourceArgs.origin,
+      );
+    },
+    afterLoadResource(args) {
+      const resourceArgs = args as ObservabilityResourceLoadResultArgs;
+      if (!prepareRuntimeOrigin(resourceArgs.origin)) {
+        return;
+      }
+
+      const remote = createRemoteInfo(resourceArgs.remote);
+      const phase =
+        resourceArgs.resourceType === 'manifest' ||
+        resourceArgs.resourceType === 'remoteEntry'
+          ? resourceArgs.resourceType
+          : 'preload';
+      const isError =
+        resourceArgs.outcome === 'error' || resourceArgs.outcome === 'timeout';
+      const status: ObservabilityEventStatus =
+        resourceArgs.outcome === 'recovered'
+          ? 'complete'
+          : isError
+            ? 'error'
+            : 'success';
+      const resource: ObservabilityResourceInfo = {
+        type: resourceArgs.resourceType,
+        initiator: resourceArgs.initiator,
+        outcome: resourceArgs.outcome,
+        url: resourceArgs.url,
+        startedAt: resourceArgs.startedAt,
+        endedAt: resourceArgs.endedAt,
+        duration: resourceArgs.duration,
+        httpStatus: resourceArgs.httpStatus,
+        mimeType: resourceArgs.mimeType,
+        redirected: resourceArgs.redirected,
+        cacheSource: resourceArgs.cacheSource,
+        errorType: resourceArgs.errorType,
+      };
+
+      recordEvent(
+        {
+          phase,
+          status,
+          requestId: resourceArgs.id,
+          remote,
+          expose: resourceArgs.expose,
+          url: resourceArgs.url,
+          timestamp: resourceArgs.endedAt,
+          duration: resourceArgs.duration,
+          lifecycle: 'afterLoadResource',
+          message: `resource:${resourceArgs.resourceType}:${resourceArgs.outcome}`,
+          error:
+            isError || resourceArgs.outcome === 'recovered'
+              ? resourceArgs.error
+              : undefined,
+          recovered: resourceArgs.outcome === 'recovered',
+          cached: resourceArgs.outcome === 'cached',
+          resource,
+          errorContext:
+            isError || resourceArgs.outcome === 'recovered'
+              ? {
+                  resourceType: resourceArgs.resourceType,
+                  initiator: resourceArgs.initiator,
+                  outcome: resourceArgs.outcome,
+                  errorType: resourceArgs.errorType,
+                  httpStatus: resourceArgs.httpStatus,
+                }
+              : undefined,
+          metadata: clipObservabilityMetadata({
+            resourceType: resourceArgs.resourceType,
+            initiator: resourceArgs.initiator,
+            outcome: resourceArgs.outcome,
+            httpStatus: resourceArgs.httpStatus,
+            mimeType: resourceArgs.mimeType,
+            redirected: resourceArgs.redirected,
+            cacheSource: resourceArgs.cacheSource,
+            errorType: resourceArgs.errorType,
+          }),
+        },
+        resourceArgs.origin,
+      );
+    },
     beforeRequest(args) {
       const requestArgs = args as ObservabilityRemoteBeforeRequestArgs;
       if (!prepareRuntimeOrigin(requestArgs.origin)) {
@@ -5505,6 +5765,9 @@ export function createObservability(
       }
 
       const snapshotArgs = args as ObservabilitySnapshotLoadArgs;
+      if (supportsResourceLifecycle(lastRuntimeOrigin)) {
+        return returnHookArgs(args);
+      }
       const moduleRemote = createRemoteInfo(snapshotArgs.moduleInfo);
       const snapshotRemoteEntry =
         snapshotArgs.remoteSnapshot?.remoteEntry ||
@@ -5577,6 +5840,9 @@ export function createObservability(
       }
 
       const snapshotArgs = args as ObservabilityRemoteSnapshotLoadArgs;
+      if (supportsResourceLifecycle(lastRuntimeOrigin)) {
+        return returnHookArgs(args);
+      }
       if (snapshotArgs.from !== 'manifest') {
         return returnHookArgs(args);
       }
@@ -5733,6 +5999,7 @@ export function createObservability(
     loadEntry(args) {
       const entryArgs = args as ObservabilityRemoteEntryLoadArgs;
       if (
+        supportsResourceLifecycle(entryArgs.origin) ||
         shouldSkipRuntimeHook(entryArgs.origin) ||
         !prepareRuntimeOrigin(entryArgs.origin)
       ) {
@@ -5756,6 +6023,7 @@ export function createObservability(
     afterLoadEntry(args) {
       const entryArgs = args as ObservabilityRemoteEntryAfterLoadArgs;
       if (
+        (supportsResourceLifecycle(entryArgs.origin) && !entryArgs.recovered) ||
         shouldSkipRuntimeHook(entryArgs.origin) ||
         !prepareRuntimeOrigin(entryArgs.origin)
       ) {
@@ -6203,6 +6471,39 @@ export function createObservability(
           sanitizeRequestId(preloadResult.id) ||
           remote?.name ||
           sanitizeText(preloadResult.preloadConfig?.nameOrAlias, 160);
+
+        if (supportsResourceLifecycle(preloadArgs.origin)) {
+          const failedResource = preloadResult.results?.find(
+            (assetResult) =>
+              assetResult.status === 'error' ||
+              assetResult.status === 'timeout',
+          );
+          recordEvent(
+            {
+              phase: 'preload',
+              status: 'complete',
+              requestId,
+              remote,
+              lifecycle: 'afterPreloadRemote',
+              message: failedResource
+                ? 'preload:completed-with-errors'
+                : 'preload:complete',
+              error: failedResource?.error,
+              metadata: clipObservabilityMetadata({
+                resourceCount: preloadResult.results?.length || 0,
+                failedResourceCount:
+                  preloadResult.results?.filter(
+                    (assetResult) =>
+                      assetResult.status === 'error' ||
+                      assetResult.status === 'timeout',
+                  ).length || 0,
+                preloadNameOrAlias: preloadResult.preloadConfig?.nameOrAlias,
+              }),
+            },
+            preloadArgs.origin,
+          );
+          return;
+        }
 
         preloadResult.results?.forEach((assetResult) => {
           const isError =

--- a/packages/runtime-core/__tests__/hooks.spec.ts
+++ b/packages/runtime-core/__tests__/hooks.spec.ts
@@ -608,6 +608,7 @@ describe('hooks', () => {
       headers: { 'Content-Type': 'application/json' },
     });
     let lastFetchRemoteInfo: any;
+    const manifestResults: Array<Record<string, unknown>> = [];
     const fetchPlugin: () => ModuleFederationRuntimePlugin = () => ({
       name: 'fetch-plugin',
       fetch(url, options, remoteInfo, resourceContext) {
@@ -630,7 +631,17 @@ describe('hooks', () => {
           entry: 'http://mockxxx.com/loader-fetch-hooks-mf-manifest.json',
         },
       ],
-      plugins: [fetchPlugin()],
+      plugins: [
+        fetchPlugin(),
+        {
+          name: 'manifest-resource-recorder',
+          afterLoadResource(args) {
+            if (args.resourceType === 'manifest') {
+              manifestResults.push(args);
+            }
+          },
+        },
+      ],
     });
 
     const res = await INSTANCE.loadRemote<() => string>(
@@ -641,6 +652,16 @@ describe('hooks', () => {
     expect(lastFetchRemoteInfo).toMatchObject({
       name: '@loader-hooks/app2',
       entry: 'http://mockxxx.com/loader-fetch-hooks-mf-manifest.json',
+    });
+    expect(manifestResults).toHaveLength(1);
+    expect(manifestResults[0]).toMatchObject({
+      id: '@loader-hooks/app2/say',
+      initiator: 'loadRemote',
+      resourceType: 'manifest',
+      outcome: 'success',
+      httpStatus: 200,
+      mimeType: 'application/json',
+      redirected: false,
     });
   });
 
@@ -714,6 +735,77 @@ describe('hooks', () => {
     assert(res);
     expect(res()).toBe('hello app2');
     expect(snapshotEvents).toEqual(['loadSnapshot', 'manifest']);
+  });
+
+  it('reports a concurrent manifest waiter as cache reuse without refetching', async () => {
+    const manifestUrl = 'http://mockxxx.com/concurrent-hooks-mf-manifest.json';
+    const data = {
+      id: '@loader-hooks/concurrent',
+      name: '@loader-hooks/concurrent',
+      metaData: {
+        name: '@loader-hooks/concurrent',
+        publicPath: 'http://localhost:1111/',
+        type: 'app',
+        buildInfo: { buildVersion: 'custom' },
+        remoteEntry: {
+          name: 'federation-remote-entry.js',
+          path: 'resources/hooks/app2/',
+        },
+        types: { name: 'index.d.ts', path: './' },
+        globalName: '@loader-hooks/app2',
+      },
+      remotes: [],
+      shared: [],
+      exposes: [],
+    };
+    let fetchCount = 0;
+    const results: Array<Record<string, any>> = [];
+    const instance = new ModuleFederation({
+      name: '@loader-hooks/concurrent-host',
+      remotes: [],
+      plugins: [
+        {
+          name: 'delayed-manifest-fetch',
+          async fetch(url) {
+            if (url !== manifestUrl) {
+              return undefined;
+            }
+            fetchCount += 1;
+            await Promise.resolve();
+            return new Response(JSON.stringify(data), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          },
+        },
+        {
+          name: 'concurrent-manifest-recorder',
+          afterLoadResource(args) {
+            if (args.resourceType === 'manifest') {
+              results.push(args);
+            }
+          },
+        },
+      ],
+    });
+    const moduleInfo = {
+      name: '@loader-hooks/concurrent',
+      entry: manifestUrl,
+    } as const;
+
+    await Promise.all([
+      instance.snapshotHandler.loadRemoteSnapshotInfo({ moduleInfo }),
+      instance.snapshotHandler.loadRemoteSnapshotInfo({ moduleInfo }),
+    ]);
+
+    expect(fetchCount).toBe(1);
+    expect(results.map((item) => item.outcome).sort()).toEqual([
+      'cached',
+      'success',
+    ]);
+    expect(results.find((item) => item.outcome === 'cached')?.cacheSource).toBe(
+      'mf-memory',
+    );
   });
 
   it('loaderEntry hooks', async () => {

--- a/packages/runtime-core/__tests__/load-remote-diagnostics.spec.ts
+++ b/packages/runtime-core/__tests__/load-remote-diagnostics.spec.ts
@@ -90,6 +90,7 @@ describe('loadRemote diagnostics', () => {
 
   it('emits an afterLoadRemote hook after a successful remote load', async () => {
     const events: Array<Record<string, unknown>> = [];
+    const resourceResults: Array<Record<string, unknown>> = [];
     const mf = new ModuleFederation({
       name: 'load-remote-diagnostics-host',
       remotes: [
@@ -99,7 +100,15 @@ describe('loadRemote diagnostics', () => {
             'http://localhost:1111/resources/main/federation-manifest.json',
         },
       ],
-      plugins: [createDiagnosticsRecorder(events)],
+      plugins: [
+        createDiagnosticsRecorder(events),
+        {
+          name: 'resource-diagnostics-test-plugin',
+          afterLoadResource(args) {
+            resourceResults.push(args);
+          },
+        },
+      ],
     });
 
     const say = await mf.loadRemote<() => string>('@demo/main/say');
@@ -150,6 +159,24 @@ describe('loadRemote diagnostics', () => {
         }),
       ]),
     );
+    expect(resourceResults).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resourceType: 'manifest',
+          outcome: 'success',
+          httpStatus: 200,
+        }),
+        expect.objectContaining({
+          resourceType: 'remoteEntry',
+          outcome: 'success',
+        }),
+      ]),
+    );
+    const remoteEntryResult = resourceResults.find(
+      (result) => result.resourceType === 'remoteEntry',
+    );
+    expect(remoteEntryResult).not.toHaveProperty('httpStatus');
+    expect(remoteEntryResult).not.toHaveProperty('mimeType');
   });
 
   it('emits the expose phase before a missing expose bubbles to loadRemote', async () => {

--- a/packages/runtime-core/__tests__/load.spec.ts
+++ b/packages/runtime-core/__tests__/load.spec.ts
@@ -8,6 +8,11 @@ import {
   RUNTIME_015,
 } from '@module-federation/error-codes';
 import { mockStaticServer, removeScriptTags } from './mock/utils';
+import type {
+  ResourceLoadEvent,
+  ResourceLoadResult,
+} from '../src/type/preload';
+import type { ModuleFederationRuntimePlugin } from '../src/type/plugin';
 
 // All fixture URLs are served via two complementary mechanisms both pointing to __tests__/:
 //   1. mockScriptDomResponse (setup.ts) — patches Element.prototype.appendChild, executes
@@ -23,6 +28,28 @@ mockStaticServer({
 });
 
 const createMF = () => new ModuleFederation({ name: 'test-host', remotes: [] });
+
+function createResourceRecorder(): {
+  plugin: ModuleFederationRuntimePlugin;
+  starts: ResourceLoadEvent[];
+  results: ResourceLoadResult[];
+} {
+  const starts: ResourceLoadEvent[] = [];
+  const results: ResourceLoadResult[] = [];
+  return {
+    starts,
+    results,
+    plugin: {
+      name: 'resource-recorder',
+      beforeLoadResource(args) {
+        starts.push(args);
+      },
+      afterLoadResource(args) {
+        results.push(args);
+      },
+    },
+  };
+}
 
 describe('getRemoteEntry - script load error discrimination', () => {
   beforeEach(() => {
@@ -109,5 +136,284 @@ describe('getRemoteEntry - script load error discrimination', () => {
     expect(err.message).toContain(RUNTIME_015);
     expect(err.message).toContain('remote init failed');
     expect(err.message).toContain('remoteEntryUrl');
+  });
+
+  it.each([
+    ['success.js', 'success', undefined],
+    ['missing.js', 'error', 'network'],
+    ['exec-error.js', 'error', 'execution'],
+    ['no-global.js', 'error', 'initialization'],
+  ] as const)(
+    'emits one real resource result for %s',
+    async (fixture, outcome, errorType) => {
+      const recorder = createResourceRecorder();
+      const origin = new ModuleFederation({
+        name: `resource-${fixture}`,
+        remotes: [],
+        plugins: [recorder.plugin],
+      });
+      const remoteInfo = getRemoteInfo({
+        name: 'remote',
+        entry: `${BASE}/${fixture}`,
+      });
+
+      await getRemoteEntry({ origin, remoteInfo }).catch(() => undefined);
+
+      expect(recorder.starts).toHaveLength(1);
+      expect(recorder.results).toHaveLength(1);
+      expect(recorder.results[0]).toMatchObject({
+        initiator: 'loadRemote',
+        resourceType: 'remoteEntry',
+        url: `${BASE}/${fixture}`,
+        outcome,
+      });
+      if (errorType) {
+        expect(recorder.results[0].errorType).toBe(errorType);
+      } else {
+        expect(recorder.results[0]).not.toHaveProperty('errorType');
+      }
+      expect(recorder.results[0].endedAt).toBeGreaterThanOrEqual(
+        recorder.results[0].startedAt,
+      );
+      expect(recorder.results[0].duration).toBeGreaterThanOrEqual(0);
+      expect(recorder.results[0]).not.toHaveProperty('httpStatus');
+      expect(recorder.results[0]).not.toHaveProperty('mimeType');
+    },
+  );
+
+  it('reports one real attempt plus a cache hit for a concurrent waiter', async () => {
+    const recorder = createResourceRecorder();
+    const container = { get: rs.fn(), init: rs.fn() };
+    const origin = new ModuleFederation({
+      name: 'resource-concurrent',
+      remotes: [],
+      plugins: [
+        recorder.plugin,
+        {
+          name: 'delayed-entry',
+          async loadEntry() {
+            await Promise.resolve();
+            return container;
+          },
+        },
+      ],
+    });
+    const remoteInfo = getRemoteInfo({
+      name: 'concurrent-remote',
+      entry: 'https://remote.test/concurrent.js',
+    });
+
+    const [first, second] = await Promise.all([
+      getRemoteEntry({ origin, remoteInfo }),
+      getRemoteEntry({ origin, remoteInfo }),
+    ]);
+
+    expect(first).toBe(container);
+    expect(second).toBe(container);
+    expect(recorder.starts).toHaveLength(2);
+    expect(recorder.results).toHaveLength(2);
+    expect(recorder.results.map((item) => item.outcome).sort()).toEqual([
+      'cached',
+      'success',
+    ]);
+    expect(
+      recorder.results.find((item) => item.outcome === 'cached')?.cacheSource,
+    ).toBe('mf-memory');
+  });
+
+  it('reports explicit remote exports reuse as an MF memory cache hit', async () => {
+    const recorder = createResourceRecorder();
+    const container = { get: rs.fn(), init: rs.fn() };
+    const origin = new ModuleFederation({
+      name: 'resource-cache',
+      remotes: [],
+      plugins: [recorder.plugin],
+    });
+    const remoteInfo = getRemoteInfo({
+      name: 'cached-remote',
+      entry: 'https://remote.test/cached.js',
+    });
+
+    await getRemoteEntry({
+      origin,
+      remoteInfo,
+      remoteEntryExports: container,
+    });
+
+    expect(recorder.starts).toHaveLength(1);
+    expect(recorder.results).toHaveLength(1);
+    expect(recorder.results[0]).toMatchObject({
+      outcome: 'cached',
+      cacheSource: 'mf-memory',
+    });
+  });
+
+  it('reports a remote entry timeout without inventing a network response', async () => {
+    const recorder = createResourceRecorder();
+    const appendSpy = rs
+      .spyOn(document.head, 'appendChild')
+      .mockImplementation((node) => node);
+    const origin = new ModuleFederation({
+      name: 'resource-timeout',
+      remotes: [],
+      plugins: [
+        recorder.plugin,
+        {
+          name: 'short-entry-timeout',
+          createScript() {
+            return {
+              script: document.createElement('script'),
+              timeout: 5,
+            };
+          },
+        },
+      ],
+    });
+    const remoteInfo = getRemoteInfo({
+      name: 'timeout-remote',
+      entry: 'https://remote.test/timeout.js',
+    });
+
+    try {
+      await expect(getRemoteEntry({ origin, remoteInfo })).rejects.toThrow(
+        RUNTIME_008,
+      );
+    } finally {
+      appendSpy.mockRestore();
+    }
+
+    expect(recorder.results).toHaveLength(1);
+    expect(recorder.results[0]).toMatchObject({
+      outcome: 'timeout',
+      errorType: 'timeout',
+    });
+    expect(recorder.results[0]).not.toHaveProperty('httpStatus');
+    expect(recorder.results[0]).not.toHaveProperty('mimeType');
+  });
+
+  it('records a real Node remote entry completion', async () => {
+    const recorder = createResourceRecorder();
+    const origin = new ModuleFederation({
+      name: 'resource-node',
+      remotes: [],
+      plugins: [recorder.plugin],
+    });
+    origin.options.inBrowser = false;
+    const remoteInfo = getRemoteInfo({
+      name: 'nodeRemote',
+      entry: `${BASE}/node-success.js`,
+    });
+
+    await expect(getRemoteEntry({ origin, remoteInfo })).resolves.toEqual(
+      expect.objectContaining({
+        get: expect.any(Function),
+        init: expect.any(Function),
+      }),
+    );
+
+    expect(recorder.results).toHaveLength(1);
+    expect(recorder.results[0]).toMatchObject({
+      resourceType: 'remoteEntry',
+      outcome: 'success',
+    });
+    expect(recorder.results[0]).not.toHaveProperty('httpStatus');
+    expect(recorder.results[0]).not.toHaveProperty('mimeType');
+  });
+
+  it('keeps the original failure and the recovered resource attempt', async () => {
+    const recorder = createResourceRecorder();
+    const container = { get: rs.fn(), init: rs.fn() };
+    let attempts = 0;
+    const origin = new ModuleFederation({
+      name: 'resource-recovery',
+      remotes: [],
+      plugins: [
+        recorder.plugin,
+        {
+          name: 'recover-entry',
+          loadEntry() {
+            attempts += 1;
+            if (attempts === 1) {
+              const loadError = new Error(
+                '#RUNTIME-008 ScriptNetworkError: network failed',
+              );
+              loadError.name = 'ScriptNetworkError';
+              throw loadError;
+            }
+            return container;
+          },
+          async loadEntryError(args) {
+            delete args.globalLoading[args.uniqueKey];
+            return args.getRemoteEntry({
+              origin: args.origin,
+              remoteInfo: args.remoteInfo,
+              remoteEntryExports: args.remoteEntryExports,
+            });
+          },
+        },
+      ],
+    });
+    const remoteInfo = getRemoteInfo({
+      name: 'recovered-remote',
+      entry: 'https://remote.test/recovered.js',
+    });
+
+    await expect(getRemoteEntry({ origin, remoteInfo })).resolves.toBe(
+      container,
+    );
+
+    expect(recorder.results.map((result) => result.outcome)).toEqual([
+      'error',
+      'success',
+    ]);
+    expect(recorder.results[0]).toMatchObject({
+      errorType: 'network',
+      error: {
+        name: 'ScriptNetworkError',
+        message: expect.stringContaining('network failed'),
+      },
+    });
+  });
+
+  it('covers ESM and SystemJS remote entry completion', async () => {
+    const recorder = createResourceRecorder();
+    const origin = new ModuleFederation({
+      name: 'resource-module-types',
+      remotes: [],
+      plugins: [recorder.plugin],
+    });
+    const esmRemote = getRemoteInfo({
+      name: 'esm-remote',
+      entry: 'data:text/javascript,export%20const%20value%3D1',
+      type: 'module',
+    });
+    const systemContainer = { get: rs.fn(), init: rs.fn() };
+    const previousSystem = (globalThis as any).System;
+    (globalThis as any).System = {
+      import: rs.fn().mockResolvedValue(systemContainer),
+    };
+
+    try {
+      await expect(
+        getRemoteEntry({ origin, remoteInfo: esmRemote }),
+      ).resolves.toBeDefined();
+      await expect(
+        getRemoteEntry({
+          origin,
+          remoteInfo: getRemoteInfo({
+            name: 'system-remote',
+            entry: 'https://remote.test/system.js',
+            type: 'system',
+          }),
+        }),
+      ).resolves.toBe(systemContainer);
+    } finally {
+      (globalThis as any).System = previousSystem;
+    }
+
+    expect(recorder.results.map((result) => result.outcome)).toEqual([
+      'success',
+      'success',
+    ]);
   });
 });

--- a/packages/runtime-core/__tests__/preload-assets.spec.ts
+++ b/packages/runtime-core/__tests__/preload-assets.spec.ts
@@ -4,7 +4,9 @@ import { ModuleFederation } from '../src/core';
 import type { RemoteInfo } from '../src/type';
 import type {
   ResourceLoadContext,
+  ResourceLoadEvent,
   ResourceLoadInitiator,
+  ResourceLoadResult,
 } from '../src/type/preload';
 import type { ModuleFederationRuntimePlugin } from '../src/type/plugin';
 import { preloadAssets } from '../src/utils/preload';
@@ -19,10 +21,12 @@ type ResourceCall = {
 type ResourceCalls = {
   links: ResourceCall[];
   scripts: ResourceCall[];
+  starts: ResourceLoadEvent[];
+  results: ResourceLoadResult[];
 };
 
 function createResourceCalls(): ResourceCalls {
-  return { links: [], scripts: [] };
+  return { links: [], scripts: [], starts: [], results: [] };
 }
 
 function completeLoadWhenHandlerIsAttached(element: HTMLElement): void {
@@ -58,6 +62,12 @@ function createResourceCapturePlugin(
     beforeInit(args) {
       args.options.inBrowser = true;
       return args;
+    },
+    beforeLoadResource(args) {
+      calls.starts.push(args);
+    },
+    afterLoadResource(args) {
+      calls.results.push(args);
     },
     createLink({ url, attrs = {}, remoteInfo, resourceContext }) {
       calls.links.push({ url, attrs, remoteInfo, resourceContext });
@@ -323,6 +333,190 @@ describe('preloadAssets', () => {
         resourceType: 'js',
         url: scriptUrl,
       },
+    });
+  });
+
+  it('records successful JS and CSS completion exactly once', async () => {
+    const calls = await runPreload({
+      type: 'global',
+      cssAssets: ['https://remote.test/styles.css'],
+      jsAssetsWithoutEntry: ['https://remote.test/chunk.js'],
+    });
+
+    expect(calls.starts).toHaveLength(2);
+    expect(calls.results).toHaveLength(2);
+    expect(calls.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resourceType: 'css',
+          outcome: 'success',
+        }),
+        expect.objectContaining({
+          resourceType: 'js',
+          outcome: 'success',
+        }),
+      ]),
+    );
+    calls.results.forEach((result) => {
+      expect(result.endedAt).toBeGreaterThanOrEqual(result.startedAt);
+      expect(result.duration).toBeGreaterThanOrEqual(0);
+      expect(result).not.toHaveProperty('httpStatus');
+      expect(result).not.toHaveProperty('mimeType');
+    });
+  });
+
+  it('keeps partial preload failures visible without dropping successes', async () => {
+    const calls = createResourceCalls();
+    const host = new ModuleFederation({
+      name: 'partial-preload-host',
+      plugins: [
+        {
+          name: 'partial-preload-loader',
+          beforeInit(args) {
+            args.options.inBrowser = true;
+            return args;
+          },
+          beforeLoadResource(args) {
+            calls.starts.push(args);
+          },
+          afterLoadResource(args) {
+            calls.results.push(args);
+          },
+          createLink({ url }) {
+            const link = document.createElement('link');
+            link.href = url;
+            let onload: GlobalEventHandlers['onload'] | null = null;
+            let onerror: OnErrorEventHandler | null = null;
+            Object.defineProperties(link, {
+              onload: {
+                configurable: true,
+                get: () => onload,
+                set(handler: GlobalEventHandlers['onload'] | null) {
+                  onload = handler;
+                  if (handler && url.includes('success')) {
+                    queueMicrotask(() => handler.call(link, new Event('load')));
+                  }
+                },
+              },
+              onerror: {
+                configurable: true,
+                get: () => onerror,
+                set(handler: OnErrorEventHandler | null) {
+                  onerror = handler;
+                  if (handler && url.includes('failure')) {
+                    queueMicrotask(() =>
+                      handler.call(link, new Event('error'), '', 0, 0, null),
+                    );
+                  }
+                },
+              },
+            });
+            return link;
+          },
+        },
+      ],
+    });
+
+    const results = await preloadAssets(
+      createRemoteInfo('global'),
+      host,
+      {
+        cssAssets: [
+          'https://remote.test/success.css',
+          'https://remote.test/failure.css',
+        ],
+        jsAssetsWithoutEntry: [],
+        entryAssets: [],
+      },
+      true,
+    );
+
+    expect(results.map((result) => result.status)).toEqual([
+      'success',
+      'error',
+    ]);
+    expect(calls.results.map((result) => result.outcome)).toEqual([
+      'success',
+      'error',
+    ]);
+    expect(calls.results[1]).toMatchObject({
+      errorType: 'network',
+      error: {
+        name: 'LinkNetworkError',
+        message: expect.stringContaining('failure.css'),
+      },
+    });
+  });
+
+  it('reports an existing preload element as a browser cache reuse', async () => {
+    const url = 'https://remote.test/cached.css';
+    const existingLink = document.createElement('link');
+    existingLink.href = url;
+    existingLink.rel = 'preload';
+    document.head.appendChild(existingLink);
+
+    try {
+      const calls = await runPreload({
+        type: 'global',
+        cssAssets: [url],
+        useLinkPreload: true,
+        initiator: 'preloadRemote',
+      });
+
+      expect(calls.results).toHaveLength(1);
+      expect(calls.results[0]).toMatchObject({
+        outcome: 'cached',
+        cacheSource: 'browser',
+      });
+    } finally {
+      existingLink.remove();
+    }
+  });
+
+  it('reports preload timeout as a timeout result', async () => {
+    const calls = createResourceCalls();
+    const host = new ModuleFederation({
+      name: 'timeout-preload-host',
+      plugins: [
+        {
+          name: 'timeout-preload-loader',
+          beforeInit(args) {
+            args.options.inBrowser = true;
+            return args;
+          },
+          beforeLoadResource(args) {
+            calls.starts.push(args);
+          },
+          afterLoadResource(args) {
+            calls.results.push(args);
+          },
+          createLink({ url }) {
+            const link = document.createElement('link');
+            link.href = url;
+            return { link, timeout: 5 };
+          },
+        },
+      ],
+    });
+
+    const results = await preloadAssets(
+      createRemoteInfo('global'),
+      host,
+      {
+        cssAssets: ['https://remote.test/timeout.css'],
+        jsAssetsWithoutEntry: [],
+        entryAssets: [],
+      },
+      true,
+    );
+
+    expect(results[0]).toMatchObject({
+      status: 'timeout',
+      errorType: 'timeout',
+    });
+    expect(calls.results[0]).toMatchObject({
+      outcome: 'timeout',
+      errorType: 'timeout',
     });
   });
 });

--- a/packages/runtime-core/__tests__/resources/load/node-success.js
+++ b/packages/runtime-core/__tests__/resources/load/node-success.js
@@ -1,0 +1,6 @@
+module.exports = {
+  get() {
+    return () => Promise.resolve({ default: 'node remote' });
+  },
+  init() {},
+};

--- a/packages/runtime-core/src/core.ts
+++ b/packages/runtime-core/src/core.ts
@@ -23,6 +23,8 @@ import {
   SharedLoadContext,
   BridgeOperationContext,
   BridgeOperationResult,
+  ResourceLoadEvent,
+  ResourceLoadResult,
 } from './type';
 import { getBuilderId, registerPlugins, getRemoteEntry, error } from './utils';
 import {
@@ -117,6 +119,12 @@ export class ModuleFederation {
   remoteHandler: RemoteHandler;
   shareScopeMap: ShareScopeMap;
   loaderHook = new PluginSystem({
+    beforeLoadResource: new AsyncHook<[ResourceLoadEvent], void>(
+      'beforeLoadResource',
+    ),
+    afterLoadResource: new AsyncHook<[ResourceLoadResult], void>(
+      'afterLoadResource',
+    ),
     // FIXME: may not be suitable , not open to the public yet
     getModuleInfo: new SyncHook<
       [

--- a/packages/runtime-core/src/module/index.ts
+++ b/packages/runtime-core/src/module/index.ts
@@ -4,6 +4,7 @@ import {
   processModuleAlias,
   optionsToMFContext,
   composeRemoteRequestId,
+  emitCachedResourceLoad,
 } from '../utils';
 import { safeToString, ModuleInfo } from '@module-federation/sdk';
 import {
@@ -109,6 +110,19 @@ class Module {
 
   async getEntry(expose?: string): Promise<RemoteEntryExports> {
     if (this.remoteEntryExports) {
+      await emitCachedResourceLoad(this.host, {
+        context: {
+          initiator: 'loadRemote',
+          id: composeRemoteRequestId(this.remoteInfo.name, expose),
+          resourceType: 'remoteEntry',
+          url: this.remoteInfo.entry,
+          expose,
+        },
+        url: this.remoteInfo.entry,
+        remoteInfo: this.remoteInfo,
+        expose,
+        cacheSource: 'mf-memory',
+      });
       return this.remoteEntryExports;
     }
 
@@ -120,6 +134,7 @@ class Module {
         initiator: 'loadRemote',
         id: composeRemoteRequestId(this.remoteInfo.name, expose),
         resourceType: 'remoteEntry',
+        expose,
       },
     });
 

--- a/packages/runtime-core/src/plugins/snapshot/SnapshotHandler.ts
+++ b/packages/runtime-core/src/plugins/snapshot/SnapshotHandler.ts
@@ -14,10 +14,13 @@ import {
 } from '@module-federation/error-codes';
 import { Options, Remote, ResourceLoadInitiator } from '../../type';
 import {
+  classifyResourceLoadError,
+  emitCachedResourceLoad,
   isRemoteInfoWithEntry,
   error,
   optionsToMFContext,
   getRemoteInfo,
+  startResourceLoad,
 } from '../../utils';
 import {
   getGlobalSnapshot,
@@ -298,93 +301,169 @@ export class SnapshotHandler {
   ): Promise<Manifest> {
     const getManifest = async (): Promise<Manifest> => {
       const remoteInfo = getRemoteInfo(moduleInfo);
+      const resourceContext = {
+        initiator: resourceOptions?.initiator || ('loadRemote' as const),
+        id: resourceOptions?.id || moduleInfo.name,
+        url: manifestUrl,
+        resourceType: 'manifest' as const,
+      };
       let manifestJson: Manifest | undefined =
         this.manifestCache.get(manifestUrl);
       if (manifestJson) {
+        await emitCachedResourceLoad(this.HostInstance, {
+          context: resourceContext,
+          url: manifestUrl,
+          remoteInfo,
+          cacheSource: 'mf-memory',
+        });
         return manifestJson;
       }
+
+      const attempt = await startResourceLoad(this.HostInstance, {
+        context: resourceContext,
+        url: manifestUrl,
+        remoteInfo,
+      });
+      let responseInfo:
+        | {
+            httpStatus?: number;
+            mimeType?: string;
+            redirected?: boolean;
+          }
+        | undefined;
+      let originalError: unknown;
+      let recovered = false;
+      let httpError: Error | undefined;
+
       try {
-        let res = await this.loaderHook.lifecycle.fetch.emit(
-          manifestUrl,
-          {},
-          remoteInfo,
-          resourceOptions
-            ? {
-                ...resourceOptions,
-                url: manifestUrl,
-                resourceType: 'manifest',
-              }
-            : undefined,
-        );
-        if (!res || !(res instanceof Response)) {
-          res = await fetch(manifestUrl, {});
+        try {
+          let res = await this.loaderHook.lifecycle.fetch.emit(
+            manifestUrl,
+            {},
+            remoteInfo,
+            resourceContext,
+          );
+          if (!res || !(res instanceof Response)) {
+            res = await fetch(manifestUrl, {});
+          }
+          responseInfo = {
+            httpStatus: res.status,
+            mimeType: res.headers.get('content-type') || undefined,
+            redirected: res.redirected,
+          };
+          if (!res.ok) {
+            httpError = new Error(
+              `Manifest request failed with HTTP status ${res.status}.`,
+            );
+          }
+          manifestJson = (await res.json()) as Manifest;
+        } catch (err) {
+          originalError = err;
+          manifestJson =
+            (await this.HostInstance.remoteHandler.hooks.lifecycle.errorLoadRemote.emit(
+              {
+                id: manifestUrl,
+                error: err,
+                from: 'runtime',
+                lifecycle: 'afterResolve',
+                remote: remoteInfo,
+                origin: this.HostInstance,
+              },
+            )) as Manifest | undefined;
+
+          if (!manifestJson) {
+            delete this.manifestLoading[manifestUrl];
+            const errorType = classifyResourceLoadError(err, 'network');
+            await attempt.finish(
+              errorType === 'timeout' ? 'timeout' : 'error',
+              {
+                ...responseInfo,
+                error: err,
+                errorType,
+              },
+            );
+            error(
+              RUNTIME_003,
+              runtimeDescMap,
+              {
+                manifestUrl,
+                moduleName: moduleInfo.name,
+                hostName: this.HostInstance.options.name,
+              },
+              `${err}`,
+              optionsToMFContext(this.HostInstance.options),
+            );
+          }
+          recovered = true;
         }
-        manifestJson = (await res.json()) as Manifest;
-      } catch (err) {
-        manifestJson =
-          (await this.HostInstance.remoteHandler.hooks.lifecycle.errorLoadRemote.emit(
+
+        const missingRequiredFields = [
+          !manifestJson.metaData && 'metaData',
+          !manifestJson.exposes && 'exposes',
+          !manifestJson.shared && 'shared',
+        ].filter(Boolean);
+        if (missingRequiredFields.length > 0) {
+          const contentError = new Error(
+            `"${manifestUrl}" is not a valid federation manifest for remote "${moduleInfo.name}". Missing required fields: ${missingRequiredFields.join(', ')}.`,
+          );
+          await this.HostInstance.remoteHandler.hooks.lifecycle.errorLoadRemote.emit(
             {
               id: manifestUrl,
-              error: err,
+              error: contentError,
               from: 'runtime',
               lifecycle: 'afterResolve',
               remote: remoteInfo,
               origin: this.HostInstance,
             },
-          )) as Manifest | undefined;
+          );
+          await attempt.finish('error', {
+            ...responseInfo,
+            error: contentError,
+            errorType: 'content',
+          });
+        }
 
-        if (!manifestJson) {
-          delete this.manifestLoading[manifestUrl];
+        if (missingRequiredFields.length > 0) {
           error(
-            RUNTIME_003,
+            RUNTIME_013,
             runtimeDescMap,
             {
               manifestUrl,
               moduleName: moduleInfo.name,
               hostName: this.HostInstance.options.name,
+              missingFields: missingRequiredFields.join(','),
             },
-            `${err}`,
+            undefined,
             optionsToMFContext(this.HostInstance.options),
           );
         }
+        this.manifestCache.set(manifestUrl, manifestJson);
+        if (httpError) {
+          await attempt.finish('error', {
+            ...responseInfo,
+            error: httpError,
+            errorType: 'http',
+          });
+        } else {
+          await attempt.finish(recovered ? 'recovered' : 'success', {
+            ...responseInfo,
+            error: recovered ? originalError : undefined,
+            errorType: recovered
+              ? classifyResourceLoadError(originalError, 'network')
+              : undefined,
+          });
+        }
+        return manifestJson;
+      } catch (manifestError) {
+        delete this.manifestLoading[manifestUrl];
+        const errorType = classifyResourceLoadError(manifestError, 'content');
+        await attempt.finish(errorType === 'timeout' ? 'timeout' : 'error', {
+          ...responseInfo,
+          error: manifestError,
+          errorType,
+        });
+        throw manifestError;
       }
-
-      const missingRequiredFields = [
-        !manifestJson.metaData && 'metaData',
-        !manifestJson.exposes && 'exposes',
-        !manifestJson.shared && 'shared',
-      ].filter(Boolean);
-      if (missingRequiredFields.length > 0) {
-        await this.HostInstance.remoteHandler.hooks.lifecycle.errorLoadRemote.emit(
-          {
-            id: manifestUrl,
-            error: new Error(
-              `"${manifestUrl}" is not a valid federation manifest for remote "${moduleInfo.name}". Missing required fields: ${missingRequiredFields.join(', ')}.`,
-            ),
-            from: 'runtime',
-            lifecycle: 'afterResolve',
-            remote: remoteInfo,
-            origin: this.HostInstance,
-          },
-        );
-      }
-
-      if (missingRequiredFields.length > 0) {
-        error(
-          RUNTIME_013,
-          runtimeDescMap,
-          {
-            manifestUrl,
-            moduleName: moduleInfo.name,
-            hostName: this.HostInstance.options.name,
-            missingFields: missingRequiredFields.join(','),
-          },
-          undefined,
-          optionsToMFContext(this.HostInstance.options),
-        );
-      }
-      this.manifestCache.set(manifestUrl, manifestJson);
-      return manifestJson;
     };
 
     return getManifest();
@@ -422,9 +501,24 @@ export class SnapshotHandler {
       return remoteSnapshotRes;
     };
 
-    if (!this.manifestLoading[manifestUrl]) {
-      this.manifestLoading[manifestUrl] = asyncLoadProcess().then((res) => res);
+    const existingLoading = this.manifestLoading[manifestUrl];
+    if (existingLoading) {
+      const remoteSnapshot = await existingLoading;
+      await emitCachedResourceLoad(this.HostInstance, {
+        context: {
+          initiator: resourceOptions?.initiator || 'loadRemote',
+          id: resourceOptions?.id || moduleInfo.name,
+          resourceType: 'manifest',
+          url: manifestUrl,
+        },
+        url: manifestUrl,
+        remoteInfo: getRemoteInfo(moduleInfo),
+        cacheSource: 'mf-memory',
+      });
+      return remoteSnapshot;
     }
+
+    this.manifestLoading[manifestUrl] = asyncLoadProcess().then((res) => res);
     return this.manifestLoading[manifestUrl];
   }
 }

--- a/packages/runtime-core/src/type/preload.ts
+++ b/packages/runtime-core/src/type/preload.ts
@@ -27,9 +27,65 @@ export interface ResourceLoadContext {
   id: string;
   resourceType: ResourceLoadType;
   url?: string;
+  expose?: string;
 }
 
-export type PreloadAssetStatus = 'success' | 'error' | 'timeout' | 'cached';
+export type ResourceLoadOutcome =
+  | 'success'
+  | 'error'
+  | 'timeout'
+  | 'cached'
+  | 'recovered';
+
+export type ResourceLoadCacheSource =
+  | 'network'
+  | 'browser'
+  | 'service-worker'
+  | 'mf-memory'
+  | 'unknown';
+
+export type ResourceLoadErrorType =
+  | 'network'
+  | 'http'
+  | 'content'
+  | 'execution'
+  | 'initialization'
+  | 'timeout'
+  | 'unknown';
+
+export interface ResourceLoadRemote {
+  name: string;
+  alias?: string;
+  version?: string;
+  buildVersion?: string;
+  type?: string;
+  entryGlobalName?: string;
+}
+
+export interface ResourceLoadErrorSummary {
+  name?: string;
+  message: string;
+}
+
+export interface ResourceLoadEvent extends ResourceLoadContext {
+  url: string;
+  remote?: ResourceLoadRemote;
+  startedAt: number;
+}
+
+export interface ResourceLoadResult extends ResourceLoadEvent {
+  endedAt: number;
+  duration: number;
+  outcome: ResourceLoadOutcome;
+  httpStatus?: number;
+  mimeType?: string;
+  redirected?: boolean;
+  cacheSource?: ResourceLoadCacheSource;
+  errorType?: ResourceLoadErrorType;
+  error?: ResourceLoadErrorSummary;
+}
+
+export type PreloadAssetStatus = ResourceLoadOutcome;
 
 export interface PreloadAssetResult {
   url: string;
@@ -37,6 +93,11 @@ export interface PreloadAssetResult {
   resourceType: ResourceLoadType;
   initiator: ResourceLoadInitiator;
   id: string;
+  startedAt?: number;
+  endedAt?: number;
+  duration?: number;
+  cacheSource?: ResourceLoadCacheSource;
+  errorType?: ResourceLoadErrorType;
   error?: unknown;
 }
 

--- a/packages/runtime-core/src/utils/index.ts
+++ b/packages/runtime-core/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './env';
 export * from './tool';
 export * from './manifest';
+export * from './resource';
 export * from './logger';
 export * from './plugin';
 export * from './load';

--- a/packages/runtime-core/src/utils/load.ts
+++ b/packages/runtime-core/src/utils/load.ts
@@ -19,6 +19,11 @@ import {
   RUNTIME_008,
   runtimeDescMap,
 } from '@module-federation/error-codes';
+import {
+  classifyResourceLoadError,
+  emitCachedResourceLoad,
+  startResourceLoad,
+} from './resource';
 
 // Declare the ENV_TARGET constant that will be defined by DefinePlugin
 declare const ENV_TARGET: 'web' | 'node';
@@ -301,41 +306,101 @@ export async function getRemoteEntry(params: {
     _inErrorHandling = false,
   } = params;
   const uniqueKey = getRemoteEntryUniqueKey(remoteInfo);
+  const effectiveResourceContext: ResourceLoadContext = resourceContext || {
+    initiator: 'loadRemote',
+    id: remoteInfo.name,
+    resourceType: 'remoteEntry',
+    url: remoteInfo.entry,
+  };
   if (remoteEntryExports) {
+    await emitCachedResourceLoad(origin, {
+      context: effectiveResourceContext,
+      url: remoteInfo.entry,
+      remoteInfo,
+      cacheSource: 'mf-memory',
+    });
     return remoteEntryExports;
+  }
+
+  const existingLoading = globalLoading[uniqueKey];
+  if (existingLoading) {
+    const result = await existingLoading;
+    if (result) {
+      await emitCachedResourceLoad(origin, {
+        context: effectiveResourceContext,
+        url: remoteInfo.entry,
+        remoteInfo,
+        cacheSource: 'mf-memory',
+      });
+    }
+    return result;
   }
 
   if (!globalLoading[uniqueKey]) {
     const loadEntryHook = origin.remoteHandler.hooks.lifecycle.loadEntry;
     const loaderHook = origin.loaderHook;
-
-    globalLoading[uniqueKey] = loadEntryHook
-      .emit({
-        origin,
-        loaderHook,
+    const loadResource = async () => {
+      const attempt = await startResourceLoad(origin, {
+        context: effectiveResourceContext,
+        url: remoteInfo.entry,
         remoteInfo,
-        remoteEntryExports,
-      })
-      .then((res) => {
-        if (res) {
-          return res;
-        }
-        // Use ENV_TARGET if defined, otherwise fallback to isBrowserEnvValue
-        const isWebEnvironment =
-          typeof ENV_TARGET !== 'undefined'
-            ? ENV_TARGET === 'web'
-            : isBrowserEnvValue;
+      });
 
-        return isWebEnvironment
-          ? loadEntryDom({
-              remoteInfo,
-              remoteEntryExports,
-              loaderHook,
-              getEntryUrl,
-              resourceContext,
-            })
-          : loadEntryNode({ remoteInfo, loaderHook, resourceContext });
-      })
+      try {
+        let res = await loadEntryHook.emit({
+          origin,
+          loaderHook,
+          remoteInfo,
+          remoteEntryExports,
+        });
+        let cached = false;
+        if (!res) {
+          const existingRemoteEntryExports = getRemoteEntryExports(
+            remoteInfo.name,
+            remoteInfo.entryGlobalName,
+          ).entryExports;
+          if (existingRemoteEntryExports) {
+            res = existingRemoteEntryExports;
+            cached = true;
+          }
+        }
+        if (!res) {
+          // Use ENV_TARGET if defined, otherwise fallback to isBrowserEnvValue
+          const isWebEnvironment =
+            typeof ENV_TARGET !== 'undefined'
+              ? ENV_TARGET === 'web'
+              : (origin.options.inBrowser ?? isBrowserEnvValue);
+
+          res = isWebEnvironment
+            ? await loadEntryDom({
+                remoteInfo,
+                remoteEntryExports,
+                loaderHook,
+                getEntryUrl,
+                resourceContext: effectiveResourceContext,
+              })
+            : await loadEntryNode({
+                remoteInfo,
+                loaderHook,
+                resourceContext: effectiveResourceContext,
+              });
+        }
+
+        await attempt.finish(cached ? 'cached' : 'success', {
+          cacheSource: cached ? 'mf-memory' : undefined,
+        });
+        return res;
+      } catch (loadError) {
+        const errorType = classifyResourceLoadError(loadError, 'execution');
+        await attempt.finish(errorType === 'timeout' ? 'timeout' : 'error', {
+          error: loadError,
+          errorType,
+        });
+        throw loadError;
+      }
+    };
+
+    globalLoading[uniqueKey] = loadResource()
       .then(async (res) => {
         await origin.loaderHook.lifecycle.afterLoadEntry.emit({
           origin,

--- a/packages/runtime-core/src/utils/preload.ts
+++ b/packages/runtime-core/src/utils/preload.ts
@@ -8,6 +8,8 @@ import {
   Remote,
   RemoteInfo,
   ResourceLoadContext,
+  ResourceLoadOutcome,
+  ResourceLoadResult,
   ResourceLoadType,
   depsPreloadArg,
 } from '../type';
@@ -15,6 +17,11 @@ import { matchRemote } from './manifest';
 import { assert } from './logger';
 import { ModuleFederation } from '../core';
 import { getRemoteEntry, isEsmRemoteType } from './load';
+import {
+  classifyResourceLoadError,
+  emitCachedResourceLoad,
+  startResourceLoad,
+} from './resource';
 
 export function defaultPreloadArgs(
   preloadConfig: PreloadRemoteArgs | depsPreloadArg,
@@ -78,6 +85,7 @@ function createAssetResult(
   url: string,
   status: PreloadAssetResult['status'],
   error?: unknown,
+  resourceResult?: ResourceLoadResult,
 ): PreloadAssetResult {
   return {
     url,
@@ -85,7 +93,12 @@ function createAssetResult(
     resourceType: context.resourceType,
     initiator: context.initiator,
     id: context.id,
-    error,
+    startedAt: resourceResult?.startedAt,
+    endedAt: resourceResult?.endedAt,
+    duration: resourceResult?.duration,
+    cacheSource: resourceResult?.cacheSource,
+    errorType: resourceResult?.errorType,
+    error: resourceResult?.error || error,
   };
 }
 
@@ -98,7 +111,16 @@ async function waitForRemoteEntryPreload(
   const cachedRemote = host.moduleCache.get(entryRemoteInfo.name);
   const url = entryRemoteInfo.entry;
   if (cachedRemote?.remoteEntryExports) {
-    return createAssetResult(context, url, 'cached');
+    const resourceResult = await emitCachedResourceLoad(host, {
+      context: {
+        ...context,
+        url,
+      },
+      url,
+      remoteInfo: entryRemoteInfo,
+      cacheSource: 'mf-memory',
+    });
+    return createAssetResult(context, url, 'cached', undefined, resourceResult);
   }
 
   try {
@@ -140,45 +162,71 @@ function waitForLinkPreload({
   context: ResourceLoadContext;
   needDeleteLink?: boolean;
 }): Promise<PreloadAssetResult> {
-  return new Promise((resolve) => {
-    const { link, needAttach } = createLink({
+  return startResourceLoad(host, {
+    context: {
+      ...context,
       url,
-      cb: () => {
-        resolve(
-          createAssetResult(context, url, needAttach ? 'success' : 'cached'),
-        );
-      },
-      onErrorCallback: (error) => {
-        resolve(
-          createAssetResult(
-            context,
-            url,
-            isTimeoutError(error) ? 'timeout' : 'error',
-            error,
-          ),
-        );
-      },
-      attrs,
-      createLinkHook: (hookUrl, hookAttrs) => {
-        const res = host.loaderHook.lifecycle.createLink.emit({
-          url: hookUrl,
-          attrs: hookAttrs,
-          remoteInfo,
-          resourceContext: {
-            ...context,
-            url: hookUrl,
+    },
+    url,
+    remoteInfo,
+  }).then(
+    (attempt) =>
+      new Promise((resolve) => {
+        let needAttach = true;
+        const settle = (outcome: ResourceLoadOutcome, error?: unknown) => {
+          const errorType = error
+            ? classifyResourceLoadError(error, 'network')
+            : undefined;
+          void attempt
+            .finish(outcome, {
+              cacheSource: outcome === 'cached' ? 'browser' : undefined,
+              error,
+              errorType,
+            })
+            .then((resourceResult) => {
+              resolve(
+                createAssetResult(
+                  context,
+                  url,
+                  resourceResult.outcome,
+                  resourceResult.error,
+                  resourceResult,
+                ),
+              );
+            });
+        };
+        const createdLink = createLink({
+          url,
+          cb: () => {
+            settle(needAttach ? 'success' : 'cached');
           },
+          onErrorCallback: (error) => {
+            settle(isTimeoutError(error) ? 'timeout' : 'error', error);
+          },
+          attrs,
+          createLinkHook: (hookUrl, hookAttrs) => {
+            const res = host.loaderHook.lifecycle.createLink.emit({
+              url: hookUrl,
+              attrs: hookAttrs,
+              remoteInfo,
+              resourceContext: {
+                ...context,
+                url: hookUrl,
+              },
+            });
+            if (res instanceof HTMLLinkElement) {
+              return res;
+            }
+            return res;
+          },
+          needDeleteLink,
         });
-        if (res instanceof HTMLLinkElement) {
-          return res;
-        }
-        return res;
-      },
-      needDeleteLink,
-    });
+        const { link } = createdLink;
+        needAttach = createdLink.needAttach;
 
-    needAttach && document.head.appendChild(link);
-  });
+        needAttach && document.head.appendChild(link);
+      }),
+  );
 }
 
 function waitForScriptPreload({
@@ -194,45 +242,74 @@ function waitForScriptPreload({
   attrs: Record<string, string>;
   context: ResourceLoadContext;
 }): Promise<PreloadAssetResult> {
-  return new Promise((resolve) => {
-    const { script, needAttach } = createScript({
+  return startResourceLoad(host, {
+    context: {
+      ...context,
       url,
-      cb: () => {
-        resolve(
-          createAssetResult(context, url, needAttach ? 'success' : 'cached'),
-        );
-      },
-      onErrorCallback: (error) => {
-        resolve(
-          createAssetResult(
-            context,
-            url,
-            isTimeoutError(error) ? 'timeout' : 'error',
-            error,
-          ),
-        );
-      },
-      attrs,
-      createScriptHook: (hookUrl: string, hookAttrs: any) => {
-        const res = host.loaderHook.lifecycle.createScript.emit({
-          url: hookUrl,
-          attrs: hookAttrs,
-          remoteInfo,
-          resourceContext: {
-            ...context,
-            url: hookUrl,
+    },
+    url,
+    remoteInfo,
+  }).then(
+    (attempt) =>
+      new Promise((resolve) => {
+        let needAttach = true;
+        const settle = (outcome: ResourceLoadOutcome, error?: unknown) => {
+          const errorType = error
+            ? classifyResourceLoadError(error, 'network')
+            : undefined;
+          void attempt
+            .finish(outcome, {
+              cacheSource: outcome === 'cached' ? 'browser' : undefined,
+              error,
+              errorType,
+            })
+            .then((resourceResult) => {
+              resolve(
+                createAssetResult(
+                  context,
+                  url,
+                  resourceResult.outcome,
+                  resourceResult.error,
+                  resourceResult,
+                ),
+              );
+            });
+        };
+        const createdScript = createScript({
+          url,
+          cb: () => {
+            settle(needAttach ? 'success' : 'cached');
           },
+          onErrorCallback: (error) => {
+            settle(isTimeoutError(error) ? 'timeout' : 'error', error);
+          },
+          attrs,
+          createScriptHook: (hookUrl: string, hookAttrs: any) => {
+            const res = host.loaderHook.lifecycle.createScript.emit({
+              url: hookUrl,
+              attrs: hookAttrs,
+              remoteInfo,
+              resourceContext: {
+                ...context,
+                url: hookUrl,
+              },
+            });
+            if (res instanceof HTMLScriptElement) {
+              return res;
+            }
+            return res;
+          },
+          needDeleteScript: true,
         });
-        if (res instanceof HTMLScriptElement) {
-          return res;
-        }
-        return res;
-      },
-      needDeleteScript: true,
-    });
+        const { script } = createdScript;
+        needAttach = createdScript.needAttach;
 
-    needAttach && document.head.appendChild(script);
-  });
+        needAttach && document.head.appendChild(script);
+        if (!needAttach) {
+          queueMicrotask(() => settle('cached'));
+        }
+      }),
+  );
 }
 
 function createResourceContext(

--- a/packages/runtime-core/src/utils/resource.ts
+++ b/packages/runtime-core/src/utils/resource.ts
@@ -1,0 +1,189 @@
+import type { ModuleFederation } from '../core';
+import type {
+  RemoteInfo,
+  ResourceLoadCacheSource,
+  ResourceLoadContext,
+  ResourceLoadErrorSummary,
+  ResourceLoadErrorType,
+  ResourceLoadEvent,
+  ResourceLoadOutcome,
+  ResourceLoadRemote,
+  ResourceLoadResult,
+} from '../type';
+
+const RESOURCE_ERROR_URL_PATTERN = /https?:\/\/[^\s'"<>]+/g;
+const RESOURCE_ERROR_SENSITIVE_PATTERN =
+  /\b(token|authorization|cookie|secret|password|session|access_token|refresh_token|api_key|apikey|key)\s*[:=]\s*([^&\s'",;<>]+)/gi;
+const RESOURCE_ERROR_ABSOLUTE_PATH_PATTERN =
+  /(?:file:\/\/)?(?:\/(?:Users|private|var|tmp|home|workspace|opt|usr)\/[^\s)]+|[A-Za-z]:\\[^\s)]+)/g;
+
+function sanitizeResourceErrorText(value: unknown, maxLength = 800): string {
+  const sanitized = String(value)
+    .replace(RESOURCE_ERROR_URL_PATTERN, (rawUrl) => {
+      try {
+        const url = new URL(rawUrl);
+        url.search = '';
+        url.hash = '';
+        return url.toString();
+      } catch {
+        return '[redacted-url]';
+      }
+    })
+    .replace(RESOURCE_ERROR_SENSITIVE_PATTERN, '[redacted]')
+    .replace(RESOURCE_ERROR_ABSOLUTE_PATH_PATTERN, '[redacted-path]');
+
+  return sanitized.length > maxLength
+    ? `${sanitized.slice(0, maxLength)}...`
+    : sanitized;
+}
+
+function createResourceLoadErrorSummary(
+  error: unknown,
+): ResourceLoadErrorSummary | undefined {
+  if (error === undefined || error === null) {
+    return undefined;
+  }
+
+  if (error instanceof Error) {
+    return {
+      name: sanitizeResourceErrorText(error.name, 120),
+      message: sanitizeResourceErrorText(error.message),
+    };
+  }
+
+  return {
+    message: sanitizeResourceErrorText(error),
+  };
+}
+
+function getResourceLoadRemote(
+  remoteInfo?: RemoteInfo,
+): ResourceLoadRemote | undefined {
+  if (!remoteInfo) {
+    return undefined;
+  }
+
+  return {
+    name: remoteInfo.name,
+    alias: remoteInfo.alias,
+    version: remoteInfo.version,
+    buildVersion: remoteInfo.buildVersion,
+    type: remoteInfo.type,
+    entryGlobalName: remoteInfo.entryGlobalName,
+  };
+}
+
+export interface ResourceLoadAttempt {
+  event: ResourceLoadEvent;
+  finish(
+    outcome: ResourceLoadOutcome,
+    details?: {
+      httpStatus?: number;
+      mimeType?: string;
+      redirected?: boolean;
+      cacheSource?: ResourceLoadCacheSource;
+      errorType?: ResourceLoadErrorType;
+      error?: unknown;
+    },
+  ): Promise<ResourceLoadResult>;
+}
+
+export function classifyResourceLoadError(
+  error: unknown,
+  fallback: ResourceLoadErrorType = 'unknown',
+): ResourceLoadErrorType {
+  if (!(error instanceof Error)) {
+    return fallback;
+  }
+
+  const value = `${error.name} ${error.message}`.toLowerCase();
+  if (value.includes('timeout') || value.includes('timed out')) {
+    return 'timeout';
+  }
+  if (
+    value.includes('scriptexecutionerror') ||
+    value.includes('execution error')
+  ) {
+    return 'execution';
+  }
+  if (
+    value.includes('network') ||
+    value.includes('failed to fetch') ||
+    value.includes('cors') ||
+    value.includes('unreachable') ||
+    value.includes('enoent')
+  ) {
+    return 'network';
+  }
+  if (value.includes('runtime-001') || value.includes('global not found')) {
+    return 'initialization';
+  }
+  if (
+    error instanceof SyntaxError ||
+    value.includes('json') ||
+    value.includes('valid federation manifest')
+  ) {
+    return 'content';
+  }
+
+  return fallback;
+}
+
+export async function startResourceLoad(
+  origin: ModuleFederation,
+  options: {
+    context: ResourceLoadContext;
+    url: string;
+    remoteInfo?: RemoteInfo;
+    expose?: string;
+  },
+): Promise<ResourceLoadAttempt> {
+  const event: ResourceLoadEvent = {
+    ...options.context,
+    url: options.url,
+    remote: getResourceLoadRemote(options.remoteInfo),
+    expose: options.expose || options.context.expose,
+    startedAt: Date.now(),
+  };
+  await origin.loaderHook.lifecycle.beforeLoadResource.emit(event);
+
+  let result: ResourceLoadResult | undefined;
+  return {
+    event,
+    async finish(outcome, details = {}) {
+      if (result) {
+        return result;
+      }
+
+      const endedAt = Date.now();
+      const { error, ...safeDetails } = details;
+      const errorSummary = createResourceLoadErrorSummary(error);
+      result = {
+        ...event,
+        ...safeDetails,
+        ...(errorSummary ? { error: errorSummary } : {}),
+        endedAt,
+        duration: Math.max(0, endedAt - event.startedAt),
+        outcome,
+      };
+      await origin.loaderHook.lifecycle.afterLoadResource.emit(result);
+      return result;
+    },
+  };
+}
+
+export async function emitCachedResourceLoad(
+  origin: ModuleFederation,
+  options: {
+    context: ResourceLoadContext;
+    url: string;
+    remoteInfo?: RemoteInfo;
+    expose?: string;
+    cacheSource: ResourceLoadCacheSource;
+  },
+): Promise<ResourceLoadResult> {
+  const attempt = await startResourceLoad(origin, options);
+  return attempt.finish('cached', {
+    cacheSource: options.cacheSource,
+  });
+}


### PR DESCRIPTION

## What changed

- Add reliable resource lifecycle reporting for manifests, remote entries, preload JavaScript, preload CSS, and Node remote entries.
- Record real outcomes for success, failure, timeout, cache reuse, and recovery.
- Preserve available response status, content type, redirects, timing, and safe error details without guessing unavailable information.
- Prevent concurrent loads from being reported as duplicate network requests.
- Add resource events to the existing Observability remote timeline with correct `instanceRef` attribution.
- Keep late-injection and older-runtime reports marked as partial when complete history is unavailable.
- Add a patch changeset for Runtime Core and Observability Plugin.

## Why

The existing reports could show that a load started, but could not always prove whether the underlying manifest, remote entry, or preload resource actually completed. This change provides trustworthy completion results while preserving existing loading behavior.

## Impact

Remote diagnostics can now distinguish network failures, invalid content, execution failures, initialization failures, timeouts, cache reuse, and successful recovery.

Reports remain safe: URLs and errors are sanitized, and response objects, page elements, remote exports, containers, factories, headers, cookies, and tokens are not exposed.

## Validation

- `pnpm --filter @module-federation/runtime-core test` — 117 tests passed.
- `pnpm --filter @module-federation/runtime-core build` — passed.
- `pnpm --filter @module-federation/observability-plugin test` — 99 tests passed.
- `pnpm --filter @module-federation/observability-plugin build` — passed.
- `pnpm run ci:local --only=build-and-test` — 43 package builds and 76 tasks passed.
- Targeted lint for Runtime Core and Observability Plugin — passed.
- Formatting for all changed files — passed.
- Changeset parsing and release-plan validation — passed.

## Skipped or unrelated checks

Metro, application E2E, DevTools, bundle-size, and GitHub-only checks were not run because their corresponding areas were not changed.

The repository-wide formatting check still reports an existing issue in `packages/playground/src/generated/bridgeRuntimeFiles.ts`. This file is unrelated to the change and was left untouched.