### PR TITLE
feat(rspress): support remote code block transforms

### DIFF
--- a/.changeset/transform-rspress-code-blocks.md
+++ b/.changeset/transform-rspress-code-blocks.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/rspress-plugin": patch
+---
+
+Allow consumers to replace fenced code block content in exposed Rspress documents.

--- a/packages/rspress-plugin/README.md
+++ b/packages/rspress-plugin/README.md
@@ -1,33 +1,50 @@
-# @examples/mf-react-component
+# @module-federation/rspress-plugin
 
-This example demonstrates how to use Rslib to build a simple Module Federation React component.
+Module Federation integration for Rspress.
 
-### Command
+## Transform remote code blocks
 
-Build package
+Enable the capability on the Rspress producer:
 
-```
-nx build rslib-module
-```
-
-Serve package
-
-```
-nx serve rslib-module
+```ts
+pluginModuleFederation(mfConfig, {
+  transformCodeBlocks: true,
+});
 ```
 
-Dev package
+The producer keeps authoring regular Markdown. It does not need to add an id or
+create a code-block component:
 
-1.
+````md
+## View all commands
 
+```bash
+npx mf -h
 ```
-nx dev rslib-module
+````
+
+The consumer creates a transformer with the browser-safe runtime entry and
+passes it to the remote MDX document:
+
+```tsx
+import Cli from 'mf-doc/cli-en';
+import { transformCodeBlock } from '@module-federation/rspress-plugin/runtime';
+
+export const replaceCliName = transformCodeBlock({
+  replace: [[/\bmf\b/g, 'vmok']],
+  filter: ({ lang }) => lang === 'bash' || lang === 'text',
+});
+
+export default function Page() {
+  return <Cli name="Vmok" cmd="vmok" transformCodeBlock={replaceCliName} />;
+}
 ```
 
-2.
+Replacement rules run in order. Without `filter`, they are considered for every
+fenced code block in the remote document; blocks with no matching content keep
+their original highlighting. A transformer can also return a different
+language when the replacement changes the code type.
 
-```
-nx storybook rslib-module
-```
-
-visit http://localhost:6006
+The transformation runs while rendering the remote MDX document, so the same
+result is used by browser rendering and SSG. Existing HTML-based llms/Markdown
+rebuilds also read the transformed output.

--- a/packages/rspress-plugin/package.json
+++ b/packages/rspress-plugin/package.json
@@ -25,6 +25,10 @@
     ".": {
       "types": "./dist/plugin.d.ts",
       "import": "./dist/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/runtime/index.d.ts",
+      "import": "./dist/runtime.js"
     }
   },
   "module": "./dist/index.js",
@@ -33,17 +37,24 @@
     "build": "rslib build",
     "build:watch": "rslib build --watch",
     "dev": "pnpm run build:watch",
+    "test": "rstest",
     "pre-release": "pnpm exec turbo run build --filter=@module-federation/webpack-bundler-runtime"
   },
   "devDependencies": {
+    "@mdx-js/mdx": "^3.1.1",
     "@rslib/core": "^0.23.2",
     "@rspress/core": "2.0.14",
+    "@rstest/core": "^0.10.6",
     "@types/html-to-text": "^9.0.4",
     "@types/lodash-es": "^4.17.12",
     "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.1",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
     "typescript": "7.0.2"
   },
   "dependencies": {
+    "@mdx-js/react": "^3.1.1",
     "cheerio": "1.0.0-rc.12",
     "@module-federation/sdk": "workspace:*",
     "html-to-text": "9.0.5",
@@ -54,6 +65,7 @@
     "@rspress/shared": "2.0.14"
   },
   "peerDependencies": {
-    "@rspress/core": "2.0.14"
+    "@rspress/core": "2.0.14",
+    "react": ">=18.0.0"
   }
 }

--- a/packages/rspress-plugin/rslib.config.ts
+++ b/packages/rspress-plugin/rslib.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
   source: {
     entry: {
       index: 'src/plugin.ts',
+      runtime: 'src/runtime/index.tsx',
     },
+    tsconfigPath: './tsconfig.lib.json',
   },
   lib: [
     {

--- a/packages/rspress-plugin/rstest.config.ts
+++ b/packages/rspress-plugin/rstest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  testEnvironment: 'node',
+});

--- a/packages/rspress-plugin/src/plugin.ts
+++ b/packages/rspress-plugin/src/plugin.ts
@@ -8,11 +8,19 @@ import type { moduleFederationPlugin } from '@module-federation/sdk';
 import type { RspressPlugin, RouteMeta } from '@rspress/core';
 import { rebuildLlmsByHtml } from './rebuildLlmsByHtml';
 import { rebuildSearchIndexByHtml } from './rebuildSearchIndexByHtml';
+import { remarkCodeBlockTransform } from './remarkCodeBlockTransform';
 
-type RspressPluginOptions = {
+export type RspressPluginOptions = {
   autoShared?: boolean;
   rebuildSearchIndex?: boolean;
   rebuildLlms?: boolean;
+  /**
+   * Allow exposed MDX documents to transform fenced code blocks through a
+   * `transformCodeBlock` prop.
+   *
+   * @default false
+   */
+  transformCodeBlocks?: boolean;
 };
 
 const isDev = () => process.env.NODE_ENV === 'development';
@@ -25,6 +33,7 @@ export function pluginModuleFederation(
     autoShared = true,
     rebuildSearchIndex = true,
     rebuildLlms = true,
+    transformCodeBlocks = false,
   } = rspressOptions || {};
 
   if (autoShared) {
@@ -66,6 +75,11 @@ export function pluginModuleFederation(
 
   return {
     name: 'plugin-module-federation',
+    markdown: transformCodeBlocks
+      ? {
+          remarkPlugins: [remarkCodeBlockTransform],
+        }
+      : undefined,
     async config(config) {
       if (!isDev() && config.ssg !== false) {
         enableSSG = true;

--- a/packages/rspress-plugin/src/remarkCodeBlockTransform.test.ts
+++ b/packages/rspress-plugin/src/remarkCodeBlockTransform.test.ts
@@ -1,0 +1,85 @@
+import { compile } from '@mdx-js/mdx';
+import { compile as compileRspressMdx } from '@rspress/core/dist/node/mdx/processor.js';
+import type { PluginDriver } from '@rspress/core/dist/node/PluginDriver.js';
+import { describe, expect, it } from '@rstest/core';
+import path from 'node:path';
+import { pluginModuleFederation } from './plugin';
+import {
+  codeBlockTransformRuntimeModule,
+  remarkCodeBlockTransform,
+} from './remarkCodeBlockTransform';
+
+describe('remarkCodeBlockTransform', () => {
+  it('injects the runtime as the implicit MDX layout', async () => {
+    const output = String(
+      await compile('# Title\n\n```bash\nnpx mf -h\n```', {
+        providerImportSource: '@mdx-js/react',
+        remarkPlugins: [remarkCodeBlockTransform],
+      }),
+    );
+
+    expect(output).toContain(
+      `import MDXLayout from "${codeBlockTransformRuntimeModule}";`,
+    );
+    expect(output).toContain('_jsx(MDXLayout');
+    expect(output).toContain('...props');
+  });
+
+  it('preserves an explicit user layout', async () => {
+    const source = [
+      'export default function CustomLayout({ children }) {',
+      '  return <section>{children}</section>;',
+      '}',
+      '',
+      '# Title',
+    ].join('\n');
+    const output = String(
+      await compile(source, {
+        providerImportSource: '@mdx-js/react',
+        remarkPlugins: [remarkCodeBlockTransform],
+      }),
+    );
+
+    expect(output).toContain('function CustomLayout');
+    expect(output).not.toContain(codeBlockTransformRuntimeModule);
+  });
+
+  it('works in the real Rspress Markdown pipeline', async () => {
+    const plugin = pluginModuleFederation(
+      { name: 'rspress-code-block-test' },
+      { transformCodeBlocks: true },
+    );
+    const docDirectory = process.cwd();
+    const filepath = path.join(docDirectory, 'code-block-test.mdx');
+    const pluginDriver = {
+      getPlugins: () => [plugin],
+    } as PluginDriver;
+
+    const output = await compileRspressMdx({
+      source: [
+        '# Commands',
+        '',
+        'Other content.',
+        '',
+        '```bash title=cli wrapCode lineNumbers',
+        'npx mf -h',
+        '```',
+      ].join('\n'),
+      filepath,
+      docDirectory,
+      config: { markdown: {} },
+      routeService: null,
+      pluginDriver,
+    });
+
+    expect(output).toContain(
+      `import MDXLayout from "${codeBlockTransformRuntimeModule}";`,
+    );
+    expect(output).toContain('className: "shiki css-variables"');
+    expect(output).toContain('lang: "bash"');
+    expect(output).toContain('title: "cli"');
+    expect(output).toContain('lineNumbers: true');
+    expect(output).toContain('wrapCode: true');
+    expect(output).toContain('"Other content."');
+  });
+});

