### PR TITLE
docs: fix non-existent `bridge-react/react` import path

### DIFF
--- a/apps/website-new/docs/en/guide/bridge/react/getting-started.mdx
+++ b/apps/website-new/docs/en/guide/bridge/react/getting-started.mdx
@@ -34,7 +34,7 @@
 | ------------- | ----------- |
 | React 19      | `@module-federation/bridge-react/v19` |
 | React 18      | `@module-federation/bridge-react/v18` |
-| React 16 / 17 | `@module-federation/bridge-react/react` |
+| React 16 / 17 | `@module-federation/bridge-react` |
 
 :::warning Important
 
@@ -56,8 +56,8 @@ shared: {
 
 | API                        | Description                                                                                         | Import Path                              |
 | -------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `createRemoteAppComponent` | Loads and renders a remote Bridge component in the host, automatically handling rendering context and router integration | `@module-federation/bridge-react/react` |
-| `lazyLoadComponentPlugin`  | Prefetch and lazy-loading plugin                                                                    | `@module-federation/bridge-react/react` |
+| `createRemoteAppComponent` | Loads and renders a remote Bridge component in the host, automatically handling rendering context and router integration | `@module-federation/bridge-react` |
+| `lazyLoadComponentPlugin`  | Prefetch and lazy-loading plugin                                                                    | `@module-federation/bridge-react` |
 
 ### 💡 Examples
 

--- a/apps/website-new/docs/en/guide/bridge/react/getting-started.mdx
+++ b/apps/website-new/docs/en/guide/bridge/react/getting-started.mdx
@@ -57,7 +57,7 @@ shared: {
 | API                        | Description                                                                                         | Import Path                              |
 | -------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------- |
 | `createRemoteAppComponent` | Loads and renders a remote Bridge component in the host, automatically handling rendering context and router integration | `@module-federation/bridge-react` |
-| `lazyLoadComponentPlugin`  | Prefetch and lazy-loading plugin                                                                    | `@module-federation/bridge-react` |
+| `lazyLoadComponentPlugin`  | Prefetch and lazy-loading plugin                                                                    | `@module-federation/bridge-react/lazy-load-component-plugin` |
 
 ### 💡 Examples
 

--- a/apps/website-new/docs/pt-BR/guide/bridge/react/getting-started.mdx
+++ b/apps/website-new/docs/pt-BR/guide/bridge/react/getting-started.mdx
@@ -57,7 +57,7 @@ shared: {
 | API                        | Description                                                                                         | Importe Caminho                              |
 | -------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------- |
 | `createRemoteAppComponent` | Carrega e renders uma remote Bridge componente em o host, automatically handling rendering context e router integração | `@module-federation/bridge-react` |
-| `lazyLoadComponentPlugin`  | Pré-busca e lazy-carregamento plugin                                                                    | `@module-federation/bridge-react` |
+| `lazyLoadComponentPlugin`  | Pré-busca e lazy-carregamento plugin                                                                    | `@module-federation/bridge-react/lazy-load-component-plugin` |
 
 ### 💡 Exemplos
 

--- a/apps/website-new/docs/pt-BR/guide/bridge/react/getting-started.mdx
+++ b/apps/website-new/docs/pt-BR/guide/bridge/react/getting-started.mdx
@@ -34,7 +34,7 @@
 | ------------- | ----------- |
 | React 19      | `@module-federation/bridge-react/v19` |
 | React 18      | `@module-federation/bridge-react/v18` |
-| React 16 / 17 | `@module-federation/bridge-react/react` |
+| React 16 / 17 | `@module-federation/bridge-react` |
 
 :::warning Important
 
@@ -56,8 +56,8 @@ shared: {
 
 | API                        | Description                                                                                         | Importe Caminho                              |
 | -------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `createRemoteAppComponent` | Carrega e renders uma remote Bridge componente em o host, automatically handling rendering context e router integração | `@module-federation/bridge-react/react` |
-| `lazyLoadComponentPlugin`  | Pré-busca e lazy-carregamento plugin                                                                    | `@module-federation/bridge-react/react` |
+| `createRemoteAppComponent` | Carrega e renders uma remote Bridge componente em o host, automatically handling rendering context e router integração | `@module-federation/bridge-react` |
+| `lazyLoadComponentPlugin`  | Pré-busca e lazy-carregamento plugin                                                                    | `@module-federation/bridge-react` |
 
 ### 💡 Exemplos
 

--- a/apps/website-new/docs/zh/guide/bridge/react/getting-started.mdx
+++ b/apps/website-new/docs/zh/guide/bridge/react/getting-started.mdx
@@ -34,7 +34,7 @@
 |---------|---------|
 | React 19 | `@module-federation/bridge-react/v19` |
 | React 18 | `@module-federation/bridge-react/v18` |
-| React 16 / 17 | `@module-federation/bridge-react/react` |
+| React 16 / 17 | `@module-federation/bridge-react` |
 
 :::warning 重要
 
@@ -57,8 +57,8 @@ shared: {
 
 | API | 描述 | 导入路径 |
 |-----|------|----------|
-| `createRemoteAppComponent` | 在宿主中加载并渲染远程 Bridge 组件，自动处理渲染上下文与路由集成 | `@module-federation/bridge-react/react` |
-| `lazyLoadComponentPlugin` | 预取与懒加载插件 | `@module-federation/bridge-react/react` |
+| `createRemoteAppComponent` | 在宿主中加载并渲染远程 Bridge 组件，自动处理渲染上下文与路由集成 | `@module-federation/bridge-react` |
+| `lazyLoadComponentPlugin` | 预取与懒加载插件 | `@module-federation/bridge-react` |
 
 ### 💡 示例
 

--- a/apps/website-new/docs/zh/guide/bridge/react/getting-started.mdx
+++ b/apps/website-new/docs/zh/guide/bridge/react/getting-started.mdx
@@ -58,7 +58,7 @@ shared: {
 | API | 描述 | 导入路径 |
 |-----|------|----------|
 | `createRemoteAppComponent` | 在宿主中加载并渲染远程 Bridge 组件，自动处理渲染上下文与路由集成 | `@module-federation/bridge-react` |
-| `lazyLoadComponentPlugin` | 预取与懒加载插件 | `@module-federation/bridge-react` |
+| `lazyLoadComponentPlugin` | 预取与懒加载插件 | `@module-federation/bridge-react/lazy-load-component-plugin` |
 
 ### 💡 示例
 


### PR DESCRIPTION
## Description

The Producer API and Consumer API tables in the React Bridge getting-started guide point readers at `@module-federation/bridge-react/react`. That subpath is not in the package's `exports` map, so an import copied from these tables fails to resolve:

```console
$ node -e "require.resolve('@module-federation/bridge-react/react')"
MODULE_NOT_FOUND
```

`git log -S'"./react"' -- packages/bridge/bridge-react/package.json` returns no commits, so this is a path that never existed rather than one that was removed and needs restoring. Neither of the two open PRs that modify that `exports` map (#4837, #4869) adds it.

The correct entry point for the legacy (React 16/17) `createBridgeComponent`, for `createRemoteAppComponent` and for `lazyLoadComponentPlugin` is the package root:

- `apps/router-demo` uses the package root for all six of its `createBridgeComponent` / `createRemoteAppComponent` imports, and `/v18`, `/v19` and `/plugin` for the rest. `/react` appears zero times.
- The sibling `load-app.mdx` and `export-app.mdx` guides already use the package root in their code samples.

So the getting-started tables currently contradict both the working examples and the neighbouring pages. A reader following the entry-point tables — the first concrete instruction on the page — hits a module resolution error before anything else.

This PR replaces all 9 occurrences across the English, Simplified Chinese and Brazilian Portuguese pages.

This is a documentation-only change. It does not change runtime behavior or the public API.

### Validation

- `prettier --check apps/website-new/docs/{en,zh,pt-BR}/guide/bridge/react/getting-started.mdx` — all matched files use Prettier code style

## Related Issue

N/A — documentation-only correction.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
