### PR TITLE
refactor: reuse normalizeSharedOptions and shared createBundlerLogger

### DIFF
--- a/packages/enhanced/src/lib/sharing/tree-shaking/IndependentSharedPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/tree-shaking/IndependentSharedPlugin.ts
@@ -7,11 +7,7 @@ import type {
   WebpackOptionsNormalized,
 } from 'webpack';
 import type { moduleFederationPlugin, Stats } from '@module-federation/sdk';
-import {
-  encodeName,
-  isRequiredVersion,
-  StatsFileName,
-} from '@module-federation/sdk';
+import { encodeName, StatsFileName } from '@module-federation/sdk';
 import CollectSharedEntryPlugin, {
   type ShareRequestsMap,
 } from './CollectSharedEntryPlugin';
@@ -19,10 +15,11 @@ import SharedUsedExportsOptimizerPlugin from './SharedUsedExportsOptimizerPlugin
 import SharedContainerPlugin, {
   SharedContainerPluginOptions,
 } from './SharedContainerPlugin/SharedContainerPlugin';
-import { parseOptions } from '../../container/options';
-type SharedConfig = moduleFederationPlugin.SharedConfig;
 import ConsumeSharedPlugin from '../ConsumeSharedPlugin';
-import { NormalizedSharedOptions } from '../SharePlugin';
+import {
+  normalizeSharedOptions,
+  type NormalizedSharedOptions,
+} from '../SharePlugin';
 import IndependentSharedRuntimeModule from './IndependentSharedRuntimeModule';
 
 const IGNORED_ENTRY = 'ignored-entry';
@@ -105,29 +102,7 @@ export default class IndependentSharedPlugin {
     this.manifest = manifest;
     this.injectTreeShakingUsedExports = injectTreeShakingUsedExports ?? true;
     this.library = library;
-    this.sharedOptions = parseOptions(
-      shared,
-      (item, key) => {
-        if (typeof item !== 'string')
-          throw new Error(
-            `Unexpected array in shared configuration for key "${key}"`,
-          );
-        const config: SharedConfig =
-          item === key || !isRequiredVersion(item)
-            ? {
-                import: item,
-              }
-            : {
-                import: key,
-                requiredVersion: item,
-              };
-
-        return config;
-      },
-      (item) => {
-        return item;
-      },
-    );
+    this.sharedOptions = normalizeSharedOptions(shared);
   }
 
   static IndependentShareBuildAssetsFilename =

--- a/packages/node/src/plugins/DynamicFilesystemChunkLoadingRuntimeModule.ts
+++ b/packages/node/src/plugins/DynamicFilesystemChunkLoadingRuntimeModule.ts
@@ -23,10 +23,7 @@ import {
   generateInstallChunk,
   generateExternalInstallChunkCode,
 } from './webpackChunkUtilities';
-import {
-  createInfrastructureLogger,
-  createLogger,
-} from '@module-federation/sdk';
+import { createBundlerLogger } from './createBundlerLogger';
 import {
   fileSystemRunInContextStrategy,
   httpEvalStrategy,
@@ -49,11 +46,6 @@ interface DynamicFilesystemChunkLoadingRuntimeModuleOptions {
 interface ChunkLoadingContext {
   webpack: Compiler['webpack'];
 }
-
-const createBundlerLogger: typeof createLogger =
-  typeof createInfrastructureLogger === 'function'
-    ? (createInfrastructureLogger as unknown as typeof createLogger)
-    : createLogger;
 
 class DynamicFilesystemChunkLoadingRuntimeModule extends RuntimeModule {
   private runtimeRequirements: Set<string>;

--- a/packages/node/src/plugins/NodeFederationPlugin.ts
+++ b/packages/node/src/plugins/NodeFederationPlugin.ts
@@ -3,11 +3,8 @@
 import type { Compiler, container } from 'webpack';
 import type { ModuleFederationPluginOptions } from '../types';
 import EntryChunkTrackerPlugin from './EntryChunkTrackerPlugin';
-import {
-  bindLoggerToCompiler,
-  createInfrastructureLogger,
-  createLogger,
-} from '@module-federation/sdk';
+import { bindLoggerToCompiler } from '@module-federation/sdk';
+import { createBundlerLogger } from './createBundlerLogger';
 /**
  * Interface for NodeFederationOptions which extends ModuleFederationPluginOptions
  * @interface
@@ -26,11 +23,6 @@ interface NodeFederationOptions extends ModuleFederationPluginOptions {
 interface Context {
   ModuleFederationPlugin?: typeof container.ModuleFederationPlugin;
 }
-
-const createBundlerLogger: typeof createLogger =
-  typeof createInfrastructureLogger === 'function'
-    ? (createInfrastructureLogger as unknown as typeof createLogger)
-    : createLogger;
 
 function getRuntimePluginPath(): string {
   return require.resolve(

--- a/packages/node/src/plugins/createBundlerLogger.ts
+++ b/packages/node/src/plugins/createBundlerLogger.ts
@@ -1,0 +1,9 @@
+import {
+  createInfrastructureLogger,
+  createLogger,
+} from '@module-federation/sdk';
+
+export const createBundlerLogger: typeof createLogger =
+  typeof createInfrastructureLogger === 'function'
+    ? (createInfrastructureLogger as unknown as typeof createLogger)
+    : createLogger;


### PR DESCRIPTION
## Description

Internal dedup with no intended behavior change:

- `IndependentSharedPlugin` now calls existing `normalizeSharedOptions` from `SharePlugin` (same helper `TreeShakingSharedPlugin` already uses).
- Extract duplicated `createBundlerLogger` fallback into `packages/node/src/plugins/createBundlerLogger.ts` and import it from `NodeFederationPlugin` and `DynamicFilesystemChunkLoadingRuntimeModule`.

## Related Issue

N/A — maintainability cleanup from codebase inspection.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.

## Testing

- [x] `pnpm exec prettier --write` on touched files
- [x] Diff reviewed for behavior parity (same normalize + logger fallback)

## Risks

- Low: pure extract/reuse. No public API change. No changeset (no user-facing behavior change).