### PR TITLE
docs(bridge): document the router-free `/base` entry for non-webpack hosts

### DIFF
--- a/apps/website-new/docs/en/guide/bridge/react/load-app.mdx
+++ b/apps/website-new/docs/en/guide/bridge/react/load-app.mdx
@@ -276,9 +276,13 @@ By default, `@module-federation/bridge-react` includes `react-router-dom` in you
 - Router context passing
 - Nested routing support
 
-If you don't need React Router integration (or you use a different router), disable `enableBridgeRouter` to reduce bundle size (about ~3KB gzipped) and avoid unnecessary router integration.
+If you don't need React Router integration (or you use a different router), you can drop it to reduce bundle size (about ~3KB gzipped) and avoid unnecessary router integration.
 
-### How to Disable Router Dependency
+How you do that depends on how your host is built.
+
+### With webpack or Rspack: `enableBridgeRouter: false`
+
+`@module-federation/enhanced` (webpack) and `@module-federation/rspack` accept a `bridge` option:
 
 ```ts title="rsbuild.config.ts"
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
@@ -303,5 +307,33 @@ By default, Bridge enables router support to provide the best development experi
 :::info How It Works
 
 The plugin automatically resolves imports of `@module-federation/bridge-react` to `@module-federation/bridge-react/base`. That entry does not bundle `react-router-dom`, so no code changes are required.
+
+:::
+
+### Everywhere else: import from `/base`
+
+The `bridge` option is implemented by the webpack and Rspack plugins only. If your host does not run one of them there is no plugin to rewrite the import, so point at the router-free entry yourself:
+
+```ts
+// Router-enabled entry (default):
+// import { createRemoteAppComponent } from '@module-federation/bridge-react';
+
+// Router-free entry:
+import { createRemoteAppComponent } from '@module-federation/bridge-react/base';
+```
+
+Use this when:
+
+- you build with [`@module-federation/vite`](/integrations/build-tool/vite.html), which has no `bridge` option
+- your host is a **pure runtime host** — it calls `init()` from `@module-federation/runtime` and `registerRemotes()` directly, with no Module Federation build plugin in the pipeline
+- you use a router other than React Router, such as `@tanstack/react-router`
+
+`/base` exposes the same API as the package root — `createBridgeComponent`, `createRemoteComponent`, `createRemoteAppComponent`, `createLazyComponent`, `lazyLoadComponentPlugin` and the data-fetch helpers — without the React Router integration.
+
+The one behavioural difference is basename handling. The default entry derives a remote's `basename` from the surrounding React Router context; `/base` does not, so pass `basename` to the remote explicitly and let the remote's own router consume it.
+
+:::tip Peer dependency
+
+`react-router-dom` is declared in the package's `peerDependencies`, but it is only required by the router-enabled entry. A host that imports exclusively from `/base` can leave it uninstalled and ignore the unmet-peer warning.
 
 :::


### PR DESCRIPTION
## Description

The "Bundle Size Optimization" section of the React Bridge load-app guide presents `bridge.enableBridgeRouter` as the way to drop `react-router-dom` from a host bundle. That option is implemented in `packages/enhanced` (webpack) and `packages/rspack` only, so two common setups have no plugin that can honour it:

- **`@module-federation/vite`** — its `ModuleFederationOptions` type has no `bridge` key at all.
- **Pure runtime hosts** — hosts that call `init()` from `@module-federation/runtime` and `registerRemotes()` directly, with no Module Federation build plugin in the pipeline.

For both, the only way to avoid `react-router-dom` is to import `@module-federation/bridge-react/base` directly. Today that entry is mentioned exactly once in the whole documentation set, inside an `:::info How It Works` aside that describes it as a plugin implementation detail requiring "no code changes" — which is the opposite of what these users must do. In practice the router-free path is discoverable only by reading the package `exports` map or inspecting the built bundle.

### What this changes

The section is split into the two paths:

- **With webpack or Rspack** — the existing `enableBridgeRouter: false` content, unchanged, now labelled with the toolchains that actually implement it.
- **Everywhere else** — import from `/base` directly, listing the cases that need it (Vite, pure runtime hosts, and non-React-Router routers such as `@tanstack/react-router`).

It also documents two behaviours that are not evident from the type signatures:

- **Basename handling differs.** The default entry derives a remote's `basename` from the surrounding React Router context; `/base` does not, so it must be passed explicitly. (`src/remote/base-component/` contains no `basename` handling; `src/remote/router-component/component.tsx` derives it.)
- **The peer dependency is conditional.** `react-router-dom` is declared in `peerDependencies`, but only the router-enabled entry needs it. A host importing exclusively from `/base` can leave it uninstalled and ignore the unmet-peer warning.

### Why it is worth documenting

`/base` shipped in #4227 (2025-11-24) and does exactly what #4191 asked for, down to the import line in that issue's "Suggested solution". But #4191 was auto-closed as `not_planned` for inactivity on 2026-01-30, and the entry was never surfaced in the docs as a user-facing option — only as something a plugin does on your behalf. This PR closes that gap so the capability is discoverable by the users who need it most: the ones with no plugin to do it for them.

English only, to keep the diff reviewable. Happy to mirror to zh and pt-BR in this PR or a follow-up, whichever the maintainers prefer.

This is a documentation-only change. It does not change runtime behavior or the public API.

### Validation

- `prettier --check apps/website-new/docs/en/guide/bridge/react/load-app.mdx` — all matched files use Prettier code style

## Related Issue

Documents the entry point requested in #4191 (`@module-federation/bridge-react - react-router optionality`), which was closed as `not_planned` after the capability had already shipped in #4227.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
