### PR TITLE
feat(runtime): deduplicate preloaded asset URLs

### DIFF
--- a/.changeset/filter-loaded-preload-assets.md
+++ b/.changeset/filter-loaded-preload-assets.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime-core': patch
+---
+
+Allow automatic preload configuration through `beforePreloadRemote` and skip JS or CSS URLs that are already loading or loaded using a bounded, configurable URL cache.

--- a/apps/website-new/docs/en/guide/runtime/runtime-api.mdx
+++ b/apps/website-new/docs/en/guide/runtime/runtime-api.mdx
@@ -789,6 +789,9 @@ type PreloadRemoteArgs = {
   // When not configured, resources are not filtered
   // After configuration, unnecessary resources will be filtered
   filter?: (assetUrl: string) => boolean;
+  // Whether to record preloaded JS and CSS URLs and skip duplicate loading
+  // Defaults to true
+  recordPreloadedAssets?: boolean;
 };
 ```
 
@@ -869,6 +872,8 @@ preloadRemote([
 ```
 
 When `exposes` is not specified, the resource id for this preload is `remoteName/*`. When `exposes` is specified, the runtime generates resources per expose, and the resource id is `remoteName/expose`.
+
+By default, the runtime records each JS and CSS URL before starting its preload. Later attempts to preload the same loading or loaded URL are skipped and reported as `cached`. This URL tracking does not change the existing lifecycle of the generated link or script element. Up to 2,000 URLs are retained; when the limit is exceeded, the oldest URL is removed. Set `recordPreloadedAssets: false` to disable both URL lookup and recording for a preload operation.
 
 <Tabs>
   <Tab label="Build Plugin (Use build plugin)">

