### PR TITLE
fix(runtime-core): resolve remote runtime instance identity explicitly during removal

### DIFF
--- a/.changeset/quiet-remote-instance-cleanup.md
+++ b/.changeset/quiet-remote-instance-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime-core': patch
+---
+
+removeRemote now also matches the remote's runtime instance by entryGlobalName and warns when no instance can be found, instead of silently leaving stale instances in __FEDERATION__.__INSTANCES__ after registerRemotes({ force: true }).

--- a/.changeset/quiet-remote-instance-cleanup.md
+++ b/.changeset/quiet-remote-instance-cleanup.md
@@ -2,4 +2,4 @@
 '@module-federation/runtime-core': patch
 ---
 
-removeRemote now also matches the remote's runtime instance by entryGlobalName and warns when no instance can be found, instead of silently leaving stale instances in __FEDERATION__.__INSTANCES__ after registerRemotes({ force: true }).
+removeRemote (run by registerRemotes({ force: true })) now resolves the remote's runtime instance in __FEDERATION__.__INSTANCES__ explicitly: registered name + buildVersion, then entryGlobalName + buildVersion, and only when no buildVersion is known the registered name or a unique entryGlobalName. A versioned lookup never falls back to a name-only match and an ambiguous match removes nothing. Share-scope entries are released by the instance's own name (options.name), never by the registration alias. A warning is logged only for ambiguous matches or when same-named instances exist with a different build version; plain containers without a runtime instance stay silent.

--- a/packages/runtime-core/__tests__/register-remotes.spec.ts
+++ b/packages/runtime-core/__tests__/register-remotes.spec.ts
@@ -1,5 +1,9 @@
 import { assert, describe, it, expect, rs } from '@rstest/core';
