### PR TITLE
fix(devtools): support proxy core interop exports

### DIFF
--- a/.changeset/fix-devtools-proxy-core-default.md
+++ b/.changeset/fix-devtools-proxy-core-default.md
@@ -2,4 +2,4 @@
 "@module-federation/devtools": patch
 ---
 
-Fix remote overrides to load the proxy core from its default export.
+Fix remote overrides to support both direct and default proxy core exports.

--- a/.changeset/fix-devtools-proxy-core-default.md
+++ b/.changeset/fix-devtools-proxy-core-default.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/devtools": patch
+---
+
+Fix remote overrides to load the proxy core from its default export.

--- a/packages/chrome-devtools/__tests__/override-remote.spec.ts
+++ b/packages/chrome-devtools/__tests__/override-remote.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+
+import {
+  BasicProxyCore,
+  resolveBasicProxyCore,
+} from '../src/utils/chrome/resolve-basic-proxy-core';
+
+describe('resolveBasicProxyCore', () => {
+  const basicProxyCore: BasicProxyCore = {
+    registerOverridePlugin: () => undefined,
+  };
+
+  it('uses a direct CommonJS export', () => {
+    expect(resolveBasicProxyCore(basicProxyCore)).toBe(basicProxyCore);
+  });
+
+  it('unwraps an interop default export', () => {
+    expect(resolveBasicProxyCore({ default: basicProxyCore })).toBe(
+      basicProxyCore,
+    );
+  });
+});
+
+describe('override remote entry', () => {
+  beforeEach(() => {
+    rs.resetModules();
+
+    const testWindow = window as Record<string, any>;
+    testWindow.__FEDERATION__ = {
+      __GLOBAL_PLUGIN__: [],
+      moduleInfo: {},
+    };
+    testWindow.__VMOK__ = testWindow.__FEDERATION__;
+  });
+
+  it('registers the override plugin', async () => {
+    await import('../src/utils/chrome/override-remote');
+
+    expect(
+      (window as any).__FEDERATION__.__GLOBAL_PLUGIN__.map(
+        (plugin: { name: string }) => plugin.name,
+      ),
+    ).toContain('mf-chrome-devtools-override-remotes-plugin');
+  });
+});

--- a/packages/chrome-devtools/src/utils/chrome/override-remote.ts
+++ b/packages/chrome-devtools/src/utils/chrome/override-remote.ts
@@ -1,10 +1,13 @@
-const basicProxyCore = (
-  require('../../vendor/basic-proxy-core.js') as {
-    default: {
-      registerOverridePlugin(globalObject?: typeof globalThis): unknown;
-    };
-  }
-).default;
+import {
+  BasicProxyCore,
+  resolveBasicProxyCore,
+} from './resolve-basic-proxy-core';
+
+const basicProxyCore = resolveBasicProxyCore(
+  require('../../vendor/basic-proxy-core.js') as
+    | BasicProxyCore
+    | { default: BasicProxyCore },
+);
 
 basicProxyCore.registerOverridePlugin(globalThis);
 

--- a/packages/chrome-devtools/src/utils/chrome/override-remote.ts
+++ b/packages/chrome-devtools/src/utils/chrome/override-remote.ts
@@ -1,6 +1,10 @@
-const basicProxyCore = require('../../vendor/basic-proxy-core.js') as {
-  registerOverridePlugin(globalObject?: typeof globalThis): unknown;
-};
+const basicProxyCore = (
+  require('../../vendor/basic-proxy-core.js') as {
+    default: {
+      registerOverridePlugin(globalObject?: typeof globalThis): unknown;
+    };
+  }
+).default;
 
 basicProxyCore.registerOverridePlugin(globalThis);
 

--- a/packages/chrome-devtools/src/utils/chrome/resolve-basic-proxy-core.ts
+++ b/packages/chrome-devtools/src/utils/chrome/resolve-basic-proxy-core.ts
@@ -1,0 +1,10 @@
+export interface BasicProxyCore {
+  registerOverridePlugin(globalObject?: typeof globalThis): unknown;
+}
+
+export const resolveBasicProxyCore = (
+  basicProxyCoreModule: BasicProxyCore | { default: BasicProxyCore },
+): BasicProxyCore =>
+  'default' in basicProxyCoreModule
+    ? basicProxyCoreModule.default
+    : basicProxyCoreModule;


### PR DESCRIPTION
## Description

Fix Chrome DevTools remote override registration by normalizing both direct CommonJS and interop default exports from `basic-proxy-core` before calling `registerOverridePlugin`.

The module can be represented either as the direct export object or under `.default`, depending on the consuming build path. The injected entry now handles both shapes and includes regression coverage for each representation plus plugin registration. This PR also adds a patch changeset for `@module-federation/devtools`.

Validation:

- `pnpm exec prettier --check .`
- `pnpm exec turbo run build --filter=@module-federation/devtools --force`
- `pnpm exec turbo run test --filter=@module-federation/devtools --force`
- `pnpm --filter @module-federation/devtools run build:devtool`
- Direct execution of the generated extension and library entries, verifying `mf-chrome-devtools-override-remotes-plugin` is registered

## Related Issue

No related issue.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
