### PR TITLE
Release v2.8.1

### DIFF
--- a/.changeset/fast-manifests-flush.md
+++ b/.changeset/fast-manifests-flush.md
@@ -1,7 +1,0 @@
----
-'@module-federation/nextjs-mf': patch
-'@module-federation/node': patch
-'@module-federation/sdk': patch
----
-
-Use manifest expose assets for Next.js chunk flushing, including aliased remotes, and derive legacy federated stats compatibility assets without an extra Webpack stats traversal.

--- a/.changeset/fix-runtime-esm-preload.md
+++ b/.changeset/fix-runtime-esm-preload.md
@@ -1,7 +1,0 @@
----
-'@module-federation/runtime-core': patch
----
-
-fix(runtime): preload ESM remote chunks with `modulepreload` links instead of
-executable module scripts before container initialization. Loader plugins now
-observe these implicit ESM preloads through `createLink`.

--- a/.changeset/fix-windows-hoisted-bundles.md
+++ b/.changeset/fix-windows-hoisted-bundles.md
@@ -1,5 +1,0 @@
----
-"@module-federation/metro": patch
----
-
-fix(metro): normalize Windows separators before encoding parent directory segments in split-bundle URLs.

--- a/.changeset/secure-dts-archives.md
+++ b/.changeset/secure-dts-archives.md
@@ -1,5 +1,0 @@
----
-"@module-federation/dts-plugin": patch
----
-
-chore(dts-plugin): upgrade adm-zip to 0.6.0 to prevent crafted remote type archives from exhausting process memory during extraction.

--- a/apps/node-dynamic-remote-new-version/CHANGELOG.md
+++ b/apps/node-dynamic-remote-new-version/CHANGELOG.md
@@ -1,5 +1,12 @@
 # node-dynamic-remote-new-version
 
+## 1.0.15
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/node@2.7.48
+
 ## 1.0.14
 
 ### Patch Changes

--- a/apps/node-dynamic-remote-new-version/package.json
+++ b/apps/node-dynamic-remote-new-version/package.json
@@ -6,7 +6,7 @@
     "@module-federation/node": "workspace:*",
     "lodash": "4.18.1"
   },
-  "version": "1.0.14",
+  "version": "1.0.15",
   "scripts": {
     "build": "NODE_OPTIONS=--max_old_space_size=4096 pnpm exec webpack-cli --config webpack.config.js --output-path dist --mode production",
     "build:development": "NODE_OPTIONS=--max_old_space_size=4096 pnpm exec webpack-cli --config webpack.config.js --output-path dist --mode development",

--- a/apps/node-dynamic-remote/CHANGELOG.md
+++ b/apps/node-dynamic-remote/CHANGELOG.md
@@ -1,5 +1,12 @@
 # node-dynamic-remote
 
+## 1.0.15
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/node@2.7.48
+
 ## 1.0.14
 
 ### Patch Changes

--- a/apps/node-dynamic-remote/package.json
+++ b/apps/node-dynamic-remote/package.json
@@ -6,7 +6,7 @@
     "@module-federation/node": "workspace:*",
     "lodash": "4.18.1"
   },