-import { ModuleFederation } from '../src/index';
+import {
+  ModuleFederation,
+  CurrentGlobal,
+  setGlobalFederationInstance,
+} from '../src/index';
 
 describe('ModuleFederation', () => {
   it('registers new remotes and loads them correctly', async () => {
@@ -101,6 +105,136 @@ describe('ModuleFederation', () => {
     const newApp1Res = await newApp1Module();
     // Value is different from the registered remote
     expect(newApp1Res).toBe('hello app1 entry2');
+  });
+  it('removes the remote runtime instance matched by entryGlobalName when force registering', async () => {
+    const buildName = '@register-remotes/app1';
+    const registeredName = '@register-remotes/app1-alias';
+    // Drop any container global left behind by earlier tests so the entry
+    // script is executed again instead of being reused.
+    delete (CurrentGlobal as Record<string, unknown>)[buildName];
+    const FM = new ModuleFederation({
+      name: '@federation/instance',
+      version: '1.0.1',
+      remotes: [
+        {
+          // Registered name differs from the name the remote was built with
+          name: registeredName,
+          entryGlobalName: buildName,
+          entry:
+            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js',
+        },
+      ],
+    });
+    const app1Module = await FM.loadRemote<Promise<() => string>>(
+      `${registeredName}/say`,
+    );
+    assert(app1Module);
+    expect(await app1Module()).toBe('hello app1 entry1');
+
+    // Simulate the remote's own runtime instance, named after its build name
+    const remoteInstance = new ModuleFederation({
+      name: buildName,
+      remotes: [],
+    });
+    setGlobalFederationInstance(remoteInstance);
+    expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).toContain(
+      remoteInstance,
+    );
+    const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      FM.registerRemotes(
+        [
+          {
+            name: registeredName,
+            entryGlobalName: buildName,
+            entry:
+              'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry2.js',
+          },
+        ],
+        { force: true },
+      );
+
+      expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).not.toContain(
+        remoteInstance,
+      );
+      expect(FM.moduleCache.has(registeredName)).toBe(false);
+      expect(
+        warnSpy.mock.calls.some((call) =>
+          call.some(
+            (arg) =>
+              typeof arg === 'string' &&
+              arg.includes('__FEDERATION__.__INSTANCES__'),
+          ),
+        ),
+      ).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    const newApp1Module = await FM.loadRemote<Promise<() => string>>(
+      `${registeredName}/say`,
+    );
+    assert(newApp1Module);
+    expect(await newApp1Module()).toBe('hello app1 entry2');
+  });
+  it('warns and keeps __INSTANCES__ unchanged when no runtime instance matches the removed remote', async () => {
+    delete (CurrentGlobal as Record<string, unknown>)['@register-remotes/app1'];
+    const FM = new ModuleFederation({
+      name: '@federation/instance',
+      version: '1.0.1',
+      remotes: [
+        {
+          name: '@register-remotes/app1',
+          entry:
+            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js',
+        },
+      ],
+    });
+    const app1Module = await FM.loadRemote<Promise<() => string>>(
+      '@register-remotes/app1/say',
+    );
+    assert(app1Module);
+    expect(await app1Module()).toBe('hello app1 entry1');
+
+    const unrelatedInstance = new ModuleFederation({
+      name: '@register-remotes/unrelated',
+      remotes: [],
+    });
+    setGlobalFederationInstance(unrelatedInstance);
+    const instancesBefore = [...CurrentGlobal.__FEDERATION__.__INSTANCES__];
+    const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      FM.registerRemotes(
+        [
+          {
+            name: '@register-remotes/app1',
+            entry:
+              'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry2.js',
+          },
+        ],
+        { force: true },
+      );
+
+      expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).toEqual(
+        instancesBefore,
+      );
+      const warning = warnSpy.mock.calls
+        .flat()
+        .find(
+          (arg) =>
+            typeof arg === 'string' &&
+            arg.includes('__FEDERATION__.__INSTANCES__'),
+        );
+      expect(warning).toBeDefined();
+      expect(warning).toContain('"@register-remotes/app1"');
+      expect(warning).toContain(
+        'share scope and instance could not be released',
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
   it('reloads manifest snapshots when a manifest remote is force registered with the same entry', async () => {
     const manifestUrl =

--- a/packages/runtime-core/__tests__/register-remotes.spec.ts
+++ b/packages/runtime-core/__tests__/register-remotes.spec.ts
@@ -2,6 +2,7 @@ import { assert, describe, it, expect, rs } from '@rstest/core';
 import {
   ModuleFederation,
   CurrentGlobal,
+  Global,
   setGlobalFederationInstance,
 } from '../src/index';
 
@@ -106,135 +107,208 @@ describe('ModuleFederation', () => {
     // Value is different from the registered remote
     expect(newApp1Res).toBe('hello app1 entry2');
   });
-  it('removes the remote runtime instance matched by entryGlobalName when force registering', async () => {
-    const buildName = '@register-remotes/app1';
-    const registeredName = '@register-remotes/app1-alias';
-    // Drop any container global left behind by earlier tests so the entry
-    // script is executed again instead of being reused.
-    delete (CurrentGlobal as Record<string, unknown>)[buildName];
-    const FM = new ModuleFederation({
-      name: '@federation/instance',
-      version: '1.0.1',
-      remotes: [
-        {
-          // Registered name differs from the name the remote was built with
-          name: registeredName,
-          entryGlobalName: buildName,
-          entry:
-            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js',
-        },
-      ],
+  describe('removeRemote runtime instance ownership', () => {
+    const BUILD_NAME = '@register-remotes/app1';
+    const HOST_NAME = '@federation/instance';
+    const ENTRY1 =
+      'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
+    const ENTRY2 =
+      'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry2.js';
+    const remoteOf = (
+      entry: string,
+      registeredName: string,
+      entryGlobalName?: string,
+    ) => ({
+      name: registeredName,
+      entry,
+      ...(entryGlobalName ? { entryGlobalName } : {}),
     });
-    const app1Module = await FM.loadRemote<Promise<() => string>>(
-      `${registeredName}/say`,
-    );
-    assert(app1Module);
-    expect(await app1Module()).toBe('hello app1 entry1');
-
-    // Simulate the remote's own runtime instance, named after its build name
-    const remoteInstance = new ModuleFederation({
-      name: buildName,
-      remotes: [],
-    });
-    setGlobalFederationInstance(remoteInstance);
-    expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).toContain(
-      remoteInstance,
-    );
-    const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
-
-    try {
-      FM.registerRemotes(
-        [
+    const loadApp1 = async (
+      registeredName = BUILD_NAME,
+      entryGlobalName?: string,
+    ) => {
+      // Drop any container global left behind by earlier tests so the entry
+      // script is executed again instead of being reused.
+      delete (CurrentGlobal as Record<string, unknown>)[BUILD_NAME];
+      const FM = new ModuleFederation({
+        name: HOST_NAME,
+        version: '1.0.1',
+        remotes: [remoteOf(ENTRY1, registeredName, entryGlobalName)],
+      });
+      const mod = await FM.loadRemote<Promise<() => string>>(
+        `${registeredName}/say`,
+      );
+      assert(mod);
+      expect(await mod()).toBe('hello app1 entry1');
+      return FM;
+    };
+    const setBuildVersion = (
+      FM: ModuleFederation,
+      registeredName: string,
+      buildVersion: string,
+    ) => {
+      const loaded = FM.moduleCache.get(registeredName);
+      assert(loaded);
+      loaded.remoteInfo.buildVersion = buildVersion;
+    };
+    const addInstance = (name: string, version?: string, id?: string) => {
+      const instance = new ModuleFederation({ name, version, remotes: [] });
+      if (id !== undefined) {
+        instance.options.id = id;
+      }
+      setGlobalFederationInstance(instance);
+      return instance;
+    };
+    const forceReRegister = (
+      FM: ModuleFederation,
+      registeredName = BUILD_NAME,
+      entryGlobalName?: string,
+    ) => {
+      const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        FM.registerRemotes(
+          [remoteOf(ENTRY2, registeredName, entryGlobalName)],
           {
-            name: registeredName,
-            entryGlobalName: buildName,
-            entry:
-              'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry2.js',
+            force: true,
           },
-        ],
-        { force: true },
-      );
-
-      expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).not.toContain(
-        remoteInstance,
-      );
-      expect(FM.moduleCache.has(registeredName)).toBe(false);
-      expect(
-        warnSpy.mock.calls.some((call) =>
-          call.some(
-            (arg) =>
+        );
+        return warnSpy.mock.calls
+          .flat()
+          .filter(
+            (arg): arg is string =>
               typeof arg === 'string' &&
               arg.includes('__FEDERATION__.__INSTANCES__'),
-          ),
-        ),
-      ).toBe(false);
-    } finally {
-      warnSpy.mockRestore();
-    }
+          );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    };
+    const makeShared = (from: string, useIn: string[], loaded: boolean) =>
+      ({
+        version: '18.0.0',
+        get: () => () => ({}),
+        shareConfig: {},
+        scope: ['default'],
+        useIn,
+        from,
+        deps: [],
+        loaded,
+        strategy: 'version-first',
+      }) as any;
+    const instances = () => CurrentGlobal.__FEDERATION__.__INSTANCES__;
 
-    const newApp1Module = await FM.loadRemote<Promise<() => string>>(
-      `${registeredName}/say`,
-    );
-    assert(newApp1Module);
-    expect(await newApp1Module()).toBe('hello app1 entry2');
-  });
-  it('warns and keeps __INSTANCES__ unchanged when no runtime instance matches the removed remote', async () => {
-    delete (CurrentGlobal as Record<string, unknown>)['@register-remotes/app1'];
-    const FM = new ModuleFederation({
-      name: '@federation/instance',
-      version: '1.0.1',
-      remotes: [
-        {
-          name: '@register-remotes/app1',
-          entry:
-            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js',
-        },
-      ],
+    it('removes only the instance with the matching build version when two share a build name', async () => {
+      const FM = await loadApp1();
+      setBuildVersion(FM, BUILD_NAME, '2.0.0');
+      const v1 = addInstance(BUILD_NAME, '1.0.0');
+      const v2 = addInstance(BUILD_NAME, '2.0.0');
+
+      const warnings = forceReRegister(FM);
+
+      expect(instances()).toContain(v1);
+      expect(instances()).not.toContain(v2);
+      expect(warnings).toEqual([]);
     });
-    const app1Module = await FM.loadRemote<Promise<() => string>>(
-      '@register-remotes/app1/say',
-    );
-    assert(app1Module);
-    expect(await app1Module()).toBe('hello app1 entry1');
 
-    const unrelatedInstance = new ModuleFederation({
-      name: '@register-remotes/unrelated',
-      remotes: [],
+    it('resolves the instance through entryGlobalName when the registration alias differs from the build name', async () => {
+      const alias = '@register-remotes/app1-alias';
+      const FM = await loadApp1(alias, BUILD_NAME);
+      const remoteInstance = addInstance(BUILD_NAME);
+
+      const warnings = forceReRegister(FM, alias, BUILD_NAME);
+
+      expect(instances()).not.toContain(remoteInstance);
+      expect(FM.moduleCache.has(alias)).toBe(false);
+      expect(warnings).toEqual([]);
+
+      const next = await FM.loadRemote<Promise<() => string>>(`${alias}/say`);
+      assert(next);
+      expect(await next()).toBe('hello app1 entry2');
     });
-    setGlobalFederationInstance(unrelatedInstance);
-    const instancesBefore = [...CurrentGlobal.__FEDERATION__.__INSTANCES__];
-    const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
 
-    try {
-      FM.registerRemotes(
-        [
-          {
-            name: '@register-remotes/app1',
-            entry:
-              'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry2.js',
-          },
-        ],
-        { force: true },
-      );
+    it('deletes unloaded shares produced by the remote instance from the global share scope', async () => {
+      const FM = await loadApp1();
+      addInstance(BUILD_NAME);
+      const shareScope = Global.__FEDERATION__.__SHARE__;
+      shareScope[BUILD_NAME] = {
+        default: { react: { '18.0.0': makeShared(BUILD_NAME, [], false) } },
+      };
 
-      expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).toEqual(
-        instancesBefore,
+      forceReRegister(FM);
+
+      expect(shareScope[BUILD_NAME]).toBeUndefined();
+    });
+
+    it('keeps shares still consumed by another host and only drops the producer from useIn', async () => {
+      const FM = await loadApp1();
+      addInstance(BUILD_NAME);
+      const shareScope = Global.__FEDERATION__.__SHARE__;
+      const shared = makeShared(BUILD_NAME, [HOST_NAME, BUILD_NAME], true);
+      shareScope[BUILD_NAME] = { default: { react: { '18.0.0': shared } } };
+
+      forceReRegister(FM);
+
+      expect(shareScope[BUILD_NAME]?.default?.react?.['18.0.0']).toBe(shared);
+      expect(shared.useIn).toEqual([HOST_NAME]);
+    });
+
+    it('removes nothing and warns about ambiguity when two unversioned instances share the name', async () => {
+      const FM = await loadApp1();
+      const first = addInstance(BUILD_NAME);
+      const second = addInstance(BUILD_NAME);
+
+      const warnings = forceReRegister(FM);
+
+      expect(instances()).toContain(first);
+      expect(instances()).toContain(second);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('ambiguous');
+      expect(warnings[0]).toContain('2 runtime instances');
+      expect(warnings[0]).toContain('"registeredName"');
+    });
+
+    it('warns when instances with the same name exist but none has the requested build version', async () => {
+      const FM = await loadApp1();
+      setBuildVersion(FM, BUILD_NAME, '3.0.0');
+      const v1 = addInstance(BUILD_NAME, '1.0.0');
+
+      const warnings = forceReRegister(FM);
+
+      expect(instances()).toContain(v1);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('"3.0.0"');
+      expect(warnings[0]).toContain('found versions: 1.0.0');
+    });
+
+    it('stays silent and still clears the module cache for a container without a runtime instance', async () => {
+      const FM = await loadApp1();
+      const unrelated = addInstance('@register-remotes/unrelated');
+      const before = [...instances()];
+
+      const warnings = forceReRegister(FM);
+
+      expect(warnings).toEqual([]);
+      expect(instances()).toEqual(before);
+      expect(instances()).toContain(unrelated);
+      expect(FM.moduleCache.has(BUILD_NAME)).toBe(false);
+
+      const next = await FM.loadRemote<Promise<() => string>>(
+        `${BUILD_NAME}/say`,
       );
-      const warning = warnSpy.mock.calls
-        .flat()
-        .find(
-          (arg) =>
-            typeof arg === 'string' &&
-            arg.includes('__FEDERATION__.__INSTANCES__'),
-        );
-      expect(warning).toBeDefined();
-      expect(warning).toContain('"@register-remotes/app1"');
-      expect(warning).toContain(
-        'share scope and instance could not be released',
-      );
-    } finally {
-      warnSpy.mockRestore();
-    }
+      assert(next);
+      expect(await next()).toBe('hello app1 entry2');
+    });
+
+    it('resolves a versioned instance by options.name and options.version when options.id is custom', async () => {
+      const FM = await loadApp1();
+      setBuildVersion(FM, BUILD_NAME, '2.0.0');
+      const custom = addInstance(BUILD_NAME, '2.0.0', 'custom-build-id');
+
+      const warnings = forceReRegister(FM);
+
+      expect(instances()).not.toContain(custom);
+      expect(warnings).toEqual([]);
+    });
   });
   it('reloads manifest snapshots when a manifest remote is force registered with the same entry', async () => {
     const manifestUrl =

--- a/packages/runtime-core/__tests__/resolve-remote-runtime-instance.spec.ts
+++ b/packages/runtime-core/__tests__/resolve-remote-runtime-instance.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from '@rstest/core';
+import { resolveRemoteRuntimeInstance } from '../src/remote/resolveRemoteRuntimeInstance';
+import type { ModuleFederation } from '../src/core';
+import type { RemoteInfo } from '../src/type';
+
+const instance = (name: string, version?: string, id = '') =>
+  ({ name, options: { id, name, version } }) as unknown as ModuleFederation;
+
+const remoteInfo = (
+  name: string,
+  extra: Partial<RemoteInfo> = {},
+): RemoteInfo => ({
+  name,
+  entry: 'http://localhost/remoteEntry.js',
+  type: 'global',
+  entryGlobalName: name,
+  shareScope: 'default',
+  ...extra,
+});
+
+describe('resolveRemoteRuntimeInstance', () => {
+  it('matches registered name + buildVersion by composed options.id', () => {
+    const target = instance('other', undefined, 'app:1.0.0');
+    const res = resolveRemoteRuntimeInstance(
+      remoteInfo('app', { buildVersion: '1.0.0' }),
+      [instance('app', '2.0.0'), target],
+    );
+    expect(res.instance).toBe(target);
+    expect(res.index).toBe(1);
+    expect(res.level).toBe('registeredName+buildVersion');
+    expect(res.identity).toEqual({
+      registeredName: 'app',
+      buildName: 'app',
+      buildVersion: '1.0.0',
+      instanceId: 'app:1.0.0',
+    });
+  });
+
+  it('matches registered name + buildVersion by options.name/options.version', () => {
+    const target = instance('app', '1.0.0', 'custom-id');
+    const res = resolveRemoteRuntimeInstance(
+      remoteInfo('app', { buildVersion: '1.0.0' }),
+      [target, instance('app', '2.0.0')],
+    );
+    expect(res.instance).toBe(target);
+    expect(res.ambiguous).toBe(false);
+  });
+
+  it('falls through to buildName + buildVersion when the alias does not match', () => {
+    const target = instance('build', '1.0.0');
+    const res = resolveRemoteRuntimeInstance(
+      remoteInfo('alias', { entryGlobalName: 'build', buildVersion: '1.0.0' }),
+      [instance('alias', '2.0.0'), target],
+    );
+    expect(res.instance).toBe(target);
+    expect(res.level).toBe('buildName+buildVersion');
+  });
+
+  it('never degrades a versioned lookup into a name-only match', () => {
+    const res = resolveRemoteRuntimeInstance(
+      remoteInfo('alias', { entryGlobalName: 'build', buildVersion: '9.9.9' }),
+      [instance('alias'), instance('build', '1.0.0')],
+    );
+    expect(res.instance).toBeUndefined();
+    expect(res.index).toBe(-1);
+    expect(res.ambiguous).toBe(false);
+    expect(res.level).toBeUndefined();
+  });
+
+  it('matches registered name alone when no buildVersion is known', () => {
+    const target = instance('app');
+    const res = resolveRemoteRuntimeInstance(remoteInfo('app'), [
+      instance('other'),
+      target,
+    ]);
+    expect(res.instance).toBe(target);
+    expect(res.level).toBe('registeredName');
+  });
+
+  it('matches entryGlobalName alone only when unambiguous', () => {
+    const target = instance('build');
+    const ok = resolveRemoteRuntimeInstance(
+      remoteInfo('alias', { entryGlobalName: 'build' }),
+      [instance('other'), target],
+    );
+    expect(ok.instance).toBe(target);
+    expect(ok.level).toBe('buildName');
+
+    const dup = resolveRemoteRuntimeInstance(
+      remoteInfo('alias', { entryGlobalName: 'build' }),
+      [instance('build'), instance('build')],
+    );
+    expect(dup.instance).toBeUndefined();
+    expect(dup.ambiguous).toBe(true);
+    expect(dup.level).toBe('buildName');
+    expect(dup.candidateCount).toBe(2);
+  });
+
+  it('reports ambiguity instead of guessing when a level yields several candidates', () => {
+    const res = resolveRemoteRuntimeInstance(
+      remoteInfo('app', { buildVersion: '1.0.0' }),
+      [instance('app', '1.0.0'), instance('app', '1.0.0'), instance('app')],
+    );
+    expect(res.instance).toBeUndefined();
+    expect(res.ambiguous).toBe(true);
+    expect(res.level).toBe('registeredName+buildVersion');
+    expect(res.candidateCount).toBe(2);
+  });
+
+  it('does not use entryGlobalName as a level when it equals the registered name', () => {
+    const res = resolveRemoteRuntimeInstance(
+      remoteInfo('app', { entryGlobalName: 'app' }),
+      [instance('build')],
+    );
+    expect(res.instance).toBeUndefined();
+    expect(res.candidateCount).toBe(0);
+  });
+});

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -762,17 +762,29 @@ export class RemoteHandler {
         let remoteInsId = remoteInfo.buildVersion
           ? composeKeyWithSeparator(remoteInfo.name, remoteInfo.buildVersion)
           : remoteInfo.name;
-        const remoteInsIndex =
-          CurrentGlobal.__FEDERATION__.__INSTANCES__.findIndex((ins) => {
-            if (remoteInfo.buildVersion) {
-              return ins.options.id === remoteInsId;
-            } else {
-              return ins.name === remoteInsId;
-            }
-          });
+        const instances = CurrentGlobal.__FEDERATION__.__INSTANCES__;
+        let remoteInsIndex = instances.findIndex((ins) => {
+          if (remoteInfo.buildVersion) {
+            return ins.options.id === remoteInsId;
+          } else {
+            return ins.name === remoteInsId;
+          }
+        });
+        // The registered name may differ from the name the remote was built
+        // with. The remote's runtime instance is named after its build name,
+        // which for enhanced/webpack containers equals entryGlobalName.
+        const { entryGlobalName } = remoteInfo;
+        const canMatchByEntryGlobalName =
+          typeof entryGlobalName === 'string' &&
+          entryGlobalName !== '' &&
+          entryGlobalName !== remoteInfo.name;
+        if (remoteInsIndex === -1 && canMatchByEntryGlobalName) {
+          remoteInsIndex = instances.findIndex(
+            (ins) => ins.name === entryGlobalName,
+          );
+        }
         if (remoteInsIndex !== -1) {
-          const remoteIns =
-            CurrentGlobal.__FEDERATION__.__INSTANCES__[remoteInsIndex];
+          const remoteIns = instances[remoteInsIndex];
           remoteInsId = remoteIns.options.id || remoteInsId;
           const globalShareScopeMap = getGlobalShareScope();
 
@@ -834,7 +846,16 @@ export class RemoteHandler {
               ];
             },
           );
-          CurrentGlobal.__FEDERATION__.__INSTANCES__.splice(remoteInsIndex, 1);
+          instances.splice(remoteInsIndex, 1);
+        } else {
+          // Containers built without the federation runtime legitimately have
+          // no instance, so only warn: a stale instance would otherwise stay
+          // in __INSTANCES__ and leak once the remote is loaded again.
+          logger.warn(
+            `No runtime instance named "${remoteInfo.name}"${
+              canMatchByEntryGlobalName ? ` (or "${entryGlobalName}")` : ''
+            } was found in __FEDERATION__.__INSTANCES__ while removing remote "${remote.name}", so its share scope and instance could not be released. Make sure the registered remote name matches the name the remote was built with.`,
+          );
         }
 
         host.moduleCache.delete(remote.name);

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -1,7 +1,6 @@
 import {
   isBrowserEnvValue,
   warn,
-  composeKeyWithSeparator,
   ModuleInfo,
   GlobalModuleInfo,
 } from '@module-federation/sdk';
@@ -23,6 +22,7 @@ import {
   RemoteInfo,
   RemoteEntryExports,
   CallFrom,
+  GlobalShareScopeMap,
 } from '../type';
 import { ModuleFederation } from '../core';
 import {
@@ -48,6 +48,10 @@ import { Module, ModuleOptions } from '../module';
 import { formatPreloadArgs, preloadAssets } from '../utils/preload';
 import { getGlobalShareScope } from '../utils/share';
 import { getGlobalRemoteInfo } from '../plugins/snapshot/SnapshotHandler';
+import {
+  resolveRemoteRuntimeInstance,
+  type ResolvedRemoteRuntimeInstance,
+} from './resolveRemoteRuntimeInstance';
 
 export interface LoadRemoteMatch {
   id: string;
@@ -705,164 +709,180 @@ export class RemoteHandler {
   private removeRemote(remote: Remote): void {
     try {
       const { host } = this;
-      const { name } = remote;
-      const remoteIndex = host.options.remotes.findIndex(
-        (item) => item.name === name,
-      );
-      if (remoteIndex !== -1) {
-        host.options.remotes.splice(remoteIndex, 1);
-      }
-      const globalSnapshotKey = getInfoWithoutType(
-        CurrentGlobal.__FEDERATION__.moduleInfo,
-        getFMId(remote),
-      ).key;
-      delete CurrentGlobal.__FEDERATION__.moduleInfo[globalSnapshotKey];
-
-      if ('entry' in remote) {
-        host.snapshotHandler.manifestCache.delete(remote.entry);
-        delete Global.__FEDERATION__.__MANIFEST_LOADING__[remote.entry];
-      }
-
-      const { hostGlobalSnapshot } = getGlobalRemoteInfo(remote, host);
-      if (hostGlobalSnapshot) {
-        const remoteKey =
-          hostGlobalSnapshot &&
-          'remotesInfo' in hostGlobalSnapshot &&
-          hostGlobalSnapshot.remotesInfo &&
-          getInfoWithoutType(hostGlobalSnapshot.remotesInfo, remote.name).key;
-        if (remoteKey) {
-          delete hostGlobalSnapshot.remotesInfo[remoteKey];
-        }
-      }
+      this.removeRemoteRegistration(remote);
+      this.clearRemoteSnapshots(remote);
 
       const loadedModule = host.moduleCache.get(remote.name);
       if (loadedModule) {
-        const remoteInfo = loadedModule.remoteInfo;
-        const key = remoteInfo.entryGlobalName as keyof typeof CurrentGlobal;
+        const { remoteInfo } = loadedModule;
+        this.clearRemoteEntryState(remote, remoteInfo);
 
-        if (CurrentGlobal[key]) {
-          if (
-            Object.getOwnPropertyDescriptor(CurrentGlobal, key)?.configurable
-          ) {
-            delete CurrentGlobal[key];
-          } else {
-            // @ts-ignore
-            CurrentGlobal[key] = undefined;
-          }
-        }
-        const remoteEntryUniqueKey = getRemoteEntryUniqueKey(
-          loadedModule.remoteInfo,
-        );
-
-        if (globalLoading[remoteEntryUniqueKey]) {
-          delete globalLoading[remoteEntryUniqueKey];
-        }
-
-        // delete unloaded shared and instance
-        let remoteInsId = remoteInfo.buildVersion
-          ? composeKeyWithSeparator(remoteInfo.name, remoteInfo.buildVersion)
-          : remoteInfo.name;
         const instances = CurrentGlobal.__FEDERATION__.__INSTANCES__;
-        let remoteInsIndex = instances.findIndex((ins) => {
-          if (remoteInfo.buildVersion) {
-            return ins.options.id === remoteInsId;
-          } else {
-            return ins.name === remoteInsId;
-          }
-        });
-        // The registered name may differ from the name the remote was built
-        // with. The remote's runtime instance is named after its build name,
-        // which for enhanced/webpack containers equals entryGlobalName.
-        const { entryGlobalName } = remoteInfo;
-        const canMatchByEntryGlobalName =
-          typeof entryGlobalName === 'string' &&
-          entryGlobalName !== '' &&
-          entryGlobalName !== remoteInfo.name;
-        if (remoteInsIndex === -1 && canMatchByEntryGlobalName) {
-          remoteInsIndex = instances.findIndex(
-            (ins) => ins.name === entryGlobalName,
-          );
-        }
-        if (remoteInsIndex !== -1) {
-          const remoteIns = instances[remoteInsIndex];
-          remoteInsId = remoteIns.options.id || remoteInsId;
-          const globalShareScopeMap = getGlobalShareScope();
-
-          let isAllSharedNotUsed = true;
-          const needDeleteKeys: Array<[string, string, string, string]> = [];
-          Object.keys(globalShareScopeMap).forEach((instId) => {
-            const shareScopeMap = globalShareScopeMap[instId];
-            shareScopeMap &&
-              Object.keys(shareScopeMap).forEach((shareScope) => {
-                const shareScopeVal = shareScopeMap[shareScope];
-                shareScopeVal &&
-                  Object.keys(shareScopeVal).forEach((shareName) => {
-                    const sharedPkgs = shareScopeVal[shareName];
-                    sharedPkgs &&
-                      Object.keys(sharedPkgs).forEach((shareVersion) => {
-                        const shared = sharedPkgs[shareVersion];
-                        if (
-                          shared &&
-                          typeof shared === 'object' &&
-                          shared.from === remoteInfo.name
-                        ) {
-                          if (shared.loaded || shared.loading) {
-                            shared.useIn = shared.useIn.filter(
-                              (usedHostName) =>
-                                usedHostName !== remoteInfo.name,
-                            );
-                            if (shared.useIn.length) {
-                              isAllSharedNotUsed = false;
-                            } else {
-                              needDeleteKeys.push([
-                                instId,
-                                shareScope,
-                                shareName,
-                                shareVersion,
-                              ]);
-                            }
-                          } else {
-                            needDeleteKeys.push([
-                              instId,
-                              shareScope,
-                              shareName,
-                              shareVersion,
-                            ]);
-                          }
-                        }
-                      });
-                  });
-              });
+        const resolved = resolveRemoteRuntimeInstance(remoteInfo, instances);
+        if (resolved.instance) {
+          this.releaseRuntimeInstanceShares({
+            instance: resolved.instance,
+            globalShareScopeMap: getGlobalShareScope(),
           });
-
-          if (isAllSharedNotUsed) {
-            remoteIns.shareScopeMap = {};
-            delete globalShareScopeMap[remoteInsId];
-          }
-          needDeleteKeys.forEach(
-            ([insId, shareScope, shareName, shareVersion]) => {
-              delete globalShareScopeMap[insId]?.[shareScope]?.[shareName]?.[
-                shareVersion
-              ];
-            },
-          );
-          instances.splice(remoteInsIndex, 1);
+          instances.splice(resolved.index, 1);
         } else {
-          // Containers built without the federation runtime legitimately have
-          // no instance, so only warn: a stale instance would otherwise stay
-          // in __INSTANCES__ and leak once the remote is loaded again.
-          logger.warn(
-            `No runtime instance named "${remoteInfo.name}"${
-              canMatchByEntryGlobalName ? ` (or "${entryGlobalName}")` : ''
-            } was found in __FEDERATION__.__INSTANCES__ while removing remote "${remote.name}", so its share scope and instance could not be released. Make sure the registered remote name matches the name the remote was built with.`,
-          );
+          this.warnUnresolvedRuntimeInstance(remote, resolved, instances);
         }
-
-        host.moduleCache.delete(remote.name);
       }
     } catch (err) {
       logger.error(
         `removeRemote failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private removeRemoteRegistration(remote: Remote): void {
+    const { remotes } = this.host.options;
+    const remoteIndex = remotes.findIndex((item) => item.name === remote.name);
+    if (remoteIndex !== -1) {
+      remotes.splice(remoteIndex, 1);
+    }
+  }
+
+  private clearRemoteSnapshots(remote: Remote): void {
+    const { host } = this;
+    const globalSnapshotKey = getInfoWithoutType(
+      CurrentGlobal.__FEDERATION__.moduleInfo,
+      getFMId(remote),
+    ).key;
+    delete CurrentGlobal.__FEDERATION__.moduleInfo[globalSnapshotKey];
+
+    if ('entry' in remote) {
+      host.snapshotHandler.manifestCache.delete(remote.entry);
+      delete Global.__FEDERATION__.__MANIFEST_LOADING__[remote.entry];
+    }
+
+    const { hostGlobalSnapshot } = getGlobalRemoteInfo(remote, host);
+    if (hostGlobalSnapshot) {
+      const remoteKey =
+        'remotesInfo' in hostGlobalSnapshot &&
+        hostGlobalSnapshot.remotesInfo &&
+        getInfoWithoutType(hostGlobalSnapshot.remotesInfo, remote.name).key;
+      if (remoteKey) {
+        delete hostGlobalSnapshot.remotesInfo[remoteKey];
+      }
+    }
+  }
+
+  private clearRemoteEntryState(remote: Remote, remoteInfo: RemoteInfo): void {
+    const key = remoteInfo.entryGlobalName as keyof typeof CurrentGlobal;
+    if (CurrentGlobal[key]) {
+      if (Object.getOwnPropertyDescriptor(CurrentGlobal, key)?.configurable) {
+        delete CurrentGlobal[key];
+      } else {
+        // @ts-ignore
+        CurrentGlobal[key] = undefined;
+      }
+    }
+    const remoteEntryUniqueKey = getRemoteEntryUniqueKey(remoteInfo);
+    if (globalLoading[remoteEntryUniqueKey]) {
+      delete globalLoading[remoteEntryUniqueKey];
+    }
+    this.host.moduleCache.delete(remote.name);
+  }
+
+  // Shares are keyed by the producing runtime instance, never by the
+  // registration alias: `from` is the instance's own name and `useIn` only
+  // ever lists it under that name.
+  private releaseRuntimeInstanceShares({
+    instance,
+    globalShareScopeMap,
+  }: {
+    instance: ModuleFederation;
+    globalShareScopeMap: GlobalShareScopeMap;
+  }): void {
+    const producerName = instance.options.name ?? instance.name;
+    const instanceId = instance.options.id || producerName;
+
+    let isAllSharedNotUsed = true;
+    const needDeleteKeys: Array<[string, string, string, string]> = [];
+    Object.keys(globalShareScopeMap).forEach((instId) => {
+      const shareScopeMap = globalShareScopeMap[instId];
+      shareScopeMap &&
+        Object.keys(shareScopeMap).forEach((shareScope) => {
+          const shareScopeVal = shareScopeMap[shareScope];
+          shareScopeVal &&
+            Object.keys(shareScopeVal).forEach((shareName) => {
+              const sharedPkgs = shareScopeVal[shareName];
+              sharedPkgs &&
+                Object.keys(sharedPkgs).forEach((shareVersion) => {
+                  const shared = sharedPkgs[shareVersion];
+                  if (
+                    shared &&
+                    typeof shared === 'object' &&
+                    shared.from === producerName
+                  ) {
+                    if (shared.loaded || shared.loading) {
+                      shared.useIn = shared.useIn.filter(
+                        (usedHostName) => usedHostName !== producerName,
+                      );
+                      if (shared.useIn.length) {
+                        isAllSharedNotUsed = false;
+                      } else {
+                        needDeleteKeys.push([
+                          instId,
+                          shareScope,
+                          shareName,
+                          shareVersion,
+                        ]);
+                      }
+                    } else {
+                      needDeleteKeys.push([
+                        instId,
+                        shareScope,
+                        shareName,
+                        shareVersion,
+                      ]);
+                    }
+                  }
+                });
+            });
+        });
+    });
+
+    if (isAllSharedNotUsed) {
+      instance.shareScopeMap = {};
+      delete globalShareScopeMap[instanceId];
+    }
+    needDeleteKeys.forEach(([insId, shareScope, shareName, shareVersion]) => {
+      delete globalShareScopeMap[insId]?.[shareScope]?.[shareName]?.[
+        shareVersion
+      ];
+    });
+  }
+
+  // Only suspicious misses are reported. A container built without the
+  // federation runtime has no instance at all, which is legitimate and silent.
+  private warnUnresolvedRuntimeInstance(
+    remote: Remote,
+    resolved: ResolvedRemoteRuntimeInstance,
+    instances: ModuleFederation[],
+  ): void {
+    const { registeredName, buildName, buildVersion } = resolved.identity;
+    if (resolved.ambiguous) {
+      logger.warn(
+        `Found ${resolved.candidateCount} runtime instances matching "${resolved.level}" for remote "${remote.name}" in __FEDERATION__.__INSTANCES__; the match is ambiguous, so no instance or share scope was released.`,
+      );
+      return;
+    }
+    if (!buildVersion) {
+      return;
+    }
+    const sameNameVersions = instances
+      .filter((ins) => ins.name === registeredName || ins.name === buildName)
+      .map((ins) => ins.options.version ?? ins.options.id ?? '<unknown>');
+    if (sameNameVersions.length) {
+      logger.warn(
+        `No runtime instance named "${registeredName}"${
+          buildName && buildName !== registeredName
+            ? ` (or "${buildName}")`
+            : ''
+        } with build version "${buildVersion}" was found in __FEDERATION__.__INSTANCES__ while removing remote "${remote.name}" (found versions: ${sameNameVersions.join(', ')}), so its share scope and instance were not released.`,
       );
     }
   }

--- a/packages/runtime-core/src/remote/resolveRemoteRuntimeInstance.ts
+++ b/packages/runtime-core/src/remote/resolveRemoteRuntimeInstance.ts
@@ -1,0 +1,120 @@
+import { composeKeyWithSeparator } from '@module-federation/sdk';
+import type { ModuleFederation } from '../core';
+import type { RemoteInfo } from '../type';
+
+// A remote is known under several distinct names while it is loaded:
+// - registeredName: the alias the host registered it under (remoteInfo.name)
+// - buildName: the name/global it was built with (remoteInfo.entryGlobalName)
+// - buildVersion: the build version reported by its snapshot
+// - instanceId: the runtime instance id (instance.options.id)
+// The share producer name (instance.options.name) and the consuming host
+// name (host.options.name) are separate again and never used for lookup here.
+export interface RemoteRuntimeIdentity {
+  registeredName: string;
+  buildName?: string;
+  buildVersion?: string;
+  instanceId?: string;
+}
+
+export type RemoteRuntimeMatchLevel =
+  | 'registeredName+buildVersion'
+  | 'buildName+buildVersion'
+  | 'registeredName'
+  | 'buildName';
+
+export interface ResolvedRemoteRuntimeInstance {
+  instance?: ModuleFederation;
+  index: number;
+  identity: RemoteRuntimeIdentity;
+  // more than one candidate matched at the chosen level
+  ambiguous: boolean;
+  level?: RemoteRuntimeMatchLevel;
+  candidateCount: number;
+}
+
+type Matcher = (instance: ModuleFederation) => boolean;
+
+function matchVersioned(name: string, version: string): Matcher {
+  const id = composeKeyWithSeparator(name, version);
+  return (ins) =>
+    ins.options.id === id ||
+    (ins.options.name === name && ins.options.version === version);
+}
+
+function matchName(name: string): Matcher {
+  return (ins) => ins.name === name || ins.options.name === name;
+}
+
+// Matching is monotonic: the first level that yields candidates wins, and a
+// versioned lookup never degrades into an unversioned name match.
+export function resolveRemoteRuntimeInstance(
+  remoteInfo: RemoteInfo,
+  instances: ModuleFederation[],
+): ResolvedRemoteRuntimeInstance {
+  const registeredName = remoteInfo.name;
+  const { buildVersion } = remoteInfo;
+  const buildName =
+    typeof remoteInfo.entryGlobalName === 'string' &&
+    remoteInfo.entryGlobalName !== ''
+      ? remoteInfo.entryGlobalName
+      : undefined;
+  const identity: RemoteRuntimeIdentity = {
+    registeredName,
+    buildName,
+    buildVersion,
+  };
+  const hasDistinctBuildName =
+    buildName !== undefined && buildName !== registeredName;
+
+  const levels: Array<[RemoteRuntimeMatchLevel, Matcher]> = [];
+  if (buildVersion) {
+    levels.push([
+      'registeredName+buildVersion',
+      matchVersioned(registeredName, buildVersion),
+    ]);
+    if (hasDistinctBuildName) {
+      levels.push([
+        'buildName+buildVersion',
+        matchVersioned(buildName, buildVersion),
+      ]);
+    }
+  } else {
+    levels.push(['registeredName', matchName(registeredName)]);
+    if (hasDistinctBuildName) {
+      levels.push(['buildName', matchName(buildName)]);
+    }
+  }
+
+  for (const [level, matcher] of levels) {
+    const indexes: number[] = [];
+    instances.forEach((ins, index) => {
+      if (matcher(ins)) {
+        indexes.push(index);
+      }
+    });
+    if (indexes.length === 0) {
+      continue;
+    }
+    if (indexes.length > 1) {
+      return {
+        index: -1,
+        identity,
+        ambiguous: true,
+        level,
+        candidateCount: indexes.length,
+      };
+    }
+    const index = indexes[0];
+    const instance = instances[index];
+    return {
+      instance,
+      index,
+      identity: { ...identity, instanceId: instance.options.id },
+      ambiguous: false,
+      level,
+      candidateCount: 1,
+    };
+  }
+
+  return { index: -1, identity, ambiguous: false, candidateCount: 0 };
+}

--- a/packages/runtime/__tests__/register-remotes.spec.ts
+++ b/packages/runtime/__tests__/register-remotes.spec.ts
@@ -1,4 +1,8 @@
-import { assert, describe, it, expect } from '@rstest/core';
+import { assert, describe, it, expect, rs } from '@rstest/core';
+import {
+  CurrentGlobal,
+  setGlobalFederationInstance,
+} from '@module-federation/runtime-core';
 import { ModuleFederation } from '../src/index';
 
 describe('ModuleFederation', () => {
@@ -101,5 +105,135 @@ describe('ModuleFederation', () => {
     const newApp1Res = await newApp1Module();
     // Value is different from the registered remote
     expect(newApp1Res).toBe('hello app1 entry2');
+  });
+  it('removes the remote runtime instance matched by entryGlobalName when force registering', async () => {
+    const buildName = '@register-remotes/app1';
+    const registeredName = '@register-remotes/app1-alias';
+    // Drop any container global left behind by earlier tests so the entry
+    // script is executed again instead of being reused.
+    delete (CurrentGlobal as Record<string, unknown>)[buildName];
+    const FM = new ModuleFederation({
+      name: '@federation/instance',
+      version: '1.0.1',
+      remotes: [
+        {
+          // Registered name differs from the name the remote was built with
+          name: registeredName,
+          entryGlobalName: buildName,
+          entry:
+            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js',
+        },
+      ],
+    });
+    const app1Module = await FM.loadRemote<Promise<() => string>>(
+      `${registeredName}/say`,
+    );
+    assert(app1Module);
+    expect(await app1Module()).toBe('hello app1 entry1');
+
+    // Simulate the remote's own runtime instance, named after its build name
+    const remoteInstance = new ModuleFederation({
+      name: buildName,
+      remotes: [],
+    });
+    setGlobalFederationInstance(remoteInstance);
+    expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).toContain(
+      remoteInstance,
+    );
+    const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      FM.registerRemotes(
+        [
+          {
+            name: registeredName,
+            entryGlobalName: buildName,
+            entry:
+              'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry2.js',
+          },
+        ],
+        { force: true },
+      );
+
+      expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).not.toContain(
+        remoteInstance,
+      );
+      expect(FM.moduleCache.has(registeredName)).toBe(false);
+      expect(
+        warnSpy.mock.calls.some((call) =>
+          call.some(
+            (arg) =>
+              typeof arg === 'string' &&
+              arg.includes('__FEDERATION__.__INSTANCES__'),
+          ),
+        ),
+      ).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    const newApp1Module = await FM.loadRemote<Promise<() => string>>(
+      `${registeredName}/say`,
+    );
+    assert(newApp1Module);
+    expect(await newApp1Module()).toBe('hello app1 entry2');
+  });
+  it('warns and keeps __INSTANCES__ unchanged when no runtime instance matches the removed remote', async () => {
+    delete (CurrentGlobal as Record<string, unknown>)['@register-remotes/app1'];
+    const FM = new ModuleFederation({
+      name: '@federation/instance',
+      version: '1.0.1',
+      remotes: [
+        {
+          name: '@register-remotes/app1',
+          entry:
+            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js',
+        },
+      ],
+    });
+    const app1Module = await FM.loadRemote<Promise<() => string>>(
+      '@register-remotes/app1/say',
+    );
+    assert(app1Module);
+    expect(await app1Module()).toBe('hello app1 entry1');
+
+    const unrelatedInstance = new ModuleFederation({
+      name: '@register-remotes/unrelated',
+      remotes: [],
+    });
+    setGlobalFederationInstance(unrelatedInstance);
+    const instancesBefore = [...CurrentGlobal.__FEDERATION__.__INSTANCES__];
+    const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      FM.registerRemotes(
+        [
+          {
+            name: '@register-remotes/app1',
+            entry:
+              'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry2.js',
+          },
+        ],
+        { force: true },
+      );
+
+      expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).toEqual(
+        instancesBefore,
+      );
+      const warning = warnSpy.mock.calls
+        .flat()
+        .find(
+          (arg) =>
+            typeof arg === 'string' &&
+            arg.includes('__FEDERATION__.__INSTANCES__'),
+        );
+      expect(warning).toBeDefined();
+      expect(warning).toContain('"@register-remotes/app1"');
+      expect(warning).toContain(
+        'share scope and instance could not be released',
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/runtime/__tests__/register-remotes.spec.ts
+++ b/packages/runtime/__tests__/register-remotes.spec.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it, expect, rs } from '@rstest/core';
 import {
   CurrentGlobal,
+  Global,
   setGlobalFederationInstance,
 } from '@module-federation/runtime-core';
 import { ModuleFederation } from '../src/index';
@@ -106,134 +107,207 @@ describe('ModuleFederation', () => {
     // Value is different from the registered remote
     expect(newApp1Res).toBe('hello app1 entry2');
   });
-  it('removes the remote runtime instance matched by entryGlobalName when force registering', async () => {
-    const buildName = '@register-remotes/app1';
-    const registeredName = '@register-remotes/app1-alias';
-    // Drop any container global left behind by earlier tests so the entry
-    // script is executed again instead of being reused.
-    delete (CurrentGlobal as Record<string, unknown>)[buildName];
-    const FM = new ModuleFederation({
-      name: '@federation/instance',
-      version: '1.0.1',
-      remotes: [
-        {
-          // Registered name differs from the name the remote was built with
-          name: registeredName,
-          entryGlobalName: buildName,
-          entry:
-            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js',
-        },
-      ],
+  describe('removeRemote runtime instance ownership', () => {
+    const BUILD_NAME = '@register-remotes/app1';
+    const HOST_NAME = '@federation/instance';
+    const ENTRY1 =
+      'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
+    const ENTRY2 =
+      'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry2.js';
+    const remoteOf = (
+      entry: string,
+      registeredName: string,
+      entryGlobalName?: string,
+    ) => ({
+      name: registeredName,
+      entry,
+      ...(entryGlobalName ? { entryGlobalName } : {}),
     });
-    const app1Module = await FM.loadRemote<Promise<() => string>>(
-      `${registeredName}/say`,
-    );
-    assert(app1Module);
-    expect(await app1Module()).toBe('hello app1 entry1');
-
-    // Simulate the remote's own runtime instance, named after its build name
-    const remoteInstance = new ModuleFederation({
-      name: buildName,
-      remotes: [],
-    });
-    setGlobalFederationInstance(remoteInstance);
-    expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).toContain(
-      remoteInstance,
-    );
-    const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
-
-    try {
-      FM.registerRemotes(
-        [
+    const loadApp1 = async (
+      registeredName = BUILD_NAME,
+      entryGlobalName?: string,
+    ) => {
+      // Drop any container global left behind by earlier tests so the entry
+      // script is executed again instead of being reused.
+      delete (CurrentGlobal as Record<string, unknown>)[BUILD_NAME];
+      const FM = new ModuleFederation({
+        name: HOST_NAME,
+        version: '1.0.1',
+        remotes: [remoteOf(ENTRY1, registeredName, entryGlobalName)],
+      });
+      const mod = await FM.loadRemote<Promise<() => string>>(
+        `${registeredName}/say`,
+      );
+      assert(mod);
+      expect(await mod()).toBe('hello app1 entry1');
+      return FM;
+    };
+    const setBuildVersion = (
+      FM: ModuleFederation,
+      registeredName: string,
+      buildVersion: string,
+    ) => {
+      const loaded = FM.moduleCache.get(registeredName);
+      assert(loaded);
+      loaded.remoteInfo.buildVersion = buildVersion;
+    };
+    const addInstance = (name: string, version?: string, id?: string) => {
+      const instance = new ModuleFederation({ name, version, remotes: [] });
+      if (id !== undefined) {
+        instance.options.id = id;
+      }
+      setGlobalFederationInstance(instance);
+      return instance;
+    };
+    const forceReRegister = (
+      FM: ModuleFederation,
+      registeredName = BUILD_NAME,
+      entryGlobalName?: string,
+    ) => {
+      const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        FM.registerRemotes(
+          [remoteOf(ENTRY2, registeredName, entryGlobalName)],
           {
-            name: registeredName,
-            entryGlobalName: buildName,
-            entry:
-              'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry2.js',
+            force: true,
           },
-        ],
-        { force: true },
-      );
-
-      expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).not.toContain(
-        remoteInstance,
-      );
-      expect(FM.moduleCache.has(registeredName)).toBe(false);
-      expect(
-        warnSpy.mock.calls.some((call) =>
-          call.some(
-            (arg) =>
+        );
+        return warnSpy.mock.calls
+          .flat()
+          .filter(
+            (arg): arg is string =>
               typeof arg === 'string' &&
               arg.includes('__FEDERATION__.__INSTANCES__'),
-          ),
-        ),
-      ).toBe(false);
-    } finally {
-      warnSpy.mockRestore();
-    }
+          );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    };
+    const makeShared = (from: string, useIn: string[], loaded: boolean) =>
+      ({
+        version: '18.0.0',
+        get: () => () => ({}),
+        shareConfig: {},
+        scope: ['default'],
+        useIn,
+        from,
+        deps: [],
+        loaded,
+        strategy: 'version-first',
+      }) as any;
+    const instances = () => CurrentGlobal.__FEDERATION__.__INSTANCES__;
 
-    const newApp1Module = await FM.loadRemote<Promise<() => string>>(
-      `${registeredName}/say`,
-    );
-    assert(newApp1Module);
-    expect(await newApp1Module()).toBe('hello app1 entry2');
-  });
-  it('warns and keeps __INSTANCES__ unchanged when no runtime instance matches the removed remote', async () => {
-    delete (CurrentGlobal as Record<string, unknown>)['@register-remotes/app1'];
-    const FM = new ModuleFederation({
-      name: '@federation/instance',
-      version: '1.0.1',
-      remotes: [
-        {
-          name: '@register-remotes/app1',
-          entry:
-            'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js',
-        },
-      ],
+    it('removes only the instance with the matching build version when two share a build name', async () => {
+      const FM = await loadApp1();
+      setBuildVersion(FM, BUILD_NAME, '2.0.0');
+      const v1 = addInstance(BUILD_NAME, '1.0.0');
+      const v2 = addInstance(BUILD_NAME, '2.0.0');
+
+      const warnings = forceReRegister(FM);
+
+      expect(instances()).toContain(v1);
+      expect(instances()).not.toContain(v2);
+      expect(warnings).toEqual([]);
     });
-    const app1Module = await FM.loadRemote<Promise<() => string>>(
-      '@register-remotes/app1/say',
-    );
-    assert(app1Module);
-    expect(await app1Module()).toBe('hello app1 entry1');
 
-    const unrelatedInstance = new ModuleFederation({
-      name: '@register-remotes/unrelated',
-      remotes: [],
+    it('resolves the instance through entryGlobalName when the registration alias differs from the build name', async () => {
+      const alias = '@register-remotes/app1-alias';
+      const FM = await loadApp1(alias, BUILD_NAME);
+      const remoteInstance = addInstance(BUILD_NAME);
+
+      const warnings = forceReRegister(FM, alias, BUILD_NAME);
+
+      expect(instances()).not.toContain(remoteInstance);
+      expect(FM.moduleCache.has(alias)).toBe(false);
+      expect(warnings).toEqual([]);
+
+      const next = await FM.loadRemote<Promise<() => string>>(`${alias}/say`);
+      assert(next);
+      expect(await next()).toBe('hello app1 entry2');
     });
-    setGlobalFederationInstance(unrelatedInstance);
-    const instancesBefore = [...CurrentGlobal.__FEDERATION__.__INSTANCES__];
-    const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
 
-    try {
-      FM.registerRemotes(
-        [
-          {
-            name: '@register-remotes/app1',
-            entry:
-              'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry2.js',
-          },
-        ],
-        { force: true },
-      );
+    it('deletes unloaded shares produced by the remote instance from the global share scope', async () => {
+      const FM = await loadApp1();
+      addInstance(BUILD_NAME);
+      const shareScope = Global.__FEDERATION__.__SHARE__;
+      shareScope[BUILD_NAME] = {
+        default: { react: { '18.0.0': makeShared(BUILD_NAME, [], false) } },
+      };
 
-      expect(CurrentGlobal.__FEDERATION__.__INSTANCES__).toEqual(
-        instancesBefore,
+      forceReRegister(FM);
+
+      expect(shareScope[BUILD_NAME]).toBeUndefined();
+    });
+
+    it('keeps shares still consumed by another host and only drops the producer from useIn', async () => {
+      const FM = await loadApp1();
+      addInstance(BUILD_NAME);
+      const shareScope = Global.__FEDERATION__.__SHARE__;
+      const shared = makeShared(BUILD_NAME, [HOST_NAME, BUILD_NAME], true);
+      shareScope[BUILD_NAME] = { default: { react: { '18.0.0': shared } } };
+
+      forceReRegister(FM);
+
+      expect(shareScope[BUILD_NAME]?.default?.react?.['18.0.0']).toBe(shared);
+      expect(shared.useIn).toEqual([HOST_NAME]);
+    });
+
+    it('removes nothing and warns about ambiguity when two unversioned instances share the name', async () => {
+      const FM = await loadApp1();
+      const first = addInstance(BUILD_NAME);
+      const second = addInstance(BUILD_NAME);
+
+      const warnings = forceReRegister(FM);
+
+      expect(instances()).toContain(first);
+      expect(instances()).toContain(second);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('ambiguous');
+      expect(warnings[0]).toContain('2 runtime instances');
+      expect(warnings[0]).toContain('"registeredName"');
+    });
+
+    it('warns when instances with the same name exist but none has the requested build version', async () => {
+      const FM = await loadApp1();
+      setBuildVersion(FM, BUILD_NAME, '3.0.0');
+      const v1 = addInstance(BUILD_NAME, '1.0.0');
+
+      const warnings = forceReRegister(FM);
+
+      expect(instances()).toContain(v1);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('"3.0.0"');
+      expect(warnings[0]).toContain('found versions: 1.0.0');
+    });
+
+    it('stays silent and still clears the module cache for a container without a runtime instance', async () => {
+      const FM = await loadApp1();
+      const unrelated = addInstance('@register-remotes/unrelated');
+      const before = [...instances()];
+
+      const warnings = forceReRegister(FM);
+
+      expect(warnings).toEqual([]);
+      expect(instances()).toEqual(before);
+      expect(instances()).toContain(unrelated);
+      expect(FM.moduleCache.has(BUILD_NAME)).toBe(false);
+
+      const next = await FM.loadRemote<Promise<() => string>>(
+        `${BUILD_NAME}/say`,
       );
-      const warning = warnSpy.mock.calls
-        .flat()
-        .find(
-          (arg) =>
-            typeof arg === 'string' &&
-            arg.includes('__FEDERATION__.__INSTANCES__'),
-        );
-      expect(warning).toBeDefined();
-      expect(warning).toContain('"@register-remotes/app1"');
-      expect(warning).toContain(
-        'share scope and instance could not be released',
-      );
-    } finally {
-      warnSpy.mockRestore();
-    }
+      assert(next);
+      expect(await next()).toBe('hello app1 entry2');
+    });
+
+    it('resolves a versioned instance by options.name and options.version when options.id is custom', async () => {
+      const FM = await loadApp1();
+      setBuildVersion(FM, BUILD_NAME, '2.0.0');
+      const custom = addInstance(BUILD_NAME, '2.0.0', 'custom-build-id');
+
+      const warnings = forceReRegister(FM);
+
+      expect(instances()).not.toContain(custom);
+      expect(warnings).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Found while investigating #4566.

`RemoteHandler.removeRemote` (called by `registerRemotes(remotes, { force: true })` when a name is re-registered) looks up the remote's own runtime instance in `__FEDERATION__.__INSTANCES__` so it can release the remote's share-scope entries and splice the instance out. It matched only on the registered `name` (or `name:buildVersion`), so whenever the registration alias differed from the name the remote was built with, the instance leaked on every forced re-registration, silently.

This PR makes the identity used for that lookup explicit and monotonic, releases shares by the instance's own name, and only warns when the situation is actually suspicious.

## Identity model

A loaded remote is known under five distinct names, and the code now keeps them apart:

| Identity | Source | Used for |
| --- | --- | --- |
| registration alias | `remoteInfo.name` | `host.options.remotes`, `moduleCache`, snapshots |
| remote build / global name | `remoteInfo.entryGlobalName` | container global, instance lookup |
| runtime instance id | `instance.options.id` | `__SHARE__` map key |
| share producer name | `instance.options.name ?? instance.name` | `shared.from` / `shared.useIn` |
| consuming host name | `host.options.name` | never used for lookup |

## Matching order (`resolveRemoteRuntimeInstance`)

New pure helper `packages/runtime-core/src/remote/resolveRemoteRuntimeInstance.ts`. The first level that yields any candidate wins; a level with more than one candidate returns `ambiguous: true` and no instance (nothing is guessed):

1. registered name + `buildVersion` — `options.id === name:buildVersion`, or `options.name === name && options.version === buildVersion`
2. `entryGlobalName` + `buildVersion` — same two comparisons, only when `entryGlobalName` differs from the registered name
3. registered name alone — only when no `buildVersion` is known
4. `entryGlobalName` alone — only when no `buildVersion` is known and exactly one instance matches

A versioned lookup never degrades into an unversioned name match.

## Share release

`removeRemote` is split into single-purpose private steps run in the previous order under the existing `try/catch`: `removeRemoteRegistration`, `clearRemoteSnapshots`, `clearRemoteEntryState` (container global, `globalLoading`, `moduleCache`), then `releaseRuntimeInstanceShares`. Share release derives `producerName = instance.options.name ?? instance.name` and uses it for `shared.from`; `useIn` only drops `producerName` (the remote consuming its own share), never the registration alias. `isAllSharedNotUsed` / `needDeleteKeys` semantics and the `globalShareScopeMap[instance.options.id || producerName]` deletion are unchanged.

## Warning

`logger.warn` fires only when:

- the match is ambiguous (message names the level and the candidate count), or
- a versioned lookup found instances with the same registered name / `entryGlobalName` but none with the requested build version (message lists the versions found).

A container with no runtime instance at all (plain containers) is the legitimate case and stays silent.

## Tests

`packages/runtime-core/__tests__/register-remotes.spec.ts`, mirrored in `packages/runtime/__tests__/register-remotes.spec.ts` (synthetic instances injected into `__INSTANCES__`):

- two instances with the same build name and different build versions: only the matching version is removed
- registration alias differing from the build name (`entryGlobalName` = instance name): resolved and removed, no warning
- unloaded share produced by the remote instance is deleted from the global share scope
- share still consumed by the host is kept and `useIn` no longer contains the remote's own name
- unversioned lookup with two same-named instances: nothing removed, one ambiguity warning
- same-named instances with a different build version: one warning listing the versions found
- container without any runtime instance: no warning, no throw, module cache cleared, new entry loads
- instance whose `options.id` is custom but whose `options.name`/`options.version` match: still resolved

`packages/runtime-core/__tests__/resolve-remote-runtime-instance.spec.ts` unit-tests every level, the versioned-never-falls-back rule, ambiguity, and `entryGlobalName === name` not forming a level.

`pnpm --filter @module-federation/runtime-core test` (142 passed) and `pnpm --filter @module-federation/runtime test` (101 passed).

A `patch` changeset for `@module-federation/runtime-core` is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
