### PR TITLE
ci(metro): pin idb-companion 1.1.8

### DIFF
--- a/.github/workflows/e2e-metro.yml
+++ b/.github/workflows/e2e-metro.yml
@@ -134,6 +134,10 @@ jobs:
       RUBY_VERSION: 3.4.9
       MAESTRO_VERSION: 1.39.13
       MAESTRO_DRIVER_STARTUP_TIMEOUT: 600000
+      # Last formula revision that installs idb-companion 1.1.8 on Xcode 16.4.
+      IDB_COMPANION_VERSION: 1.1.8
+      IDB_COMPANION_FORMULA_COMMIT: c0386793f59da10c619787f2aa18d938ef1d69c9
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - name: Check out repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -181,7 +185,9 @@ jobs:
         run: |
           curl -Ls "https://get.maestro.mobile.dev" | bash
           brew tap facebook/fb
+          git -C "$(brew --repository facebook/fb)" checkout "${IDB_COMPANION_FORMULA_COMMIT}"
           brew install facebook/fb/idb-companion
+          test "$(brew list --versions idb-companion)" = "idb-companion ${IDB_COMPANION_VERSION}"
           echo "${HOME}/.maestro/bin" >> "$GITHUB_PATH"
         shell: bash
 


### PR DESCRIPTION
## Description

The Metro iOS E2E job started failing while installing `facebook/fb/idb-companion`. The tap's unversioned formula moved from 1.1.8 to 1.5.0.b2 and now requires Xcode 26, while this workflow intentionally runs Xcode 16.4 on `macos-15` for React Native 0.80 compatibility.

This change:

- pins the facebook/fb tap to formula commit `c0386793f59da10c619787f2aa18d938ef1d69c9`, which installs `idb-companion 1.1.8`
- disables Homebrew auto-update for the job so the pinned tap is not advanced before installation
- verifies that the installed version is exactly `1.1.8`

The version was taken from the [last successful Metro iOS E2E job](https://github.com/module-federation/core/actions/runs/32000829484/job/95301803734). The regression is visible in the [failing job](https://github.com/module-federation/core/actions/runs/32226919898/job/95999348701).

## Related Issue

CI regression observed on PR #4997.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes. (Workflow-only change; no unit test applies.)
- [x] All applicable local checks passed.
- [ ] I have updated the documentation. (Not applicable.)

## Validation

- `pnpm exec prettier --check .github/workflows/e2e-metro.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/e2e-metro.yml'); puts 'YAML syntax OK'"`
- `git diff --check`
- `pnpm run ci:local --only=actionlint` (the local runner reports actionlint as GitHub-only)
- Full Metro iOS E2E verification is left to the GitHub macOS runner.
