### PR TITLE
fix(sdk): await a concurrently-linking ESM module before reusing it

### DIFF
--- a/.changeset/quiet-otters-linger.md
+++ b/.changeset/quiet-otters-linger.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/sdk': patch
+---
+
+Wait for a concurrently-linking ESM module before handing it to a second importer, so a remote entry graph that reaches one module by two sibling paths links when that module has imports of its own. Cyclic graphs still receive the in-progress instance rather than deadlocking.

--- a/packages/sdk/__tests__/node-esm-diamond.spec.ts
+++ b/packages/sdk/__tests__/node-esm-diamond.spec.ts
@@ -1,0 +1,124 @@
+import { jest } from '@jest/globals';
+
+const ORIGIN = 'http://example.com';
+
+const createResponse = (body: string) => ({
+  text: async () => body,
+});
+
+const setModuleFetchMock = (modules: Record<string, string>) => {
+  const fetchMock = jest.fn(async (url: string) => {
+    const body = modules[url];
+    if (body === undefined) {
+      throw new Error(`${url} should not be fetched`);
+    }
+
+    return createResponse(body.trim());
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  return fetchMock;
+};
+
+const loadNodeEsmScript = async <T = unknown>(
+  url: string,
+): Promise<{ error?: Error; namespace?: T }> => {
+  const { createScriptNode } = await import('../src/node');
+
+  return new Promise((resolve) => {
+    createScriptNode(
+      url,
+      (error, scriptContext) =>
+        resolve({ error, namespace: scriptContext as T }),
+      { type: 'module' },
+    );
+  });
+};
+
+describe('Node ESM graphs that reach one module twice', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // `loadModule` publishes a module to its cache before linking it, so a
+  // cyclic import can still see it. `link()` resolves a module's dependencies
+  // concurrently, so a module reachable by two sibling paths could be handed
+  // to the second path while its own linking was still in flight - leaving its
+  // imports as unresolved requests on an unlinked module. That only became
+  // observable once such a shared module had imports of its own.
+  it('links a module reached by two sibling paths when it has imports of its own', async () => {
+    setModuleFetchMock({
+      [`${ORIGIN}/a.js`]: `
+        import { c } from './c.js'
+        import { b } from './b.js'
+        export const a = 'a' + b + c
+      `,
+      [`${ORIGIN}/b.js`]: `
+        import { c } from './c.js'
+        export const b = 'b' + c
+      `,
+      [`${ORIGIN}/c.js`]: `
+        import { d } from './d.js'
+        export const c = 'c' + d
+      `,
+      [`${ORIGIN}/d.js`]: `export const d = 'd'`,
+    });
+
+    const { error, namespace } = await loadNodeEsmScript<{ a: string }>(
+      `${ORIGIN}/a.js`,
+    );
+
+    expect(error).toBeUndefined();
+    expect(namespace?.a).toBe('abcdcd');
+  });
+
+  it('links a module reached by two sibling paths when it has no imports', async () => {
+    setModuleFetchMock({
+      [`${ORIGIN}/a.js`]: `
+        import { c } from './c.js'
+        import { b } from './b.js'
+        export const a = 'a' + b + c
+      `,
+      [`${ORIGIN}/b.js`]: `
+        import { c } from './c.js'
+        export const b = 'b' + c
+      `,
+      [`${ORIGIN}/c.js`]: `export const c = 'c'`,
+    });
+
+    const { error, namespace } = await loadNodeEsmScript<{ a: string }>(
+      `${ORIGIN}/a.js`,
+    );
+
+    expect(error).toBeUndefined();
+    expect(namespace?.a).toBe('abcc');
+  });
+
+  // A module in a cycle has to keep receiving the unlinked instance from the
+  // cache: waiting for it to finish linking would wait on the request it is
+  // already serving. This loader does not support cyclic entry graphs, and
+  // this pins that they fail rather than hang.
+  it('reports an error rather than hanging when two modules import each other', async () => {
+    setModuleFetchMock({
+      [`${ORIGIN}/a.js`]: `
+        import { b } from './b.js'
+        export function a() { return 'a' + b() }
+      `,
+      [`${ORIGIN}/b.js`]: `
+        import { a } from './a.js'
+        export function b() { return 'b' }
+      `,
+    });
+
+    const { error } = await loadNodeEsmScript(`${ORIGIN}/a.js`);
+
+    expect(error).toBeInstanceOf(Error);
+  }, 15000);
+});

--- a/packages/sdk/__tests__/node-esm-diamond.spec.ts
+++ b/packages/sdk/__tests__/node-esm-diamond.spec.ts
@@ -101,6 +101,32 @@ describe('Node ESM graphs that reach one module twice', () => {
     expect(namespace?.a).toBe('abcc');
   });
 
+  // Two modules that import each other are both reachable from the entry, so
+  // neither is the other's creation parent. Waiting on a module whose own
+  // linking is blocked on the waiter has to be refused by reachability through
+  // the wait graph, not by a parent chain, or both sides wait forever.
+  it('reports an error rather than hanging when two siblings of the entry import each other', async () => {
+    setModuleFetchMock({
+      [`${ORIGIN}/a.js`]: `
+        import { b } from './b.js'
+        import { c } from './c.js'
+        export const a = 'a' + b + c
+      `,
+      [`${ORIGIN}/b.js`]: `
+        import { c } from './c.js'
+        export const b = 'b' + c
+      `,
+      [`${ORIGIN}/c.js`]: `
+        import { b } from './b.js'
+        export const c = 'c' + b
+      `,
+    });
+
+    const { error } = await loadNodeEsmScript(`${ORIGIN}/a.js`);
+
+    expect(error).toBeInstanceOf(Error);
+  }, 15000);
+
   // A module in a cycle has to keep receiving the unlinked instance from the
   // cache: waiting for it to finish linking would wait on the request it is
   // already serving. This loader does not support cyclic entry graphs, and

--- a/packages/sdk/src/node.ts
+++ b/packages/sdk/src/node.ts
@@ -247,6 +247,31 @@ export const loadScriptNode =
       };
 
 const esmModuleCache = new Map<string, any>();
