### PR TITLE
fix(rstest): coordinate Node configuration ownership

### DIFF
--- a/.changeset/rstest-legacy-node-defaults.md
+++ b/.changeset/rstest-legacy-node-defaults.md
@@ -1,5 +1,6 @@
 ---
 '@module-federation/rsbuild-plugin': patch
+'@module-federation/rstest': patch
 ---
 
-Preserve existing Node federation defaults when Rstest is used without the Rstest federation companion plugin.
+Coordinate Node configuration ownership between the Rsbuild and Rstest federation plugins while preserving Rstest's runtime chunk and split-chunk behavior.

--- a/.changeset/rstest-legacy-node-defaults.md
+++ b/.changeset/rstest-legacy-node-defaults.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rsbuild-plugin': patch
+---
+
+Preserve existing Node federation defaults when Rstest is used without the Rstest federation companion plugin.

--- a/apps/website-new/docs/zh/_nav.json
+++ b/apps/website-new/docs/zh/_nav.json
@@ -27,6 +27,10 @@
         "link": "/integrations/build-tool/rslib"
       },
       {
+        "text": "Rstest",
+        "link": "/integrations/build-tool/rstest"
+      },
+      {
         "text": "Vite",
         "link": "/integrations/build-tool/vite"
       },

--- a/packages/rsbuild-plugin/src/cli/index.ts
+++ b/packages/rsbuild-plugin/src/cli/index.ts
@@ -60,6 +60,7 @@ type ExposedAPIType = {
   };
   assetResources: Record<string, StatsAssetResource>;
   getOptions: () => ModuleFederationOptions;
+  registerNodeTargetConfigOwner?: () => void;
   registerOptionsTransformer: (
     transformer: ModuleFederationOptionsTransformer,
   ) => void;
