### PR TITLE
fix(runtime-core): cache synchronous shared factories

### DIFF
--- a/.changeset/tidy-pandas-share.md
+++ b/.changeset/tidy-pandas-share.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/runtime-core": patch
+---
+
+Cache factories returned by synchronous shared getters for subsequent loads.

--- a/packages/runtime-core/__tests__/instance.spec.ts
+++ b/packages/runtime-core/__tests__/instance.spec.ts
@@ -11,6 +11,31 @@ describe('ModuleFederation', () => {
     });
   });
 
+  it('caches shared factories returned by synchronous getters', () => {
+    const factory = () => ({ value: 'shared' });
+    const getShared = rs.fn(() => factory);
+    const federation = new ModuleFederation({
+      name: '@federation/sync-shared-cache',
+      remotes: [],
+      shared: {
+        'sync-shared': {
+          version: '1.0.0',
+          get: getShared,
+        },
+      },
+    });
+
+    const firstFactory = federation.loadShareSync('sync-shared');
+    const secondFactory = federation.loadShareSync('sync-shared');
+
+    expect(firstFactory).toBe(factory);
+    expect(secondFactory).toBe(factory);
+    expect(getShared).toHaveBeenCalledTimes(1);
+    expect(federation.shareScopeMap.default['sync-shared']['1.0.0'].lib).toBe(
+      factory,
+    );
+  });
+
   it('deduplicates concurrent remote module init', async () => {
     let beforeInitContainerCalls = 0;
     let initContainerCalls = 0;

--- a/packages/runtime-core/src/shared/index.ts
+++ b/packages/runtime-core/src/shared/index.ts
@@ -698,6 +698,7 @@ export class SharedHandler {
       merge(targetShared, 'loaded', loaded);
       merge(targetShared, 'loading', loading);
       merge(targetShared, 'get', get);
+      merge(targetShared, 'lib', lib);
     };
     scopes.forEach((sc) => {
       if (!this.shareScopeMap[sc]) {


### PR DESCRIPTION
Cache factories returned by synchronous shared getters in the registered share record so subsequent `loadShareSync` calls reuse the loaded factory.

The existing behavior dates back to the v1 implementation, where `setShared` returned immediately for an existing version. In the current runtime this leaves the share marked as loaded without a `lib`, causing later synchronous loads to invoke `get` again. The merge now fills `lib` only when the registered share does not already have one, preserving the existing provider and factory precedence.

A regression test verifies that the getter runs once and that the factory is stored in the share scope.

Validation:

- `pnpm exec turbo run test --filter=@module-federation/runtime-core --force` (12 test files, 97 tests passed)
- `pnpm run ci:local --only=build-and-test` (44 package builds and 60 affected test tasks passed)
- Changeset scope/status validation for `@module-federation/runtime-core` patch
- `pnpm exec prettier --check .` reports the unchanged baseline file `packages/playground/src/generated/bridgeRuntimeFiles.ts`; the CI changed-file format check passes for all files in this PR