### PR TITLE
feat(bridge): hide bridge router debug logs behind a config switch

### DIFF
--- a/.changeset/show-bridge-router-logs.md
+++ b/.changeset/show-bridge-router-logs.md
@@ -1,0 +1,7 @@
+---
+'@module-federation/bridge-react-webpack-plugin': patch
+'@module-federation/sdk': patch
+'@module-federation/enhanced': patch
+---
+
+Add `showBridgeRouterLogs` to the React bridge webpack plugin. Router alias debug logs are off by default and print only when this option is true.

--- a/apps/website-new/docs/en/guide/bridge/react/export-app.mdx
+++ b/apps/website-new/docs/en/guide/bridge/react/export-app.mdx
@@ -89,6 +89,8 @@ export default {
       bridge: {
         // Enable Bridge Router routing capabilities, default is true
         enableBridgeRouter: true,
+        // Print router alias debug logs during compilation, default is false
+        showBridgeRouterLogs: false,
       }
     }),
   ],
@@ -99,6 +101,8 @@ export default {
 
 - **`enableBridgeRouter: true`** (default) - Automatically handles basename and routing coordination, supports React Router v5, v6, v7
 - **`enableBridgeRouter: false`** - Disables Bridge's default routing proxy capabilities, users need to handle routing integration manually
+- **`showBridgeRouterLogs: true`** - Prints the React bridge webpack plugin's router alias debug logs during compilation
+- **`showBridgeRouterLogs: false`** (default) - Hides those debug logs
 
 :::warning Important
 When enabling Bridge Router, do not configure `react-router-dom` as a shared dependency, otherwise it will cause routing functionality issues.

--- a/apps/website-new/docs/pt-BR/guide/bridge/react/export-app.mdx
+++ b/apps/website-new/docs/pt-BR/guide/bridge/react/export-app.mdx
@@ -89,6 +89,8 @@ export default {
       bridge: {
         // Enable Bridge Router routing capabilities, default is true
         enableBridgeRouter: true,
+        // Print router alias debug logs during compilation, default is false
+        showBridgeRouterLogs: false,
       }
     }),
   ],
@@ -99,6 +101,8 @@ export default {
 
 - **`enableBridgeRouter: true`** (padrão) - Automatically handles basename e routing coordination, suporta React Router v5, v6, v7
 - **`enableBridgeRouter: false`** - Disables Bridge's padrão routing proxy capabilities, users precisa handle routing integração manually
+- **`showBridgeRouterLogs: true`** - Prints o React bridge webpack plugin's router alias debug logs during compilation
+- **`showBridgeRouterLogs: false`** (padrão) - Hides those debug logs
 
 :::warning Important
 Quando enabling Bridge Router, não configure `react-router-dom` as uma dependência compartilhada, caso contrário it vai cause routing functionality issues.

--- a/apps/website-new/docs/zh/guide/bridge/react/export-app.mdx
+++ b/apps/website-new/docs/zh/guide/bridge/react/export-app.mdx
@@ -90,6 +90,8 @@ export default {
       bridge: {
         // 启用 Bridge Router 路由能力，默认为 true
         enableBridgeRouter: true,
+        // 编译时打印路由 alias 调试日志，默认为 false
+        showBridgeRouterLogs: false,
       }
     }),
   ],
