### PR TITLE
docs(bridge): meta-framework host recipes for export-app

### DIFF
--- a/.changeset/bridge-meta-framework-hosts.md
+++ b/.changeset/bridge-meta-framework-hosts.md
@@ -1,0 +1,5 @@
+---
+'website-new': patch
+---
+
+Document loading the same Bridge export-app from Nuxt, Next, and Modern.js hosts.

--- a/apps/website-new/docs/en/guide/bridge/overview.mdx
+++ b/apps/website-new/docs/en/guide/bridge/overview.mdx
@@ -20,7 +20,7 @@ These capabilities make Bridge the core infrastructure for building modern, scal
 
 Bridge remotes are framework-agnostic at the host boundary: export once with `createBridgeComponent`, load with the host’s `createRemoteAppComponent`.
 
-- **Nuxt** (Vue consumer): catch-all route + `@module-federation/bridge-vue3` — see [Vue Bridge practice](/integrations/practice/vue#meta-framework-hosts-nuxt-next-modernjs).
+- **Nuxt** (Vue consumer): catch-all route + `@module-federation/bridge-vue3` — see [Vue Bridge practice](/integrations/practice/vue.html#meta-framework-hosts-nuxt-next-modernjs).
 - **Next.js / Modern.js** (React consumer): `/remote/*` + `@module-federation/bridge-react` (or `@module-federation/modern-js-v3/react`).
 - The **same** Vue `./bridge/export-app` can be mounted in Nuxt **and** React/Next without a second remote build.
 

--- a/apps/website-new/docs/en/guide/bridge/overview.mdx
+++ b/apps/website-new/docs/en/guide/bridge/overview.mdx
@@ -16,6 +16,16 @@ Through Bridge, you can:
 
 These capabilities make Bridge the core infrastructure for building modern, scalable micro-frontend architectures.
 
+## Meta-framework hosts
+
+Bridge remotes are framework-agnostic at the host boundary: export once with `createBridgeComponent`, load with the host’s `createRemoteAppComponent`.
+
+- **Nuxt** (Vue consumer): catch-all route + `@module-federation/bridge-vue3` — see [Vue Bridge practice](/integrations/practice/vue#meta-framework-hosts-nuxt-next-modernjs).
+- **Next.js / Modern.js** (React consumer): `/remote/*` + `@module-federation/bridge-react` (or `@module-federation/modern-js-v3/react`).
+- The **same** Vue `./bridge/export-app` can be mounted in Nuxt **and** React/Next without a second remote build.
+
+Component-level SSR inside Nuxt remains `@module-federation/nuxt`; Bridge is for application-level routing remotes.
+
 ## Supported Frameworks
 
 ### React Bridge (`@module-federation/bridge-react`)

--- a/apps/website-new/docs/en/integrations/practice/vue.mdx
+++ b/apps/website-new/docs/en/integrations/practice/vue.mdx
@@ -159,7 +159,7 @@ const RemoteApp = createRemoteAppComponent({
 
 ### React / Next / Modern.js host tips
 
-Load the **same Vue Bridge remote** with the React consumer. Basename comes from the host route (or an explicit `basename` prop on the React wrapper):
+Load the **same Vue Bridge remote** with the React consumer:
 
 ```tsx
 import { createRemoteAppComponent } from '@module-federation/bridge-react';
@@ -173,8 +173,15 @@ const RemoteVueApp = createRemoteAppComponent({
   fallback: BridgeFallback,
   loading: <div>loading</div>,
 });
+```
 
-// route: { path: '/bridge/*', element: <RemoteVueApp /> }
+- **React Router / Modern.js**: a host route like `/bridge/*` can supply basename via router context.
+- **Next.js** (no React Router context): pass `basename` explicitly on the wrapper, e.g. under `app/bridge/[[...path]]/page.tsx`:
+
+```tsx
+export default function BridgePage() {
+  return <RemoteVueApp basename="/bridge" />;
+}
 ```
 
 Modern.js re-exports React Bridge APIs from `@module-federation/modern-js-v3/react` — use the same `createRemoteAppComponent` pattern.

--- a/apps/website-new/docs/en/integrations/practice/vue.mdx
+++ b/apps/website-new/docs/en/integrations/practice/vue.mdx
@@ -131,6 +131,54 @@ const router = createRouter({
 export default router;
 ```
 
+## Meta-framework hosts (Nuxt, Next, Modern.js)
+
+One Bridge remote (`createBridgeComponent` → `./bridge/export-app`) can be loaded by many hosts. The remote does not need a per-host build.
+
+| Host | Consumer API | Typical mount route |
+| --- | --- | --- |
+| Vue / Nuxt | `@module-federation/bridge-vue3` `createRemoteAppComponent` | `/remote/:pathMatch(.*)*` |
+| React / Next / Modern.js | `@module-federation/bridge-react` `createRemoteAppComponent` | `/remote/*` |
+
+### Nuxt host tips
+
+- Mount the Bridge remote as a **client island** (`ClientOnly` / `ssr: false` for that page). Bridge SSR for meta-framework adapters is out of scope of the Vue Bridge CSR path.
+- Prefer a host catch-all that uses Vue Router’s `:pathMatch(.*)*`, or pass an explicit `basename` (recommended) once available on `createRemoteAppComponent`.
+- If you also use `@module-federation/nuxt` component federation, expose the Bridge entry with a **slashed** name (for example `./bridge/export-app`) so host manifest discovery does not register it as a Vue component.
+
+```ts
+// Nuxt host — catch-all page (client only)
+import { createRemoteAppComponent } from '@module-federation/bridge-vue3';
+
+const RemoteApp = createRemoteAppComponent({
+  loader: () => import('remote/bridge/export-app'),
+  basename: '/bridge',
+  asyncComponentOptions: { suspensible: false },
+});
+```
+
+### React / Next / Modern.js host tips
+
+Load the **same Vue Bridge remote** with the React consumer. Basename comes from the host route (or an explicit `basename` prop):
+
+```tsx
+import { createRemoteAppComponent } from '@module-federation/bridge-react';
+
+const RemoteVueApp = createRemoteAppComponent({
+  loader: () => import('remote/bridge/export-app'),
+  fallback: <div>failed</div>,
+  loading: <div>loading</div>,
+});
+
+// route: { path: '/bridge/*', element: <RemoteVueApp /> }
+```
+
+Modern.js re-exports React Bridge APIs from `@module-federation/modern-js-v3/react` — use the same `createRemoteAppComponent` pattern.
+
+### What this is not
+
+Bridge remotes are isolated Vue/React apps with their own router. They do not share Nuxt `#app` / Nitro or Next App Router internals across the boundary. For Nuxt↔Nuxt **component** SSR, keep using `@module-federation/nuxt` component federation.
+
 ## Parameters
 
 ### createRemoteAppComponent
@@ -171,6 +219,9 @@ const Remote1App = createRemoteAppComponent({ loader: () => loadRemote('remote1/
   * `rootAttrs`
     * type: `Record<string, unknown>`
     * Purpose: Attributes that will be bound to the root container where the remote Vue application will be mounted
+  * `basename`
+    * type: `string`
+    * Purpose: Optional host mount prefix for the remote router. When set, skips route-based basename derivation (useful for Nuxt and other meta-framework catch-all pages).
 ```tsx
 // remote
 export const provider = createBridgeComponent({

--- a/apps/website-new/docs/en/integrations/practice/vue.mdx
+++ b/apps/website-new/docs/en/integrations/practice/vue.mdx
@@ -143,30 +143,34 @@ One Bridge remote (`createBridgeComponent` → `./bridge/export-app`) can be loa
 ### Nuxt host tips
 
 - Mount the Bridge remote as a **client island** (`ClientOnly` / `ssr: false` for that page). Bridge SSR for meta-framework adapters is out of scope of the Vue Bridge CSR path.
-- Prefer a host catch-all that uses Vue Router’s `:pathMatch(.*)*`, or pass an explicit `basename` (recommended) once available on `createRemoteAppComponent`.
+- Prefer a host catch-all that uses Vue Router’s `:pathMatch(.*)*` so basename auto-detect works. An explicit `basename` option on `createRemoteAppComponent` is tracked in [core#4984](https://github.com/module-federation/core/pull/4984).
 - If you also use `@module-federation/nuxt` component federation, expose the Bridge entry with a **slashed** name (for example `./bridge/export-app`) so host manifest discovery does not register it as a Vue component.
 
 ```ts
 // Nuxt host — catch-all page (client only)
+// Register route path: '/bridge/:pathMatch(.*)*'
 import { createRemoteAppComponent } from '@module-federation/bridge-vue3';
 
 const RemoteApp = createRemoteAppComponent({
   loader: () => import('remote/bridge/export-app'),
-  basename: '/bridge',
   asyncComponentOptions: { suspensible: false },
 });
 ```
 
 ### React / Next / Modern.js host tips
 
-Load the **same Vue Bridge remote** with the React consumer. Basename comes from the host route (or an explicit `basename` prop):
+Load the **same Vue Bridge remote** with the React consumer. Basename comes from the host route (or an explicit `basename` prop on the React wrapper):
 
 ```tsx
 import { createRemoteAppComponent } from '@module-federation/bridge-react';
 
+function BridgeFallback() {
+  return <div>failed</div>;
+}
+
 const RemoteVueApp = createRemoteAppComponent({
   loader: () => import('remote/bridge/export-app'),
-  fallback: <div>failed</div>,
+  fallback: BridgeFallback,
   loading: <div>loading</div>,
 });
 
@@ -219,9 +223,6 @@ const Remote1App = createRemoteAppComponent({ loader: () => loadRemote('remote1/
   * `rootAttrs`
     * type: `Record<string, unknown>`
     * Purpose: Attributes that will be bound to the root container where the remote Vue application will be mounted
-  * `basename`
-    * type: `string`
-    * Purpose: Optional host mount prefix for the remote router. When set, skips route-based basename derivation (useful for Nuxt and other meta-framework catch-all pages).
 ```tsx
 // remote
 export const provider = createBridgeComponent({


### PR DESCRIPTION
## Summary
- Vue Bridge practice: Nuxt / Next / Modern.js host recipes for one `./bridge/export-app`.
- Bridge overview: short meta-framework hosts section.
- Recipes use shipped APIs today (`:pathMatch(.*)*` catch-alls); point to #4984 for upcoming explicit `basename`.

## Plan (Bridge meta-framework remotes)

| Step | PR | Role |
| --- | --- | --- |
| 1 | #4984 | `bridge-vue3` basename (foundation) |
| 2 | [module-federation/nuxt#21](https://github.com/module-federation/nuxt/pull/21) | Nuxt demo: remote + host Bridge mount |
| 3 | **This PR** | Docs tying the cross-host story together |

SSR for Bridge islands: #4869 (Nuxt/Modern adapters still out of scope there).

## Testing
- [ ] Docs preview (Netlify) after push

## Risks
- Low (docs only). Deep links / recipes stay valid without #4984; improve further once basename ships.

## Related
- Blocked conceptually by / pairs with #4984
- Examples: [module-federation/nuxt#21](https://github.com/module-federation/nuxt/pull/21)
- SSR track: #4869