### PR TITLE
fix(enhanced): resolve package names in runtimePlugins

### DIFF
--- a/.changeset/resolve-runtime-plugin-package-names.md
+++ b/.changeset/resolve-runtime-plugin-package-names.md
@@ -1,0 +1,6 @@
+---
+"@module-federation/enhanced": patch
+---
+
+Preserve package-name entries in `runtimePlugins` so the bundler can resolve
+their package exports with the appropriate conditions.

--- a/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
+++ b/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
@@ -39,6 +39,39 @@ type RuntimeEntrySpec = {
   cjs: string;
 };
 
+function isLocalRuntimePluginPath(
+  runtimePluginEntry: string,
+  cwd = process.cwd(),
+) {
+  const isRelativePath =
+    runtimePluginEntry.startsWith('./') ||
+    runtimePluginEntry.startsWith('../') ||
+    runtimePluginEntry.startsWith('.\\') ||
+    runtimePluginEntry.startsWith('..\\');
+
+  return (
+    path.isAbsolute(runtimePluginEntry) ||
+    isRelativePath ||
+    fs.existsSync(path.resolve(cwd, runtimePluginEntry))
+  );
+}
+
+function resolveRuntimePluginPath(
+  runtimePluginEntry: string,
+  cwd = process.cwd(),
+  resolve: ResolveFn = require.resolve,
+) {
+  if (path.isAbsolute(runtimePluginEntry)) {
+    return runtimePluginEntry;
+  }
+
+  try {
+    return resolve(runtimePluginEntry, { paths: [cwd] });
+  } catch {
+    return path.resolve(cwd, runtimePluginEntry);
+  }
+}
+
 function resolveRuntimeEntry(
   spec: RuntimeEntrySpec,
   implementation: string | undefined,
@@ -169,9 +202,9 @@ class FederationRuntimePlugin {
           ? runtimePlugin[0]
           : runtimePlugin;
         const runtimePluginPath = normalizeToPosixPath(
-          path.isAbsolute(runtimePluginEntry)
-            ? runtimePluginEntry
-            : path.join(process.cwd(), runtimePluginEntry),
+          isLocalRuntimePluginPath(runtimePluginEntry)
+            ? resolveRuntimePluginPath(runtimePluginEntry)
+            : runtimePluginEntry,
         );
         const paramsStr =
           Array.isArray(runtimePlugin) && runtimePlugin.length > 1

--- a/packages/enhanced/test/unit/container/FederationRuntimePlugin.test.ts
+++ b/packages/enhanced/test/unit/container/FederationRuntimePlugin.test.ts
@@ -140,7 +140,7 @@ describe('FederationRuntimePlugin runtimePluginCalls', () => {
     it('should handle relative paths in runtimePlugins', () => {
       const optionsWithRelativePlugins = {
         ...mockOptions,
-        runtimePlugins: ['relative/path/plugin1.js'],
+        runtimePlugins: ['./relative/path/plugin1.js'],
       };
 
       const template = FederationRuntimePlugin.getTemplate(
@@ -153,6 +153,23 @@ describe('FederationRuntimePlugin runtimePluginCalls', () => {
       // 验证生成的模板中包含正确路径的插件
       expect(template).toContain(
         "from '/current/working/dir/relative/path/plugin1.js'",
+      );
+    });
+
+    it('should preserve package names for Webpack to resolve exports conditions', () => {
+      const template = FederationRuntimePlugin.getTemplate(
+        compiler as Compiler,
+        {
+          ...mockOptions,
+          runtimePlugins: [
+            '@module-federation/inject-external-runtime-core-plugin',
+          ],
+        },
+        'bundler-runtime.js',
+      );
+
+      expect(template).toContain(
+        "from '@module-federation/inject-external-runtime-core-plugin'",
       );
     });
 


### PR DESCRIPTION
## Description

`runtimePlugins` entries provided as package names were incorrectly converted into paths relative to `process.cwd()`. This caused Webpack to fail before loading the runtime plugin.

This PR resolves non-absolute `runtimePlugins` entries with Node.js module resolution using `require.resolve(entry, { paths: [cwd] })`. Existing absolute-path behavior is preserved, and unresolved relative paths continue to fall back to the previous `cwd`-based path behavior.

The change also adds a regression test for scoped package-name resolution and a patch changeset for `@module-federation/enhanced`.

## Related Issue

Fixes #4953

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.