### PR TITLE
fix(runtime): keep top-level singleton on first init

### DIFF
--- a/.changeset/runtime-singleton-first-wins.md
+++ b/.changeset/runtime-singleton-first-wins.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+init() no longer re-points the top-level runtime singleton when a later instance is created in the same process, so a remote container sharing the host's runtime copy cannot hijack loadRemote/registerRemotes/getInstance.

--- a/packages/runtime/__tests__/api.spec.ts
+++ b/packages/runtime/__tests__/api.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@rstest/core';
+import { describe, it, expect, rs } from '@rstest/core';
 import { createInstance, getInstance, init } from '../src';
 
 // eslint-disable-next-line max-lines-per-function
@@ -86,10 +86,12 @@ describe('api', () => {
   });
 
   it('returns the default instance when no finder is provided', () => {
-    const defaultInstance = init({
+    init({
       name: '@federation/default-instance',
       remotes: [],
     });
+    const defaultInstance = getInstance();
+    expect(defaultInstance).not.toBeNull();
 
     createInstance({
       name: '@federation/secondary-instance',
@@ -97,6 +99,38 @@ describe('api', () => {
     });
 
     expect(getInstance()).toBe(defaultInstance);
+  });
+
+  it('keeps the first initialized instance as the top-level singleton', async () => {
+    // Load a fresh copy of the runtime so the module-level singleton is unset
+    rs.resetModules();
+    const runtime = await import('../src');
+
+    const host = runtime.init({
+      name: '@federation/singleton-host',
+      remotes: [],
+    });
+    // Simulates a remote container whose bundler runtime calls init() through
+    // the same @module-federation/runtime copy as the host
+    const remote = runtime.init({
+      name: '@federation/singleton-remote',
+      remotes: [],
+    });
+    expect(remote).not.toBe(host);
+
+    expect(runtime.getInstance()).toBe(host);
+
+    runtime.registerRemotes([
+      {
+        name: '@federation/singleton-sub',
+        entry: 'http://localhost:1111/singleton-sub/remoteEntry.js',
+      },
+    ]);
+
+    expect(host.options.remotes.map((remoteInfo) => remoteInfo.name)).toContain(
+      '@federation/singleton-sub',
+    );
+    expect(remote.options.remotes).toHaveLength(0);
   });
 
   it('finds the first matching registered instance', () => {

--- a/packages/runtime/__tests__/api.spec.ts
+++ b/packages/runtime/__tests__/api.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, rs } from '@rstest/core';
+import { describe, it, expect, rs, beforeEach } from '@rstest/core';
+import { resetFederationGlobalInfo } from '@module-federation/runtime-core';
 import { createInstance, getInstance, init } from '../src';
 
 // eslint-disable-next-line max-lines-per-function
@@ -101,36 +102,154 @@ describe('api', () => {
     expect(getInstance()).toBe(defaultInstance);
   });
 
-  it('keeps the first initialized instance as the top-level singleton', async () => {
-    // Load a fresh copy of the runtime so the module-level singleton is unset
-    rs.resetModules();
-    const runtime = await import('../src');
+  describe('default instance contract', () => {
+    type Runtime = typeof import('../src');
+    let runtime: Runtime;
 
-    const host = runtime.init({
-      name: '@federation/singleton-host',
-      remotes: [],
+    // Fresh module copy (module-level default) and fresh global instance list
+    beforeEach(async () => {
+      resetFederationGlobalInfo();
+      rs.resetModules();
+      runtime = await import('../src');
     });
-    // Simulates a remote container whose bundler runtime calls init() through
-    // the same @module-federation/runtime copy as the host
-    const remote = runtime.init({
-      name: '@federation/singleton-remote',
-      remotes: [],
+
+    const remote = (name: string) => ({
+      name,
+      entry: `http://localhost:1111/${name}/remoteEntry.js`,
     });
-    expect(remote).not.toBe(host);
+    const remoteNames = (instance: {
+      options: { remotes: { name: string }[] };
+    }) => instance.options.remotes.map((remoteInfo) => remoteInfo.name);
 
-    expect(runtime.getInstance()).toBe(host);
+    it('first init() establishes the default', () => {
+      expect(runtime.getInstance()).toBeNull();
+      const host = runtime.init({ name: '@federation/host', remotes: [] });
+      expect(runtime.getInstance()).toBe(host);
+    });
 
-    runtime.registerRemotes([
-      {
-        name: '@federation/singleton-sub',
-        entry: 'http://localhost:1111/singleton-sub/remoteEntry.js',
-      },
-    ]);
+    it('second init() with a different name returns its own instance and keeps the default', () => {
+      const host = runtime.init({ name: '@federation/host', remotes: [] });
+      // Simulates a remote container whose bundler runtime calls init() through
+      // the same @module-federation/runtime copy as the host
+      const remoteInstance = runtime.init({
+        name: '@federation/remote',
+        remotes: [],
+      });
+      expect(remoteInstance).not.toBe(host);
+      expect(remoteInstance.name).toBe('@federation/remote');
+      expect(runtime.getInstance()).toBe(host);
+    });
 
-    expect(host.options.remotes.map((remoteInfo) => remoteInfo.name)).toContain(
-      '@federation/singleton-sub',
-    );
-    expect(remote.options.remotes).toHaveLength(0);
+    it('repeated init() with the same name reuses the instance and merges options', () => {
+      const host = runtime.init({ name: '@federation/host', remotes: [] });
+      const again = runtime.init({
+        name: '@federation/host',
+        remotes: [remote('@federation/sub')],
+      });
+      expect(again).toBe(host);
+      expect(remoteNames(host)).toContain('@federation/sub');
+      expect(runtime.getInstance()).toBe(host);
+    });
+
+    it('createInstance() never establishes the default', () => {
+      runtime.createInstance({ name: '@federation/created', remotes: [] });
+      expect(runtime.getInstance()).toBeNull();
+    });
+
+    it('createInstance() after a default never changes it', () => {
+      const host = runtime.init({ name: '@federation/host', remotes: [] });
+      runtime.createInstance({ name: '@federation/created', remotes: [] });
+      expect(runtime.getInstance()).toBe(host);
+    });
+
+    it('getInstance(finder) searches global instances independently of the default', () => {
+      const host = runtime.init({ name: '@federation/host', remotes: [] });
+      const created = runtime.createInstance({
+        name: '@federation/created',
+        remotes: [],
+      });
+      expect(runtime.getInstance()).toBe(host);
+      expect(
+        runtime.getInstance(
+          (instance) => instance.name === '@federation/created',
+        ),
+      ).toBe(created);
+      expect(
+        runtime.getInstance(
+          (instance) => instance.name === '@federation/missing',
+        ),
+      ).toBeNull();
+    });
+
+    it('routes every top-level API to the default instance', async () => {
+      const host = runtime.init({ name: '@federation/host', remotes: [] });
+      const other = runtime.init({ name: '@federation/other', remotes: [] });
+
+      const methods = [
+        'registerRemotes',
+        'registerShared',
+        'registerPlugins',
+        'preloadRemote',
+        'loadRemote',
+        'loadShare',
+      ] as const;
+      const spy = (instance: typeof host) =>
+        Object.fromEntries(
+          methods.map((method) => [
+            method,
+            rs.spyOn(instance, method).mockImplementation(async () => null),
+          ]),
+        ) as Record<(typeof methods)[number], ReturnType<typeof rs.spyOn>>;
+      const hostSpies = spy(host);
+      const otherSpies = spy(other);
+
+      runtime.registerRemotes([remote('@federation/sub')]);
+      runtime.registerShared({});
+      runtime.registerPlugins([]);
+      await runtime.preloadRemote([{ nameOrAlias: '@federation/sub' }]);
+      await runtime.loadRemote('@federation/sub/Widget');
+      await runtime.loadShare('react');
+
+      for (const method of methods) {
+        expect(hostSpies[method]).toHaveBeenCalledTimes(1);
+        expect(otherSpies[method]).not.toHaveBeenCalled();
+      }
+    });
+
+    it('top-level registerRemotes mutates the default, not a later init() instance', () => {
+      const host = runtime.init({ name: '@federation/host', remotes: [] });
+      const remoteInstance = runtime.init({
+        name: '@federation/remote',
+        remotes: [],
+      });
+      runtime.registerRemotes([remote('@federation/sub')]);
+      expect(remoteNames(host)).toContain('@federation/sub');
+      expect(remoteInstance.options.remotes).toHaveLength(0);
+    });
+
+    it('an instance from createInstance() becomes the default when init() adopts it and none exists', () => {
+      const created = runtime.createInstance({
+        name: '@federation/created',
+        remotes: [],
+      });
+      expect(runtime.getInstance()).toBeNull();
+      expect(runtime.init({ name: '@federation/created', remotes: [] })).toBe(
+        created,
+      );
+      expect(runtime.getInstance()).toBe(created);
+    });
+
+    it('an instance from createInstance() does not become the default via init() when one exists', () => {
+      const host = runtime.init({ name: '@federation/host', remotes: [] });
+      const created = runtime.createInstance({
+        name: '@federation/created',
+        remotes: [],
+      });
+      expect(runtime.init({ name: '@federation/created', remotes: [] })).toBe(
+        created,
+      );
+      expect(runtime.getInstance()).toBe(host);
+    });
   });
 
   it('finds the first matching registered instance', () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -43,8 +43,14 @@ export function init(options: UserOptions): ModuleFederation {
   const instance = getGlobalFederationInstance(options.name, options.version);
   const normalizedOptions = { ...options, id: options.id || '' };
   if (!instance) {
-    FederationInstance = createInstance(normalizedOptions);
-    return FederationInstance;
+    const createdInstance = createInstance(normalizedOptions);
+    // The top-level API singleton is first-wins: a later init() call (for
+    // example from a remote container that shares this runtime copy) must
+    // not re-point loadRemote/registerRemotes/getInstance to its instance.
+    if (!FederationInstance) {
+      FederationInstance = createdInstance;
+    }
+    return createdInstance;
   } else {
     // Merge options
     instance.initOptions(normalizedOptions);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -25,6 +25,11 @@ export {
 
 export { ModuleFederation };
 
+/**
+ * Creates a new ModuleFederation instance and registers it in the global
+ * instance list. Unlike `init()`, this never establishes or changes the
+ * module-level default instance used by the top-level convenience APIs.
+ */
 export function createInstance(options: UserOptions) {
   // Retrieve debug constructor
   const ModuleFederationConstructor =
@@ -37,82 +42,98 @@ export function createInstance(options: UserOptions) {
   return instance;
 }
 
-let FederationInstance: ModuleFederation | null = null;
+let DefaultFederationInstance: ModuleFederation | null = null;
+
+/**
+ * Initializes (or re-initializes) the ModuleFederation instance for
+ * `options.name` / `options.version`.
+ *
+ * Default-instance contract:
+ * - The first successful `init()` establishes the module-level default that
+ *   backs the top-level convenience APIs (`loadRemote`, `loadShare`,
+ *   `loadShareSync`, `preloadRemote`, `registerRemotes`, `registerPlugins`,
+ *   `registerShared` and `getInstance()` called without a finder).
+ * - Later `init()` calls create or reuse named instances and return them, but
+ *   never redirect the top-level APIs away from the established default.
+ * - `createInstance()` never establishes or changes the default.
+ * - An instance created by `createInstance()` and later passed through `init()`
+ *   with the same name becomes the default only if no default exists yet.
+ */
 export function init(options: UserOptions): ModuleFederation {
-  // Retrieve the same instance with the same name
-  const instance = getGlobalFederationInstance(options.name, options.version);
   const normalizedOptions = { ...options, id: options.id || '' };
-  if (!instance) {
-    const createdInstance = createInstance(normalizedOptions);
-    // The top-level API singleton is first-wins: a later init() call (for
-    // example from a remote container that shares this runtime copy) must
-    // not re-point loadRemote/registerRemotes/getInstance to its instance.
-    if (!FederationInstance) {
-      FederationInstance = createdInstance;
-    }
-    return createdInstance;
-  } else {
+  // Retrieve the same instance with the same name
+  let instance = getGlobalFederationInstance(options.name, options.version);
+  if (instance) {
     // Merge options
     instance.initOptions(normalizedOptions);
-    if (!FederationInstance) {
-      FederationInstance = instance;
-    }
-    return instance;
+  } else {
+    instance = createInstance(normalizedOptions);
   }
+  DefaultFederationInstance ??= instance;
+  return instance;
 }
 
 export function loadRemote<T>(
   ...args: Parameters<ModuleFederation['loadRemote']>
 ): Promise<T | null> {
-  assert(FederationInstance, RUNTIME_009, runtimeDescMap);
-  const loadRemote: typeof FederationInstance.loadRemote<T> =
-    FederationInstance.loadRemote;
+  assert(DefaultFederationInstance, RUNTIME_009, runtimeDescMap);
+  const loadRemote: typeof DefaultFederationInstance.loadRemote<T> =
+    DefaultFederationInstance.loadRemote;
   // eslint-disable-next-line prefer-spread
-  return loadRemote.apply(FederationInstance, args);
+  return loadRemote.apply(DefaultFederationInstance, args);
 }
 
 export function loadShare<T>(
   ...args: Parameters<ModuleFederation['loadShare']>
 ): Promise<false | (() => T | undefined)> {
-  assert(FederationInstance, RUNTIME_009, runtimeDescMap);
+  assert(DefaultFederationInstance, RUNTIME_009, runtimeDescMap);
   // eslint-disable-next-line prefer-spread
-  const loadShare: typeof FederationInstance.loadShare<T> =
-    FederationInstance.loadShare;
-  return loadShare.apply(FederationInstance, args);
+  const loadShare: typeof DefaultFederationInstance.loadShare<T> =
+    DefaultFederationInstance.loadShare;
+  return loadShare.apply(DefaultFederationInstance, args);
 }
 
 export function loadShareSync<T>(
   ...args: Parameters<ModuleFederation['loadShareSync']>
 ): () => T | never {
-  assert(FederationInstance, RUNTIME_009, runtimeDescMap);
-  const loadShareSync: typeof FederationInstance.loadShareSync<T> =
-    FederationInstance.loadShareSync;
+  assert(DefaultFederationInstance, RUNTIME_009, runtimeDescMap);
+  const loadShareSync: typeof DefaultFederationInstance.loadShareSync<T> =
+    DefaultFederationInstance.loadShareSync;
   // eslint-disable-next-line prefer-spread
-  return loadShareSync.apply(FederationInstance, args);
+  return loadShareSync.apply(DefaultFederationInstance, args);
 }
 
 export function preloadRemote(
   ...args: Parameters<ModuleFederation['preloadRemote']>
 ): ReturnType<ModuleFederation['preloadRemote']> {
-  assert(FederationInstance, RUNTIME_009, runtimeDescMap);
+  assert(DefaultFederationInstance, RUNTIME_009, runtimeDescMap);
   // eslint-disable-next-line prefer-spread
-  return FederationInstance.preloadRemote.apply(FederationInstance, args);
+  return DefaultFederationInstance.preloadRemote.apply(
+    DefaultFederationInstance,
+    args,
+  );
 }
 
 export function registerRemotes(
   ...args: Parameters<ModuleFederation['registerRemotes']>
 ): ReturnType<ModuleFederation['registerRemotes']> {
-  assert(FederationInstance, RUNTIME_009, runtimeDescMap);
+  assert(DefaultFederationInstance, RUNTIME_009, runtimeDescMap);
   // eslint-disable-next-line prefer-spread
-  return FederationInstance.registerRemotes.apply(FederationInstance, args);
+  return DefaultFederationInstance.registerRemotes.apply(
+    DefaultFederationInstance,
+    args,
+  );
 }
 
 export function registerPlugins(
   ...args: Parameters<ModuleFederation['registerPlugins']>
 ): ReturnType<ModuleFederation['registerRemotes']> {
-  assert(FederationInstance, RUNTIME_009, runtimeDescMap);
+  assert(DefaultFederationInstance, RUNTIME_009, runtimeDescMap);
   // eslint-disable-next-line prefer-spread
-  return FederationInstance.registerPlugins.apply(FederationInstance, args);
+  return DefaultFederationInstance.registerPlugins.apply(
+    DefaultFederationInstance,
+    args,
+  );
 }
 
 export function getInstance(): ModuleFederation | null;
@@ -121,7 +142,7 @@ export function getInstance(
 ): ModuleFederation | null;
 export function getInstance(finder?: (instance: ModuleFederation) => boolean) {
   if (!finder) {
-    return FederationInstance;
+    return DefaultFederationInstance;
   }
 
   return CurrentGlobal.__FEDERATION__.__INSTANCES__.find(finder) || null;
@@ -130,9 +151,12 @@ export function getInstance(finder?: (instance: ModuleFederation) => boolean) {
 export function registerShared(
   ...args: Parameters<ModuleFederation['registerShared']>
 ): ReturnType<ModuleFederation['registerShared']> {
-  assert(FederationInstance, RUNTIME_009, runtimeDescMap);
+  assert(DefaultFederationInstance, RUNTIME_009, runtimeDescMap);
   // eslint-disable-next-line prefer-spread
-  return FederationInstance.registerShared.apply(FederationInstance, args);
+  return DefaultFederationInstance.registerShared.apply(
+    DefaultFederationInstance,
+    args,
+  );
 }
 
 // Inject for debug


### PR DESCRIPTION
## Contract: `init()` and the default instance

`packages/runtime/src/index.ts` keeps a module-level default instance (`DefaultFederationInstance`) that backs the top-level convenience APIs `loadRemote`, `loadShare`, `loadShareSync`, `preloadRemote`, `registerRemotes`, `registerPlugins`, `registerShared` and `getInstance()` (called without a finder). This PR makes the contract explicit, documents it in JSDoc on `init()` / `createInstance()`, and encodes it in tests:

- The **first successful `init()`** establishes the default.
- **Later `init()` calls** create or reuse named instances and return them, but **never redirect** the top-level APIs away from the established default.
- **`createInstance()` never** establishes or changes the default.
- An instance created by `createInstance()` and later passed through `init()` with the same name becomes the default **only if no default exists yet**.
- `getInstance(finder)` searches `__FEDERATION__.__INSTANCES__` independently of the default (unchanged).

`init()` is restructured so instance selection happens first and the default is assigned in exactly one place:

```ts
export function init(options: UserOptions): ModuleFederation {
  const normalizedOptions = { ...options, id: options.id || '' };
  let instance = getGlobalFederationInstance(options.name, options.version);
  if (instance) {
    instance.initOptions(normalizedOptions);
  } else {
    instance = createInstance(normalizedOptions);
  }
  DefaultFederationInstance ??= instance;
  return instance;
}
```

## Defect this fixes

Previously `init()` unconditionally overwrote the singleton whenever it created a new instance:

```ts
if (!instance) {
  FederationInstance = createInstance(normalizedOptions); // overwrites unconditionally
  return FederationInstance;
}
```

When a remote entry resolves `@module-federation/runtime` to the same module copy as the host (typical for Node SSR builds that externalize `node_modules`), executing the remote container calls `init({ name: '<remote>' })` through the bundler runtime. That created a new instance and silently re-pointed the host's top-level API at the remote.

## Measured hijack

In a Node repro, after a single `loadRemote('repro_remote/Widget')`:

- `getInstance().name` changed from `repro_host` to `repro_remote`
- a subsequent top-level `registerRemotes(...)` wrote into the remote instance's empty `options.remotes` instead of the host's

This breaks any host that refreshes remote definitions at runtime (see #4566).

## Tests

New `default instance contract` block in `packages/runtime/__tests__/api.spec.ts`. Each test gets a fresh runtime module (`rs.resetModules()` + dynamic import) **and** a fresh global instance list (`resetFederationGlobalInfo()` from `@module-federation/runtime-core`), so neither the module-level default nor `__FEDERATION__.__INSTANCES__` leaks between tests. Covered:

- first `init()` establishes the default (`getInstance()` is `null` before, the host after)
- second `init()` with a different name returns its own instance and does not replace the default
- repeated `init()` with the same name reuses the instance and merges options (a remote registered by the second call is visible on the first instance)
- `createInstance()` never establishes the default; `createInstance()` after a default never changes it
- `getInstance(finder)` still searches global instances independently of the default
- every top-level API (`registerRemotes`, `registerShared`, `registerPlugins`, `preloadRemote`, `loadRemote`, `loadShare`) routes to the default: spies on both instances assert the call lands on the default and not on the second `init()` instance
- top-level `registerRemotes` mutates the host's `options.remotes`, not the later `init()` instance's (the original regression)
- a `createInstance()` instance adopted by `init()` becomes the default when none exists, and does not when one already exists

The "returns the default instance when no finder is provided" test now reads the current default via `getInstance()` instead of assuming the latest `init` wins.

Sanity check: reverting `??=` to `=` in `init()` fails 4 of the new tests.

`pnpm --filter @module-federation/runtime test`: 12 files, 103 tests, all passing.

Changeset added for `@module-federation/runtime` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
