### PR TITLE
fix(devtools): render the shared packages badge count once

### DIFF
--- a/.changeset/shared-deps-packages-badge-count.md
+++ b/.changeset/shared-deps-packages-badge-count.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/devtools": patch
+---
+
+Fix the shared dependencies packages badge rendering its count twice. The badge printed `stats.totalPackages` next to the `packagesBadge` translation, which already interpolates the same value, so a single package showed as "11 packages".

--- a/packages/chrome-devtools/src/component/SharedDepsExplorer/index.tsx
+++ b/packages/chrome-devtools/src/component/SharedDepsExplorer/index.tsx
@@ -450,7 +450,6 @@ function SharedDepsExplorer({
               <span className={styles.badgeGroup}>
                 <Box className={styles.iconSmall} />
                 <span>
-                  {stats.totalPackages}
                   {t('sharedDeps.stats.scopes.packagesBadge', {
                     count: stats.totalPackages,
                   })}


### PR DESCRIPTION
## Description

The packages badge in the Shared Dependencies overview renders its count twice, so a scope holding a single shared package is displayed as **"11 packages"**.

`SharedDepsExplorer` prints `stats.totalPackages` and then calls the `packagesBadge` translation, which already interpolates the same value through `{{count}}`:

```tsx
// packages/chrome-devtools/src/component/SharedDepsExplorer/index.tsx
<span>
  {stats.totalPackages}
  {t('sharedDeps.stats.scopes.packagesBadge', { count: stats.totalPackages })}
</span>
```

```ts
// packages/chrome-devtools/src/i18n/index.ts
packagesBadge: '{{count}} packages'   // en
packagesBadge: '{{count}} 个包'        // zh-CN
```

So the badge renders `1` + `1 packages`. Any count is affected — 33 packages reads as "3333 packages".


<img width="889" height="441" alt="screenshot" src="https://github.com/user-attachments/assets/c7d732e1-3271-4018-b113-f1224ed35f0e" />


This PR drops the extra JSX expression and lets the translation carry the count. The opposite fix (removing `{{count}}` from the translations) is not viable: the zh-CN string places the number before the classifier, so the count has to stay inside the translation for the word order to hold.

The other stat cards in the same row (`totalProviders`, `totalScopes`, `totalVersions`, `loadedCount`, `reusedCount`) render their value and label separately and are unaffected.

## Related Issue

No existing issue — filing the context here instead.

This is a regression from #4305 (`feat: devtools support dark mode`, 813923c59). That PR moved the hardcoded `packages` label into i18n but kept the JSX count:

```diff
-<span>{stats.totalPackages} packages</span>
+<span>
+  {stats.totalPackages}
+  {t('sharedDeps.stats.scopes.packagesBadge', {
+    count: stats.totalPackages,
+  })}
+</span>
```

Before #4305 the badge rendered `{stats.totalPackages} packages`, which is what this change restores.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