@@ -152,7 +153,7 @@ export const pluginModuleFederation = (
   name: RSBUILD_PLUGIN_MODULE_FEDERATION_NAME,
   setup: (api) => {
     let moduleFederationOptions = initialModuleFederationOptions;
-    let hasOptionsTransformer = false;
+    let hasNodeTargetConfigOwner = false;
 
     if (!moduleFederationOptions?.name) {
       throw new Error(
@@ -181,7 +182,7 @@ export const pluginModuleFederation = (
     const isRslib = callerName === CALL_NAME_MAP.RSLIB;
     const isRspress = callerName === CALL_NAME_MAP.RSPRESS;
     const isRstest = callerName === 'rstest';
-    const isRstestCompanionActive = () => isRstest && hasOptionsTransformer;
+    const isRstestCompanionActive = () => isRstest && hasNodeTargetConfigOwner;
     const isSSR = target === 'dual';
     const environment =
       configuredEnvironment ??
@@ -327,8 +328,10 @@ export const pluginModuleFederation = (
       },
       assetResources: {},
       getOptions: () => moduleFederationOptions,
+      registerNodeTargetConfigOwner: () => {
+        hasNodeTargetConfigOwner = true;
+      },
       registerOptionsTransformer: (transformer) => {
-        hasOptionsTransformer = true;
         moduleFederationOptions = transformer(moduleFederationOptions);
       },
       isSSRConfig,
@@ -484,6 +487,11 @@ export const pluginModuleFederation = (
             : undefined;
 
           if (!isRstestCompanionActive()) {
+            if (bundlerConfig.optimization?.runtimeChunk) {
+              logger.warn(
+                '`optimization.runtimeChunk` is disabled because Module Federation requires its runtime to remain with each entry. The Rstest federation companion is the supported exception because its worker loads the shared runtime explicitly.',
+              );
+            }
             delete bundlerConfig.optimization?.runtimeChunk;
           }
           const externals = bundlerConfig.externals;

--- a/packages/rsbuild-plugin/src/cli/index.ts
+++ b/packages/rsbuild-plugin/src/cli/index.ts
@@ -152,6 +152,7 @@ export const pluginModuleFederation = (
   name: RSBUILD_PLUGIN_MODULE_FEDERATION_NAME,
   setup: (api) => {
     let moduleFederationOptions = initialModuleFederationOptions;
+    let hasOptionsTransformer = false;
 
     if (!moduleFederationOptions?.name) {
       throw new Error(
@@ -180,6 +181,7 @@ export const pluginModuleFederation = (
     const isRslib = callerName === CALL_NAME_MAP.RSLIB;
     const isRspress = callerName === CALL_NAME_MAP.RSPRESS;
     const isRstest = callerName === 'rstest';
+    const isRstestCompanionActive = () => isRstest && hasOptionsTransformer;
     const isSSR = target === 'dual';
     const environment =
       configuredEnvironment ??
@@ -295,7 +297,7 @@ export const pluginModuleFederation = (
             `Can not find environment '${environment}' when using target: 'node'. Available environments: ${availableEnvironmentsLabel}.`,
           );
         }
-        if (!isRstest) {
+        if (!isRstestCompanionActive()) {
           patchToolsTspack(nodeTargetEnv, (config) => {
             config.target = 'async-node';
           });
@@ -326,6 +328,7 @@ export const pluginModuleFederation = (
       assetResources: {},
       getOptions: () => moduleFederationOptions,
       registerOptionsTransformer: (transformer) => {
+        hasOptionsTransformer = true;
         moduleFederationOptions = transformer(moduleFederationOptions);
       },
       isSSRConfig,
@@ -435,7 +438,7 @@ export const pluginModuleFederation = (
           isRspress && isRspressSSGEnvironmentConfig;
         const shouldUseSSRPluginConfig =
           isSSRConfig(bundlerConfig.name) ||
-          (isNodeTargetEnvironmentConfig && !isRstest);
+          (isNodeTargetEnvironmentConfig && !isRstestCompanionActive());
 
         if (
           target === 'node' &&
@@ -480,7 +483,7 @@ export const pluginModuleFederation = (
             ? createSSRMFConfig(moduleFederationOptions)
             : undefined;
 
-          if (!isRstest) {
+          if (!isRstestCompanionActive()) {
             delete bundlerConfig.optimization?.runtimeChunk;
           }
           const externals = bundlerConfig.externals;
@@ -541,7 +544,7 @@ export const pluginModuleFederation = (
             bundlerConfig.output!.chunkLoadingGlobal = `chunk_${moduleFederationOptions.name}`;
           }
 
-          if (isNodeTargetEnvironmentConfig && !isRstest) {
+          if (isNodeTargetEnvironmentConfig && !isRstestCompanionActive()) {
             patchNodeConfig(
               bundlerConfig,
               ssrModuleFederationOptions ?? moduleFederationOptions,
@@ -569,7 +572,7 @@ export const pluginModuleFederation = (
             if (shouldUseSSRPluginConfig || isNodeTargetEnvironmentConfig) {
               const ssrMFConfig =
                 ssrModuleFederationOptions ??
-                (isRstest
+                (isRstestCompanionActive()
                   ? moduleFederationOptions
                   : createSSRMFConfig(moduleFederationOptions));
               exposedFederationApi.options.nodePlugin =

--- a/packages/rsbuild-plugin/src/cli/node-target.spec.ts
+++ b/packages/rsbuild-plugin/src/cli/node-target.spec.ts
@@ -135,6 +135,9 @@ describe('pluginModuleFederation node target environment behavior', () => {
   });
 
   it('preserves legacy Node defaults when the Rstest companion is absent', () => {
+    const warningSpy = rs
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     const plugin = pluginModuleFederation(createMfOptions(), {
       target: 'node',
       environment: 'rstest',
@@ -173,9 +176,63 @@ describe('pluginModuleFederation node target environment behavior', () => {
     });
     expect(bundlerConfig.optimization?.runtimeChunk).toBeUndefined();
     expect(bundlerConfig.plugins).toHaveLength(1);
+    expect(warningSpy.mock.calls.flat().map(String).join('\n')).toContain(
+      'optimization.runtimeChunk',
+    );
+    warningSpy.mockRestore();
   });
 
   it('lets the Rstest companion own Node test-worker defaults', () => {
+    const plugin = pluginModuleFederation(createMfOptions(), {
+      target: 'node',
+      environment: 'rstest',
+    });
+    const { api, state, rsbuildConfig } = createMockApi(
+      {
+        environments: {
+          rstest: {},
+        },
+      },
+      'rstest',
+      true,
+    );
+    const bundlerConfig: Rspack.Configuration = {
+      name: 'rstest',
+      output: {
+        path: '/tmp/rstest',
+      },
+      optimization: {
+        runtimeChunk: {
+          name: 'rstest-runtime',
+        },
+      },
+      plugins: [],
+    };
+
+    plugin.setup(api as any);
+    const exposedApi = (api.expose as ReturnType<typeof rs.fn>).mock.calls.find(
+      ([name]) => name === RSBUILD_PLUGIN_MODULE_FEDERATION_NAME,
+    )?.[1] as ExposedAPIType;
+    exposedApi.registerNodeTargetConfigOwner!();
+    exposedApi.registerOptionsTransformer((options) => options);
+    state.modifyRsbuildConfig!(rsbuildConfig);
+    state.beforeCreateCompiler!({
+      bundlerConfigs: [bundlerConfig],
+    });
+
+    expect(rsbuildConfig.environments.rstest.tools?.rspack).toBeUndefined();
+    expect(bundlerConfig.target).toBeUndefined();
+    expect(bundlerConfig.output?.chunkLoading).toBeUndefined();
+    expect(bundlerConfig.optimization?.runtimeChunk).toEqual({
+      name: 'rstest-runtime',
+    });
+    expect(bundlerConfig.plugins).toHaveLength(1);
+  });
+
+  it('does not treat a generic options transformer as a Node config owner', () => {
+    const warningSpy = rs
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     const plugin = pluginModuleFederation(createMfOptions(), {
       target: 'node',
       environment: 'rstest',
@@ -212,13 +269,10 @@ describe('pluginModuleFederation node target environment behavior', () => {
       bundlerConfigs: [bundlerConfig],
     });
 
-    expect(rsbuildConfig.environments.rstest.tools?.rspack).toBeUndefined();
-    expect(bundlerConfig.target).toBeUndefined();
-    expect(bundlerConfig.output?.chunkLoading).toBeUndefined();
-    expect(bundlerConfig.optimization?.runtimeChunk).toEqual({
-      name: 'rstest-runtime',
-    });
-    expect(bundlerConfig.plugins).toHaveLength(1);
+    expect(rsbuildConfig.environments.rstest.tools?.rspack).toBeDefined();
+    expect(bundlerConfig.target).toBe('async-node');
+    expect(bundlerConfig.optimization?.runtimeChunk).toBeUndefined();
+    warningSpy.mockRestore();
   });
 
   it('still applies MF to the selected node environment when output is commonjs-like', () => {

--- a/packages/rsbuild-plugin/src/cli/node-target.spec.ts
+++ b/packages/rsbuild-plugin/src/cli/node-target.spec.ts
@@ -13,11 +13,13 @@ type MockApiState = {
   beforeCreateCompiler?: (args: {
     bundlerConfigs?: Rspack.Configuration[];
   }) => void;
+  modifyRsbuildConfig?: (config: Record<string, any>) => void;
 };
 
 function createMockApi(
   rsbuildConfig: Record<string, any>,
   callerName = 'rsbuild',
+  deferRsbuildConfig = false,
 ) {
   const originalConfig = JSON.parse(JSON.stringify(rsbuildConfig));
   const state: MockApiState = {};
@@ -29,7 +31,11 @@ function createMockApi(
     getRsbuildConfig: (kind?: 'original') =>
       kind === 'original' ? originalConfig : rsbuildConfig,
     modifyRsbuildConfig: (callback: (config: Record<string, any>) => void) => {
-      callback(rsbuildConfig);
+      if (deferRsbuildConfig) {
+        state.modifyRsbuildConfig = callback;
+      } else {
+        callback(rsbuildConfig);
+      }
     },
     modifyEnvironmentConfig: rs.fn(),
     expose: rs.fn(),
@@ -128,7 +134,7 @@ describe('pluginModuleFederation node target environment behavior', () => {
     expect(rsbuildConfig.environments.web.tools?.rspack).toBeUndefined();
   });
 
-  it('lets Rstest own Node test-worker chunk loading', () => {
+  it('preserves legacy Node defaults when the Rstest companion is absent', () => {
     const plugin = pluginModuleFederation(createMfOptions(), {
       target: 'node',
       environment: 'rstest',
@@ -159,7 +165,55 @@ describe('pluginModuleFederation node target environment behavior', () => {
       bundlerConfigs: [bundlerConfig],
     });
 
+    expect(rsbuildConfig.environments.rstest.tools?.rspack).toBeDefined();
+    expect(bundlerConfig.target).toBe('async-node');
+    expect(bundlerConfig.output?.chunkLoading).toBe('async-node');
+    expect(bundlerConfig.output?.library).toEqual({
+      type: 'commonjs-module',
+    });
+    expect(bundlerConfig.optimization?.runtimeChunk).toBeUndefined();
+    expect(bundlerConfig.plugins).toHaveLength(1);
+  });
+
+  it('lets the Rstest companion own Node test-worker defaults', () => {
+    const plugin = pluginModuleFederation(createMfOptions(), {
+      target: 'node',
+      environment: 'rstest',
+    });
+    const { api, state, rsbuildConfig } = createMockApi(
+      {
+        environments: {
+          rstest: {},
+        },
+      },
+      'rstest',
+      true,
+    );
+    const bundlerConfig: Rspack.Configuration = {
+      name: 'rstest',
+      output: {
+        path: '/tmp/rstest',
+      },
+      optimization: {
+        runtimeChunk: {
+          name: 'rstest-runtime',
+        },
+      },
+      plugins: [],
+    };
+
+    plugin.setup(api as any);
+    const exposedApi = (api.expose as ReturnType<typeof rs.fn>).mock.calls.find(
+      ([name]) => name === RSBUILD_PLUGIN_MODULE_FEDERATION_NAME,
+    )?.[1] as ExposedAPIType;
+    exposedApi.registerOptionsTransformer((options) => options);
+    state.modifyRsbuildConfig!(rsbuildConfig);
+    state.beforeCreateCompiler!({
+      bundlerConfigs: [bundlerConfig],
+    });
+
     expect(rsbuildConfig.environments.rstest.tools?.rspack).toBeUndefined();
+    expect(bundlerConfig.target).toBeUndefined();
     expect(bundlerConfig.output?.chunkLoading).toBeUndefined();
     expect(bundlerConfig.optimization?.runtimeChunk).toEqual({
       name: 'rstest-runtime',

--- a/packages/rstest/src/index.test.ts
+++ b/packages/rstest/src/index.test.ts
@@ -61,8 +61,8 @@ type BeforeCreateCompilerHookDescriptor =
 // happens once, at the hook boundary in runRspackHooks.
 type TestRspackConfig = {
   target?: unknown;
-  output?: { module?: boolean };
-  optimization?: { splitChunks?: unknown };
+  output?: { chunkLoading?: unknown; module?: boolean };
+  optimization?: { runtimeChunk?: unknown; splitChunks?: unknown };
   experiments?: { outputModule?: boolean };
   externals?: unknown[];
   plugins?: unknown[];
@@ -114,19 +114,26 @@ const getFederationPluginOptions = (
 
 const createRsbuildFederationExposeAPI = (
   initialOptions: ModuleFederationOptions,
-): RsbuildFederationExposeAPI => {
+): RsbuildFederationExposeAPI & { ownsNodeTargetConfig: boolean } => {
   let options = initialOptions;
-
-  return {
+  const exposedApi: RsbuildFederationExposeAPI & {
+    ownsNodeTargetConfig: boolean;
+  } = {
     options: {},
     assetResources: {},
+    ownsNodeTargetConfig: false,
     getOptions: () => options,
+    registerNodeTargetConfigOwner: () => {
+      exposedApi.ownsNodeTargetConfig = true;
+    },
     registerOptionsTransformer: (transformer) => {
       options = transformer(options);
     },
     isSSRConfig: () => false,
     isRspressSSGConfig: () => false,
   };
+
+  return exposedApi;
 };
 
 // Minimal Rsbuild API surface used by the plugin.
@@ -417,6 +424,7 @@ describe('federation()', () => {
 
     setupFederationPlugin(federation(), 'rstest', {}, { rsbuildFederation });
 
+    expect(rsbuildFederation.ownsNodeTargetConfig).toBe(true);
     expect(rsbuildFederation.getOptions()).toMatchObject({
       name: 'rsbuild_owned_host',
       remoteType: 'script',
@@ -431,6 +439,21 @@ describe('federation()', () => {
         },
       },
     });
+  });
+
+  it('remains compatible with an older Rsbuild exposed API', () => {
+    const rsbuildFederation = createRsbuildFederationExposeAPI({
+      name: 'legacy_rsbuild_host',
+    });
+    delete (rsbuildFederation as Partial<RsbuildFederationExposeAPI>)
+      .registerNodeTargetConfigOwner;
+
+    expect(() =>
+      setupFederationPlugin(federation(), 'rstest', {}, { rsbuildFederation }),
+    ).not.toThrow();
+    expect(
+      rsbuildFederation.getOptions().experiments?.optimization?.target,
+    ).toBe('node');
   });
 
   it('creates one compiler plugin from Rsbuild-owned options', () => {
@@ -470,16 +493,53 @@ describe('federation()', () => {
     expect(rstestConfig.federation).toBeUndefined();
   });
 
-  it('patches rspack config to force CJS output in node/jsdom workers', () => {
+  it('preserves Rstest chunk defaults while supplying a missing Node target', () => {
+    const splitChunks = { chunks: 'all' };
+    const runtimeChunk = { name: 'rstest-runtime' };
     const { merged, rspackConfig } = applyFederationPlugin(federation(), {
       rsbuildFederation: createRsbuildFederationExposeAPI({ name: 'host' }),
+      rspackConfig: {
+        output: {},
+        optimization: { runtimeChunk, splitChunks },
+        plugins: [],
+      },
     });
 
     expect(merged.output?.target).toBe('node');
     expect(rspackConfig.target).toBe('async-node');
-    expect(rspackConfig.optimization?.splitChunks).toBe(false);
+    expect(rspackConfig.optimization?.splitChunks).toBe(splitChunks);
+    expect(rspackConfig.optimization?.runtimeChunk).toBe(runtimeChunk);
     expect(rspackConfig.experiments?.outputModule).toBe(false);
     expect(rspackConfig.output?.module).toBe(false);
+  });
+
+  it('normalizes incompatible compiler settings without changing Rstest chunk policy', () => {
+    const splitChunks = { chunks: 'async' };
+    const runtimeChunk = { name: 'custom-runtime' };
+    const { result, warnings } = captureWarnings(() =>
+      applyFederationPlugin(federation(), {
+        rsbuildFederation: createRsbuildFederationExposeAPI({ name: 'host' }),
+        rspackConfig: {
+          target: 'web',
+          output: { chunkLoading: 'jsonp', module: true },
+          optimization: { runtimeChunk, splitChunks },
+          plugins: [],
+        },
+      }),
+    );
+
+    expect(result.rspackConfig.target).toBe('async-node');
+    expect(result.rspackConfig.output).toEqual({
+      chunkLoading: 'async-node',
+      module: false,
+    });
+    expect(result.rspackConfig.optimization).toEqual({
+      runtimeChunk,
+      splitChunks,
+    });
+    expect(warnings.join('\n')).toContain('target "web"');
+    expect(warnings.join('\n')).toContain('output.module');
+    expect(warnings.join('\n')).toContain('output.chunkLoading "jsonp"');
   });
 
   it('keeps federation remote requests bundled via externals bypass', () => {
@@ -609,7 +669,7 @@ describe('federation()', () => {
     );
   });
 
-  it('auto-applies ModuleFederationPlugin with node defaults', () => {
+  it('auto-applies ModuleFederationPlugin with federation-specific Node defaults', () => {
     const { rspackConfig } = applyFederationPlugin(
       federation({
         name: 'main_app_web',
@@ -623,7 +683,7 @@ describe('federation()', () => {
     );
 
     expect(rspackConfig.target).toBe('async-node');
-    expect(rspackConfig.optimization?.splitChunks).toBe(false);
+    expect(rspackConfig.optimization?.splitChunks).toBeUndefined();
     expect(rspackConfig.experiments?.outputModule).toBe(false);
     expect(rspackConfig.output?.module).toBe(false);
 
@@ -675,7 +735,7 @@ describe('federation()', () => {
     expect(options.dev).toBe(true);
   });
 
-  it('preserves user overrides while still injecting node runtime plugin', () => {
+  it('preserves compatible overrides while enforcing the container identity', () => {
     const { result: options, warnings } = captureWarnings(() => {
       const { rspackConfig } = applyFederationPlugin(
         federation({
@@ -708,11 +768,11 @@ describe('federation()', () => {
       'custom/runtimePlugin',
     ]);
     expect(warnings.join('\n')).toContain(
-      'library.name "custom_library_name" is overridden with the container name "component_app"',
+      'library.name "custom_library_name" is incompatible with the container name "component_app"',
     );
   });
 
-  it('forces node optimization target even when configured otherwise', () => {
+  it('enforces the Node optimization target and warns on incompatible input', () => {
     const { result: options, warnings } = captureWarnings(() => {
       const { rspackConfig } = applyFederationPlugin(
         federation({
@@ -729,12 +789,12 @@ describe('federation()', () => {
 
     expect(options.experiments?.optimization?.target).toBe('node');
     expect(warnings.join('\n')).toContain(
-      'experiments.optimization.target "web" is overridden with "node"',
+      'experiments.optimization.target "web" is incompatible with Node test workers',
     );
   });
 
   it.each(['module', 'modern-module'] as const)(
-    'normalizes incompatible %s library output',
+    'normalizes incompatible %s library output with a warning',
     (libraryType) => {
       const { result: options, warnings } = captureWarnings(() => {
         const { rspackConfig } = applyFederationPlugin(
@@ -753,12 +813,12 @@ describe('federation()', () => {
         type: 'commonjs-module',
       });
       expect(warnings.join('\n')).toContain(
-        `library.type "${libraryType}" is overridden with "commonjs-module"`,
+        `library.type "${libraryType}" is incompatible with Rstest's CommonJS federation worker`,
       );
     },
   );
 
-  it('forces async startup and warns when disabled manually', () => {
+  it('enforces async startup and warns when explicitly disabled', () => {
     const { result: options, warnings } = captureWarnings(() => {
       const { rspackConfig } = applyFederationPlugin(
         federation({
@@ -773,7 +833,7 @@ describe('federation()', () => {
 
     expect(options.experiments?.asyncStartup).toBe(true);
     expect(warnings.join('\n')).toContain(
-      'experiments.asyncStartup was set to false but is forced to true',
+      'experiments.asyncStartup is false and incompatible with Rstest federation startup',
     );
   });
 

--- a/packages/rstest/src/node-defaults.ts
+++ b/packages/rstest/src/node-defaults.ts
@@ -7,7 +7,7 @@ export const withRstestDefaults = (
 ): ModuleFederationOptions => {
   if (options.experiments?.asyncStartup === false) {
     logger.warn(
-      'experiments.asyncStartup was set to false but is forced to true: rstest bootstraps federation containers inside test workers, which requires async startup.',
+      'experiments.asyncStartup is false and incompatible with Rstest federation startup; it is overridden with true.',
     );
   }
 
@@ -56,14 +56,14 @@ export const withNodeDefaults = (
 
   if (merged.library?.name != null && merged.library.name !== merged.name) {
     logger.warn(
-      `library.name "${String(merged.library.name)}" is overridden with the container name "${String(merged.name)}" so the container can be resolved in Node test workers.`,
+      `library.name "${String(merged.library.name)}" is incompatible with the container name "${String(merged.name)}" required by Node test workers; it is overridden.`,
     );
   }
 
   const userOptimizationTarget = merged.experiments?.optimization?.target;
   if (userOptimizationTarget != null && userOptimizationTarget !== 'node') {
     logger.warn(
-      `experiments.optimization.target "${String(userOptimizationTarget)}" is overridden with "node": rstest executes federation builds in Node test workers.`,
+      `experiments.optimization.target "${String(userOptimizationTarget)}" is incompatible with Node test workers; it is overridden with "node".`,
     );
   }
 
@@ -76,7 +76,7 @@ export const withNodeDefaults = (
 
   if (usesEsmLibrary) {
     logger.warn(
-      `library.type "${userLibraryType}" is overridden with "commonjs-module": rstest disables module output in Node test workers.`,
+      `library.type "${userLibraryType}" is incompatible with Rstest's CommonJS federation worker; it is overridden with "commonjs-module".`,
     );
   }
 

--- a/packages/rstest/src/plugin.ts
+++ b/packages/rstest/src/plugin.ts
@@ -160,6 +160,9 @@ export const federation = (
         );
       }
 
+      if (isNodeTarget) {
+        rsbuildFederationApi.registerNodeTargetConfigOwner?.();
+      }
       rsbuildFederationApi.registerOptionsTransformer(normalizeOptions);
       getEffectiveOptions = rsbuildFederationApi.getOptions;
     }

--- a/packages/rstest/src/rspack-hook.ts
+++ b/packages/rstest/src/rspack-hook.ts
@@ -1,17 +1,54 @@
 import type { Rspack } from '@rsbuild/core';
+import { logger } from './logger';
+
+const isNodeTarget = (target: Rspack.Configuration['target']): boolean => {
+  const targets = Array.isArray(target) ? target : [target];
+  return targets.some(
+    (value) =>
+      typeof value === 'string' &&
+      (value === 'async-node' || value === 'node' || /^node\d/.test(value)),
+  );
+};
+
+const formatConfigValue = (value: unknown): string =>
+  typeof value === 'string'
+    ? `"${value}"`
+    : (JSON.stringify(value) ?? String(value));
 
 export const applyNodeRspackDefaults = (
   rspackConfig: Rspack.Configuration,
 ): void => {
+  if (rspackConfig.target != null && !isNodeTarget(rspackConfig.target)) {
+    logger.warn(
+      `target ${formatConfigValue(rspackConfig.target)} may not support Node federation chunk loading; use "async-node" unless the custom target is intentional.`,
+    );
+  }
   rspackConfig.target = 'async-node';
-  rspackConfig.optimization ??= {};
-  rspackConfig.optimization.splitChunks = false;
+
+  if (rspackConfig.output?.module === true) {
+    logger.warn(
+      'output.module is enabled, but Rstest federation requires its CommonJS worker loader; it is overridden with false.',
+    );
+  }
+
+  const chunkLoading = rspackConfig.output?.chunkLoading;
+  if (
+    chunkLoading != null &&
+    chunkLoading !== 'async-node' &&
+    chunkLoading !== 'require'
+  ) {
+    logger.warn(
+      `output.chunkLoading ${formatConfigValue(chunkLoading)} is incompatible with Node federation test workers; it is overridden with "async-node".`,
+    );
+  }
+
+  rspackConfig.output ??= {};
+  rspackConfig.output.module = false;
+  rspackConfig.output.chunkLoading = 'async-node';
 
   rspackConfig.experiments ??= {};
   // `experiments.outputModule` only exists on rspack/rsbuild 1.x (the peer
   // range still allows it); there `output.module` alone is not enough when
   // the experiment is enabled. On 2.x the assignment is a harmless no-op.
   (rspackConfig.experiments as { outputModule?: boolean }).outputModule = false;
-  rspackConfig.output ??= {};
-  rspackConfig.output.module = false;
 };


### PR DESCRIPTION
## Description

This follow-up to #4920 makes Node configuration ownership explicit between `@module-federation/rsbuild-plugin` and `@module-federation/rstest`. Checking only `callerName === 'rstest'` skipped Rsbuild's established Node normalization even when the Rstest federation companion was absent, while treating any options transformer as the companion was too broad.

The Rstest companion now explicitly claims the Node target configuration when it is active. It preserves Rstest's named runtime chunk and split-chunk behavior, while enforcing only the proven Federation invariants: async Node/CommonJS chunk loading, CommonJS worker output, async startup, Node optimization, and the worker-resolvable container identity. Incompatible explicit values produce focused warnings before normalization. The ownership hook is optional so the companion remains compatible with the previous Rsbuild exposed API.

Without the companion, the Rsbuild plugin retains its existing Node defaults and now warns when it must disable an incompatible `optimization.runtimeChunk`. Regression tests cover the legacy path, the explicit ownership path, unrelated options transformers, incompatible user configuration, and backward compatibility.

The Chinese Integrations navigation links to the Rstest guide, and the changeset covers both published plugins.

Validation completed locally:

- `pnpm --filter @module-federation/rsbuild-plugin run build`
- `pnpm --filter @module-federation/rsbuild-plugin run test`
- `pnpm --filter @module-federation/rstest run test`
- `pnpm run ci:local --only=e2e-rstest`
- Pre-commit lint for both changed packages
- Changed-file Prettier, changeset scope/status, and `git diff --check`

The realistic three-app Rstest E2E suite passed with two Node tests, one browser test, and one browser ESM test. The full repository Prettier scan was not repeated because the validation build generates `apps/website-new/doc_build`, which produces thousands of non-source warnings; every changed source file passes Prettier.

## Related Issue

Follow-up to #4920.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