-  "version": "1.0.14",
+  "version": "1.0.15",
   "scripts": {
     "build": "NODE_OPTIONS=--max_old_space_size=4096 pnpm exec webpack-cli --config webpack.config.js --output-path dist --mode production",
     "build:development": "NODE_OPTIONS=--max_old_space_size=4096 pnpm exec webpack-cli --config webpack.config.js --output-path dist --mode development",

--- a/apps/router-demo/router-remote5-2005/CHANGELOG.md
+++ b/apps/router-demo/router-remote5-2005/CHANGELOG.md
@@ -1,5 +1,12 @@
 # remote5
 
+## 2.0.17
+
+### Patch Changes
+
+- @module-federation/rsbuild-plugin@2.8.1
+- @module-federation/bridge-react@2.8.1
+
 ## 2.0.16
 
 ### Patch Changes

--- a/apps/router-demo/router-remote5-2005/package.json
+++ b/apps/router-demo/router-remote5-2005/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote5",
   "private": true,
-  "version": "2.0.16",
+  "version": "2.0.17",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/router-demo/router-remote6-2006/CHANGELOG.md
+++ b/apps/router-demo/router-remote6-2006/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.17
+
+### Patch Changes
+
+- @module-federation/rsbuild-plugin@2.8.1
+- @module-federation/bridge-react@2.8.1
+
 ## 2.0.16
 
 ### Patch Changes

--- a/apps/router-demo/router-remote6-2006/package.json
+++ b/apps/router-demo/router-remote6-2006/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote6",
   "private": true,
-  "version": "2.0.16",
+  "version": "2.0.17",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/apps/shared-tree-shaking/no-server/host/CHANGELOG.md
+++ b/apps/shared-tree-shaking/no-server/host/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.17
+
+### Patch Changes
+
+- @module-federation/enhanced@2.8.1
+
 ## 1.0.16
 
 ### Patch Changes

--- a/apps/shared-tree-shaking/no-server/host/package.json
+++ b/apps/shared-tree-shaking/no-server/host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-no-server-host",
   "private": true,
-  "version": "1.0.16",
+  "version": "1.0.17",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "TS_NODE_COMPILER=typescript-compiler modern dev",

--- a/apps/shared-tree-shaking/no-server/provider/CHANGELOG.md
+++ b/apps/shared-tree-shaking/no-server/provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.17
+
+### Patch Changes
+
+- @module-federation/enhanced@2.8.1
+
 ## 1.0.16
 
 ### Patch Changes

--- a/apps/shared-tree-shaking/no-server/provider/package.json
+++ b/apps/shared-tree-shaking/no-server/provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-no-server-provider",
   "private": true,
-  "version": "1.0.16",
+  "version": "1.0.17",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "TS_NODE_COMPILER=typescript-compiler modern dev",

--- a/apps/shared-tree-shaking/with-server/host/CHANGELOG.md
+++ b/apps/shared-tree-shaking/with-server/host/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.17
+
+### Patch Changes
+
+- @module-federation/modern-js-v3@2.8.1
+
 ## 1.0.16
 
 ### Patch Changes

--- a/apps/shared-tree-shaking/with-server/host/package.json
+++ b/apps/shared-tree-shaking/with-server/host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-with-server-host",
   "private": true,
-  "version": "1.0.16",
+  "version": "1.0.17",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "TS_NODE_COMPILER=typescript-compiler modern dev",

--- a/apps/shared-tree-shaking/with-server/provider/CHANGELOG.md
+++ b/apps/shared-tree-shaking/with-server/provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # modernjs-ssr-nested-remote
 
+## 1.0.17
+
+### Patch Changes
+
+- @module-federation/modern-js-v3@2.8.1
+
 ## 1.0.16
 
 ### Patch Changes

--- a/apps/shared-tree-shaking/with-server/provider/package.json
+++ b/apps/shared-tree-shaking/with-server/provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-tree-shaking-with-server-provider",
   "private": true,
-  "version": "1.0.16",
+  "version": "1.0.17",
   "scripts": {
     "reset": "npx rimraf ./**/node_modules",
     "dev": "TS_NODE_COMPILER=typescript-compiler modern dev",

--- a/apps/website-new/CHANGELOG.md
+++ b/apps/website-new/CHANGELOG.md
@@ -1,5 +1,13 @@
 # website-new
 
+## 1.3.29
+
+### Patch Changes
+
+- @module-federation/rspress-plugin@2.8.1
+- @module-federation/runtime@2.8.1
+- @module-federation/error-codes@2.8.1
+
 ## 1.3.28
 
 ### Patch Changes

--- a/apps/website-new/package.json
+++ b/apps/website-new/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website-new",
-  "version": "1.3.28",
+  "version": "1.3.29",
   "private": true,
   "description": "Federation example for website-new",
   "scripts": {

--- a/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
+++ b/packages/bridge/bridge-react-webpack-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/bridge-react-webpack-plugin
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/bridge/bridge-react-webpack-plugin/package.json
+++ b/packages/bridge/bridge-react-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react-webpack-plugin",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/bridge-react/CHANGELOG.md
+++ b/packages/bridge/bridge-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/bridge-react
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/bridge/bridge-react/package.json
+++ b/packages/bridge/bridge-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-react",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/bridge/bridge-shared/CHANGELOG.md
+++ b/packages/bridge/bridge-shared/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/bridge-shared
 
+## 2.8.1
+
 ## 2.8.0
 
 ## 2.7.0

--- a/packages/bridge/bridge-shared/package.json
+++ b/packages/bridge/bridge-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/bridge-shared",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bridge/vue3-bridge/CHANGELOG.md
+++ b/packages/bridge/vue3-bridge/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/bridge-vue3
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/runtime@2.8.1
+  - @module-federation/bridge-shared@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/bridge/vue3-bridge/package.json
+++ b/packages/bridge/vue3-bridge/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/module-federation/core.git",
     "directory": "packages/bridge/vue3-bridge"
   },
-  "version": "2.8.0",
+  "version": "2.8.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/chrome-devtools/CHANGELOG.md
+++ b/packages/chrome-devtools/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/devtools
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/observability-plugin@2.5.5
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/chrome-devtools/package.json
+++ b/packages/chrome-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/devtools",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/cli
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+- Updated dependencies [641a0b6]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/dts-plugin@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/cli",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "type": "commonjs",
   "description": "Module Federation CLI",
   "homepage": "https://module-federation.io",

--- a/packages/create-module-federation/CHANGELOG.md
+++ b/packages/create-module-federation/CHANGELOG.md
@@ -1,5 +1,7 @@
 # create-module-federation
 
+## 2.8.1
+
 ## 2.8.0
 
 ## 2.7.0

--- a/packages/create-module-federation/package.json
+++ b/packages/create-module-federation/package.json
@@ -3,7 +3,7 @@
   "description": "Create a new Module Federation project",
   "public": true,
   "sideEffects": false,
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/dts-plugin/CHANGELOG.md
+++ b/packages/dts-plugin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @module-federation/dts-plugin
 
+## 2.8.1
+
+### Patch Changes
+
+- 641a0b6: chore(dts-plugin): upgrade adm-zip to 0.6.0 to prevent crafted remote type archives from exhausting process memory during extraction.
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/managers@2.8.1
+  - @module-federation/third-party-dts-extractor@2.8.1
+  - @module-federation/error-codes@2.8.1
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/dts-plugin/package.json
+++ b/packages/dts-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/dts-plugin",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "author": "hanric <hanric.zhang@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/esm/index.mjs",

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @module-federation/enhanced
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+- Updated dependencies [641a0b6]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/dts-plugin@2.8.1
+  - @module-federation/bridge-react-webpack-plugin@2.8.1
+  - @module-federation/cli@2.8.1
+  - @module-federation/managers@2.8.1
+  - @module-federation/manifest@2.8.1
+  - @module-federation/rspack@2.8.1
+  - @module-federation/webpack-bundler-runtime@2.8.1
+  - @module-federation/runtime-tools@2.8.1
+  - @module-federation/inject-external-runtime-core-plugin@2.8.1
+  - @module-federation/error-codes@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/enhanced",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "repository": {

--- a/packages/error-codes/CHANGELOG.md
+++ b/packages/error-codes/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/error-codes
 
+## 2.8.1
+
 ## 2.8.0
 
 ## 2.7.0

--- a/packages/error-codes/package.json
+++ b/packages/error-codes/package.json
@@ -4,7 +4,7 @@
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "public": true,
   "sideEffects": false,
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/esbuild/CHANGELOG.md
+++ b/packages/esbuild/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/esbuild
 
+## 0.0.112
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/runtime@2.8.1
+  - @module-federation/webpack-bundler-runtime@2.8.1
+
 ## 0.0.111
 
 ### Patch Changes

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/esbuild",
-  "version": "0.0.111",
+  "version": "0.0.112",
   "author": "Zack Jackson (@ScriptedAlchemy)",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/managers/CHANGELOG.md
+++ b/packages/managers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/managers
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/managers/package.json
+++ b/packages/managers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/managers",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "MIT",
   "description": "Provide managers for helping handle mf data .",
   "keywords": [

--- a/packages/manifest/CHANGELOG.md
+++ b/packages/manifest/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/manifest
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+- Updated dependencies [641a0b6]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/dts-plugin@2.8.1
+  - @module-federation/managers@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/manifest",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "MIT",
   "description": "Provide manifest/stats for webpack/rspack MF project .",
   "keywords": [

--- a/packages/metro-core/CHANGELOG.md
+++ b/packages/metro-core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @module-federation/metro
 
+## 2.8.1
+
+### Patch Changes
+
+- 1ed404a: fix(metro): normalize Windows separators before encoding parent directory segments in split-bundle URLs.
+- Updated dependencies [d901e2c]
+- Updated dependencies [641a0b6]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/dts-plugin@2.8.1
+  - @module-federation/runtime@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/metro-core/package.json
+++ b/packages/metro-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Module Federation for Metro bundler",
   "keywords": [
     "module-federation",

--- a/packages/metro-plugin-rnc-cli/CHANGELOG.md
+++ b/packages/metro-plugin-rnc-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/metro-plugin-rnc-cli
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [1ed404a]
+  - @module-federation/metro@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/metro-plugin-rnc-cli/package.json
+++ b/packages/metro-plugin-rnc-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro-plugin-rnc-cli",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Metro Module Federation plugin for React Native Enterprise Framework (RNEF)",
   "keywords": [
     "rnc",

--- a/packages/metro-plugin-rnef/CHANGELOG.md
+++ b/packages/metro-plugin-rnef/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/metro-plugin-rnef
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [1ed404a]
+  - @module-federation/metro@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/metro-plugin-rnef/package.json
+++ b/packages/metro-plugin-rnef/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro-plugin-rnef",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Metro Module Federation plugin for React Native Enterprise Framework (RNEF). Deprecated: use @module-federation/metro-plugin-rock instead.",
   "keywords": [
     "rnef",

--- a/packages/metro-plugin-rock/CHANGELOG.md
+++ b/packages/metro-plugin-rock/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/metro-plugin-rock
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [1ed404a]
+  - @module-federation/metro@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/metro-plugin-rock/package.json
+++ b/packages/metro-plugin-rock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/metro-plugin-rock",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Metro Module Federation plugin for Rock",
   "keywords": [
     "rock",

--- a/packages/modernjs-v3/CHANGELOG.md
+++ b/packages/modernjs-v3/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @module-federation/modern-js-v3
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/node@2.7.48
+  - @module-federation/sdk@2.8.1
+  - @module-federation/rsbuild-plugin@2.8.1
+  - @module-federation/bridge-react@2.8.1
+  - @module-federation/cli@2.8.1
+  - @module-federation/enhanced@2.8.1
+  - @module-federation/runtime@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/modernjs-v3/package.json
+++ b/packages/modernjs-v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/modern-js-v3",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "files": [
     "dist/",
     "types.d.ts",

--- a/packages/modernjs/CHANGELOG.md
+++ b/packages/modernjs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @module-federation/modern-js
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/node@2.7.48
+  - @module-federation/sdk@2.8.1
+  - @module-federation/rsbuild-plugin@2.8.1
+  - @module-federation/bridge-react@2.8.1
+  - @module-federation/cli@2.8.1
+  - @module-federation/enhanced@2.8.1
+  - @module-federation/runtime@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/modernjs/package.json
+++ b/packages/modernjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/modern-js",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "files": [
     "dist/",
     "types.d.ts",

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @module-federation/nextjs-mf
 
+## 8.8.72
+
+### Patch Changes
+
+- d901e2c: Use manifest expose assets for Next.js chunk flushing, including aliased remotes, and derive legacy federated stats compatibility assets without an extra Webpack stats traversal.
+- Updated dependencies [d901e2c]
+- Updated dependencies [65cdf34]
+  - @module-federation/node@2.7.48
+  - @module-federation/sdk@2.8.1
+  - @module-federation/runtime-core@2.8.1
+  - @module-federation/enhanced@2.8.1
+  - @module-federation/runtime@2.8.1
+  - @module-federation/webpack-bundler-runtime@2.8.1
+
 ## 8.8.71
 
 ### Patch Changes

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "8.8.71",
+  "version": "8.8.72",
   "license": "MIT",
   "main": "dist/src/index.js",
   "module": "dist/src/index.mjs",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/node
 
+## 2.7.48
+
+### Patch Changes
+
+- d901e2c: Use manifest expose assets for Next.js chunk flushing, including aliased remotes, and derive legacy federated stats compatibility assets without an extra Webpack stats traversal.
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/enhanced@2.8.1
+  - @module-federation/runtime@2.8.1
+
 ## 2.7.47
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "2.7.47",
+  "version": "2.7.48",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "module": "./dist/src/index.mjs",

--- a/packages/observability-plugin/CHANGELOG.md
+++ b/packages/observability-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/observability-plugin
 
+## 2.5.5
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+
 ## 2.5.4
 
 ### Patch Changes

--- a/packages/observability-plugin/package.json
+++ b/packages/observability-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/observability-plugin",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "author": "module-federation",
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/playground/CHANGELOG.md
+++ b/packages/playground/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/playground
 
+## 0.0.4
+
+### Patch Changes
+
+- @module-federation/bridge-react@2.8.1
+- @module-federation/runtime@2.8.1
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/playground",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Module Federation Playground",
   "homepage": "https://module-federation.io",
   "repository": {

--- a/packages/retry-plugin/CHANGELOG.md
+++ b/packages/retry-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/retry-plugin
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/runtime@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/retry-plugin/package.json
+++ b/packages/retry-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/retry-plugin",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "author": "danpeen <dapeen.feng@gmail.com>",
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/rsbuild-plugin/CHANGELOG.md
+++ b/packages/rsbuild-plugin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/rsbuild-plugin
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/node@2.7.48
+  - @module-federation/sdk@2.8.1
+  - @module-federation/enhanced@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/rsbuild-plugin/package.json
+++ b/packages/rsbuild-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rsbuild-plugin",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Module Federation plugin for Rsbuild",
   "homepage": "https://module-federation.io",
   "bugs": {

--- a/packages/rspack/CHANGELOG.md
+++ b/packages/rspack/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @module-federation/rspack
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+- Updated dependencies [641a0b6]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/dts-plugin@2.8.1
+  - @module-federation/bridge-react-webpack-plugin@2.8.1
+  - @module-federation/managers@2.8.1
+  - @module-federation/manifest@2.8.1
+  - @module-federation/runtime-tools@2.8.1
+  - @module-federation/inject-external-runtime-core-plugin@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rspack",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "MIT",
   "keywords": [
     "Module Federation",

--- a/packages/rspress-plugin/CHANGELOG.md
+++ b/packages/rspress-plugin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/rspress-plugin
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/rsbuild-plugin@2.8.1
+  - @module-federation/enhanced@2.8.1
+  - @module-federation/error-codes@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/rspress-plugin/package.json
+++ b/packages/rspress-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/rspress-plugin",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "type": "module",
   "description": "Module Federation plugin for Rspress",
   "keywords": [

--- a/packages/runtime-core/CHANGELOG.md
+++ b/packages/runtime-core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @module-federation/runtime
 
+## 2.8.1
+
+### Patch Changes
+
+- 65cdf34: fix(runtime): preload ESM remote chunks with `modulepreload` links instead of
+  executable module scripts before container initialization. Loader plugins now
+  observe these implicit ESM preloads through `createLink`.
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/error-codes@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-core",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "type": "module",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs",

--- a/packages/runtime-plugins/inject-external-runtime-core-plugin/CHANGELOG.md
+++ b/packages/runtime-plugins/inject-external-runtime-core-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/inject-external-runtime-core-plugin
 
+## 2.8.1
+
+### Patch Changes
+
+- @module-federation/runtime-tools@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/runtime-plugins/inject-external-runtime-core-plugin/package.json
+++ b/packages/runtime-plugins/inject-external-runtime-core-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/inject-external-runtime-core-plugin",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "type": "module",
   "license": "MIT",
   "description": "A sdk for support module federation",

--- a/packages/runtime-tools/CHANGELOG.md
+++ b/packages/runtime-tools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/runtime-tools
 
+## 2.8.1
+
+### Patch Changes
+
+- @module-federation/runtime@2.8.1
+- @module-federation/webpack-bundler-runtime@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/runtime-tools/package.json
+++ b/packages/runtime-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-tools",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "type": "module",
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "main": "./dist/index.cjs",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/runtime
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+- Updated dependencies [65cdf34]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/runtime-core@2.8.1
+  - @module-federation/error-codes@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "type": "module",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @module-federation/sdk
 
+## 2.8.1
+
+### Patch Changes
+
+- d901e2c: Use manifest expose assets for Next.js chunk flushing, including aliased remotes, and derive legacy federated stats compatibility assets without an extra Webpack stats traversal.
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/sdk",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "type": "module",
   "license": "MIT",
   "description": "A sdk for support module federation",

--- a/packages/storybook-addon/CHANGELOG.md
+++ b/packages/storybook-addon/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/storybook-addon
 
+## 6.0.17
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/enhanced@2.8.1
+
 ## 6.0.16
 
 ### Patch Changes

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/storybook-addon",
-  "version": "6.0.16",
+  "version": "6.0.17",
   "description": "Storybook addon to consume remote module federated apps/components",
   "type": "module",
   "license": "MIT",
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@rsbuild/core": "^1.0.1 || ^2.0.0-0",
-    "@module-federation/sdk": "^2.8.0",
+    "@module-federation/sdk": "^2.8.1",
     "@nx/react": ">= 16.0.0",
     "@nx/webpack": ">= 16.0.0",
     "@nx/module-federation": ">= 16.0.0",

--- a/packages/third-party-dts-extractor/CHANGELOG.md
+++ b/packages/third-party-dts-extractor/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/third-party-dts-extractor
 
+## 2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/third-party-dts-extractor/package.json
+++ b/packages/third-party-dts-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/third-party-dts-extractor",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "files": [
     "dist/",
     "README.md"

--- a/packages/treeshake-frontend/CHANGELOG.md
+++ b/packages/treeshake-frontend/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/treeshake-frontend
 
+## 2.8.1
+
 ## 2.8.0
 
 ## 2.7.0

--- a/packages/treeshake-frontend/package.json
+++ b/packages/treeshake-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/treeshake-frontend",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build && rslib build",

--- a/packages/treeshake-server/CHANGELOG.md
+++ b/packages/treeshake-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @module-federation/treeshake-server
 
+## 2.8.1
+
 ## 2.8.0
 
 ## 2.7.0

--- a/packages/treeshake-server/package.json
+++ b/packages/treeshake-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/treeshake-server",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Build service powered by Hono that installs dependencies, builds with Rspack, and uploads artifacts.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @module-federation/utilities
 
+## 3.1.100
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+
 ## 3.1.99
 
 ### Patch Changes

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/utilities",
-  "version": "3.1.99",
+  "version": "3.1.100",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/webpack-bundler-runtime/CHANGELOG.md
+++ b/packages/webpack-bundler-runtime/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @module-federation/webpack-bundler-runtime
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [d901e2c]
+  - @module-federation/sdk@2.8.1
+  - @module-federation/runtime@2.8.1
+  - @module-federation/error-codes@2.8.1
+
 ## 2.8.0
 
 ### Patch Changes

--- a/packages/webpack-bundler-runtime/package.json
+++ b/packages/webpack-bundler-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/webpack-bundler-runtime",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "type": "module",
   "license": "MIT",
   "description": "Module Federation Runtime for webpack",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at release-v2.8.1 -->

## What's Changed
### New Features 🎉
* feat(nextjs-mf): add skipFederatedStats option by @shashank-u03 in https://github.com/module-federation/core/pull/4732
### Performance 🚀
* perf(nextjs-mf): derive federated stats from manifest by @ScriptedAlchemy in https://github.com/module-federation/core/pull/4909
### Bug Fixes 🐞
* fix(runtime-core): avoid executing ESM remote chunks before init by @dmchoi77 in https://github.com/module-federation/core/pull/4886
* fix(metro): resolve Windows hoisted split bundles by @jbroma in https://github.com/module-federation/core/pull/4912
### Other Changes
* ci(e2e): gate affected workflows before runner setup by @ScriptedAlchemy in https://github.com/module-federation/core/pull/4864
* chore(deps): bump axios from 1.16.1 to 1.18.0 by @dependabot[bot] in https://github.com/module-federation/core/pull/4915
* chore(deps): bump axios from 1.16.1 to 1.18.0 in /packages/typescript by @dependabot[bot] in https://github.com/module-federation/core/pull/4914
* chore(deps): bump adm-zip from 0.5.10 to 0.6.0 in /packages/dts-plugin by @dependabot[bot] in https://github.com/module-federation/core/pull/4910
* chore(deps): bump adm-zip from 0.5.10 to 0.6.0 by @dependabot[bot] in https://github.com/module-federation/core/pull/4911
* chore(deps-dev): bump vitest from 1.2.2 to 3.2.6 by @dependabot[bot] in https://github.com/module-federation/core/pull/4803
* chore(deps-dev): bump js-yaml from 4.2.0 to 4.3.0 by @dependabot[bot] in https://github.com/module-federation/core/pull/4917


**Full Changelog**: https://github.com/module-federation/core/compare/v2.8.0...v2.8.1