### PR TITLE
fix(third-party-dts-extractor): use createRequire for require.resolve in ESM build

### DIFF
--- a/.changeset/fix-third-party-dts-extractor-esm-require.md
+++ b/.changeset/fix-third-party-dts-extractor-esm-require.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/third-party-dts-extractor': patch
+---
+
+Fix `extractThirdParty` silently producing no output when `@module-federation/dts-plugin` runs as ESM. `getPackageRootDir()` and `resolvePackageJson()` called the bare `require.resolve()`, which tsup's ESM build shims to a stub without `.resolve`; the resulting TypeError was swallowed, leaving third-party type extraction a no-op. Both now resolve via `createRequire(import.meta.url)`, matching existing usage elsewhere in the monorepo.

--- a/packages/third-party-dts-extractor/src/ThirdPartyExtractor.ts
+++ b/packages/third-party-dts-extractor/src/ThirdPartyExtractor.ts
@@ -1,7 +1,11 @@
 import { copyFile, lstat, mkdir, readdir } from 'fs/promises';
 import { existsSync, readFileSync } from 'fs';
 import path from 'path';
+import { createRequire } from 'node:module';
 import { getTypedName, getPackageRootDir, resolvePackageJson } from './utils';
+
+// See utils.ts: bare `require` is not a real require in tsup's ESM output.
+const require = createRequire(import.meta.url);
 
 const ignoredPkgs = ['typescript'];
 

--- a/packages/third-party-dts-extractor/src/utils.ts
+++ b/packages/third-party-dts-extractor/src/utils.ts
@@ -1,5 +1,12 @@
 import path from 'node:path';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
+// tsup's ESM output shims bare `require` to a stub whose `.resolve` is
+// undefined, so `getPackageRootDir`/`resolvePackageJson` silently failed
+// (caught by their callers) whenever this package ran as ESM. A require
+// bound via createRequire() works in both the cjs and esm builds.
+const require = createRequire(import.meta.url);
 
 function getTypedName(name: string) {
   return `@types/${name.replace(/^@/, '').replace('/', '__')}`;

--- a/packages/third-party-dts-extractor/tsup.config.ts
+++ b/packages/third-party-dts-extractor/tsup.config.ts
@@ -7,6 +7,11 @@ const shared = {
   splitting: true,
   outDir: join('packages', 'third-party-dts-extractor', 'dist'),
   external: [join(__dirname, 'package.json')],
+  // Needed so createRequire(import.meta.url) in src/utils.ts and
+  // src/ThirdPartyExtractor.ts resolves to a real file URL in the cjs
+  // build too — without this, esbuild leaves import.meta empty under
+  // the cjs target and createRequire(undefined) throws at load time.
+  shims: true,
 };
 
 export default defineConfig([


### PR DESCRIPTION
## Current Behavior

With `@module-federation/vite` in a `"type": "module"` project, `dts.generateTypes.extractThirdParty` never copies anything into `@mf-types/node_modules`, with no error or warning — the build reports success.

## Root Cause

`getPackageRootDir()` and `resolvePackageJson()` in `packages/third-party-dts-extractor/src/utils.ts` call the bare `require.resolve()`. This package is built by tsup into both a CJS (`dist/index.js`) and ESM (`dist/index.mjs`) bundle. In the ESM output, tsup shims bare `require` to a stub whose `.resolve` is `undefined` (since `require` doesn't natively exist in ESM), so both calls throw a `TypeError`.

That error is caught by the `try/catch` in `ThirdPartyExtractor.inferPkgDir()` (which has the same bare `require.resolve()` call itself), so `this.pkgs` stays empty and `copyDts()` silently does nothing. The CJS bundle is unaffected since `require` is real there.

## Fix

Bind a real `require` via `createRequire(import.meta.url)` at module scope in both `utils.ts` and `ThirdPartyExtractor.ts`, instead of relying on the ambient global. This matches the existing precedent in `packages/rsbuild-plugin/src/utils/ssr.ts`:

```ts
const require = createRequire(import.meta.url);
```

`createRequire` works identically under both the CJS and ESM builds, so this doesn't change behavior for the CJS bundle at all — it only fixes the ESM path.

Included a changeset for `@module-federation/third-party-dts-extractor` (patch).

## Verification

Reasoned through and matched against the reporter's own minimal repro (`require.resolve` under `node --input-type=module` vs. plain `node -e`) and the existing `createRequire(import.meta.url)` pattern already shipping in `packages/rsbuild-plugin`. I wasn't able to run a full `pnpm install`/build of this monorepo locally to execute the existing `ThirdPartyExtractor.spec.ts` suite end-to-end — happy to iterate on CI feedback.

Closes #5007
