### PR TITLE
feat(rspack): support eager exposes

### DIFF
--- a/.changeset/eager-exposes-rspack.md
+++ b/.changeset/eager-exposes-rspack.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/rspack': patch
+---
+
+Add opt-in eager expose bundling for Rspack so selected exposes can be included in the container entry chunk without changing Rspack itself.

--- a/packages/rspack/README.md
+++ b/packages/rspack/README.md
@@ -1,1 +1,51 @@
 # `@module-federation/rspack` Documentation
+
+## Eager exposes
+
+Rspack exposes can be included in the container entry chunk by setting
+`eager: true`:
+
+```js
+const { ModuleFederationPlugin } = require('@module-federation/enhanced/rspack');
+
+module.exports = {
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'remote',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './data-loader': {
+          import: './src/data-loader',
+          eager: true,
+        },
+      },
+    }),
+  ],
+};
+```
+
+The exposed module is bundled into `remoteEntry.js`, but it is not evaluated
+until its container factory is called. `container.get()` remains asynchronous.
+
+`ExposeEagerPlugin` is also exported from `@module-federation/rspack/plugin`
+for use alongside Rspack's built-in module federation plugin:
+
+```js
+const rspack = require('@rspack/core');
+const { ExposeEagerPlugin } = require('@module-federation/rspack/plugin');
+
+const federationOptions = {
+  name: 'remote',
+  filename: 'remoteEntry.js',
+  exposes: {
+    './data-loader': {
+      import: './src/data-loader',
+      eager: true,
+    },
+  },
+};
+
+module.exports = {
+  plugins: [new ExposeEagerPlugin(federationOptions), new rspack.container.ModuleFederationPlugin(federationOptions)],
+};
+```

