### PR TITLE
fix(dts-plugin): mark typescript peer dependency optional

### DIFF
--- a/.changeset/chatty-zoos-study.md
+++ b/.changeset/chatty-zoos-study.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+Mark typescript peer dependency as optional

--- a/packages/dts-plugin/package.json
+++ b/packages/dts-plugin/package.json
@@ -92,6 +92,9 @@
     "vue-tsc": ">=1.0.24"
   },
   "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    },
     "vue-tsc": {
       "optional": true
     }


### PR DESCRIPTION
## Description

`@module-federation/dts-plugin` defines `typescript` as a peer dependency, but not an optional one. For users of `@module-federation/vite`, `dts-plugin` is always installed along with the 30MB `tsc` binary (or 50MB for WASM/platform-agnostic).

[<img width="2130" height="1532" alt="pkg-size.dev screenshot" src="https://github.com/user-attachments/assets/c0f86037-a82d-4062-9d9b-3c8c7f7da542" />](https://pkg-size.dev/@module-federation%2Fvite)

https://github.com/module-federation/vite/blob/8c58d47c8ef4706e98e9fd12b000242c09d74d34/src/index.ts#L964-L970

The Vite plugin already ignores importing `dts-plugin` when disabled, but `typescript` is still installed.

This PR marks `typescript` as an optional peer dependency, so that users of the Vite plugin don't need to have `typescript` installed even when they aren't using it for anything.

## Related Issue

- #4271 proposes a different solution for the same problem

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