--- a/apps/website-new/docs/en/guide/runtime/runtime-hooks.mdx
+++ b/apps/website-new/docs/en/guide/runtime/runtime-hooks.mdx
@@ -504,6 +504,8 @@ mf.loadShare('react').then((reactFactory) => {
 
 Called before the preload handler executes any preload logic.
 
+It runs for both explicit `preloadRemote` calls and snapshot-driven automatic preloading during `loadRemote`. Mutate `args.preloadOps` in place to adjust the configuration used to generate preload assets.
+
 ```ts
 async function beforePreloadRemote(
   args: BeforePreloadRemoteOptions,

--- a/apps/website-new/docs/zh/guide/runtime/runtime-api.mdx
+++ b/apps/website-new/docs/zh/guide/runtime/runtime-api.mdx
@@ -789,6 +789,9 @@ type PreloadRemoteArgs = {
   // 未配置时不过滤资源
   // 配置了后将会过滤不需要的资源
   filter?: (assetUrl: string) => boolean;
+  // 是否记录预加载的 JS 和 CSS URL，并跳过重复加载
+  // 默认为 true
+  recordPreloadedAssets?: boolean;
 };
 ```
 
@@ -869,6 +872,8 @@ preloadRemote([
 ```
 
 如果没有指定 `exposes`，本次预加载的资源 id 是 `remoteName/*`。如果指定了 `exposes`，运行时会按 expose 单独生成资源，资源 id 是 `remoteName/expose`。
+
+运行时默认会在开始预加载前记录每个 JS 和 CSS 的 URL。后续如果再次预加载同一个正在加载或已经加载的 URL，会跳过资源加载并将结果标记为 `cached`。URL 记录不会改变所生成 link 或 script 标签原有的生命周期。最多保留 2000 个 URL，超过上限时会删除最早记录的 URL。设置 `recordPreloadedAssets: false` 可以让本次预加载不查询也不记录 URL。
 
 <Tabs>
   <Tab label="Build Plugin（使用构建插件）">

--- a/apps/website-new/docs/zh/guide/runtime/runtime-hooks.mdx
+++ b/apps/website-new/docs/zh/guide/runtime/runtime-hooks.mdx
@@ -467,6 +467,8 @@ mf.loadShare('react').then((reactFactory) => {
 
 在预加载处理程序执行任何预加载逻辑之前调用
 
+显式调用 `preloadRemote`，以及 `loadRemote` 基于 snapshot 自动预加载时都会触发该 hook。可以原地修改 `args.preloadOps`，调整后续生成预加载资源时使用的配置。
+
 ```ts
 async function beforePreloadRemote(
   args: BeforePreloadRemoteOptions,

--- a/packages/runtime-core/__tests__/hooks.spec.ts
+++ b/packages/runtime-core/__tests__/hooks.spec.ts
@@ -2,7 +2,7 @@ import { assert, describe, test, it } from '@rstest/core';
 import { ModuleFederation } from '../src/core';
 import { ModuleFederationRuntimePlugin } from '../src/type/plugin';
 import { mockStaticServer, removeScriptTags } from './mock/utils';
-import { addGlobalSnapshot } from '../src/global';
+import { Global, addGlobalSnapshot } from '../src/global';
 import {
   AsyncHook,
   AsyncWaterfallHook,
@@ -493,7 +493,7 @@ describe('hooks', () => {
     reset();
   });
 
-  it('uses exact expose ids when preloadRemote is configured with exposes', async () => {
+  it('uses exact expose ids when URL recording is disabled', async () => {
     const remotePublicPath = 'http://localhost:1111/';
     const reset = addGlobalSnapshot({
       '@loader-hooks/globalinfo': {
@@ -541,11 +541,10 @@ describe('hooks', () => {
           name: 'force-expose-preload-assets',
           async generatePreloadAssets(args) {
             generatedExposes.push(args.preloadOptions.preloadConfig.exposes);
-            const expose = args.preloadOptions.preloadConfig.exposes?.[0];
             return {
               cssAssets: [],
               jsAssetsWithoutEntry: [
-                `http://localhost:1111/__virtual__/${expose}.js`,
+                'http://localhost:1111/__virtual__/shared-expose.js',
               ],
               entryAssets: [],
             } as any;
@@ -564,7 +563,11 @@ describe('hooks', () => {
     });
 
     await INSTANCE.preloadRemote([
-      { nameOrAlias: '@loader-hooks/app3', exposes: ['Button', 'Card'] },
+      {
+        nameOrAlias: '@loader-hooks/app3',
+        exposes: ['Button', 'Card'],
+        recordPreloadedAssets: false,
+      },
     ]);
 
     expect(generatedExposes).toEqual([['Button'], ['Card']]);
@@ -572,6 +575,11 @@ describe('hooks', () => {
       '@loader-hooks/app3/Button',
       '@loader-hooks/app3/Card',
     ]);
+    expect(
+      Global.__FEDERATION__.__PRELOADED_ASSETS__.has(
+        'http://localhost:1111/__virtual__/shared-expose.js',
+      ),
+    ).toBe(false);
 
     reset();
   });

--- a/packages/runtime-core/__tests__/preload-assets.spec.ts
+++ b/packages/runtime-core/__tests__/preload-assets.spec.ts
@@ -1,6 +1,7 @@
 import type { ModuleInfo } from '@module-federation/sdk';
 import { describe, it, rs } from '@rstest/core';
 import { ModuleFederation } from '../src/core';
+import { Global, setPreloadedAsset } from '../src/global';
 import type { RemoteInfo } from '../src/type';
 import type {
   ResourceLoadContext,
@@ -166,6 +167,12 @@ describe('preloadAssets', () => {
     const moduleUrl = 'https://remote.test/expose.js';
     const calls = createResourceCalls();
     const lifecycle: string[] = [];
+    let automaticPreloadDefault: boolean | undefined;
+    let automaticPreloadArgs:
+      | Parameters<
+          NonNullable<ModuleFederationRuntimePlugin['beforePreloadRemote']>
+        >[0]
+      | undefined;
     const remoteSnapshot: ModuleInfo = {
       version: '1.0.0',
       buildVersion: '',
@@ -192,6 +199,11 @@ describe('preloadAssets', () => {
         createResourceCapturePlugin(calls),
         {
           name: 'capture-container-initialization',
+          beforePreloadRemote(args) {
+            automaticPreloadArgs = args;
+            automaticPreloadDefault = args.preloadOps[0].recordPreloadedAssets;
+            args.preloadOps[0].recordPreloadedAssets = false;
+          },
           loadEntry() {
             return {
               init() {
@@ -214,10 +226,13 @@ describe('preloadAssets', () => {
     rs.spyOn(
       host.remoteHandler.hooks.lifecycle.generatePreloadAssets,
       'emit',
-    ).mockResolvedValue({
-      cssAssets: [],
-      jsAssetsWithoutEntry: [moduleUrl],
-      entryAssets: [],
+    ).mockImplementation(async ({ preloadOptions }) => {
+      expect(preloadOptions.preloadConfig.recordPreloadedAssets).toBe(false);
+      return {
+        cssAssets: [],
+        jsAssetsWithoutEntry: [moduleUrl],
+        entryAssets: [],
+      };
     });
 
     await expect(host.loadRemote<string>(`${remoteName}/Expose`)).resolves.toBe(
@@ -225,6 +240,21 @@ describe('preloadAssets', () => {
     );
 
     expect(lifecycle).toEqual(['init', 'get']);
+    expect(automaticPreloadDefault).toBe(true);
+    expect(automaticPreloadArgs).toMatchObject({
+      preloadOps: [
+        {
+          nameOrAlias: remoteName,
+          exposes: ['./Expose'],
+          resourceCategory: 'sync',
+          share: false,
+          depsRemote: false,
+          recordPreloadedAssets: false,
+        },
+      ],
+      options: host.options,
+      origin: host,
+    });
     expect(calls.scripts).toHaveLength(0);
     expect(calls.links).toHaveLength(1);
     expect(calls.links[0]).toMatchObject({
@@ -244,6 +274,9 @@ describe('preloadAssets', () => {
         url: moduleUrl,
       },
     });
+    expect(Global.__FEDERATION__.__PRELOADED_ASSETS__.has(moduleUrl)).toBe(
+      false,
+    );
   });
 
   it('keeps executing classic chunks during loadRemote', async () => {
@@ -324,5 +357,124 @@ describe('preloadAssets', () => {
         url: scriptUrl,
       },
     });
+  });
+
+  it('skips loading and loaded preload asset URLs without changing tag cleanup', async () => {
+    const moduleUrl = 'https://remote.test/deduplicated-expose.js';
+    const calls = createResourceCalls();
+    const host = createHost(calls);
+    const assets = {
+      cssAssets: [],
+      jsAssetsWithoutEntry: [moduleUrl],
+      entryAssets: [],
+    };
+    const context = {
+      initiator: 'preloadRemote' as const,
+      id: 'preload-assets-remote/DeduplicatedExpose',
+    };
+
+    const loadingResults = preloadAssets(
+      createRemoteInfo('module'),
+      host,
+      assets,
+      true,
+      context,
+    );
+    const duplicateLoadingResults = await preloadAssets(
+      createRemoteInfo('module'),
+      host,
+      assets,
+      true,
+      context,
+    );
+
+    expect(duplicateLoadingResults).toMatchObject([
+      {
+        url: moduleUrl,
+        status: 'cached',
+        resourceType: 'js',
+      },
+    ]);
+    expect(calls.links).toHaveLength(1);
+    expect(Global.__FEDERATION__.__PRELOADED_ASSETS__.has(moduleUrl)).toBe(
+      true,
+    );
+
+    await expect(loadingResults).resolves.toMatchObject([
+      {
+        url: moduleUrl,
+        status: 'success',
+        resourceType: 'js',
+      },
+    ]);
+    await expect(
+      preloadAssets(createRemoteInfo('module'), host, assets, true, context),
+    ).resolves.toMatchObject([
+      {
+        url: moduleUrl,
+        status: 'cached',
+        resourceType: 'js',
+      },
+    ]);
+
+    expect(calls.links).toHaveLength(1);
+    expect(
+      Array.from(document.head.querySelectorAll('link')).some(
+        (link) => link.href === moduleUrl,
+      ),
+    ).toBe(false);
+  });
+
+  it('loads duplicate assets without recording their URLs when disabled', async () => {
+    const moduleUrl = 'https://remote.test/unrecorded-expose.js';
+    const calls = createResourceCalls();
+    const host = createHost(calls);
+    const assets = {
+      cssAssets: [],
+      jsAssetsWithoutEntry: [moduleUrl],
+      entryAssets: [],
+    };
+    const context = {
+      initiator: 'preloadRemote' as const,
+      id: 'preload-assets-remote/UnrecordedExpose',
+    };
+
+    await preloadAssets(
+      createRemoteInfo('module'),
+      host,
+      assets,
+      true,
+      context,
+      false,
+    );
+    await preloadAssets(
+      createRemoteInfo('module'),
+      host,
+      assets,
+      true,
+      context,
+      false,
+    );
+
+    expect(calls.links).toHaveLength(2);
+    expect(Global.__FEDERATION__.__PRELOADED_ASSETS__.has(moduleUrl)).toBe(
+      false,
+    );
+  });
+
+  it('evicts the oldest preload asset URL when the cache reaches its limit', () => {
+    const maximumPreloadedAssets = 2000;
+    const urls = Array.from(
+      { length: maximumPreloadedAssets + 1 },
+      (_, index) => `https://remote.test/preloaded-asset-${index}.js`,
+    );
+
+    urls.forEach(setPreloadedAsset);
+
+    const preloadedAssets = Global.__FEDERATION__.__PRELOADED_ASSETS__;
+    expect(preloadedAssets.size).toBe(maximumPreloadedAssets);
+    expect(preloadedAssets.has(urls[0])).toBe(false);
+    expect(preloadedAssets.has(urls[1])).toBe(true);
+    expect(preloadedAssets.has(urls[urls.length - 1])).toBe(true);
   });
 });

--- a/packages/runtime-core/src/global.ts
+++ b/packages/runtime-core/src/global.ts
@@ -23,7 +23,10 @@ export interface Federation {
   __SHARE__: GlobalShareScopeMap;
   __MANIFEST_LOADING__: Record<string, Promise<ModuleInfo>>;
   __PRELOADED_MAP__: Map<string, boolean>;
+  __PRELOADED_ASSETS__: Set<string>;
 }
+
+const MAX_PRELOADED_ASSETS = 2000;
 export const CurrentGlobal =
   typeof globalThis === 'object' ? globalThis : window;
 export const nativeGlobal: typeof global = (() => {
@@ -90,6 +93,7 @@ function setGlobalDefaultVal(target: typeof CurrentGlobal) {
       __SHARE__: {},
       __MANIFEST_LOADING__: {},
       __PRELOADED_MAP__: new Map(),
+      __PRELOADED_ASSETS__: new Set(),
     });
 
     definePropertyGlobalVal(target, '__VMOK__', target.__FEDERATION__);
@@ -101,6 +105,7 @@ function setGlobalDefaultVal(target: typeof CurrentGlobal) {
   target.__FEDERATION__.__SHARE__ ??= {};
   target.__FEDERATION__.__MANIFEST_LOADING__ ??= {};
   target.__FEDERATION__.__PRELOADED_MAP__ ??= new Map();
+  target.__FEDERATION__.__PRELOADED_ASSETS__ ??= new Set();
 }
 
 setGlobalDefaultVal(CurrentGlobal);
@@ -112,6 +117,7 @@ export function resetFederationGlobalInfo(): void {
   CurrentGlobal.__FEDERATION__.moduleInfo = {};
   CurrentGlobal.__FEDERATION__.__SHARE__ = {};
   CurrentGlobal.__FEDERATION__.__MANIFEST_LOADING__ = {};
+  CurrentGlobal.__FEDERATION__.__PRELOADED_ASSETS__.clear();
 
   Object.keys(globalLoading).forEach((key) => {
     delete globalLoading[key];
@@ -291,3 +297,18 @@ export const getPreloaded = (id: string) =>
 
 export const setPreloaded = (id: string) =>
   CurrentGlobal.__FEDERATION__.__PRELOADED_MAP__.set(id, true);
+
+export const getPreloadedAsset = (url: string) =>
+  CurrentGlobal.__FEDERATION__.__PRELOADED_ASSETS__.has(url);
+
+export const setPreloadedAsset = (url: string): void => {
+  const preloadedAssets = CurrentGlobal.__FEDERATION__.__PRELOADED_ASSETS__;
+  preloadedAssets.add(url);
+
+  if (preloadedAssets.size > MAX_PRELOADED_ASSETS) {
+    const oldestUrl = preloadedAssets.values().next().value;
+    if (oldestUrl !== undefined) {
+      preloadedAssets.delete(oldestUrl);
+    }
+  }
+};

--- a/packages/runtime-core/src/plugins/snapshot/index.ts
+++ b/packages/runtime-core/src/plugins/snapshot/index.ts
@@ -12,7 +12,7 @@ import {
   isRemoteInfoWithEntry,
   getRemoteEntryInfoFromSnapshot,
 } from '../../utils';
-import { PreloadOptions, RemoteInfo } from '../../type';
+import { PreloadOptions, PreloadRemoteArgs, RemoteInfo } from '../../type';
 import { preloadAssets } from '../../utils/preload';
 
 export function assignRemoteInfo(
@@ -52,34 +52,53 @@ export function snapshotPlugin(): ModuleFederationRuntimePlugin {
 
         assignRemoteInfo(remoteInfo, remoteSnapshot);
         // preloading assets
-        const preloadOptions: PreloadOptions[0] = {
-          remote,
-          preloadConfig: {
+        const preloadOps: PreloadRemoteArgs[] = [
+          {
             nameOrAlias: pkgNameOrAlias,
             exposes: [expose],
             resourceCategory: 'sync',
             share: false,
             depsRemote: false,
+            recordPreloadedAssets: true,
           },
-        };
+        ];
+        await origin.remoteHandler.hooks.lifecycle.beforePreloadRemote.emit({
+          preloadOps,
+          options: origin.options,
+          origin,
+        });
 
-        const assets =
-          await origin.remoteHandler.hooks.lifecycle.generatePreloadAssets.emit(
-            {
-              origin,
-              preloadOptions,
+        const [preloadConfig] = preloadOps;
+        if (preloadConfig) {
+          const preloadOptions: PreloadOptions[0] = {
+            remote,
+            preloadConfig,
+          };
+          const assets =
+            await origin.remoteHandler.hooks.lifecycle.generatePreloadAssets.emit(
+              {
+                origin,
+                preloadOptions,
+                remoteInfo,
+                remote,
+                remoteSnapshot,
+                globalSnapshot,
+              },
+            );
+
+          if (assets) {
+            preloadAssets(
               remoteInfo,
-              remote,
-              remoteSnapshot,
-              globalSnapshot,
-            },
-          );
-
-        if (assets) {
-          preloadAssets(remoteInfo, origin, assets, false, {
-            initiator: 'loadRemote',
-            id,
-          }).catch(() => undefined);
+              origin,
+              assets,
+              false,
+              {
+                initiator: 'loadRemote',
+                id,
+              },
+              preloadConfig.recordPreloadedAssets,
+            ).catch(() => undefined);
+          }
         }
 
         return {

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -438,10 +438,17 @@ export class RemoteHandler {
           if (!assets) {
             return;
           }
-          const results = await preloadAssets(remoteInfo, host, assets, true, {
-            initiator: 'preloadRemote',
-            id: preloadId,
-          });
+          const results = await preloadAssets(
+            remoteInfo,
+            host,
+            assets,
+            true,
+            {
+              initiator: 'preloadRemote',
+              id: preloadId,
+            },
+            preloadConfig.recordPreloadedAssets,
+          );
           preloadResults.push({
             remote,
             remoteInfo,

--- a/packages/runtime-core/src/type/preload.ts
+++ b/packages/runtime-core/src/type/preload.ts
@@ -9,6 +9,11 @@ export interface PreloadRemoteArgs {
   share?: boolean;
   depsRemote?: boolean | Array<depsPreloadArg>;
   filter?: (assetUrl: string) => boolean;
+  /**
+   * Record preloaded JS and CSS URLs to skip duplicate resource loading.
+   * @default true
+   */
+  recordPreloadedAssets?: boolean;
 }
 
 export type PreloadConfig = PreloadRemoteArgs;

--- a/packages/runtime-core/src/utils/preload.ts
+++ b/packages/runtime-core/src/utils/preload.ts
@@ -15,6 +15,7 @@ import { matchRemote } from './manifest';
 import { assert } from './logger';
 import { ModuleFederation } from '../core';
 import { getRemoteEntry, isEsmRemoteType } from './load';
+import { getPreloadedAsset, setPreloadedAsset } from '../global';
 
 export function defaultPreloadArgs(
   preloadConfig: PreloadRemoteArgs | depsPreloadArg,
@@ -23,6 +24,7 @@ export function defaultPreloadArgs(
     resourceCategory: 'sync',
     share: true,
     depsRemote: true,
+    recordPreloadedAssets: true,
     ...preloadConfig,
   } as PreloadConfig;
 }
@@ -87,6 +89,24 @@ function createAssetResult(
     id: context.id,
     error,
   };
+}
+
+function preloadAssetOnce(
+  context: ResourceLoadContext,
+  url: string,
+  recordPreloadedAssets: boolean,
+  preload: () => Promise<PreloadAssetResult>,
+): Promise<PreloadAssetResult> {
+  if (!recordPreloadedAssets) {
+    return preload();
+  }
+
+  if (getPreloadedAsset(url)) {
+    return Promise.resolve(createAssetResult(context, url, 'cached'));
+  }
+
+  setPreloadedAsset(url);
+  return preload();
 }
 
 async function waitForRemoteEntryPreload(
@@ -255,6 +275,7 @@ export function preloadAssets(
     initiator: 'preloadRemote',
     id: remoteInfo.name,
   },
+  recordPreloadedAssets = true,
 ): Promise<PreloadAssetResult[]> {
   const { cssAssets, jsAssetsWithoutEntry, entryAssets } = assets;
   const results: Array<Promise<PreloadAssetResult>> = [];
@@ -278,14 +299,17 @@ export function preloadAssets(
         as: 'style',
       };
       cssAssets.forEach((cssUrl) => {
+        const context = createResourceContext(baseContext, 'css');
         results.push(
-          waitForLinkPreload({
-            host,
-            remoteInfo,
-            url: cssUrl,
-            attrs: defaultAttrs,
-            context: createResourceContext(baseContext, 'css'),
-          }),
+          preloadAssetOnce(context, cssUrl, recordPreloadedAssets, () =>
+            waitForLinkPreload({
+              host,
+              remoteInfo,
+              url: cssUrl,
+              attrs: defaultAttrs,
+              context,
+            }),
+          ),
         );
       });
     } else {
@@ -294,15 +318,18 @@ export function preloadAssets(
         type: 'text/css',
       };
       cssAssets.forEach((cssUrl) => {
+        const context = createResourceContext(baseContext, 'css');
         results.push(
-          waitForLinkPreload({
-            host,
-            remoteInfo,
-            url: cssUrl,
-            attrs: defaultAttrs,
-            needDeleteLink: false,
-            context: createResourceContext(baseContext, 'css'),
-          }),
+          preloadAssetOnce(context, cssUrl, recordPreloadedAssets, () =>
+            waitForLinkPreload({
+              host,
+              remoteInfo,
+              url: cssUrl,
+              attrs: defaultAttrs,
+              needDeleteLink: false,
+              context,
+            }),
+          ),
         );
       });
     }
@@ -328,14 +355,17 @@ export function preloadAssets(
     }
 
     jsAssetsWithoutEntry.forEach((jsUrl) => {
+      const context = createResourceContext(baseContext, 'js');
       results.push(
-        preloadJsAsset({
-          host,
-          remoteInfo,
-          url: jsUrl,
-          attrs: defaultAttrs,
-          context: createResourceContext(baseContext, 'js'),
-        }),
+        preloadAssetOnce(context, jsUrl, recordPreloadedAssets, () =>
+          preloadJsAsset({
+            host,
+            remoteInfo,
+            url: jsUrl,
+            attrs: defaultAttrs,
+            context,
+          }),
+        ),
       );
     });
   }


### PR DESCRIPTION
## Description

Add URL-level deduplication at the preload execution boundary so shared JS and CSS assets are not loaded more than once when exposes preload concurrently.

The runtime now:

- records JS and CSS URLs immediately before creating their resource elements
- reports later loading or loaded duplicates as `cached`
- bounds the URL cache to 2,000 entries and evicts the oldest entry when full
- exposes `recordPreloadedAssets`, enabled by default, to opt out per preload
- invokes `beforePreloadRemote` for snapshot-driven automatic preload so plugins can adjust that configuration
- preserves the existing link and script cleanup behavior

This prevents duplicate resource loads caused by races between exposes that share the same chunks, without relying solely on HTTP cache behavior.

## Related Issue

N/A

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.

## Validation

- `pnpm --filter @module-federation/runtime-core run test` — 99 tests passed
- `pnpm exec turbo run build --filter=@module-federation/runtime-core`
- `pnpm exec turbo run lint --filter=@module-federation/runtime-core`
- targeted Prettier check for all changed files
- `git diff HEAD --check`
- changeset scope and status validation

The full `build-and-test` job was not run because this is isolated to runtime-core and the package-level build, test, and lint commands are the repository's smaller deterministic checks. The repository-wide Prettier check has unrelated existing formatting failures; all changed files pass Prettier.