### PR TITLE
fix(nextjs-mf): await async factories in server onLoad hook

### DIFF
--- a/.changeset/nextjs-mf-onload-async-factory.md
+++ b/.changeset/nextjs-mf-onload-async-factory.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/nextjs-mf": patch
+---
+
+Await async expose module factories in the server-side `onLoad` hook before Proxy-wrapping them, fixing `TypeError: Method Promise.prototype.then called on incompatible receiver` during the webpack `loadFactory: false` / `from: 'build'` path.

--- a/packages/nextjs-mf/src/plugins/container/runtimePlugin.test.ts
+++ b/packages/nextjs-mf/src/plugins/container/runtimePlugin.test.ts
@@ -193,3 +193,111 @@ describe('next-internal-plugin beforeRequest', () => {
     );
   });
 });
+
+describe('next-internal-plugin onLoad', () => {
+  const plugin = createRuntimePlugin();
+  const onLoad = plugin.onLoad!;
+  const originalWindow = global.window;
+
+  describe('server', () => {
+    beforeEach(() => {
+      // @ts-expect-error simulate server/SSR environment
+      delete global.window;
+      // @ts-expect-error used by onLoad chunk tracking
+      globalThis.usedChunks = new Set();
+    });
+
+    afterEach(() => {
+      global.window = originalWindow;
+    });
+
+    it('awaits async exposeModuleFactory on server before proxy-wrapping', async () => {
+      const moduleExports = { __esModule: true, default: null };
+      const asyncFactory = async () => moduleExports;
+
+      const result = await onLoad({
+        id: 'remote/expose',
+        exposeModuleFactory: asyncFactory,
+        exposeModule: undefined,
+      });
+
+      expect(typeof result).toBe('function');
+      expect(result()).toEqual(
+        expect.objectContaining({ __esModule: true, default: null }),
+      );
+    });
+
+    it('returns a wrapper factory for async namespace exports on server', async () => {
+      const result = await onLoad({
+        id: 'remote/expose',
+        exposeModuleFactory: async () => ({ __esModule: true, default: null }),
+        exposeModule: undefined,
+      });
+
+      expect(typeof result).toBe('function');
+      expect(result()).toEqual(
+        expect.objectContaining({ __esModule: true, default: null }),
+      );
+    });
+
+    it('does not break Promise.prototype.then when async factory resolves on server', async () => {
+      const asyncFactory = async () => ({ __esModule: true, default: null });
+
+      const result = await onLoad({
+        id: 'remote/expose',
+        exposeModuleFactory: asyncFactory,
+        exposeModule: undefined,
+      });
+
+      expect(typeof result).toBe('function');
+      expect(() =>
+        Promise.resolve(result()).then(() => undefined),
+      ).not.toThrow();
+    });
+
+    it('handles sync exposeModuleFactory on server', async () => {
+      const result = await onLoad({
+        id: 'remote/expose',
+        exposeModuleFactory: () => ({ __esModule: true, default: null }),
+        exposeModule: undefined,
+      });
+
+      expect(typeof result).toBe('function');
+      expect(result()).toEqual(
+        expect.objectContaining({ __esModule: true, default: null }),
+      );
+    });
+
+    it('propagates rejected async factory on server', async () => {
+      await expect(
+        onLoad({
+          id: 'remote/expose',
+          exposeModuleFactory: async () => {
+            throw new Error('factory failed');
+          },
+          exposeModule: undefined,
+        }),
+      ).rejects.toThrow('factory failed');
+    });
+  });
+
+  describe('client', () => {
+    afterEach(() => {
+      global.window = originalWindow;
+    });
+
+    it('returns args unchanged on the client', async () => {
+      global.window = originalWindow ?? ({} as Window & typeof globalThis);
+
+      const input = {
+        id: 'remote/expose',
+        exposeModuleFactory: async () => ({ __esModule: true, default: null }),
+        exposeModule: undefined,
+      };
+
+      const result = await onLoad(input);
+
+      expect(result).toBe(input);
+    });
+  });
+});

--- a/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
+++ b/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
@@ -113,7 +113,7 @@ export default function (): ModuleFederationRuntimePlugin {
     afterResolve: function (args: any) {
       return args;
     },
-    onLoad: function (args: any) {
+    onLoad: async function (args: any) {
       const exposeModuleFactory = args.exposeModuleFactory;
       const exposeModule = args.exposeModule;
       const id = args.id;
@@ -126,6 +126,10 @@ export default function (): ModuleFederationRuntimePlugin {
           exposedModuleExports = moduleOrFactory();
         } catch (e) {
           exposedModuleExports = moduleOrFactory;
+        }
+
+        if (exposedModuleExports instanceof Promise) {
+          exposedModuleExports = await exposedModuleExports;
         }
 
         const handler: ProxyHandler<any> = {
@@ -180,8 +184,15 @@ export default function (): ModuleFederationRuntimePlugin {
           return function () {
             return exposedModuleExports;
           };
-        } else {
-          exposedModuleExports = new Proxy(exposedModuleExports, handler);
+        }
+
+        exposedModuleExports = new Proxy(exposedModuleExports, handler);
+
+        if (exposeModuleFactory) {
+          const wrappedExports = exposedModuleExports;
+          return function () {
+            return wrappedExports;
+          };
         }
 
         return exposedModuleExports;


### PR DESCRIPTION
## Description

Remote containers in `@module-federation/runtime` expose async module factories (`RemoteEntryExports.get` returns `() => Promise<Module>`).

During the webpack build/SSR path, `runtime-core` loads remotes with `loadFactory: false` and `from: 'build'` (see `packages/webpack-bundler-runtime/src/remotes.ts`), passing the unexecuted factory to `nextjs-mf`'s `onLoad` hook as `exposeModuleFactory`.

On the server, `onLoad` synchronously invoked that factory and Proxy-wrapped the return value for chunk-usage tracking. When the factory is async, the sync invocation returns a raw `Promise`. Proxy-wrapping that `Promise` causes webpack's async module runtime to fail when calling `.then()`:

TypeError: Method Promise.prototype.then called on incompatible receiver [object Promise]

`runtime-core` catches this in `loadRemote` and routes it to `errorLoadRemote` with `lifecycle: 'onLoad'` and `from: 'build'`.

**Solution:** Make the server-side `onLoad` hook async-safe by awaiting `Promise` results from `moduleOrFactory()` before applying the existing Proxy wrapper. `runtime-core` already handles async factories in `module.wraperFactory`; this aligns `nextjs-mf` `onLoad` with that behavior.

Added regression tests in `runtimePlugin.test.ts` for the async `exposeModuleFactory` server path.

## Related Issue

https://github.com/module-federation/core/discussions/2218

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] I have updated the documentation.
