### PR TITLE
fix(modernjs-v3): compute Content-Length in bytes for served bundles

### DIFF
--- a/.changeset/modernjs-v3-content-length-bytes.md
+++ b/.changeset/modernjs-v3-content-length-bytes.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/modern-js-v3': patch
+---
+
+Fix truncated remote chunks served from `/bundles` by computing `Content-Length` in bytes instead of characters. Chunks containing non-ASCII characters were cut short, causing `SyntaxError` when an SSR consumer evaluated them.

--- a/packages/modernjs-v3/src/server/staticMiddleware.spec.ts
+++ b/packages/modernjs-v3/src/server/staticMiddleware.spec.ts
@@ -193,6 +193,49 @@ describe('staticMiddleware', () => {
       expect(result).toBe('empty-response');
       expect(nextSpy).not.toHaveBeenCalled();
     });
+
+    it('should set Content-Length in bytes for non-ASCII content', async () => {
+      // Multi-byte characters make byte length differ from string length.
+      // Using the string length here truncates the response body.
+      const mockFileContent = 'console.log("中文注释");';
+      const mockFileResult = {
+        content: mockFileContent,
+        lastModified: Date.now(),
+      };
+
+      mockContext.req.path = '/bundles/non-ascii.js';
+      (access as any).mockResolvedValue(undefined);
+      (fileCache.getFile as any).mockResolvedValue(mockFileResult);
+
+      await middleware(mockContext, nextSpy);
+
+      expect(Buffer.byteLength(mockFileContent)).toBeGreaterThan(
+        mockFileContent.length,
+      );
+      expect(mockContext.header).toHaveBeenCalledWith(
+        'Content-Length',
+        String(Buffer.byteLength(mockFileContent)),
+      );
+    });
+
+    it('should set Content-Length in bytes for ASCII content', async () => {
+      const mockFileContent = 'console.log("ascii only");';
+      const mockFileResult = {
+        content: mockFileContent,
+        lastModified: Date.now(),
+      };
+
+      mockContext.req.path = '/bundles/ascii.js';
+      (access as any).mockResolvedValue(undefined);
+      (fileCache.getFile as any).mockResolvedValue(mockFileResult);
+
+      await middleware(mockContext, nextSpy);
+
+      expect(mockContext.header).toHaveBeenCalledWith(
+        'Content-Length',
+        String(mockFileContent.length),
+      );
+    });
   });
 
   describe('asset prefix handling', () => {

--- a/packages/modernjs-v3/src/server/staticMiddleware.ts
+++ b/packages/modernjs-v3/src/server/staticMiddleware.ts
@@ -63,7 +63,10 @@ const createStaticMiddleware = (options: {
     }
 
     c.header('Content-Type', 'application/javascript');
-    c.header('Content-Length', String(fileResult.content.length));
+    // The file is read as a UTF-8 string, so `content.length` is the number of
+    // characters. Content-Length must be the number of bytes, otherwise any
+    // chunk containing non-ASCII characters is truncated by the difference.
+    c.header('Content-Length', String(Buffer.byteLength(fileResult.content)));
     return c.body(fileResult.content, 200);
   };
 };


### PR DESCRIPTION
# fix(modernjs-v3): compute Content-Length in bytes for served bundles

## Summary

`createStaticMiddleware` serves node-side federated chunks from `/bundles`. The file is read as a UTF-8 **string** by `fileCache.getFile`, but `Content-Length` is set from `content.length`, which is the number of **characters**:

```ts
// packages/modernjs-v3/src/server/staticMiddleware.ts
c.header('Content-Length', String(fileResult.content.length));
```

For any chunk containing non-ASCII characters (comments, string literals), the byte length exceeds the character length, so the response is truncated by exactly that difference. An SSR consumer then evaluates an incomplete chunk and throws.

Fixed by using `Buffer.byteLength(fileResult.content)`.

## Impact

Only affects production (`modern serve`) with SSR enabled — the middleware returns early when `NODE_ENV === 'development'`, and it is only registered when `server.ssr` is set. Chunks that are pure ASCII are unaffected because byte length equals character length, which is why this went unnoticed.

Deployments that serve remote assets via CDN or nginx do not hit this middleware at all.

## Reproduction

A Modern.js producer with SSR enabled that exposes a module whose chunk contains non-ASCII characters, consumed by a Modern.js SSR host.

```
SyntaxError: Unexpected token '}'
Federated chunk execution failed.
chunk: __federation_expose_marketing_dataops-<hash>.js
source: remote-url
location: http://127.0.0.1:3052/bundles/__federation_expose_marketing_dataops-<hash>.js
```

The chunk on disk is valid; the served copy is not:

```bash
# valid
node --check dist/bundles/__federation_expose_marketing_data<hash>.js

# truncated
curl -s http://127.0.0.1:3052/bundles/__federation_expose_marketing_data<hash>.js > /tmp/c.js
node --check /tmp/c.js
# SyntaxError: Unexpected end of input
```

Byte/character mismatch matches the truncation exactly:

```
file on disk : 1207 bytes / 1103 characters
response     : content-length: 1103  ->  104 bytes short
```

A minimal probe shows the same off-by-multibyte for any file, not just federated chunks — a 46-byte file with non-ASCII content is served as 38 bytes.

## Changes

- `packages/modernjs-v3/src/server/staticMiddleware.ts` — use `Buffer.byteLength` for `Content-Length`
- `packages/modernjs-v3/src/server/staticMiddleware.spec.ts` — cover non-ASCII and ASCII content

## Notes

`fileCache.ts` has a related fallback, `size: stat.size || content.length`, which mixes the same two units. It is only reached when `stat.size` is falsy, so it is left alone here to keep this PR to a single issue. Happy to fix it separately if you'd prefer.

## Test plan

```sh
pnpm --filter @module-federation/modern-js-v3 run test
```

The added non-ASCII test fails before the fix and passes after. Verified end to end against a Modern.js SSR host consuming a producer whose chunks contain non-ASCII characters: the served chunk now passes `node --check` and the remote module renders on the server.