--- a/packages/rspress-plugin/src/remarkCodeBlockTransform.ts
+++ b/packages/rspress-plugin/src/remarkCodeBlockTransform.ts
@@ -1,0 +1,111 @@
+const RUNTIME_MODULE = '@module-federation/rspress-plugin/runtime';
+
+type EstreeNode = {
+  type: string;
+  [key: string]: unknown;
+};
+
+type EstreeProgram = {
+  type: 'Program';
+  sourceType: 'module';
+  body: EstreeNode[];
+};
+
+type MdxNode = {
+  type: string;
+  data?: {
+    estree?: EstreeProgram;
+  };
+};
+
+type MdxRoot = {
+  children: MdxNode[];
+};
+
+function hasDefaultExport(tree: MdxRoot): boolean {
+  return tree.children.some((node) =>
+    node.data?.estree?.body?.some((statement) => {
+      if (statement.type === 'ExportDefaultDeclaration') {
+        return true;
+      }
+      if (statement.type !== 'ExportNamedDeclaration') {
+        return false;
+      }
+      const specifiers = statement.specifiers;
+      return (
+        Array.isArray(specifiers) &&
+        specifiers.some((specifier) => {
+          if (
+            typeof specifier !== 'object' ||
+            specifier === null ||
+            !('exported' in specifier)
+          ) {
+            return false;
+          }
+          const exported = specifier.exported;
+          return (
+            typeof exported === 'object' &&
+            exported !== null &&
+            'name' in exported &&
+            exported.name === 'default'
+          );
+        })
+      );
+    }),
+  );
+}
+
+function createLayoutExportNode(): MdxNode {
+  const rawSource = JSON.stringify(RUNTIME_MODULE);
+  return {
+    type: 'mdxjsEsm',
+    data: {
+      estree: {
+        type: 'Program',
+        sourceType: 'module',
+        body: [
+          {
+            type: 'ExportNamedDeclaration',
+            declaration: null,
+            specifiers: [
+              {
+                type: 'ExportSpecifier',
+                local: {
+                  type: 'Identifier',
+                  name: 'default',
+                },
+                exported: {
+                  type: 'Identifier',
+                  name: 'default',
+                },
+              },
+            ],
+            source: {
+              type: 'Literal',
+              value: RUNTIME_MODULE,
+              raw: rawSource,
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+/**
+ * Install the plugin runtime as the implicit MDX layout. MDX renders the
+ * document body as the layout's child, so the layout can provide code-block
+ * components before the body is evaluated.
+ */
+export function remarkCodeBlockTransform() {
+  return (tree: MdxRoot) => {
+    // Preserve an explicit user-authored MDX layout. Consumers can still use
+    // the runtime API directly around such documents.
+    if (hasDefaultExport(tree)) {
+      return;
+    }
+    tree.children.unshift(createLayoutExportNode());
+  };
+}
+
+export const codeBlockTransformRuntimeModule = RUNTIME_MODULE;

--- a/packages/rspress-plugin/src/runtime/index.test.tsx
+++ b/packages/rspress-plugin/src/runtime/index.test.tsx
@@ -1,0 +1,102 @@
+import { MDXProvider, useMDXComponents } from '@mdx-js/react';
+import { describe, expect, it } from '@rstest/core';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import CodeBlockTransformLayout, { transformCodeBlock } from './index';
+
+function HighlightedDocument() {
+  const components = useMDXComponents();
+  const Pre = components.pre ?? 'pre';
+  const Code = components.code ?? 'code';
+
+  return (
+    <>
+      <h2>Commands</h2>
+      <p>Run this command:</p>
+      <Pre className="shiki css-variables" lang="bash">
+        <Code>
+          <span className="line">
+            <span>npx</span>
+            <span> mf</span>
+            <span> -h</span>
+          </span>
+        </Code>
+      </Pre>
+      <pre>hand-written pre</pre>
+    </>
+  );
+}
+
+describe('code block transform runtime', () => {
+  it('replaces fenced code without changing surrounding content', () => {
+    const transformer = transformCodeBlock({
+      replace: [[/\bmf\b/g, 'vmok']],
+    });
+    const html = renderToStaticMarkup(
+      <MDXProvider components={{ pre: 'pre', code: 'code' }}>
+        <CodeBlockTransformLayout transformCodeBlock={transformer}>
+          <HighlightedDocument />
+        </CodeBlockTransformLayout>
+      </MDXProvider>,
+    );
+
+    expect(html).toContain('<h2>Commands</h2>');
+    expect(html).toContain('<p>Run this command:</p>');
+    expect(html).toContain(
+      '<span>npx</span><span> vmok</span><span> -h</span>',
+    );
+    expect(html).toContain('lang="bash"');
+    expect(html).toContain('<pre>hand-written pre</pre>');
+  });
+
+  it('keeps the original highlighted block when no replacement matches', () => {
+    const transformer = transformCodeBlock({
+      replace: [['webpack', 'rspack']],
+    });
+    const html = renderToStaticMarkup(
+      <MDXProvider components={{ pre: 'pre', code: 'code' }}>
+        <CodeBlockTransformLayout transformCodeBlock={transformer}>
+          <HighlightedDocument />
+        </CodeBlockTransformLayout>
+      </MDXProvider>,
+    );
+
+    expect(html).toContain('<span>npx</span><span> mf</span><span> -h</span>');
+  });
+
+  it('allows changing the language from the transformed content', () => {
+    const transformer = transformCodeBlock({
+      replace: [[/\bmf\b/g, 'vmok']],
+      lang: ({ code, lang }) => (code.startsWith('npx vmok') ? 'text' : lang),
+    });
+    const html = renderToStaticMarkup(
+      <MDXProvider components={{ pre: 'pre', code: 'code' }}>
+        <CodeBlockTransformLayout transformCodeBlock={transformer}>
+          <HighlightedDocument />
+        </CodeBlockTransformLayout>
+      </MDXProvider>,
+    );
+
+    expect(html).toContain(
+      '<span>npx</span><span> vmok</span><span> -h</span>',
+    );
+    expect(html).toContain('lang="text"');
+  });
+
+  it('inherits the transformer through nested MDX layouts', () => {
+    const transformer = transformCodeBlock({
+      replace: [[/\bmf\b/g, 'vmok']],
+    });
+    const html = renderToStaticMarkup(
+      <MDXProvider components={{ pre: 'pre', code: 'code' }}>
+        <CodeBlockTransformLayout transformCodeBlock={transformer}>
+          <CodeBlockTransformLayout>
+            <HighlightedDocument />
+          </CodeBlockTransformLayout>
+        </CodeBlockTransformLayout>
+      </MDXProvider>,
+    );
+
+    expect(html.match(/ vmok/g)).toHaveLength(1);
+  });
+});

--- a/packages/rspress-plugin/src/runtime/index.tsx
+++ b/packages/rspress-plugin/src/runtime/index.tsx
@@ -1,0 +1,321 @@
+import { MDXProvider, useMDXComponents } from '@mdx-js/react';
+import React, {
+  Children,
+  cloneElement,
+  createContext,
+  isValidElement,
+  type ReactNode,
+  useContext,
+  useMemo,
+} from 'react';
+
+export type CodeBlockInfo = {
+  code: string;
+  lang: string;
+  title?: string;
+};
+
+export type CodeBlockTransformResult =
+  | string
+  | {
+      code: string;
+      lang?: string;
+    }
+  | null
+  | undefined;
+
+export type CodeBlockTransformer = (
+  block: CodeBlockInfo,
+) => CodeBlockTransformResult;
+
+export type CodeBlockReplacement = readonly [from: string | RegExp, to: string];
+
+export type TransformCodeBlockOptions = {
+  /**
+   * Ordered replacements applied to every fenced code block.
+   */
+  replace: readonly CodeBlockReplacement[];
+  /**
+   * Limit replacements to selected code blocks.
+   */
+  filter?: (block: CodeBlockInfo) => boolean;
+  /**
+   * Optionally update the language after replacements have been applied.
+   */
+  lang?:
+    | string
+    | ((block: CodeBlockInfo, original: CodeBlockInfo) => string | undefined);
+};
+
+/**
+ * Create a code-block transformer from replacement rules.
+ *
+ * @example
+ * ```tsx
+ * const replaceCliName = transformCodeBlock({
+ *   replace: [[/\bmf\b/g, 'vmok']],
+ * });
+ *
+ * <RemoteDoc transformCodeBlock={replaceCliName} />
+ * ```
+ */
+export function transformCodeBlock({
+  replace,
+  filter,
+  lang,
+}: TransformCodeBlockOptions): CodeBlockTransformer {
+  return (original) => {
+    if (filter && !filter(original)) {
+      return undefined;
+    }
+
+    let code = original.code;
+    for (const [from, to] of replace) {
+      code =
+        typeof from === 'string'
+          ? code.split(from).join(to)
+          : code.replace(from, to);
+    }
+
+    const transformed = {
+      ...original,
+      code,
+    };
+    const nextLang =
+      typeof lang === 'function' ? lang(transformed, original) : lang;
+    const resolvedLang = nextLang ?? original.lang;
+
+    if (code === original.code && resolvedLang === original.lang) {
+      return undefined;
+    }
+
+    return {
+      code,
+      lang: resolvedLang,
+    };
+  };
+}
+
+type CodeBlockTransformLayoutProps = {
+  children?: ReactNode;
+  transformCodeBlock?: CodeBlockTransformer | null;
+};
+
+type TransformContextValue = {
+  transformer?: CodeBlockTransformer;
+  pre: React.ElementType;
+};
+
+type TransformPreProps = React.ComponentPropsWithoutRef<'pre'> & {
+  lang?: string;
+  title?: string;
+  wrapCode?: boolean;
+  lineNumbers?: boolean;
+  fold?: boolean;
+  height?: number;
+};
+
+const CodeBlockTransformContext = createContext<TransformContextValue | null>(
+  null,
+);
+
+function getTextContent(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+  if (!node) {
+    return '';
+  }
+  if (Array.isArray(node)) {
+    return node.map(getTextContent).join('');
+  }
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return getTextContent(node.props.children);
+  }
+  let text = '';
+  Children.forEach(node, (child) => {
+    text += getTextContent(child);
+  });
+  return text;
+}
+
+function isRspressCodeBlock(className: unknown, lang: unknown): boolean {
+  return (
+    typeof className === 'string' &&
+    className.split(/\s+/).includes('shiki') &&
+    typeof lang === 'string'
+  );
+}
+
+function replaceHighlightedText(
+  node: ReactNode,
+  originalCode: string,
+  transformedCode: string,
+): ReactNode {
+  let prefixLength = 0;
+  while (
+    prefixLength < originalCode.length &&
+    prefixLength < transformedCode.length &&
+    originalCode[prefixLength] === transformedCode[prefixLength]
+  ) {
+    prefixLength++;
+  }
+
+  let suffixLength = 0;
+  while (
+    suffixLength < originalCode.length - prefixLength &&
+    suffixLength < transformedCode.length - prefixLength &&
+    originalCode[originalCode.length - suffixLength - 1] ===
+      transformedCode[transformedCode.length - suffixLength - 1]
+  ) {
+    suffixLength++;
+  }
+
+  const oldSuffixStart = originalCode.length - suffixLength;
+  const replacement = transformedCode.slice(
+    prefixLength,
+    transformedCode.length - suffixLength,
+  );
+  let offset = 0;
+  let replacementInserted = false;
+
+  const visit = (current: ReactNode): ReactNode => {
+    if (typeof current === 'string' || typeof current === 'number') {
+      const text = String(current);
+      const start = offset;
+      const end = start + text.length;
+      offset = end;
+
+      if (end <= prefixLength || start >= oldSuffixStart) {
+        return text;
+      }
+
+      let next = '';
+      if (start < prefixLength) {
+        next += text.slice(0, prefixLength - start);
+      }
+      if (!replacementInserted) {
+        next += replacement;
+        replacementInserted = true;
+      }
+      if (end > oldSuffixStart) {
+        next += text.slice(oldSuffixStart - start);
+      }
+      return next;
+    }
+    if (Array.isArray(current)) {
+      return Children.map(current, visit);
+    }
+    if (isValidElement<{ children?: ReactNode }>(current)) {
+      return cloneElement(current, undefined, visit(current.props.children));
+    }
+    return current;
+  };
+
+  const result = visit(node);
+  return getTextContent(result) === transformedCode ? result : transformedCode;
+}
+
+function TransformedCodeBlock({
+  OriginalPre,
+  originalProps,
+  originalCode,
+  code,
+  lang,
+}: {
+  OriginalPre: React.ElementType;
+  originalProps: TransformPreProps;
+  originalCode: string;
+  code: string;
+  lang: string;
+}) {
+  const { children, ...preProps } = originalProps;
+  const codeElement = isValidElement<{ children?: ReactNode }>(children)
+    ? cloneElement(
+        children,
+        undefined,
+        replaceHighlightedText(children.props.children, originalCode, code),
+      )
+    : React.createElement('code', undefined, code);
+
+  return (
+    <OriginalPre {...preProps} lang={lang}>
+      {codeElement}
+    </OriginalPre>
+  );
+}
+
+/**
+ * Internal MDX layout injected by the Rspress plugin.
+ */
+export default function CodeBlockTransformLayout({
+  children,
+  transformCodeBlock: directTransformer,
+}: CodeBlockTransformLayoutProps) {
+  const inherited = useContext(CodeBlockTransformContext);
+  const mdxComponents = useMDXComponents();
+
+  // Nested MDX fragments inherit the parent document's provider. Avoid wrapping
+  // the same code block more than once unless a nested document explicitly
+  // supplies its own transformer.
+  if (inherited && directTransformer === undefined) {
+    return children;
+  }
+
+  const transformer =
+    directTransformer === null
+      ? undefined
+      : (directTransformer ?? inherited?.transformer);
+  const OriginalPre = inherited?.pre ?? mdxComponents.pre ?? 'pre';
+
+  const components = useMemo(
+    () => ({
+      pre: (props: TransformPreProps) => {
+        const { children: codeChildren, lang, title, className } = props;
+
+        if (!transformer || !isRspressCodeBlock(className, lang)) {
+          return <OriginalPre {...props} />;
+        }
+
+        const original: CodeBlockInfo = {
+          code: getTextContent(codeChildren as ReactNode),
+          lang: lang as string,
+          title: typeof title === 'string' ? title : undefined,
+        };
+        const result = transformer(original);
+
+        if (result == null) {
+          return <OriginalPre {...props} />;
+        }
+
+        const code = typeof result === 'string' ? result : result.code;
+        const transformedLang =
+          typeof result === 'string'
+            ? original.lang
+            : (result.lang ?? original.lang);
+
+        return (
+          <TransformedCodeBlock
+            OriginalPre={OriginalPre}
+            originalProps={props}
+            originalCode={original.code}
+            code={code}
+            lang={transformedLang}
+          />
+        );
+      },
+    }),
+    [OriginalPre, transformer],
+  );
+
+  return (
+    <CodeBlockTransformContext.Provider
+      value={{
+        transformer,
+        pre: OriginalPre,
+      }}
+    >
+      <MDXProvider components={components}>{children}</MDXProvider>
+    </CodeBlockTransformContext.Provider>
+  );
+}

--- a/packages/rspress-plugin/tsconfig.lib.json
+++ b/packages/rspress-plugin/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true
+  },
+  "exclude": [
+    "rstest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.test-*.tsx"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4006,6 +4006,9 @@ importers:
 
   packages/rspress-plugin:
     dependencies:
+      '@mdx-js/react':
+        specifier: ^3.1.1
+        version: 3.1.1(@types/react@18.3.28)(react@19.2.7)
       '@module-federation/enhanced':
         specifier: workspace:*
         version: link:../enhanced
@@ -4031,12 +4034,18 @@ importers:
         specifier: 4.18.1
         version: 4.18.1
     devDependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
       '@rslib/core':
         specifier: ^0.23.2
         version: 0.23.2(@microsoft/api-extractor@7.57.7(@types/node@26.1.1))(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)(typescript@7.0.2)
       '@rspress/core':
         specifier: 2.0.14
         version: 2.0.14(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.2(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.28)(core-js@3.49.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rstest/core':
+        specifier: ^0.10.6
+        version: 0.10.6(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)(jsdom@20.0.3)
       '@types/html-to-text':
         specifier: ^9.0.4
         version: 9.0.4
@@ -4046,6 +4055,15 @@ importers:
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.28)
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
       typescript:
         specifier: 7.0.2
         version: 7.0.2


### PR DESCRIPTION
## Description

Adds an opt-in code-block transformation capability to `@module-federation/rspress-plugin`.

Producer documents can keep ordinary fenced code blocks. A consumer can pass a transformer to a remote document to replace matching code content without creating a dedicated component in the producer. The transformed result is also available to SSG output, generated Markdown, and LLM text output.

This change includes the public helper, runtime handling, Markdown integration, tests, documentation, and a patch changeset.

Validation completed:

- `pnpm exec prettier --check .`
- `pnpm exec turbo run build --filter=@module-federation/rspress-plugin`
- `pnpm exec turbo run test --filter=@module-federation/rspress-plugin`
- Changeset validation
- An end-to-end Module Federation producer/consumer SSG build, including generated HTML, Markdown, and `llms-full.txt`

The full repository test suite was not run; validation was scoped to the affected package and its dependencies, plus the end-to-end SSG scenario.

## Related Issue

No linked issue.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.