### PR TITLE
fix(metro): reuse a preloaded config for one bundle command

### DIFF
--- a/.changeset/reuse-preloaded-metro-config.md
+++ b/.changeset/reuse-preloaded-metro-config.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/metro": patch
+---
+
+fix(metro): reuse a command-preloaded Metro configuration once when bundling federated hosts or remotes.

--- a/packages/metro-core/__tests__/commands/bundle-host-config.spec.ts
+++ b/packages/metro-core/__tests__/commands/bundle-host-config.spec.ts
@@ -1,0 +1,170 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from '@rstest/core';
+import type { ConfigT } from 'metro-config';
+import type { BundleFederatedHostArgs, Config } from '../../src/commands';
+import * as communityPlugin from '../../src/commands/utils/get-community-plugin';
+
+const TEST_CONFIG_STATE = Symbol.for(
+  '@module-federation/metro/TestConfigState',
+);
+const UPDATED_REMOTE = 'cart@https://cdn.example.com/cart.bundle';
+
+type TestConfigState = {
+  readonly generation: number;
+  readonly remotes: {
+    readonly cart: string;
+  };
+};
+
+type TestMetroConfig = ConfigT & {
+  readonly [TEST_CONFIG_STATE]: TestConfigState;
+};
+
+const tempRoots: Array<string> = [];
+const bundledConfigs: Array<ConfigT> = [];
+
+function hasTestConfigState(config: ConfigT): config is TestMetroConfig {
+  return Object.prototype.hasOwnProperty.call(config, TEST_CONFIG_STATE);
+}
+
+function getBundledConfig(index: number): TestMetroConfig {
+  const config = bundledConfigs.at(index);
+  if (!config || !hasTestConfigState(config)) {
+    throw new TypeError('Expected a bundled Metro config');
+  }
+  return config;
+}
+
+function createMetroProject(): {
+  readonly cfg: Config;
+  readonly configPath: string;
+} {
+  const projectRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'mf-metro-config-reuse-'),
+  );
+  tempRoots.push(projectRoot);
+
+  const configPath = path.join(projectRoot, 'metro.config.js');
+  fs.writeFileSync(
+    configPath,
+    `
+let generation = 0;
+
+module.exports = () => {
+  generation += 1;
+  const remotes = {
+    cart: 'cart@http://localhost:8082/cart.bundle',
+  };
+  global.__METRO_FEDERATION_CONFIG = { remotes };
+
+  return {
+    [Symbol.for('@module-federation/metro/TestConfigState')]: {
+      generation,
+      remotes,
+    },
+  };
+};
+`,
+  );
+
+  return {
+    cfg: {
+      root: projectRoot,
+      platforms: { ios: {} },
+      reactNativePath: path.dirname(
+        require.resolve('react-native/package.json'),
+      ),
+    },
+    configPath,
+  };
+}
+
+function createBundleArgs(configPath: string): BundleFederatedHostArgs {
+  return {
+    bundleOutput: 'host.bundle',
+    config: configPath,
+    dev: false,
+    entryFile: 'index.js',
+    platform: 'ios',
+    resetCache: false,
+    resetGlobalCache: false,
+    sourcemapUseAbsolutePath: false,
+    unstableTransformProfile: 'default',
+    verbose: false,
+  };
+}
+
+beforeEach(() => {
+  bundledConfigs.length = 0;
+  const command = {
+    description: 'Test command',
+    func: async () => {},
+    name: 'test',
+    options: [],
+  };
+  rs.spyOn(communityPlugin, 'getCommunityCliPlugin').mockReturnValue({
+    bundleCommand: command,
+    startCommand: command,
+    unstable_buildBundleWithConfig: async (_args, config) => {
+      bundledConfigs.push(config);
+    },
+  });
+  global.__METRO_FEDERATION_HOST_ENTRY_PATH = '/virtual/host-entry.js';
+});
+
+afterEach(() => {
+  rs.restoreAllMocks();
+  Reflect.deleteProperty(global, '__METRO_FEDERATION_CONFIG');
+  global.__METRO_FEDERATION_HOST_ENTRY_PATH = undefined;
+  global.__METRO_FEDERATION_ORIGINAL_ENTRY_PATH = undefined;
+  for (const tempRoot of tempRoots) {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+  tempRoots.length = 0;
+});
+
+describe('host command Metro config lifecycle', () => {
+  it('bundles mutations made to a preloaded config', async () => {
+    // Given
+    const { cfg, configPath } = createMetroProject();
+    const { bundleFederatedHost, loadMetroConfig } =
+      await import('../../src/commands');
+    const bundleArgs = createBundleArgs(configPath);
+    await loadMetroConfig(cfg, {
+      config: configPath,
+      maxWorkers: bundleArgs.maxWorkers,
+      resetCache: bundleArgs.resetCache,
+    });
+    global.__METRO_FEDERATION_CONFIG.remotes.cart = UPDATED_REMOTE;
+
+    // When
+    await bundleFederatedHost([], cfg, bundleArgs);
+
+    // Then
+    expect(getBundledConfig(0)[TEST_CONFIG_STATE].remotes.cart).toBe(
+      UPDATED_REMOTE,
+    );
+  });
+
+  it('loads a fresh config for a later host command', async () => {
+    // Given
+    const { cfg, configPath } = createMetroProject();
+    const { bundleFederatedHost, loadMetroConfig } =
+      await import('../../src/commands');
+    const firstBundleArgs = createBundleArgs(configPath);
+    await loadMetroConfig(cfg, {
+      config: configPath,
+      maxWorkers: firstBundleArgs.maxWorkers,
+      resetCache: firstBundleArgs.resetCache,
+    });
+    await bundleFederatedHost([], cfg, firstBundleArgs);
+
+    // When
+    await bundleFederatedHost([], cfg, createBundleArgs(configPath));
+
+    // Then
+    expect(getBundledConfig(1)[TEST_CONFIG_STATE].generation).toBe(2);
+  });
+});

--- a/packages/metro-core/src/commands/bundle-host/index.ts
+++ b/packages/metro-core/src/commands/bundle-host/index.ts
@@ -5,9 +5,9 @@ import { CLIError } from '../../utils/errors';
 import type { RequestOptions } from '../../utils/metro-compat';
 import { Server } from '../../utils/metro-compat';
 import type { Config } from '../types';
+import { resolveMetroConfigForCommand } from '../utils/command-metro-config';
 import { createResolver } from '../utils/create-resolver';
 import { getCommunityCliPlugin } from '../utils/get-community-plugin';
-import loadMetroConfig from '../utils/load-metro-config';
 import { saveBundleAndMap } from '../utils/save-bundle-and-map';
 import { toPosixPath } from '../../plugin/helpers';
 import type { BundleFederatedHostArgs } from './types';
@@ -36,11 +36,7 @@ async function bundleFederatedHost(
   // TODO: pass this without globals
   global.__METRO_FEDERATION_ORIGINAL_ENTRY_PATH = args.entryFile;
 
-  const config = await loadMetroConfig(cfg, {
-    maxWorkers: args.maxWorkers,
-    resetCache: args.resetCache,
-    config: args.config,
-  });
+  const config = await resolveMetroConfigForCommand(cfg, args);
 
   // TODO: pass this without globals
   const hostEntryFilepath = global.__METRO_FEDERATION_HOST_ENTRY_PATH;

--- a/packages/metro-core/src/commands/bundle-remote/index.ts
+++ b/packages/metro-core/src/commands/bundle-remote/index.ts
@@ -11,9 +11,9 @@ import {
 import type { OutputOptions, RequestOptions } from '../../utils/metro-compat';
 import { Server } from '../../utils/metro-compat';
 import type { Config } from '../types';
+import { resolveMetroConfigForCommand } from '../utils/command-metro-config';
 import { createModulePathRemapper } from '../utils/create-module-path-remapper';
 import { createResolver } from '../utils/create-resolver';
-import loadMetroConfig from '../utils/load-metro-config';
 import {
   normalizeOutputRelativePath,
   toFileSourceUrl,
@@ -109,11 +109,7 @@ async function bundleFederatedRemote(
   cfg: Config,
   args: BundleFederatedRemoteArgs,
 ): Promise<void> {
-  const rawConfig = await loadMetroConfig(cfg, {
-    maxWorkers: args.maxWorkers,
-    resetCache: args.resetCache,
-    config: args.config,
-  });
+  const rawConfig = await resolveMetroConfigForCommand(cfg, args);
 
   const logger = cfg.logger ?? console;
 

--- a/packages/metro-core/src/commands/index.ts
+++ b/packages/metro-core/src/commands/index.ts
@@ -2,7 +2,7 @@ import bundleFederatedHost, { bundleFederatedHostOptions } from './bundle-host';
 import bundleFederatedRemote, {
   bundleFederatedRemoteOptions,
 } from './bundle-remote';
-import loadMetroConfig from './utils/load-metro-config';
+import { preloadMetroConfigForCommand as loadMetroConfig } from './utils/command-metro-config';
 
 export {
   bundleFederatedHost,

--- a/packages/metro-core/src/commands/utils/command-metro-config.ts
+++ b/packages/metro-core/src/commands/utils/command-metro-config.ts
@@ -1,0 +1,59 @@
+import type { ConfigT, YargArguments } from 'metro-config';
+import type { Config } from '../types';
+import loadMetroConfig from './load-metro-config';
+
+type MetroConfigCommandOptions = Pick<
+  YargArguments,
+  'config' | 'maxWorkers' | 'resetCache'
+>;
+
+type PreloadedMetroConfig = {
+  readonly optionsKey: ReturnType<typeof JSON.stringify>;
+  readonly config: Promise<ConfigT>;
+};
+
+const preloadedMetroConfigs = new WeakMap<Config, PreloadedMetroConfig>();
+
+function getMetroConfigOptionsKey(options: MetroConfigCommandOptions) {
+  return JSON.stringify([
+    options.config,
+    options.maxWorkers,
+    options.resetCache,
+  ]);
+}
+
+export function preloadMetroConfigForCommand(
+  cfg: Config,
+  options: YargArguments = {},
+): Promise<ConfigT> {
+  const config = loadMetroConfig(cfg, options);
+  const preload = {
+    optionsKey: getMetroConfigOptionsKey(options),
+    config,
+  };
+  preloadedMetroConfigs.set(cfg, preload);
+  void config.then(undefined, () => {
+    if (preloadedMetroConfigs.get(cfg) === preload) {
+      preloadedMetroConfigs.delete(cfg);
+    }
+  });
+  return config;
+}
+
+export function resolveMetroConfigForCommand(
+  cfg: Config,
+  options: MetroConfigCommandOptions,
+): Promise<ConfigT> {
+  const preload = preloadedMetroConfigs.get(cfg);
+  preloadedMetroConfigs.delete(cfg);
+
+  if (preload?.optionsKey === getMetroConfigOptionsKey(options)) {
+    return preload.config;
+  }
+
+  return loadMetroConfig(cfg, {
+    maxWorkers: options.maxWorkers,
+    resetCache: options.resetCache,
+    config: options.config,
+  });
+}


### PR DESCRIPTION
## Description

This fixes a double evaluation of `metro.config.js` when consumers compose the APIs exported by `@module-federation/metro/commands`.

Previously, a wrapper could call `loadMetroConfig`, prepare state captured by config A, and then invoke `bundleFederatedHost` or `bundleFederatedRemote`. The bundle command loaded Metro config again, created config B, and built with B. Any preparation applied to A was lost.

```text
Before
  loadMetroConfig() → config A → prepare A
  bundle command → loadMetroConfig() → config B → build B

After
  loadMetroConfig() → config A → prepare A
  bundle command → consume config A once → build A
```

The concrete reproduction uses Zephyr to replace localhost remotes with deployed URLs. Zephyr updates A correctly, but the second load recreates B with localhost URLs. Because `bundle-mf-host` also produces the JavaScript bundle embedded in native Release builds, the application then crashes on launch while trying to initialize localhost remotes.

### What changed

- Added a one-shot command-scoped handoff for a preloaded `Promise<ConfigT>`.
- Keyed prepared configs by the existing React Native CLI `cfg` object.
- Matched config-relevant options: `config`, `maxWorkers`, and `resetCache`.
- Updated host and remote bundle commands to consume a matching config once.
- Preserved the existing fallback: a direct bundle command still loads config normally.
- Removed rejected preloads so a failed promise is not retained.

No public function signature changed.

### Why this approach

The existing adapters constrain the design:

- React Native CLI invokes command functions as `func(argv, cfg, args)`.
- [The RNC adapter exposes the `@module-federation/metro` bundle function directly](https://github.com/module-federation/core/blob/f5a5bf5a7ca7812f4de6e8c7c5ea46ce42a70463/packages/metro-plugin-rnc-cli/index.js#L1-L29).
- [Rock calls the same function with the same three arguments](https://github.com/module-federation/core/blob/f5a5bf5a7ca7812f4de6e8c7c5ea46ce42a70463/packages/metro-plugin-rock/src/plugin.ts#L16-L35).

Passing a fourth `context`, `dependencies`, or preloaded-config argument would create a private calling convention for one integration. This change keeps the established command contract and does not introduce Zephyr-specific concepts into `@module-federation/metro`.

This is also not a process-lifetime Metro config cache. The prepared entry is consumed once, and unmatched or direct commands continue through the normal loader.

### Resulting behavior

| Invocation                                      | Behavior                                     |
| ----------------------------------------------- | -------------------------------------------- |
| Matching preload followed by host/remote bundle | Reuse the prepared config once               |
| Bundle command without preload                  | Load config normally                         |
| Relevant options do not match                   | Discard the prepared entry and load normally |
| Preload rejects                                 | Remove the failed entry                      |

## Related Issue

Related Zephyr issue: <https://github.com/ZephyrCloudIO/zephyr-packages/issues/512>

Patch-free reproduction:

<https://github.com/gronxb/super-app-wtih-zephyr-cloud/tree/repro/metro-host-localhost>

### Validation

The behavior was tested through the public command adapters:

- RNC CLI path: one config evaluation and the prepared URL in the emitted bundle.
- Rock wrapper path: one config evaluation and the prepared URL in the emitted bundle.
- Direct Rock path without preload: successful bundle through the normal fallback load.
- Host command scenario test: fails when reuse is disabled and passes when the prepared config is consumed.

The test asserts observable output and config evaluation count rather than the internal WeakMap implementation.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.