### PR TITLE
docs: add ESM retry cache-busting defaults

### DIFF
--- a/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
+++ b/apps/website-new/docs/en/plugin/plugins/retry-plugin.mdx
@@ -133,7 +133,9 @@ const mf = createInstance({
 **addQuery**
 - Type: `boolean | ((context: { times: number; originalQuery: string }) => string)`
 - Optional
-- Whether to append a query parameter when retrying, default is false
+- Whether to append a query parameter when retrying
+- Defaults to cache-busting for `esm` and `module` remote entry retries because browsers cache failed dynamic imports by URL. Other retry paths do not add a query parameter by default
+- Set `addQuery: false` to opt out of the default ESM/module remote entry cache-busting
 - If a function is provided, it receives retry count and the original query string, and should return the new query string
 
 **fetchOptions**
@@ -198,6 +200,16 @@ Order of attempts:
 ### Cache-busting
 
 Use `addQuery` to add query parameters during retries to avoid cache interference:
+
+For remote entries with type `esm` or `module`, the plugin adds `retryCount` by default so each dynamic import retry uses a new URL. This default does not affect manifest, fetch, or classic script retries. Disable it explicitly if needed:
+
+```javascript
+const retryPlugin = RetryPlugin({
+  addQuery: false,
+});
+```
+
+To enable cache-busting for every retry path:
 
 ```javascript
 const retryPlugin = RetryPlugin({

--- a/apps/website-new/docs/zh/plugin/plugins/retry-plugin.mdx
+++ b/apps/website-new/docs/zh/plugin/plugins/retry-plugin.mdx
@@ -133,7 +133,9 @@ const mf = createInstance({
 **addQuery**
 - 类型：`boolean | ((context: { times: number; originalQuery: string }) => string)`
 - 可选
-- 是否在重试时添加查询参数，默认为 false
+- 是否在重试时添加查询参数
+- `esm` 和 `module` 类型的远程入口重试默认会添加缓存破坏参数，因为浏览器会按 URL 缓存失败的动态导入。其他重试路径默认不添加查询参数
+- 可设置 `addQuery: false` 关闭 ESM/module 远程入口的默认缓存破坏行为
 - 当为函数时，接收重试次数和原始查询字符串，返回新的查询字符串
 
 **fetchOptions**
@@ -198,6 +200,16 @@ const retryPlugin = RetryPlugin({
 ### 缓存破坏
 
 通过 `addQuery` 参数可以在重试时添加查询参数，避免浏览器缓存影响：
+
+对于 `esm` 或 `module` 类型的远程入口，插件默认添加 `retryCount`，确保每次动态导入重试使用新的 URL。此默认行为不会影响 manifest、fetch 或传统 script 重试。如需关闭：
+
+```javascript
+const retryPlugin = RetryPlugin({
+  addQuery: false,
+});
+```
+
+如需为所有重试路径启用缓存破坏：
 
 ```javascript
 const retryPlugin = RetryPlugin({

--- a/packages/retry-plugin/README.md
+++ b/packages/retry-plugin/README.md
@@ -100,13 +100,18 @@ export default () =>
 | `successTimes`    | `number`                                | `0`         | Number of successful requests required                                                           |
 | `domains`         | `string[]`                              | `[]`        | Alternative domains for script resources                                                         |
 | `manifestDomains` | `string[]`                              | `[]`        | Alternative domains for manifest files                                                           |
-| `addQuery`        | `boolean \| function`                   | `false`     | Add query parameters for cache busting                                                           |
+| `addQuery`        | `boolean \| function`                   | See below   | Add query parameters for cache busting                                                           |
 | `fetchOptions`    | `RequestInit`                           | `{}`        | Additional fetch options                                                                         |
 | `onRetry`         | `function`                              | `undefined` | Callback when retry occurs                                                                       |
 | `onSuccess`       | `function`                              | `undefined` | Callback when request succeeds                                                                   |
 | `onError`         | `function`                              | `undefined` | Callback when all retries fail                                                                   |
 
 ### addQuery Function
+
+When omitted, `addQuery` defaults to `true` only for `esm` and `module` remote
+entry retries. This gives failed dynamic imports a new URL because browsers cache
+their failures by URL. Manifest, fetch, and classic script retries still default
+to no query parameter. Set `addQuery: false` to disable the ESM/module default.
 
 ```ts
 addQuery: ({ times, originalQuery }) => {


### PR DESCRIPTION
## Description

Documents the ESM/module retry cache-busting behavior requested in PR #4877’s review  (https://github.com/module-federation/core/pull/4877#pullrequestreview-4840616409), including unchanged defaults for other retry paths and the addQuery: false opt-out.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
