### PR TITLE
docs(configure): clarify getPublicPath function-form vs return-form behavior

### DIFF
--- a/apps/website-new/docs/en/configure/getpublicpath.mdx
+++ b/apps/website-new/docs/en/configure/getpublicpath.mdx
@@ -6,19 +6,15 @@
 - Effective condition: only effective when `exposes` is set
 
 
-Used to set a dynamic `publicPath`. The value must be a stringified function or a stringified return expression. When other consumers load this provider, the string in `getPublicPath` will be executed via `new Function` to obtain the return value, which will be used as the `publicPath` prefix for the module’s static assets. For example, if your deployed project receives a dynamic `cdn_prefix`, you can configure it as:
+Used to set a dynamic `publicPath`. The value must be a stringified function or a stringified return expression, and the two forms are **not** interchangeable:
 
-- Function form: ``function(){ return window.cdn_prefix }``
-- Return form: ``return "https:" + window.navigator.cdn_host + "/resource/app/"``
+- **Return form** (e.g. ``return "https:" + window.navigator.cdn_host + "/resource/app/"``): the string is executed via `new Function` and its **return value is assigned** to the bundler's public path (`__webpack_require__.p` for webpack/Rspack), so both the Module Federation runtime *and* the bundler's own native chunk loader use it.
+- **Function form** (e.g. ``function(){ __webpack_public_path__ = window.cdn_prefix }``): the string is executed as a function call, but **its return value is discarded**. The Module Federation runtime still picks up the value via the generated manifest, but the bundler's native chunk loader (used for sub-chunks inside an `exposes` entry) does not — it only reads `__webpack_require__.p`. If you need the function form to also affect native chunk loading, the function body must **assign** `__webpack_public_path__` itself, as shown below, rather than `return` a value.
 
-In the example below, `getPublicPath` is set. When other consumers load this provider, the string in `getPublicPath` will be executed using `new Function` to obtain the value, which will be used as the `publicPath` prefix for the module’s static assets.
+If you only need to compute the public path once, prefer the return form — it covers both cases with no extra step.
 
 :::tip NOTE
 `getPublicPath` must be a stringified function or a stringified return expression.
-:::
-
-:::tip NOTE
-If you're using the module federation webpack plugin and want to set a dynamic publicPath, you should set `__webpack_public_path__ = window.cdn_prefix` in the `getPublicPath` function body.
 :::
 
 ```ts title="rspack.config.ts"
@@ -30,7 +26,12 @@ module.exports = {
         './Button': './src/components/Button.tsx',
       },
       // ...
-      getPublicPath: `function() {return "https:" + window.navigator.cdn_host + "/resource/app/"}`,
+      // Return form (recommended): also sets the bundler's native public path.
+      getPublicPath: `return "https:" + window.navigator.cdn_host + "/resource/app/"`,
+      // Function form: must assign __webpack_public_path__ itself to affect
+      // native chunk loading — a bare `return` inside this form only reaches
+      // the Module Federation runtime, not __webpack_require__.p.
+      // getPublicPath: `function() { __webpack_public_path__ = "https:" + window.navigator.cdn_host + "/resource/app/" }`,
     }),
   ],
 };


### PR DESCRIPTION
## The question this issue asked

> Is the `startsWith('function')` split in `RemoteEntryPlugin.addPublicPathEntry` intentional, or did the function-form branch just forget the `__webpack_require__.p =` prefix?

## Answer: intentional, but the docs contradict it

Checked `packages/rspack/src/RemoteEntryPlugin.ts` — current `main` matches exactly what's described in the issue: the return-form assigns to `__webpack_require__.p`, the function-form just invokes and discards the result.

The `getPublicPath` docs page already has a tip for this:

> If you're using the module federation webpack plugin and want to set a dynamic publicPath, you should set `__webpack_public_path__ = window.cdn_prefix` **in the `getPublicPath` function body**.

That's the intended workaround — the function form is expected to assign `__webpack_public_path__` itself as a side effect, not rely on its return value being captured. So the code behavior looks intentional, not a bug.

**But** the page's main example and code sample both show:
```js
getPublicPath: `function() {return "https:" + window.navigator.cdn_host + "/resource/app/"}`,
```
— a `return`-only function body, which is exactly the pattern that *doesn't* work per the tip above, and exactly what the reporter hit. The primary example contradicts the note that explains the real requirement.

## Fix

Docs-only, no runtime changes:
- States the return-form vs function-form distinction up front instead of as an easy-to-miss footnote tip.
- Fixes the code sample to actually demonstrate a working function-form (`__webpack_public_path__ = ...` assignment) instead of a `return`-only body that silently doesn't propagate to the bundler's native chunk loader.
- Recommends the return form as the simpler default when there's no other reason to use the function form.

Closes #5001
