### PR TITLE
test(ssr): add update contracts and artifact regression baseline

### DIFF
--- a/tools/ssr-cache/README.md
+++ b/tools/ssr-cache/README.md
@@ -1,0 +1,170 @@
+# SSR cache update: R0 contract and regression baseline
+
+Status: implementation contract for the RFC, not an implemented update API.
+[RFC and roadmap](https://bytedance.larkoffice.com/docx/I8VZdLKxPoI85NxNTkrcX2Zmnuf).
+
+## Run the baseline
+
+From the repository root, with Node 24 and the lockfile's pnpm version:
+
+```sh
+pnpm exec turbo run build --filter=@module-federation/runtime-tools
+node --test tools/ssr-cache/baseline.test.cjs
+```
+
+The default uses the installed `@rspack/core` (currently the lockfile's canary).
+To validate a local Rspack build, set `SSR_CACHE_RSPACK_ENTRY` to its absolute
+`packages/rspack/dist/index.js` path. The test reports the resolved path and
+version; a local build's version alone does not identify its commit.
+
+Set `SSR_CACHE_MODERN_ENTRY` to a built Modern
+`packages/server/core/dist/cjs/adapters/node/index.js` to also run the resource
+publication HTTP test. Without it, that test is explicitly **skipped**, not passed.
+No dependency or lockfile is rewritten. Each compiler case runs in its own Node
+process and owns a temporary directory, removed on completion. Application
+rebuilds within each case remain in the same process.
+
+Known failures execute as Node test TODOs. They assert the desired behavior, not
+that stale behavior is correct. An unexpected pass fails the parent test so the
+TODO must be removed. To turn all known failures into blocking failures:
+
+```sh
+SSR_CACHE_STRICT=1 node --test tools/ssr-cache/baseline.test.cjs
+```
+
+A successful baseline run with TODOs is **not** production acceptance. When fixing
+a defect, remove its TODO and keep its desired-behavior assertion. These tests are
+an explicit development command; this change does not alter the CI workflows.
+
+| Case                 | What is exercised                                   | Current expectation                                                 |
+| -------------------- | --------------------------------------------------- | ------------------------------------------------------------------- |
+| plain                | Static multi-level consumers across emitted chunks  | Reacquired page remains stale: TODO                                 |
+| concat               | Same graph with module concatenation                | Page updates; saved function remains old                            |
+| parents              | Diagnostic JS plugin supplies missing parent edges  | Page updates; unrelated module executes once                        |
+| shared               | Real provider singleton consumed by host            | Host invalidation and shared strict identity: TODO                  |
+| all non-shared cases | Drop application CJS cache, then update again       | Dynamic reference refreshes; old adapter still called: TODO         |
+| Modern (opt-in)      | Real production resource plugin and one HTTP server | Recreate resource state to publish new manifest; PID/port unchanged |
+
+The `parents` plugin and manual page invalidation/hook rebinding in the fixture
+are diagnostic interventions, not the proposed production implementation. The
+fixture temporarily uses remove + register to exercise existing code; this does
+not specify atomic update semantics. No test here proves complete React streaming,
+HTTP remote transport, hydration compatibility, native ESM unloading, cyclic or
+multi-entry graph completeness, shared lazy dependency retention, or stable heap
+usage. Those remain R1–R6 work.
+
+## Cross-layer ownership
+
+| Owner                        | Required responsibilities                                                                              | Must not assume                                                           |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| Modern coordinator           | Admission/drain, affected entry mapping, runtime lifecycle, publication, recovery, applied revision    | Clearing MF caches replaces renderer/loader/lazy references               |
+| MF runtime                   | Explicit remote configuration update and owned cache cleanup; report errors                            | It can drain arbitrary Node callers or undo business side effects         |
+| Bundler adapter              | Attach current bundler, invalidate owned execution state, generation checks, detach wrappers/listeners | A same-name MF plugin installation replaces an old closure                |
+| Rspack                       | Generic module/parent/chunk metadata and MF cache primitives                                           | Chunk identity is equivalent to a Modern route                            |
+| Modern JS compilation plugin | Map compilation metadata to application entries and indicate completeness                              | Dynamically computed remote identifiers can always be resolved statically |
+
+## MF instance and adapter lifetime (R0 decision)
+
+For a Modern-owned logical host, keep the MF instance across application rebuilds.
+A persistent control plane owns its authoritative remote configuration and its
+consumed shared records. An application generation owns its bundler adapters and
+rendering resources. Do not create a fresh same-name instance on every rebuild:
+that alone neither releases global records nor preserves shared identity.
+
+One application can own multiple hosts/bundlers, including separate loader
+bundles. Track each explicitly; a single global `currentBundler` pointer is not a
+valid contract. Do not detach adapters belonging to another still-live owner.
+
+An adapter attachment returns an idempotent disposer. Its identity is the actual
+bundler runtime plus owner/generation, not the plugin name. Register callbacks and
+wrappers once per attachment. Detach must remove its listeners, unregister its
+routing, release captured bundler references, and restore only wrappers it still
+owns (never overwrite a later third-party wrapper). Repeated attach of the same
+live binding must not stack wrappers. A disposed generation cannot write results
+into the current generation. Existing already-returned exports are not rewritten.
+
+During rebuild, drain first; use old adapters while their caches still need
+cleanup; detach before discarding the old runtime; initialize new bundles from the
+control plane's latest configuration; attach and validate new bindings before
+publication. Generated startup configuration must not silently overwrite an
+accepted dynamic update. A failed rebuild may leave no serving generation; retain
+the control plane needed to retry. This ordering must be validated in R1/R3.
+
+Consumed shared exports must retain strict object identity, including dependencies
+needed for later lazy work. The implementation may retain a provider runtime when
+safe selective invalidation is unavailable; host consumer invalidation must still
+occur. Do not promise full provider GC or mutate an in-use shared singleton into a
+new version. Shared preservation is a correctness requirement, not just a loaded
+flag. Changes to an in-use shared dependency outside this contract must be reported
+as unsupported, not silently treated as an ordinary remote update.
+
+## Update operation and revision contract (R0 decision)
+
+Names below describe internal semantics, not final public TypeScript API names.
+
+- `operationId` identifies a request for update. A retry can be related to its
+  original operation; it is not permission to apply the same mutation twice.
+- A normalized target configuration is retained separately from the last serving
+  configuration. `appliedRevision` advances only after Modern has validated and
+  published a serving runtime. Clearing MF caches alone cannot advance it.
+- Revision ordering is local to an application/worker. Do not compare opaque
+  remote version strings lexically. External sources with ordering use an explicit
+  source revision; otherwise accepted operations are serialized in arrival order.
+- Resolve every caller's Promise with its own outcome. Do not silently merge
+  distinct updates or report all callers successful because the last update worked.
+- Validate the whole requested remote set before destructive changes. Multi-remote
+  failure after mutation is not transactional rollback; recovery requires a rebuild
+  from a complete retained target configuration.
+- `registerRemotes` registers previously unknown remotes. Existing registration
+  updates use the explicit asynchronous update API; `force` is deprecated with a
+  documented migration. Adapter attach is distinct from user registration.
+
+An update result exposes operation ID, requested revision, applied revision,
+selected mode/scope and fallback reason. A failure additionally exposes phase,
+original cause, whether destructive mutation began, whether the application is
+still serving, and whether retry/rebuild is possible. The phase progression is:
+
+```text
+validate → analyze → close admission → drain → mutate → rebuild → validate runtime → publish → reopen
+```
+
+Validation/analysis failure leaves the old runtime available. Drain timeout does
+not prove old work stopped: abandon before mutation and reopen the old generation.
+After destructive mutation, failure must not reopen partially modified state.
+Retry rebuild under the closed gate, with bounded waiting and explicit failure.
+No universal rollback of arbitrary JavaScript side effects is promised.
+
+## Impact analysis and request admission (R0 decision)
+
+Start with generic module/dependency/chunk metadata, then map the affected closure
+to Modern resources and entry ownership. Static **consumption** must be traceable;
+static registration alone is insufficient. Missing graph edges, dynamic/mixed
+consumption, or inseparable shared application context require widening scope.
+If whole-application rebuild is itself unsupported, fail explicitly.
+
+A request acquires a lease on an eligible serving generation before running any
+application loader/render/action. Checking admission, selecting the generation
+and registering the lease must be coordinated. The closed gate's Promise is only
+a notification: waking requests recheck admission, including after another update
+has started. Do not capture an old handler before waiting.
+
+Old leases finish without awaiting the update that drains them. A request-context
+attempt to await its own update is rejected. Release once on real task completion;
+returning a Response, sending a stream shell, or receiving client close alone is
+not proof that rendering work has settled. R2 must establish completion/abort
+handshakes, including application-owned async work.
+
+Waiters have individual cancellation/deadlines and a capacity bound. Timeout/full
+queue returns 503, optionally Retry-After; disconnect removes the waiter, not the
+shared update. Handle request bodies/backpressure while waiting and do not replay
+side-effecting actions. Liveness/static traffic independent of the runtime can
+continue; readiness policy must distinguish a bounded update from a dead process.
+Thresholds are configurable and selected from R6 load measurements.
+
+## Remaining stage gates
+
+R0 chooses the ownership and externally observable contracts above. R1 must prove
+shared dependency retention and adapter disposal; R2 must prove stream termination;
+R3/R4 must implement Modern resource ownership and safe publication. None is marked
+implemented by this document. Arbitrary globals, unregistered tasks, native ESM
+registry eviction and deployment-owned worker rotation remain explicit boundaries.

--- a/tools/ssr-cache/VALIDATION.md
+++ b/tools/ssr-cache/VALIDATION.md
@@ -1,0 +1,59 @@
+# R0 validation — 2026-09-10
+
+This is a regression baseline, not production acceptance. Runtime sources were
+not changed. R1–R6 remain open, as does the existing E2E failure below.
+
+Source baselines:
+
+- Core: `7d503c1868cf64445e0f22c9c61a7cb09393ae22`
+- Local Rspack: `8e63776c7a5fa47665fac96f16316f874a18b806` (built version 2.2.2)
+- Local Modern: `46967f66c044572cbd0c7b66a82dd4012220695c`
+- Installed Rspack: `2.2.3-canary-8e63776c-20260908113208`
+- Node 24.18.1, pnpm 10.28.0
+
+## Commands and outcomes
+
+```sh
+pnpm exec turbo run build --filter=@module-federation/runtime-tools
+node --test tools/ssr-cache/baseline.test.cjs
+SSR_CACHE_STRICT=1 node --test tools/ssr-cache/baseline.test.cjs
+SSR_CACHE_RSPACK_ENTRY=/Users/bytedance/outter/rspack/packages/rspack/dist/index.js SSR_CACHE_MODERN_ENTRY=/Users/bytedance/work/modern.js/packages/server/core/dist/cjs/adapters/node/index.js node --test tools/ssr-cache/baseline.test.cjs
+pnpm --filter @module-federation/webpack-bundler-runtime run test -- clearCache.spec.ts
+pnpm run ci:local --only=e2e-modern-ssr
+pnpm exec prettier --check tools/ssr-cache
+pnpm exec prettier --check .
+node --check tools/ssr-cache/baseline.test.cjs
+node --check tools/ssr-cache/fixture.cjs
+node --check tools/ssr-cache/modern-fixture.cjs
+git diff --check
+```
+
+- Runtime-tools and dependency builds: 6/6 successful.
+- Installed Rspack baseline: 4 passes, 7 known-defect TODOs, 1 explicit Modern
+  skip because no Modern entry path was supplied. No unexpected failures.
+- Local Rspack + Modern: 5 passes, 7 known-defect TODOs, no skips or unexpected
+  failures. The HTTP test verifies publication with the same server/PID/port.
+- Strict mode exits 1, as intended: all seven desired-behavior assertions become
+  blocking failures (Node also counts their four parent tests as failed).
+- Existing clearCache Jest tests: 6/6 pass.
+- Modern SSR CI: package build 44/44 succeeds; Cypress shared-cache spec passes.
+  `remove-remote-cache.cy.js:51` fails because `v1Runtime.captured` is false.
+  The preceding v2 payload and absence-of-remove-error assertions pass. The capture
+  failure is not diagnosed or fixed by R0, and the CI job must not be called green.
+- Changed-file formatting, JavaScript syntax and diff whitespace checks pass.
+  Repository-wide Prettier fails on 683 files, including generated website output,
+  generated playground source and a pre-existing modified bridge source. R0 does
+  not reformat unrelated files.
+
+The first CI attempt was interrupted after sandbox DNS failures during dependency
+installation. `pnpm install --frozen-lockfile` was rerun with network access and
+completed; no lockfile changes. A concurrent first Jest attempt during dependency
+recreation could not resolve jsdom; the rerun above passes. The first Modern HTTP
+probe hit sandbox `listen EPERM`; rerunning with local-listener permission passes.
+
+Full React stream/abort/hydration, production serve under a supervisor, memory/GC
+stability, shared lazy dependencies and multi-entry graph completeness are not
+covered by R0. They remain the explicit R1–R6 acceptance tasks. Other CI jobs were
+not run because this change adds a focused SSR baseline and contracts, not runtime
+behavior. No changeset or package publication is needed for these tooling/docs-only
+changes. The baseline is a documented explicit command, not yet a CI gate.

--- a/tools/ssr-cache/baseline.test.cjs
+++ b/tools/ssr-cache/baseline.test.cjs
@@ -1,0 +1,153 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+// Each case owns a process: MF globals must not leak between compilations.
+function run(script, directory, flags = {}) {
+  const child = spawnSync(process.execPath, [path.join(__dirname, script)], {
+    env: {
+      ...process.env,
+      PARENTS: '0',
+      SHARED: '0',
+      CONCAT: '0',
+      ...flags,
+      SSR_CACHE_CASE_DIR: directory,
+    },
+    timeout: 120_000,
+    encoding: 'utf8',
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  assert.ifError(child.error);
+  assert.equal(child.status, 0, child.stderr + child.stdout);
+}
+
+// A known defect is not a passing feature test. Strict mode makes all TODOs
+// release-blocking. Unexpected passes also fail so the TODO must be removed.
+async function knownFailure(t, name, verify) {
+  if (process.env.SSR_CACHE_STRICT === '1') return t.test(name, verify);
+  let failure;
+  try {
+    verify();
+  } catch (error) {
+    failure = error;
+  }
+  assert.ok(failure, `${name}: now passes; remove its TODO designation`);
+  await t.test(
+    name,
+    { todo: 'R1: known defect, blocks production acceptance' },
+    () => {
+      throw failure;
+    },
+  );
+}
+
+for (const [variant, flags] of Object.entries({
+  plain: {},
+  concat: { CONCAT: '1' },
+  parents: { PARENTS: '1' },
+  shared: { SHARED: '1' },
+})) {
+  test(`real Rspack artifacts: ${variant}`, async (t) => {
+    const directory = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'mf-ssr-cache-')),
+    );
+    try {
+      run('fixture.cjs', directory, flags);
+      const result = JSON.parse(
+        fs.readFileSync(path.join(directory, 'result.json'), 'utf8'),
+      );
+      t.diagnostic(
+        JSON.stringify({
+          variant,
+          rspack: result.rspackVersion,
+          entry: result.rspackEntry,
+          node: result.nodeVersion,
+        }),
+      );
+      assert.equal(
+        result.static.savedHandler,
+        'v1',
+        'cache invalidation cannot mutate a retained function',
+      );
+      assert.equal(
+        result.static.otherSame,
+        true,
+        'unrelated exports retain identity',
+      );
+      assert.equal(result.static.executions.other, 1);
+      if (variant === 'plain' || variant === 'shared') {
+        await knownFailure(t, 'reacquiring a static page returns v2', () =>
+          assert.equal(result.static.reimport, 'v2'),
+        );
+      } else {
+        assert.equal(result.static.reimport, 'v2');
+        if (variant === 'parents') {
+          for (const module of ['page', 'middle', 'leaf'])
+            assert.equal(result.static.executions[module], 2);
+          assert.equal(result.rebuild.afterRebindingHook.result, 'v1');
+          assert.equal(result.rebuild.afterRebindingHook.newClearCalls, 1);
+        }
+      }
+      if (variant === 'shared') {
+        await knownFailure(
+          t,
+          'shared retention does not skip host invalidation',
+          () => assert.equal(result.static.withPageInvalidated, 'v2'),
+        );
+        await knownFailure(
+          t,
+          'consumed shared export retains strict identity',
+          () => assert.equal(result.shared.sameObject, true),
+        );
+      } else {
+        assert.equal(result.dynamic.savedHandler, 'v1');
+        assert.equal(result.dynamic.reimport, 'v1');
+        assert.equal(result.dynamic.mappingContainsDynamic, false);
+        assert.equal(result.rebuild.dynamicResult, 'v2');
+        assert.equal(result.rebuild.newBundler, true);
+        assert.equal(result.rebuild.hostChanged, false);
+        await knownFailure(
+          t,
+          'second update clears the current bundler',
+          () => {
+            assert.equal(result.rebuild.secondUpdate.oldClearCalls, 0);
+            assert.equal(result.rebuild.secondUpdate.newClearCalls, 1);
+            assert.equal(result.rebuild.secondUpdate.result, 'v1');
+          },
+        );
+      }
+      if (variant === 'plain') {
+        await t.test(
+          'Modern resource publication keeps server/PID/port',
+          {
+            skip:
+              !process.env.SSR_CACHE_MODERN_ENTRY &&
+              'Set SSR_CACHE_MODERN_ENTRY to a built Modern Node adapter',
+          },
+          () => {
+            run('modern-fixture.cjs', directory);
+            const modern = JSON.parse(
+              fs.readFileSync(
+                path.join(directory, 'modern-result.json'),
+                'utf8',
+              ),
+            );
+            assert.equal(modern.recreateResources.text, 'v2');
+            for (const key of [
+              'pidUnchanged',
+              'portUnchanged',
+              'manifestReplaced',
+              'mfInstanceReused',
+            ])
+              assert.equal(modern[key], true, key);
+          },
+        );
+      }
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+}

--- a/tools/ssr-cache/fixture.cjs
+++ b/tools/ssr-cache/fixture.cjs
@@ -1,0 +1,394 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+const { pathToFileURL } = require('node:url');
+const repo = path.resolve(__dirname, '../..');
+const root = process.env.SSR_CACHE_CASE_DIR;
+if (!root) throw new Error('Run through baseline.test.cjs');
+fs.mkdirSync(root, { recursive: true });
+const out = path.join(root, 'dist');
+const implementation = path.join(repo, 'packages/runtime-tools');
+function write(name, value) {
+  fs.writeFileSync(path.join(root, name), value);
+}
+async function main() {
+  const { rspack, container, rspackVersion, RuntimeModule, RuntimeGlobals } =
+    await import(
+      pathToFileURL(
+        process.env.SSR_CACHE_RSPACK_ENTRY || require.resolve('@rspack/core'),
+      ).href
+    );
+  write('v1.js', 'export default "v1";');
+  write('v2.js', 'export default "v2";');
+  if (process.env.SHARED === '1') {
+    write('shared.js', 'export default {identity:"shared-singleton"};');
+    for (const v of ['v1', 'v2'])
+      write(
+        v + '.js',
+        `import shared from 'shared-lib'; export {shared}; export default '${v}';`,
+      );
+  }
+  write(
+    'leaf.js',
+    'import value from "remote/Value"; globalThis.executions.leaf++; export default () => value;',
+  );
+  write(
+    'middle.js',
+    'import leaf from "./leaf"; globalThis.executions.middle++; export default () => leaf();',
+  );
+  write(
+    'page.js',
+    'import middle from "./middle"; globalThis.executions.page++; export default () => middle();',
+  );
+  write(
+    'other.js',
+    'globalThis.executions.other++; export default () => "unrelated";',
+  );
+  write(
+    'dynamic.js',
+    'globalThis.executions.dynamic++; let saved; export async function render() { saved ||= await __webpack_require__.federation.instance.loadRemote("dynamic/Value"); return saved.default; }',
+  );
+  write(
+    'host.js',
+    `globalThis.executions.boot++; export const req = __webpack_require__; export const page = () => import('./page').then(m => m.default); export const other = () => import('./other').then(m => m.default); export const dynamic = () => import('./dynamic').then(m => m.render); export const requestHandler = import('./dynamic').then(m => async () => new Response(await m.render()));`,
+  );
+  if (process.env.PARENTS === '1')
+    fs.appendFileSync(
+      path.join(root, 'host.js'),
+      'Object.assign(__webpack_require__.remotesLoadingData.consumerModuleIdToParentModuleIds,__webpack_require__.__probeParents);',
+    );
+  if (process.env.SHARED === '1')
+    fs.appendFileSync(
+      path.join(root, 'host.js'),
+      "export const share=()=>import('shared-lib');",
+    );
+  write(
+    'plugin.js',
+    `module.exports=()=>({name:'local-entry',loadEntry({remoteInfo}) { return __non_webpack_require__(remoteInfo.entry); }});`,
+  );
+  const common = {
+    context: root,
+    target: 'node',
+    mode: 'production',
+    devtool: false,
+    optimization: {
+      minimize: false,
+      concatenateModules: process.env.CONCAT === '1',
+      moduleIds: 'named',
+      chunkIds: 'named',
+    },
+    output: {
+      path: out,
+      library: { type: 'commonjs2' },
+      filename: '[name].cjs',
+      chunkFilename: '[name].cjs',
+    },
+  };
+  const configs = ['v1', 'v2'].map((v) => ({
+    ...common,
+    entry: {},
+    output: { ...common.output, uniqueName: v },
+    plugins: [
+      new container.ModuleFederationPlugin({
+        name: v,
+        implementation,
+        filename: v + '.cjs',
+        library: { type: 'commonjs-module' },
+        exposes: { './Value': './' + v + '.js' },
+        shared:
+          process.env.SHARED === '1'
+            ? {
+                'shared-lib': {
+                  import: './shared.js',
+                  version: '1.0.0',
+                  singleton: true,
+                },
+              }
+            : undefined,
+      }),
+    ],
+  }));
+  configs.push({
+    ...common,
+    entry: { host: './host.js' },
+    output: { ...common.output, uniqueName: 'probe-host' },
+    plugins: [
+      new container.ModuleFederationPlugin({
+        name: 'probe-host',
+        implementation,
+        remotes: { remote: { external: 'v1@' + path.join(out, 'v1.cjs') } },
+        runtimePlugins: [path.join(root, 'plugin.js')],
+        shared:
+          process.env.SHARED === '1'
+            ? {
+                'shared-lib': {
+                  import: false,
+                  requiredVersion: false,
+                  singleton: true,
+                },
+              }
+            : undefined,
+      }),
+    ],
+  });
+  if (process.env.PARENTS === '1')
+    configs.at(-1).plugins.push({
+      apply(compiler) {
+        compiler.hooks.thisCompilation.tap(
+          'ParentClosureProbe',
+          (compilation) => {
+            compilation.hooks.runtimeRequirementInTree
+              .for(RuntimeGlobals.ensureChunkHandlers)
+              .tap('ParentClosureProbe', (chunk) => {
+                class Parents extends RuntimeModule {
+                  constructor() {
+                    super('parent-closure-probe', 30);
+                  }
+                  generate() {
+                    const parents = {};
+                    for (const module of compilation.modules) {
+                      const id = compilation.chunkGraph.getModuleId(module);
+                      if (
+                        id == null ||
+                        !String(id).startsWith('./') ||
+                        id === './plugin.js'
+                      )
+                        continue;
+                      const ids = [];
+                      for (const edge of compilation.moduleGraph.getIncomingConnections(
+                        module,
+                      )) {
+                        if (!edge.originModule) continue;
+                        const parent = compilation.chunkGraph.getModuleId(
+                          edge.originModule,
+                        );
+                        if (
+                          parent != null &&
+                          String(parent).startsWith('./') &&
+                          !ids.includes(parent)
+                        )
+                          ids.push(parent);
+                      }
+                      if (ids.length) parents[id] = ids;
+                    }
+                    return (
+                      '__webpack_require__.__probeParents=' +
+                      JSON.stringify(parents) +
+                      ';'
+                    );
+                  }
+                }
+                compilation.addRuntimeModule(chunk, new Parents());
+              });
+          },
+        );
+      },
+    });
+  await new Promise((resolve, reject) => {
+    const c = rspack(configs);
+    c.run((e, s) =>
+      c.close((closeError) => {
+        if (e || closeError || !s || s.hasErrors())
+          reject(
+            e ||
+              closeError ||
+              new Error(
+                s?.toString({ all: false, errors: true }) ||
+                  'Missing compilation stats',
+              ),
+          );
+        else resolve();
+      }),
+    );
+  });
+  globalThis.executions = {
+    boot: 0,
+    leaf: 0,
+    middle: 0,
+    page: 0,
+    other: 0,
+    dynamic: 0,
+  };
+  let host = require(path.join(out, 'host.cjs'));
+  const beforePage = await host.page();
+  const other = await host.other();
+  assert.equal(beforePage(), 'v1');
+  assert.equal(other(), 'unrelated');
+  let sharedBefore;
+  if (host.share) {
+    sharedBefore = (await host.share()).default;
+    assert.equal((await host.share()).default, sharedBefore);
+  }
+  const mapping = JSON.parse(JSON.stringify(host.req.remotesLoadingData));
+  const instance = host.req.federation.instance;
+  const template = {
+    ...instance.options.remotes.find(
+      (r) => r.name === 'remote' || r.alias === 'remote',
+    ),
+  };
+  await instance.removeRemote('remote');
+  instance.registerRemotes([
+    { ...template, entry: path.join(out, 'v2.cjs'), entryGlobalName: 'v2' },
+  ]);
+  const afterPage = await host.page();
+  const result = {
+    rspackVersion,
+    rspackEntry:
+      process.env.SSR_CACHE_RSPACK_ENTRY || require.resolve('@rspack/core'),
+    nodeVersion: process.version,
+    mapping,
+    static: {
+      savedHandler: beforePage(),
+      reimport: afterPage(),
+      executions: { ...globalThis.executions },
+    },
+  };
+  assert.equal(result.static.savedHandler, 'v1');
+  // Desired behavior is asserted by the parent test, including known failures.
+  // Supply missing transitive parent cache invalidation only, preserving factories.
+  for (const id of Object.keys(host.req.c))
+    if (id.startsWith('./page.js')) delete host.req.c[id];
+  const patchedPage = await host.page();
+  result.static.withPageInvalidated = patchedPage();
+  result.static.otherSame = (await host.other()) === other;
+  if (host.share) {
+    const sharedAfter = (await host.share()).default;
+    result.shared = {
+      sameObject: sharedAfter === sharedBefore,
+      before: sharedBefore,
+      after: sharedAfter,
+      records: Object.values(globalThis.__FEDERATION__.__SHARE__)
+        .map((s) => s.default?.['shared-lib'])
+        .filter(Boolean)
+        .map((s) =>
+          Object.values(s).map((r) => ({
+            from: r.from,
+            useIn: r.useIn,
+            loaded: r.loaded,
+            providerState: r.providerState,
+          })),
+        ),
+      cachedModules: Object.keys(host.req.c).filter((k) =>
+        /leaf|middle|page|remote\/remote/.test(k),
+      ),
+    };
+
+    fs.writeFileSync(
+      path.join(root, 'result.json'),
+      JSON.stringify(result, null, 2),
+    );
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  instance.registerRemotes([
+    {
+      name: 'dynamic',
+      entry: path.join(out, 'v1.cjs'),
+      type: 'commonjs-module',
+      entryGlobalName: 'v1',
+    },
+  ]);
+  const dynamic = await host.dynamic();
+  assert.equal(await dynamic(), 'v1');
+  await instance.removeRemote('dynamic');
+  instance.registerRemotes([
+    {
+      name: 'dynamic',
+      entry: path.join(out, 'v2.cjs'),
+      type: 'commonjs-module',
+      entryGlobalName: 'v2',
+    },
+  ]);
+  result.dynamic = {
+    savedHandler: await dynamic(),
+    reimport: await (await host.dynamic())(),
+    mappingContainsDynamic: Object.hasOwn(
+      mapping.remoteKeyToRemoteModuleIds,
+      'dynamic',
+    ),
+  };
+  // Same process: drop all emitted CJS modules then reacquire the application.
+  const oldInstance = host.req.federation.instance;
+  const oldRequire = host.req;
+  for (const key of Object.keys(require.cache))
+    if (key.startsWith(out + path.sep)) delete require.cache[key];
+  host = require(path.join(out, 'host.cjs'));
+  result.rebuild = {
+    samePid: process.pid,
+    hostChanged: host.req.federation.instance !== oldInstance,
+    instances: globalThis.__FEDERATION__.__INSTANCES__.map((i) => i.name),
+    registered: host.req.federation.instance.options.remotes.map((r) => ({
+      name: r.name,
+      entry: r.entry,
+    })),
+    executions: { ...globalThis.executions },
+  };
+  result.rebuild.staticResult = (await host.page())();
+  result.rebuild.dynamicResult = await (await host.dynamic())();
+  result.rebuild.newBundler = host.req !== oldRequire;
+  let oldClearCalls = 0,
+    newClearCalls = 0;
+  const oldClear = oldRequire.federation.clearCache,
+    newClear = host.req.federation.clearCache;
+  oldRequire.federation.clearCache = (...a) => {
+    oldClearCalls++;
+    return oldClear(...a);
+  };
+  host.req.federation.clearCache = (...a) => {
+    newClearCalls++;
+    return newClear(...a);
+  };
+  const nextTemplate = {
+    ...host.req.federation.instance.options.remotes.find(
+      (r) => r.alias === 'remote' || r.name === 'remote',
+    ),
+  };
+  await host.req.federation.instance.removeRemote('remote');
+  host.req.federation.instance.registerRemotes([
+    { ...nextTemplate, entry: path.join(out, 'v1.cjs'), entryGlobalName: 'v1' },
+  ]);
+  result.rebuild.secondUpdate = {
+    oldClearCalls,
+    newClearCalls,
+    result: (await host.page())(),
+  };
+  assert.equal(result.dynamic.reimport, 'v1');
+  assert.equal(result.rebuild.dynamicResult, 'v2');
+
+  if (process.env.PARENTS === '1') {
+    // Diagnostic intervention only: replace stale removal callback with current bundler.
+    const current = host.req.federation.instance;
+    current.remoteHandler.hooks.removePlugin(
+      'bundler-runtime-clear-cache-plugin',
+    );
+    current.remoteHandler.hooks.applyPlugin({
+      name: 'bundler-runtime-clear-cache-plugin',
+      removeRemote({ remote }) {
+        return host.req.federation.clearCache({
+          name: remote.alias || remote.name,
+        });
+      },
+    });
+    const next = {
+      ...current.options.remotes.find(
+        (r) => r.alias === 'remote' || r.name === 'remote',
+      ),
+    };
+    await current.removeRemote('remote');
+    current.registerRemotes([next]);
+    result.rebuild.afterRebindingHook = {
+      oldClearCalls,
+      newClearCalls,
+      result: (await host.page())(),
+    };
+  }
+  fs.writeFileSync(
+    path.join(root, 'result.json'),
+    JSON.stringify(result, null, 2),
+  );
+  console.log(JSON.stringify(result, null, 2));
+}
+main().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/tools/ssr-cache/modern-fixture.cjs
+++ b/tools/ssr-cache/modern-fixture.cjs
@@ -1,0 +1,112 @@
+process.env.NODE_ENV = 'production';
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+const { injectResourcePlugin, createNodeServer } = require(
+  process.env.SSR_CACHE_MODERN_ENTRY,
+);
+const out = path.join(process.env.SSR_CACHE_CASE_DIR, 'dist');
+const route = {
+  entryName: 'main',
+  bundle: 'host.cjs',
+  entryPath: 'index.html',
+  urlPath: '/',
+};
+globalThis.executions = {
+  boot: 0,
+  leaf: 0,
+  middle: 0,
+  page: 0,
+  other: 0,
+  dynamic: 0,
+};
+fs.writeFileSync(path.join(out, 'index.html'), '<html></html>');
+function prepareResources() {
+  const context = { middlewares: [], routes: [route], distDirectory: out };
+  let prepare;
+  injectResourcePlugin().setup({
+    onPrepare(fn) {
+      prepare = fn;
+    },
+    getServerContext() {
+      return context;
+    },
+  });
+  prepare();
+  return context.middlewares.find((m) => m.name === 'inject-server-manifest')
+    .handler;
+}
+async function getManifest(middleware) {
+  const data = new Map();
+  await middleware(
+    { get: (k) => data.get(k), set: (k, v) => data.set(k, v) },
+    async () => {},
+  );
+  return data.get('serverManifest');
+}
+async function main() {
+  let resources = prepareResources();
+  let manifest = await getManifest(resources);
+  let host = manifest.renderBundles.main;
+  const instance = host.req.federation.instance;
+  const remote = (v) => ({
+    name: 'dynamic',
+    entry: path.join(out, v + '.cjs'),
+    type: 'commonjs-module',
+    entryGlobalName: v,
+  });
+  instance.registerRemotes([remote('v1')]);
+  const server = await createNodeServer(async (request) => {
+    const manifest = await getManifest(resources);
+    return (await manifest.renderBundles.main.requestHandler)(request, {});
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  const read = async () => {
+    const res = await fetch('http://127.0.0.1:' + address.port, {
+      signal: AbortSignal.timeout(10000),
+    });
+    return { status: res.status, text: await res.text() };
+  };
+  const results = { pid: process.pid, port: address.port };
+  try {
+    results.initial = await read();
+    assert.equal(results.initial.text, 'v1');
+    await instance.removeRemote('dynamic');
+    instance.registerRemotes([remote('v2')]);
+    results.remoteUpdateOnly = await read();
+    for (const key of Object.keys(require.cache))
+      if (key.startsWith(out + path.sep)) delete require.cache[key];
+    results.clearNodeCacheOnly = await read();
+    const oldManifest = manifest;
+    resources = prepareResources();
+    manifest = await getManifest(resources);
+    results.recreateResources = await read();
+    results.manifestReplaced = manifest !== oldManifest;
+    results.mfInstanceReused =
+      manifest.renderBundles.main.req.federation.instance === instance;
+    results.pidUnchanged = process.pid === results.pid;
+    results.portUnchanged = server.address().port === results.port;
+    assert.equal(results.remoteUpdateOnly.text, 'v1');
+    assert.equal(results.clearNodeCacheOnly.text, 'v1');
+    assert.equal(results.recreateResources.text, 'v2');
+    console.log(JSON.stringify(results, null, 2));
+    fs.writeFileSync(
+      path.join(process.env.SSR_CACHE_CASE_DIR, 'modern-result.json'),
+      JSON.stringify(results, null, 2),
+    );
+  } finally {
+    server.closeAllConnections();
+    await new Promise((r) => server.close(r));
+  }
+}
+main().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Description

Adds the R0 SSR update contract and portable real-artifact regression baseline on top of `feat/mf-ssr-clear-cache`. The contract defines persistent MF host ownership, disposable bundler bindings, revision/publication semantics, and Modern request admission. No production runtime behavior changes.

Four isolated Rspack fixtures cover static parent invalidation, concatenation, dynamic retained references, adapter rebinding, and shared identity. An opt-in Modern HTTP fixture verifies resource publication without changing the server/PID/port. Seven known failures execute as TODOs; strict mode makes them blocking, and unexpected passes require removing the TODO.

Validation: runtime-tools dependency build passed (6 tasks); local Rspack + Modern baseline: 5 passed / 7 TODO; installed canary: 4 passed / 7 TODO / 1 explicit Modern skip; existing clearCache Jest tests: 6 passed. Changed-file format and syntax checks passed. Modern SSR CI built 44 packages but failed the existing `remove-remote-cache.cy.js:51` runtime-capture assertion; the shared-cache spec passed. Full-repo formatting failed on 683 generated/existing files. Exact commands, environment recovery, and untested production boundaries are recorded in `tools/ssr-cache/VALIDATION.md`.

## Related Issue

No separate issue linked. Implements R0 of the agreed Modern/MF SSR cache RFC; R1–R6 remain open.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
