### PR TITLE
fix: correct stream SSR splitChunks warning and refresh stale docs

### DIFF
--- a/.changeset/fix-splitchunks-ssr-warn.md
+++ b/.changeset/fix-splitchunks-ssr-warn.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/modern-js': patch
+'@module-federation/modern-js-v3': patch
+---
+
+Fix misleading splitChunks warning under stream SSR so it only fires when chunks was not already async.

--- a/packages/modernjs-v3/src/cli/configPlugin.ts
+++ b/packages/modernjs-v3/src/cli/configPlugin.ts
@@ -348,10 +348,13 @@ export function patchBundlerConfig(options: {
     typeof splitChunkConfig === 'object' &&
     splitChunkConfig.cacheGroups
   ) {
+    const previousChunks = splitChunkConfig.chunks;
     splitChunkConfig.chunks = 'async';
-    logger.warn(
-      `splitChunks.chunks = async is not allowed with stream SSR mode, it will auto changed to "async"`,
-    );
+    if (previousChunks && previousChunks !== 'async') {
+      logger.warn(
+        `splitChunks.chunks = "${previousChunks}" is not allowed with stream SSR mode; forcing "async"`,
+      );
+    }
   }
 
   if (isDev() && chain.output.get('publicPath') === 'auto') {

--- a/packages/modernjs/src/cli/configPlugin.ts
+++ b/packages/modernjs/src/cli/configPlugin.ts
@@ -355,10 +355,13 @@ export function patchBundlerConfig(options: {
     typeof splitChunkConfig === 'object' &&
     splitChunkConfig.cacheGroups
   ) {
+    const previousChunks = splitChunkConfig.chunks;
     splitChunkConfig.chunks = 'async';
-    logger.warn(
-      `splitChunks.chunks = async is not allowed with stream SSR mode, it will auto changed to "async"`,
-    );
+    if (previousChunks && previousChunks !== 'async') {
+      logger.warn(
+        `splitChunks.chunks = "${previousChunks}" is not allowed with stream SSR mode; forcing "async"`,
+      );
+    }
   }
 
   if (isDev() && chain.output.get('publicPath') === 'auto') {

--- a/packages/rspress-plugin/README.md
+++ b/packages/rspress-plugin/README.md
@@ -1,33 +1,32 @@
-# @examples/mf-react-component
+# @module-federation/rspress-plugin
 
-This example demonstrates how to use Rslib to build a simple Module Federation React component.
+Module Federation plugin for [Rspress](https://rspress.dev/). Wraps the Rsbuild Module Federation plugin and can rebuild search / LLM indexes from HTML after the build.
 
-### Command
+## Install
 
-Build package
-
-```
-nx build rslib-module
+```bash
+pnpm add @module-federation/rspress-plugin
 ```
 
-Serve package
+## Build
 
-```
-nx serve rslib-module
-```
-
-Dev package
-
-1.
-
-```
-nx dev rslib-module
+```bash
+pnpm --filter @module-federation/rspress-plugin run build
 ```
 
-2.
+## Usage
 
-```
-nx storybook rslib-module
+```ts
+import { pluginModuleFederation } from '@module-federation/rspress-plugin';
+
+export default {
+  plugins: [
+    pluginModuleFederation({
+      name: 'doc-app',
+      // ...Module Federation options
+    }),
+  ],
+};
 ```
 
-visit http://localhost:6006
+Optional second argument controls Rspress-specific behavior (`autoShared`, `rebuildSearchIndex`, `rebuildLlms`).

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -1,22 +1,24 @@
-# utils
+# @module-federation/utilities
 
-For warning： [`@module-federation/runtime`](https://module-federation.io/guide/basic/runtime/runtime.html) is recommended as a replacement
-
-This library was generated with [Nx](https://nx.dev).
+For warning: [`@module-federation/runtime`](https://module-federation.io/guide/basic/runtime/runtime.html) is recommended as a replacement.
 
 ## Building
 
-Run `nx build utils` to build the library.
+```bash
+pnpm --filter @module-federation/utilities run build
+```
 
 ## Running unit tests
 
-Run `nx test utils` to execute the unit tests via [Jest](https://jestjs.io).
+```bash
+pnpm --filter @module-federation/utilities run test
+```
 
 ## React utilities
 
 ---
 
-`FederatedBoundary`
+`FederationBoundary`
 
 A component wrapper that provides a fallback for safe imports if something were to fail when grabbing a module off of a remote host.
 
@@ -70,7 +72,7 @@ importRemote({
 );
 
 // --
-// If it's a ESM module (this is currently the default for NX):
+// If it's an ESM module:
 // --
 const Bar = lazy(() => importRemote({ url: 'http://localhost:3001', scope: 'Foo', module: 'Bar', esm: true }));
 


### PR DESCRIPTION
## Description

- Fix self-contradictory `splitChunks.chunks` warning under stream SSR in `@module-federation/modern-js` and `@module-federation/modern-js-v3`: warn only when the previous value was set and not already async`, with an accurate message.
- Replace stale Nx scaffolding in `@module-federation/utilities` and `@module-federation/rspress-plugin` READMEs with correct package names and pnpm/Turbo commands.

## Related Issue

N/A — cleanup from codebase inspection.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.

## Testing

- [x] `pnpm exec prettier --write` on touched files
- [x] Diff limited to warning logic + READMEs + changeset

## Risks

- Low: warning text/frequency only; forced `chunks = async` behavior unchanged. Docs-only for utilities/rspress-plugin.