--- a/packages/rspack/__tests__/ExposeEagerPlugin.spec.ts
+++ b/packages/rspack/__tests__/ExposeEagerPlugin.spec.ts
@@ -1,0 +1,167 @@
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  container,
+  rspack,
+  type Configuration,
+  type Stats,
+} from '@rspack/core';
+import {
+  ExposeEagerPlugin,
+  type ExposeEagerPluginOptions,
+} from '../src/ExposeEagerPlugin';
+import { ModuleFederationPlugin } from '../src/ModuleFederationPlugin';
+
+async function runCompiler(
+  context: string,
+  plugins: NonNullable<Configuration['plugins']>,
+): Promise<Stats> {
+  const compiler = rspack({
+    context,
+    entry: {},
+    mode: 'development',
+    devtool: false,
+    output: {
+      path: path.join(context, 'dist'),
+      filename: '[name].js',
+      chunkFilename: '[name].js',
+    },
+    optimization: {
+      minimize: false,
+      splitChunks: false,
+    },
+    plugins,
+  });
+
+  try {
+    return await new Promise<Stats>((resolve, reject) => {
+      compiler.run((error, stats) => {
+        if (error) {
+          reject(error);
+        } else if (!stats) {
+          reject(new Error('Rspack completed without stats.'));
+        } else if (stats.hasErrors()) {
+          reject(new Error(stats.toString({ all: false, errors: true })));
+        } else {
+          resolve(stats);
+        }
+      });
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      compiler.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function writeFixture(context: string): Promise<void> {
+  await Promise.all([
+    writeFile(
+      path.join(context, 'eager.js'),
+      "globalThis.__MF_EAGER_EXPOSE_MARKER__ = 'eager'; export const value = 'eager';\n",
+    ),
+    writeFile(
+      path.join(context, 'lazy.js'),
+      "globalThis.__MF_LAZY_EXPOSE_MARKER__ = 'lazy'; export const value = 'lazy';\n",
+    ),
+  ]);
+}
+
+async function expectEagerOutput(context: string): Promise<void> {
+  const outputPath = path.join(context, 'dist');
+  const assets = await readdir(outputPath);
+  const remoteEntry = await readFile(
+    path.join(outputPath, 'remoteEntry.js'),
+    'utf8',
+  );
+  const lazyChunk = await readFile(
+    path.join(outputPath, 'lazy-chunk.js'),
+    'utf8',
+  );
+
+  expect(assets).toContain('remoteEntry.js');
+  expect(assets).toContain('lazy-chunk.js');
+  expect(assets).not.toContain('eager-chunk.js');
+  expect(
+    assets.some((asset) =>
+      asset.startsWith('__module_federation_expose_eager_factory__'),
+    ),
+  ).toBe(false);
+  expect(remoteEntry).toContain('__MF_EAGER_EXPOSE_MARKER__');
+  expect(remoteEntry).toContain('Promise.resolve()');
+  expect(remoteEntry).not.toContain('__MF_LAZY_EXPOSE_MARKER__');
+  expect(lazyChunk).toContain('__MF_LAZY_EXPOSE_MARKER__');
+}
+
+const exposeEagerOptions = {
+  name: 'remote',
+  exposes: {
+    './eager': {
+      import: './eager.js',
+      name: 'eager-chunk',
+      eager: true,
+    },
+    './lazy': {
+      import: './lazy.js',
+      name: 'lazy-chunk',
+    },
+  },
+} satisfies ExposeEagerPluginOptions;
+
+describe('ExposeEagerPlugin', () => {
+  it('is applied by the enhanced ModuleFederationPlugin', async () => {
+    const context = await mkdtemp(
+      path.join(tmpdir(), 'module-federation-rspack-eager-wrapper-'),
+    );
+
+    try {
+      await writeFixture(context);
+
+      await runCompiler(context, [
+        new ModuleFederationPlugin({
+          ...exposeEagerOptions,
+          filename: 'remoteEntry.js',
+          dts: false,
+          manifest: false,
+        }),
+      ]);
+
+      await expectEagerOutput(context);
+    } finally {
+      await rm(context, { recursive: true, force: true });
+    }
+  });
+
+  it('works alongside the built-in Rspack container plugin', async () => {
+    const context = await mkdtemp(
+      path.join(tmpdir(), 'module-federation-rspack-eager-standalone-'),
+    );
+
+    try {
+      await writeFixture(context);
+
+      await runCompiler(context, [
+        new ExposeEagerPlugin(exposeEagerOptions),
+        new container.ModuleFederationPlugin({
+          name: 'remote',
+          filename: 'remoteEntry.js',
+          exposes: {
+            './eager': {
+              import: './eager.js',
+              name: 'eager-chunk',
+            },
+            './lazy': {
+              import: './lazy.js',
+              name: 'lazy-chunk',
+            },
+          },
+        }),
+      ]);
+
+      await expectEagerOutput(context);
+    } finally {
+      await rm(context, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/rspack/src/ExposeEagerPlugin.ts
+++ b/packages/rspack/src/ExposeEagerPlugin.ts
@@ -1,0 +1,137 @@
+import type { Compiler, RspackPluginInstance } from '@rspack/core';
+import type { moduleFederationPlugin } from '@module-federation/sdk';
+
+const PLUGIN_NAME = 'RspackExposeEagerPlugin';
+const FACTORY_ENTRY_PREFIX = '__module_federation_expose_eager_factory__';
+const EMPTY_FACTORY_ENTRY = 'data:text/javascript,export%20%7B%7D%3B';
+
+export interface RspackExposesConfig
+  extends moduleFederationPlugin.ExposesConfig {
+  /**
+   * Include the exposed module in the container entry chunk.
+   *
+   * The module is still evaluated when the container factory is called.
+   */
+  eager?: boolean;
+}
+
+export interface RspackExposesObject {
+  [key: string]:
+    | RspackExposesConfig
+    | moduleFederationPlugin.ExposesItem
+    | moduleFederationPlugin.ExposesItems;
+}
+
+export type RspackExposes =
+  | (moduleFederationPlugin.ExposesItem | RspackExposesObject)[]
+  | RspackExposesObject;
+
+export interface RspackModuleFederationPluginOptions extends Omit<
+  moduleFederationPlugin.ModuleFederationPluginOptions,
+  'exposes'
+> {
+  exposes?: RspackExposes;
+}
+
+export interface ExposeEagerPluginOptions {
+  /** Name of the container entry that receives eager exposed modules. */
+  name: string;
+  exposes?: RspackExposes;
+}
+
+function collectEagerImports(exposes?: RspackExposes): string[] {
+  const imports = new Set<string>();
+
+  const collectFromObject = (exposesObject: RspackExposesObject) => {
+    for (const expose of Object.values(exposesObject)) {
+      if (
+        !expose ||
+        typeof expose !== 'object' ||
+        Array.isArray(expose) ||
+        expose.eager !== true
+      ) {
+        continue;
+      }
+
+      const requests = Array.isArray(expose.import)
+        ? expose.import
+        : [expose.import];
+      for (const request of requests) {
+        imports.add(request);
+      }
+    }
+  };
+
+  if (Array.isArray(exposes)) {
+    for (const expose of exposes) {
+      if (expose && typeof expose === 'object') {
+        collectFromObject(expose);
+      }
+    }
+  } else if (exposes) {
+    collectFromObject(exposes);
+  }
+
+  return [...imports];
+}
+
+/**
+ * Includes exposes marked as eager in the Rspack container entry chunk.
+ */
+export class ExposeEagerPlugin implements RspackPluginInstance {
+  readonly name = PLUGIN_NAME;
+  private readonly containerName: string;
+  private readonly eagerImports: string[];
+
+  constructor(options: ExposeEagerPluginOptions) {
+    this.containerName = options.name;
+    this.eagerImports = collectEagerImports(options.exposes);
+  }
+
+  apply(compiler: Compiler): void {
+    if (this.eagerImports.length === 0) {
+      return;
+    }
+
+    const entryPlugin = compiler.webpack.EntryPlugin;
+    const factoryEntryName = `${FACTORY_ENTRY_PREFIX}${this.containerName}`;
+
+    // addInclude uses EntryDependency, whose factory is normally installed by
+    // application entries. Register a temporary entry so pure containers with
+    // `entry: {}` are supported too. It is removed before chunk graph creation.
+    new entryPlugin(compiler.context, EMPTY_FACTORY_ENTRY, {
+      name: factoryEntryName,
+    }).apply(compiler);
+
+    const dependencies = this.eagerImports.map((request) =>
+      entryPlugin.createDependency(request),
+    );
+
+    compiler.hooks.finishMake.tapPromise(PLUGIN_NAME, async (compilation) => {
+      try {
+        if (!compilation.entries.has(this.containerName)) {
+          throw new Error(
+            `[${PLUGIN_NAME}] Cannot find container entry "${this.containerName}". ` +
+              'Apply this plugin together with a ModuleFederationPlugin that exposes modules.',
+          );
+        }
+
+        await Promise.all(
+          dependencies.map(
+            (dependency) =>
+              new Promise<void>((resolve, reject) => {
+                compilation.addInclude(
+                  compiler.context,
+                  dependency,
+                  { name: this.containerName },
+                  (error) => (error ? reject(error) : resolve()),
+                );
+              }),
+          ),
+        );
+      } finally {
+        compilation.entries.delete(factoryEntryName);
+      }
+    });
+  }
+}

--- a/packages/rspack/src/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/ModuleFederationPlugin.ts
@@ -1,7 +1,7 @@
 import type {
   Compiler,
   Falsy,
-  ModuleFederationPluginOptions,
+  ModuleFederationPluginOptions as RspackCoreModuleFederationPluginOptions,
   RspackPluginFunction,
   RspackPluginInstance,
 } from '@rspack/core';
@@ -18,6 +18,10 @@ import ReactBridgePlugin from '@module-federation/bridge-react-webpack-plugin';
 import path from 'node:path';
 import fs from 'node:fs';
 import { RemoteEntryPlugin } from './RemoteEntryPlugin';
+import {
+  ExposeEagerPlugin,
+  type RspackModuleFederationPluginOptions,
+} from './ExposeEagerPlugin';
 import logger from './logger';
 
 type ExcludeFalse<T> = T extends undefined | false ? never : T;
@@ -102,10 +106,10 @@ export function resolveRspackRuntimeAlias(
 
 export class ModuleFederationPlugin implements RspackPluginInstance {
   readonly name = PLUGIN_NAME;
-  private _options: moduleFederationPlugin.ModuleFederationPluginOptions;
+  private _options: RspackModuleFederationPluginOptions;
   private _statsPlugin?: StatsPlugin;
 
-  constructor(options: moduleFederationPlugin.ModuleFederationPluginOptions) {
+  constructor(options: RspackModuleFederationPluginOptions) {
     this._options = options;
   }
 
@@ -176,6 +180,10 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
       throw new Error('[ ModuleFederationPlugin ]: name is required');
     }
     this._checkSingleton(compiler);
+    new ExposeEagerPlugin({
+      name: options.name,
+      exposes: options.exposes,
+    }).apply(compiler);
     this._patchBundlerConfig(compiler);
     const containerManager = new ContainerManager();
     containerManager.init(options);
@@ -233,7 +241,7 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
     }
 
     new compiler.webpack.container.ModuleFederationPlugin(
-      options as unknown as ModuleFederationPluginOptions,
+      options as unknown as RspackCoreModuleFederationPluginOptions,
     ).apply(compiler);
 
     let runtimePath: string;
@@ -452,6 +460,15 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
 }
 
 export const GetPublicPathPlugin = RemoteEntryPlugin;
+
+export {
+  ExposeEagerPlugin,
+  type ExposeEagerPluginOptions,
+  type RspackExposes,
+  type RspackExposesConfig,
+  type RspackExposesObject,
+  type RspackModuleFederationPluginOptions,
+} from './ExposeEagerPlugin';
 
 export {
   TreeShakingSharedPlugin,


### PR DESCRIPTION
## Description

Add opt-in `eager: true` support for Rspack exposes without changing Rspack itself. Eager expose modules are included in the container entry chunk, avoiding a separate async chunk request while preserving the asynchronous `container.get()` contract and deferring module evaluation until the exposed factory is called.

The enhanced Rspack `ModuleFederationPlugin` applies the behavior automatically. `ExposeEagerPlugin` is also exported from `@module-federation/rspack/plugin` for use alongside Rspack's built-in module federation plugin. Integration tests cover both forms with a container-only `entry: {}` configuration and verify eager versus lazy output assets.

Validation run:

- `pnpm exec turbo run build --filter=@module-federation/rspack`
- `pnpm exec turbo run lint --filter=@module-federation/rspack --force`
- `pnpm exec turbo run test --filter=@module-federation/rspack --force`
- `pnpm exec prettier --check packages/rspack/src/ExposeEagerPlugin.ts packages/rspack/src/ModuleFederationPlugin.ts packages/rspack/__tests__/ExposeEagerPlugin.spec.ts packages/rspack/README.md .changeset/eager-exposes-rspack.md`

The full-repository `pnpm exec prettier --check .` remains blocked by 682 pre-existing generated files, primarily under `apps/website-new/doc_build`; none are part of this branch.

## Related Issue

No related issue.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