@@ -100,6 +102,8 @@ export default {
 
 - **`enableBridgeRouter: true`** (默认值) - 自动处理 basename 和路由协同，支持 React Router v5、v6、v7
 - **`enableBridgeRouter: false`** - 禁用 Bridge 默认的路由代理能力，用户需手动处理路由集成
+- **`showBridgeRouterLogs: true`** - 在编译时打印 React bridge webpack 插件的路由 alias 调试日志
+- **`showBridgeRouterLogs: false`** (默认值) - 不打印这些调试日志
 
 :::warning 重要
 启用 Bridge Router 时，请勿将 `react-router-dom` 配置为 shared 依赖，否则会导致路由功能异常。

--- a/packages/bridge/bridge-react-webpack-plugin/README.md
+++ b/packages/bridge/bridge-react-webpack-plugin/README.md
@@ -129,3 +129,18 @@ root.render(
     <App />
 );
 ```
+
+## Plugin options
+
+The React bridge webpack plugin is applied automatically by `ModuleFederationPlugin` when Bridge Router is enabled. You can control its router alias debug logs with `bridge.showBridgeRouterLogs`:
+
+```js
+new ModuleFederationPlugin({
+  name: 'remote1',
+  bridge: {
+    enableBridgeRouter: true,
+    // Off by default. Set to true to print the resolved react-router aliases.
+    showBridgeRouterLogs: true,
+  },
+});
+```

--- a/packages/bridge/bridge-react-webpack-plugin/__tests__/utils.spec.ts
+++ b/packages/bridge/bridge-react-webpack-plugin/__tests__/utils.spec.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { checkVersion, findPackageJson } from '../src/utils';
 import { getBridgeRouterAlias } from '../src/router-alias';
 
@@ -107,5 +108,35 @@ describe('test getBridgeRouterAlias: should return the correct alias for react-r
       'react-router/dist/production/index.js': resolveRouterV7,
       'react-router-dom/dist/index.js': resolveRouterV7,
     });
+  });
+});
+
+describe('test getBridgeRouterAlias: showBridgeRouterLogs option', () => {
+  afterEach(() => {
+    rs.restoreAllMocks();
+  });
+
+  it('should not log the resolved alias by default', () => {
+    const logSpy = rs.spyOn(console, 'log').mockImplementation(() => undefined);
+    getBridgeRouterAlias(resolveRouterV5);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('should log the resolved alias when showBridgeRouterLogs is true', () => {
+    const logSpy = rs.spyOn(console, 'log').mockImplementation(() => undefined);
+    getBridgeRouterAlias(resolveRouterV5, { showBridgeRouterLogs: true });
+    expect(logSpy).toHaveBeenCalledWith(
+      '<<<<<<<<<<<<< bridgeRouterAlias >>>>>>>>>>>>>',
+      expect.objectContaining({
+        'react-router-dom$':
+          '@module-federation/bridge-react/dist/router-v5.es.js',
+      }),
+    );
+  });
+
+  it('should not log the default alias by default', () => {
+    const logSpy = rs.spyOn(console, 'log').mockImplementation(() => undefined);
+    getBridgeRouterAlias('/nonexistent-mf-bridge-router-alias-test');
+    expect(logSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/bridge/bridge-react-webpack-plugin/src/index.ts
+++ b/packages/bridge/bridge-react-webpack-plugin/src/index.ts
@@ -3,14 +3,28 @@ import path from 'node:path';
 import type { moduleFederationPlugin } from '@module-federation/sdk';
 import { getBridgeRouterAlias } from './router-alias';
 
+export type ReactBridgePluginOptions = {
+  moduleFederationOptions: moduleFederationPlugin.ModuleFederationPluginOptions;
+  /**
+   * Prints router alias debug logs when true.
+   * Falls back to `moduleFederationOptions.bridge.showBridgeRouterLogs` when omitted.
+   *
+   * @default false
+   */
+  showBridgeRouterLogs?: boolean;
+};
+
 class ReactBridgeAliasChangerPlugin {
   alias: string;
   targetFile: string;
+  showBridgeRouterLogs: boolean;
   moduleFederationOptions: moduleFederationPlugin.ModuleFederationPluginOptions;
-  constructor(info: {
-    moduleFederationOptions: moduleFederationPlugin.ModuleFederationPluginOptions;
-  }) {
+  constructor(info: ReactBridgePluginOptions) {
     this.moduleFederationOptions = info.moduleFederationOptions;
+    this.showBridgeRouterLogs =
+      info.showBridgeRouterLogs ??
+      info.moduleFederationOptions?.bridge?.showBridgeRouterLogs ??
+      false;
     this.alias = 'react-router-dom$';
     this.targetFile = '@module-federation/bridge-react/dist/router.es.js';
 
@@ -45,7 +59,9 @@ class ReactBridgeAliasChangerPlugin {
         const updatedAlias: Record<string, string> = {
           // allow `alias` can be override
           // [this.alias]: targetFilePath,
-          ...getBridgeRouterAlias(originalAlias['react-router-dom']),
+          ...getBridgeRouterAlias(originalAlias['react-router-dom'], {
+            showBridgeRouterLogs: this.showBridgeRouterLogs,
+          }),
           ...originalAlias,
         };
 

--- a/packages/bridge/bridge-react-webpack-plugin/src/router-alias.ts
+++ b/packages/bridge/bridge-react-webpack-plugin/src/router-alias.ts
@@ -70,8 +70,13 @@ const setRouterAlias = (
   }
 };
 
+export type BridgeRouterAliasOptions = {
+  showBridgeRouterLogs?: boolean;
+};
+
 export const getBridgeRouterAlias = (
   originalAlias: string,
+  options: BridgeRouterAliasOptions = {},
 ): Record<string, string> => {
   const userDependencies = getDependencies();
   let reactRouterDomPath = '';
@@ -92,6 +97,12 @@ export const getBridgeRouterAlias = (
     );
   }
 
+  const logAlias = (message: string, alias: Record<string, string>) => {
+    if (options.showBridgeRouterLogs) {
+      console.log(message, alias);
+    }
+  };
+
   // Generate alias based on detected router package
   if (reactRouterDomPath) {
     const packageJsonPath = findPackageJson(reactRouterDomPath);
@@ -104,7 +115,7 @@ export const getBridgeRouterAlias = (
         majorVersion,
         reactRouterDomPath,
       );
-      console.log(
+      logAlias(
         '<<<<<<<<<<<<< bridgeRouterAlias >>>>>>>>>>>>>',
         bridgeRouterAlias,
       );
@@ -116,7 +127,7 @@ export const getBridgeRouterAlias = (
   const bridgeRouterAlias = {
     'react-router-dom$': reactRouterDomV6AliasPath,
   };
-  console.log(
+  logAlias(
     '<<<<<<<<<<<<< default bridgeRouterAlias >>>>>>>>>>>>>',
     bridgeRouterAlias,
   );

--- a/packages/enhanced/src/schemas/container/ModuleFederationPlugin.check.ts
+++ b/packages/enhanced/src/schemas/container/ModuleFederationPlugin.check.ts
@@ -482,6 +482,7 @@ const t = {
         properties: {
           enableBridgeRouter: { type: 'boolean', default: !1 },
           disableAlias: { type: 'boolean', default: !1 },
+          showBridgeRouterLogs: { type: 'boolean', default: !1 },
         },
         additionalProperties: !1,
       },
@@ -4877,7 +4878,8 @@ function D(
                                                   if (
                                                     'enableBridgeRouter' !==
                                                       t &&
-                                                    'disableAlias' !== t
+                                                    'disableAlias' !== t &&
+                                                    'showBridgeRouterLogs' !== t
                                                   )
                                                     return (
                                                       (D.errors = [
@@ -4920,6 +4922,28 @@ function D(
                                                       if (
                                                         'boolean' !=
                                                         typeof e.disableAlias
+                                                      )
+                                                        return (
+                                                          (D.errors = [
+                                                            {
+                                                              params: {
+                                                                type: 'boolean',
+                                                              },
+                                                            },
+                                                          ]),
+                                                          !1
+                                                        );
+                                                      q = t === c;
+                                                    } else q = !0;
+                                                  if (q)
+                                                    if (
+                                                      void 0 !==
+                                                      e.showBridgeRouterLogs
+                                                    ) {
+                                                      const t = c;
+                                                      if (
+                                                        'boolean' !=
+                                                        typeof e.showBridgeRouterLogs
                                                       )
                                                         return (
                                                           (D.errors = [

--- a/packages/enhanced/src/schemas/container/ModuleFederationPlugin.json
+++ b/packages/enhanced/src/schemas/container/ModuleFederationPlugin.json
@@ -919,6 +919,11 @@
           "description": "[Deprecated] Use `enableBridgeRouter: false` instead. Disables the default alias setting in the bridge. When true, users must manually handle basename through root component props.",
           "type": "boolean",
           "default": false
+        },
+        "showBridgeRouterLogs": {
+          "description": "Prints router alias debug logs emitted by the React bridge webpack plugin when true.",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/packages/enhanced/src/schemas/container/ModuleFederationPlugin.ts
+++ b/packages/enhanced/src/schemas/container/ModuleFederationPlugin.ts
@@ -1022,6 +1022,12 @@ export default {
           type: 'boolean',
           default: false,
         },
+        showBridgeRouterLogs: {
+          description:
+            'Prints router alias debug logs emitted by the React bridge webpack plugin when true.',
+          type: 'boolean',
+          default: false,
+        },
       },
       additionalProperties: false,
     },

--- a/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
+++ b/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
@@ -531,6 +531,12 @@ export interface ModuleFederationPluginOptions {
      * @default false
      */
     disableAlias?: boolean;
+    /**
+     * Prints router alias debug logs emitted by the React bridge webpack plugin.
+     *
+     * @default false
+     */
+    showBridgeRouterLogs?: boolean;
   };
   /**
    * Configuration for async boundary plugin


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

The React bridge webpack plugin always prints a log starting with `<<<<<<<<<<<<< bridgeRouterAlias >>>>>>>>>>>>>` during compilation.  These are debugs logs and look bad so I think they should be off by default.

A new `showBridgeRouterLogs` option enables them when needed:

- on the plugin: `new ReactBridgePlugin({ moduleFederationOptions, showBridgeRouterLogs: true })`
- or via Module Federation config: `bridge: { showBridgeRouterLogs: true }`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

No linked issue.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.