+// Resolves once a cached module has finished linking. The instance itself has
+// to be published to `esmModuleCache` before linking starts, so a cyclic
+// import can still see it - which means a cache hit can hand back a module
+// whose own requests are not resolved yet. Anything that is not part of that
+// cycle has to wait here instead.
+const esmModuleLinking = new Map<string, Promise<unknown>>();
+// child url -> the url whose link() asked for it, for modules currently being
+// linked. This is what tells a genuine cycle (which must receive the unlinked
+// instance, or the graph deadlocks) from a sibling that merely raced it.
+const esmLinkParents = new Map<string, string>();
+
+function isLinkAncestor(candidate: string, from?: string): boolean {
+  const seen = new Set<string>();
+  let current = from;
+
+  while (current && !seen.has(current)) {
+    if (current === candidate) {
+      return true;
+    }
+    seen.add(current);
+    current = esmLinkParents.get(current);
+  }
+
+  return false;
+}
 
 type LoadModuleOptions = {
   vm: typeof import('vm') & {
@@ -390,7 +415,7 @@ async function loadResolvedModule(
     );
   }
 
-  return loadModule(resolvedUrl, options);
+  return loadModule(resolvedUrl, options, parentUrl);
 }
 
 async function evaluateDynamicModule(module: any) {
@@ -405,10 +430,26 @@ async function evaluateDynamicModule(module: any) {
   return module;
 }
 
-async function loadModule(url: string, options: LoadModuleOptions) {
+async function loadModule(
+  url: string,
+  options: LoadModuleOptions,
+  parentUrl?: string,
+) {
   // Check cache to prevent infinite recursion in ESM loading
   if (esmModuleCache.has(url)) {
-    return esmModuleCache.get(url)!;
+    const cachedModule = esmModuleCache.get(url)!;
+    const linking = esmModuleLinking.get(url);
+
+    // Still linking. Returning it now is only correct for a cycle, where the
+    // module is an ancestor of this request and waiting would deadlock. A
+    // sibling that raced it must get the finished module, otherwise Node
+    // reports the child's own imports as unresolved requests on an unlinked
+    // module.
+    if (linking && !isLinkAncestor(url, parentUrl)) {
+      await linking;
+    }
+
+    return cachedModule;
   }
 
   const { fetch, vm } = options;
@@ -437,10 +478,21 @@ async function loadModule(url: string, options: LoadModuleOptions) {
 
   // Cache the module before linking to prevent cycles
   esmModuleCache.set(url, sourceTextModule);
+  if (parentUrl) {
+    esmLinkParents.set(url, parentUrl);
+  }
 
-  await sourceTextModule.link(async (specifier: string) => {
-    return loadResolvedModule(specifier, url, options);
-  });
+  const linking = sourceTextModule
+    .link(async (specifier: string) => {
+      return loadResolvedModule(specifier, url, options);
+    })
+    .finally(() => {
+      esmModuleLinking.delete(url);
+      esmLinkParents.delete(url);
+    });
+  esmModuleLinking.set(url, linking);
+
+  await linking;
 
   return sourceTextModule;
 }

--- a/packages/sdk/src/node.ts
+++ b/packages/sdk/src/node.ts
@@ -253,21 +253,57 @@ const esmModuleCache = new Map<string, any>();
 // whose own requests are not resolved yet. Anything that is not part of that
 // cycle has to wait here instead.
 const esmModuleLinking = new Map<string, Promise<unknown>>();
-// child url -> the url whose link() asked for it, for modules currently being
-// linked. This is what tells a genuine cycle (which must receive the unlinked
-// instance, or the graph deadlocks) from a sibling that merely raced it.
-const esmLinkParents = new Map<string, string>();
+// url -> the urls whose linking that url's own link() is currently blocked on,
+// because its linker asked for them or because it is waiting for one below.
+// Reachability through this map is what identifies a cycle: waiting on a module
+// that is already blocked on the waiter, directly or through other modules,
+// would deadlock. A module-creation parent chain is not enough, because two
+// modules that import each other can both be reached from the same importer.
+const esmLinkBlockedOn = new Map<string, Set<string>>();
 
-function isLinkAncestor(candidate: string, from?: string): boolean {
+function blockLinkOn(waiter: string, awaited: string): void {
+  const blocked = esmLinkBlockedOn.get(waiter);
+
+  if (blocked) {
+    blocked.add(awaited);
+    return;
+  }
+
+  esmLinkBlockedOn.set(waiter, new Set([awaited]));
+}
+
+function unblockLinkOn(waiter: string, awaited: string): void {
+  const blocked = esmLinkBlockedOn.get(waiter);
+  if (!blocked) {
+    return;
+  }
+
+  blocked.delete(awaited);
+  if (blocked.size === 0) {
+    esmLinkBlockedOn.delete(waiter);
+  }
+}
+
+function linkOfBlocksOn(start: string, target: string): boolean {
+  const pending = [start];
   const seen = new Set<string>();
-  let current = from;
 
-  while (current && !seen.has(current)) {
-    if (current === candidate) {
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+
+    if (current === target) {
       return true;
     }
+
+    if (seen.has(current)) {
+      continue;
+    }
     seen.add(current);
-    current = esmLinkParents.get(current);
+
+    const blocked = esmLinkBlockedOn.get(current);
+    if (blocked) {
+      pending.push(...blocked);
+    }
   }
 
   return false;
@@ -440,13 +476,22 @@ async function loadModule(
     const cachedModule = esmModuleCache.get(url)!;
     const linking = esmModuleLinking.get(url);
 
-    // Still linking. Returning it now is only correct for a cycle, where the
-    // module is an ancestor of this request and waiting would deadlock. A
-    // sibling that raced it must get the finished module, otherwise Node
-    // reports the child's own imports as unresolved requests on an unlinked
-    // module.
-    if (linking && !isLinkAncestor(url, parentUrl)) {
-      await linking;
+    // Still linking. A sibling that merely raced it must get the finished
+    // module, otherwise Node reports the child's own imports as unresolved
+    // requests on an unlinked module. Waiting is only wrong when this module's
+    // linking is itself blocked on the requester - that is a cycle, and it has
+    // to keep receiving the in-progress instance rather than hang.
+    if (linking) {
+      if (!parentUrl) {
+        await linking;
+      } else if (!linkOfBlocksOn(url, parentUrl)) {
+        blockLinkOn(parentUrl, url);
+        try {
+          await linking;
+        } finally {
+          unblockLinkOn(parentUrl, url);
+        }
+      }
     }
 
     return cachedModule;
@@ -479,7 +524,8 @@ async function loadModule(
   // Cache the module before linking to prevent cycles
   esmModuleCache.set(url, sourceTextModule);
   if (parentUrl) {
-    esmLinkParents.set(url, parentUrl);
+    // The requester's own link() cannot finish until this one does.
+    blockLinkOn(parentUrl, url);
   }
 
   const linking = sourceTextModule
@@ -488,7 +534,10 @@ async function loadModule(
     })
     .finally(() => {
       esmModuleLinking.delete(url);
-      esmLinkParents.delete(url);
+      esmLinkBlockedOn.delete(url);
+      if (parentUrl) {
+        unblockLinkOn(parentUrl, url);
+      }
     });
   esmModuleLinking.set(url, linking);
 


### PR DESCRIPTION
Fixes #5037

## The problem

`loadModule` publishes a module to `esmModuleCache` before linking it, so a
cyclic import can still see it. `SourceTextModule.link()` resolves a module's
dependencies concurrently, though, so a module reachable by two sibling paths
gets handed to the second path while its own linking is still in flight. Node
then reports its imports as unresolved requests on an unlinked module:

```
request for './d.js' can not be resolved on module '.../c.js' that is not linked
```

The race is not new. While every twice-reached module happened to be a leaf, an
unlinked cache hit had no requests left to resolve. It became reachable in
practice when `@module-federation/vite@1.21.3` changed its emitted chunk graph
so a twice-reached chunk gained an import of its own.

## The change

Track the in-flight link per URL and await it on a cache hit - except when the
awaited module's own linking is already blocked on the requester, directly or
transitively. That case is a cycle, where waiting would wait on the request it
is already serving.

Cycle detection runs over a wait graph (`esmLinkBlockedOn`: per module, the set
of modules its own `link()` is blocked on), not over a module-creation parent
chain. Two modules that import each other can both be reached from the same
importer, so neither is the other's creation parent, and a parent chain would
let each wait for the other - raised in review against the first version of
this PR, which used a parent chain.

Being explicit about what is measured: I could not get the parent-chain version
to actually deadlock - eight shapes, including forced sibling concurrency and a
three-way sibling cycle, all failed the same way as the unfixed loader instead
of hanging. The reachability check is no more code than the chain walk it
replaces, though, and a hang is much worse than a reported error, so this should
not rest on the linker's scheduling happening to interleave favourably.

Refusing to wait at all is not an option either: awaiting on *every* cache hit
fixes the sibling case and turns a cyclic graph into a hang - measured. Cyclic
entry graphs already fail today, before and after this change; this keeps them
failing fast.

## Verification

Measured against the reproduction in #5037 (four hand-written ESM modules, no
bundler, driven through `init()` / `loadRemote()`):

| case | before | after |
| --- | --- | --- |
| twice-reached module **with** an import | fails | **loads** (`abcdcd`) |
| twice-reached module with no imports | loads | loads (`abcc`) |
| two modules importing each other | fails | fails (unchanged) |
| two mutually-importing siblings of the entry | fails | fails (unchanged) |

And against the original real-world case, a Vite remote with `react` /
`react-dom` as `singleton: true` shared deps, loaded in Node with no
`loadEntry` hook, at plugin `1.21.5`:

| `@module-federation/sdk` | result |
| --- | --- |
| `2.9.0` as published | 0/10 loads |
| `2.9.0` + this change | 10/10 loads |

## Tests

`packages/sdk/__tests__/node-esm-diamond.spec.ts` adds four cases: the
sibling-path graph, the no-imports control, a direct cycle, and two
mutually-importing siblings of the entry.

The first fails on unmodified `main` with the exact production error, which I
checked before writing the fix:

```
● links a module reached by two sibling paths when it has imports of its own
  expect(received).toBeUndefined()
  Received: [Error: Script execution error: Error: request for './d.js' can not
  be resolved on module 'http://example.com/c.js' that is not linked]
```

`packages/sdk` suite: **10 suites / 70 tests** on `main` -> **11 suites / 74
tests** with this branch, no pre-existing test changed. `lint` and `build`
clean. The load results above were measured against the built
`packages/sdk/dist/node.js`, not a hand-patched copy.

One thing worth flagging separately, unrelated to this change:
`packages/sdk/src/__tests__/node-recursion.test.ts` is not matched by
`jest.config.cjs`'s `testMatch` (`<rootDir>__tests__/**/**.spec.[jt]s?(x)`), so
it never runs, and it fails 2/2 when forced to. I have left it alone rather than
widen this PR's scope, but it looks like it wants either fixing and wiring in,
or deleting.
