### PR TITLE
fix(dts-plugin): do not overwrite on extract when the types folder was just deleted

### DIFF
--- a/.changeset/quiet-symlink-guard.md
+++ b/.changeset/quiet-symlink-guard.md
@@ -2,4 +2,4 @@
 "@module-federation/dts-plugin": patch
 ---
 
-Stop passing `overwrite: true` to adm-zip's `extractAllTo` when `deleteTypesFolder` is enabled (the default). The folder is removed immediately before extraction, so overwrite was redundant there, and disabling it removes the precondition for CVE-2026-76845 (symlink following on extraction) on the default path.
+Stop passing `overwrite: true` to adm-zip's `extractAllTo` when the types folder was just deleted (the default `deleteTypesFolder: true` path). Every entry is new there, so overwrite was redundant, and disabling it removes the precondition for CVE-2026-76845 (symlink following on extraction). Overwrite stays on when `deleteTypesFolder` is false or the deletion failed, so existing behaviour is unchanged in those paths.

--- a/.changeset/quiet-symlink-guard.md
+++ b/.changeset/quiet-symlink-guard.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/dts-plugin": patch
+---
+
+Stop passing `overwrite: true` to adm-zip's `extractAllTo` when `deleteTypesFolder` is enabled (the default). The folder is removed immediately before extraction, so overwrite was redundant there, and disabling it removes the precondition for CVE-2026-76845 (symlink following on extraction) on the default path.

--- a/packages/dts-plugin/src/core/lib/archiveHandler.ts
+++ b/packages/dts-plugin/src/core/lib/archiveHandler.ts
@@ -91,7 +91,12 @@ export const downloadTypesArchive = (hostOptions: Required<HostOptions>) => {
         }
 
         const zip = new AdmZip(Buffer.from(response.data));
-        zip.extractAllTo(destinationPath, true);
+        // Only overwrite when the caller opted out of deleting the types folder.
+        // In the default path the folder was just removed, so every entry is new
+        // and overwrite is redundant. Keeping it off removes the precondition of
+        // CVE-2026-76845 (adm-zip follows symlinks at the destination only when
+        // overwrite is enabled).
+        zip.extractAllTo(destinationPath, !hostOptions.deleteTypesFolder);
         fileLog(
           `zip.extractAllTo success destinationPath: ${destinationPath}; url: ${url}`,
           'downloadTypesArchive',

--- a/packages/dts-plugin/src/core/lib/archiveHandler.ts
+++ b/packages/dts-plugin/src/core/lib/archiveHandler.ts
@@ -75,12 +75,14 @@ export const downloadTypesArchive = (hostOptions: Required<HostOptions>) => {
           );
         }
 
+        let typesFolderRemoved = false;
         try {
           if (hostOptions.deleteTypesFolder) {
             await rm(destinationPath, {
               recursive: true,
               force: true,
             });
+            typesFolderRemoved = true;
           }
         } catch (error) {
           fileLog(
@@ -91,12 +93,13 @@ export const downloadTypesArchive = (hostOptions: Required<HostOptions>) => {
         }
 
         const zip = new AdmZip(Buffer.from(response.data));
-        // Only overwrite when the caller opted out of deleting the types folder.
-        // In the default path the folder was just removed, so every entry is new
-        // and overwrite is redundant. Keeping it off removes the precondition of
+        // Overwrite is only needed when something may already exist at the
+        // destination: the caller opted out of deleting the types folder, or the
+        // deletion failed. When the folder was just removed every entry is new,
+        // and keeping overwrite off there removes the precondition of
         // CVE-2026-76845 (adm-zip follows symlinks at the destination only when
         // overwrite is enabled).
-        zip.extractAllTo(destinationPath, !hostOptions.deleteTypesFolder);
+        zip.extractAllTo(destinationPath, !typesFolderRemoved);
         fileLog(
           `zip.extractAllTo success destinationPath: ${destinationPath}; url: ${url}`,
           'downloadTypesArchive',


### PR DESCRIPTION
## Description

`downloadTypesArchive` removes the types destination folder right before extracting the remote's `@mf-types.zip` when `deleteTypesFolder` is enabled (the default), then calls `zip.extractAllTo(destinationPath, true)`. In that path every entry is new, so `overwrite: true` was redundant.

adm-zip 0.5.9 through 0.6.0 (the version dts-plugin pins) is affected by CVE-2026-76845, symlink following at the extraction destination. Per the CVE text, the write is only reachable when overwrite is enabled, because adm-zip's `existsSync` check otherwise declines. This PR passes `overwrite` only when something may already exist at the destination, tracked by whether the `rm` actually succeeded (`typesFolderRemoved`):

- Default path (`deleteTypesFolder: true`, `rm` succeeded): overwrite is off, the CVE precondition is no longer met, and the written output is unchanged since every entry is new.
- `deleteTypesFolder: false`: overwrite stays on, so users who keep an existing folder still get refreshed types, exactly as before.
- `deleteTypesFolder: true` but `rm` failed (already caught and logged): overwrite stays on, exactly as before, so consumers never get silently stale types. (Updated after review feedback; the first revision tied overwrite to the option alone.)

This is a mitigation of the reachable path in this package, not a fix of adm-zip. A fixed adm-zip release (cthackers/adm-zip#575 is open upstream) plus a bump is still the complete fix.

**Not in this PR:** `packages/native-federation-typescript` and `packages/native-federation-tests` have the same `rm` then `extractAllTo(destinationPath, true)` sequence in their `archiveHandler.ts` and also depend on `adm-zip ^0.6.0`. Happy to apply the same change there in this PR or a follow-up if maintainers want it.

## Related Issue

Fixes #5024

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.

No test added: the change is a single argument on the default path with identical output, and there is no existing test asserting the `extractAllTo` arguments. I can add one if you would like it pinned. Changeset included (`@module-federation/dts-plugin` patch).

