### PR TITLE
fix(runtime): preserve shared identity while invalidating host consumers

### DIFF
--- a/.changeset/clean-host-retain-shared.md
+++ b/.changeset/clean-host-retain-shared.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/runtime-core': patch
+'@module-federation/webpack-bundler-runtime': patch
+---
+
+Invalidate host remote consumers while preserving provider execution caches needed by in-use or loading shared modules. Preserve shared object identity and lazy dependencies across remote removal, including when the provider is no longer in the instance registry.

--- a/packages/runtime-core/__tests__/register-remotes.spec.ts
+++ b/packages/runtime-core/__tests__/register-remotes.spec.ts
@@ -212,7 +212,7 @@ describe('ModuleFederation', () => {
   });
 
   it('emits removeRemote hook before force registering an existing remote', () => {
-    const removeRemote = vi.fn();
+    const removeRemote = rs.fn();
     const FM = new ModuleFederation({
       name: '@federation/instance',
       version: '1.0.1',
@@ -249,7 +249,7 @@ describe('ModuleFederation', () => {
   });
 
   it('removes a registered remote by name and emits removeRemote hook', async () => {
-    const removeRemote = vi.fn();
+    const removeRemote = rs.fn();
     const FM = new ModuleFederation({
       name: '@federation/instance',
       version: '1.0.1',
@@ -294,8 +294,8 @@ describe('ModuleFederation', () => {
     const entry =
       'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
     const remoteEntryClear = rs.fn();
-    const libClear = vi.fn();
-    const globalClear = vi.fn();
+    const libClear = rs.fn();
+    const globalClear = rs.fn();
     const FM = new ModuleFederation({
       name: '@federation/instance',
       version: '1.0.1',
@@ -318,19 +318,19 @@ describe('ModuleFederation', () => {
         shareScope: 'default',
       },
       remoteEntryExports: {
-        get: vi.fn(),
-        init: vi.fn(),
+        get: rs.fn(),
+        init: rs.fn(),
         __webpack_clear_cache__: remoteEntryClear,
       },
       lib: {
-        get: vi.fn(),
-        init: vi.fn(),
+        get: rs.fn(),
+        init: rs.fn(),
         __webpack_clear_cache__: libClear,
       },
     } as any);
     (globalThis as any).app1 = {
       get: rs.fn(),
-      init: vi.fn(),
+      init: rs.fn(),
       __webpack_clear_cache__: globalClear,
     };
     Global.__FEDERATION__.moduleInfo = {
@@ -380,7 +380,12 @@ describe('ModuleFederation', () => {
     expect(FM.snapshotHandler.manifestCache.has(entry)).toBe(false);
   });
 
-  it('keeps a removed remote runtime while another remote uses its shared module', async () => {
+  it.each([
+    { registered: true, loading: false },
+    { registered: false, loading: false },
+    { registered: true, loading: true },
+    { registered: false, loading: true },
+  ])('keeps shared provider caches: %j', async ({ registered, loading }) => {
     const entry =
       'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
     const remoteEntryClear = rs.fn();
@@ -390,10 +395,15 @@ describe('ModuleFederation', () => {
       get: rs.fn(),
       shareConfig: { requiredVersion: false },
       scope: ['default'],
-      useIn: ['@register-remotes/app1', 'another-remote'],
+      useIn: loading
+        ? ['@register-remotes/app1']
+        : ['@register-remotes/app1', 'another-remote'],
       deps: [],
-      lib: () => ({ value: 'shared from app1' }),
-      loaded: true,
+      lib: loading ? undefined : () => ({ value: 'shared from app1' }),
+      loaded: !loading,
+      loading: loading
+        ? Promise.resolve(() => ({ value: 'shared from app1' }))
+        : undefined,
       strategy: 'version-first' as const,
     };
     const FM = new ModuleFederation({
@@ -428,11 +438,12 @@ describe('ModuleFederation', () => {
     (globalThis as any).app1 = {
       __webpack_clear_cache__: remoteEntryClear,
     };
-    Global.__FEDERATION__.__INSTANCES__.push({
-      name: '@register-remotes/app1',
-      options: { id: '@register-remotes/app1' },
-      shareScopeMap: {},
-    } as any);
+    if (registered)
+      Global.__FEDERATION__.__INSTANCES__.push({
+        name: '@register-remotes/app1',
+        options: { id: '@register-remotes/app1' },
+        shareScopeMap: {},
+      } as any);
     Global.__FEDERATION__.__SHARE__ = {
       '@register-remotes/app1': {
         default: {
@@ -452,7 +463,7 @@ describe('ModuleFederation', () => {
       expect((globalThis as any).app1).toBeDefined();
       expect(shared.from).toBe('@register-remotes/app1');
       expect(shared.providerState).toBe(1);
-      expect(shared.useIn).toEqual(['another-remote']);
+      expect(shared.useIn).toEqual(loading ? [] : ['another-remote']);
     } finally {
       Global.__FEDERATION__.__INSTANCES__.splice(
         0,
@@ -467,9 +478,9 @@ describe('ModuleFederation', () => {
   it('keeps loaded remote cleanup context when removeRemote hook clears moduleCache first', async () => {
     const entry =
       'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
-    const remoteEntryClear = vi.fn();
-    const libClear = vi.fn();
-    const globalClear = vi.fn();
+    const remoteEntryClear = rs.fn();
+    const libClear = rs.fn();
+    const globalClear = rs.fn();
     const FM = new ModuleFederation({
       name: '@federation/instance',
       version: '1.0.1',
@@ -500,19 +511,19 @@ describe('ModuleFederation', () => {
         shareScope: 'default',
       },
       remoteEntryExports: {
-        get: vi.fn(),
-        init: vi.fn(),
+        get: rs.fn(),
+        init: rs.fn(),
         __webpack_clear_cache__: remoteEntryClear,
       },
       lib: {
-        get: vi.fn(),
-        init: vi.fn(),
+        get: rs.fn(),
+        init: rs.fn(),
         __webpack_clear_cache__: libClear,
       },
     } as any);
     (globalThis as any).app1 = {
-      get: vi.fn(),
-      init: vi.fn(),
+      get: rs.fn(),
+      init: rs.fn(),
       __webpack_clear_cache__: globalClear,
     };
     Global.__FEDERATION__.moduleInfo = {

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -796,55 +796,51 @@ export class RemoteHandler {
                 return ins.name === remoteInsId;
               }
             });
-          if (remoteInsIndex !== -1) {
-            const remoteIns =
-              CurrentGlobal.__FEDERATION__.__INSTANCES__[remoteInsIndex];
+          const remoteIns =
+            remoteInsIndex !== -1
+              ? CurrentGlobal.__FEDERATION__.__INSTANCES__[remoteInsIndex]
+              : undefined;
+          if (remoteIns) {
             remoteInsId = remoteIns.options.id || remoteInsId;
-            const globalShareScopeMap = getGlobalShareScope();
+          }
+          // Shared factories can outlive removal from the instance registry.
+          // Scan their ownership even when this provider was removed before.
+          const globalShareScopeMap = getGlobalShareScope();
 
-            let isAllSharedNotUsed = true;
-            const needDeleteKeys: Array<[string, string, string, string]> = [];
-            Object.keys(globalShareScopeMap).forEach((instId) => {
-              const shareScopeMap = globalShareScopeMap[instId];
-              shareScopeMap &&
-                Object.keys(shareScopeMap).forEach((shareScope) => {
-                  const shareScopeVal = shareScopeMap[shareScope];
-                  shareScopeVal &&
-                    Object.keys(shareScopeVal).forEach((shareName) => {
-                      const sharedPkgs = shareScopeVal[shareName];
-                      sharedPkgs &&
-                        Object.keys(sharedPkgs).forEach((shareVersion) => {
-                          const shared = sharedPkgs[shareVersion];
+          let isAllSharedNotUsed = true;
+          const needDeleteKeys: Array<[string, string, string, string]> = [];
+          Object.keys(globalShareScopeMap).forEach((instId) => {
+            const shareScopeMap = globalShareScopeMap[instId];
+            shareScopeMap &&
+              Object.keys(shareScopeMap).forEach((shareScope) => {
+                const shareScopeVal = shareScopeMap[shareScope];
+                shareScopeVal &&
+                  Object.keys(shareScopeVal).forEach((shareName) => {
+                    const sharedPkgs = shareScopeVal[shareName];
+                    sharedPkgs &&
+                      Object.keys(sharedPkgs).forEach((shareVersion) => {
+                        const shared = sharedPkgs[shareVersion];
+                        if (
+                          shared &&
+                          typeof shared === 'object' &&
+                          shared.from === remoteInfo.name
+                        ) {
+                          const hasExternalConsumer = shared.useIn.some(
+                            (usedHostName) => usedHostName !== remoteInfo.name,
+                          );
                           if (
-                            shared &&
-                            typeof shared === 'object' &&
-                            shared.from === remoteInfo.name
+                            shared.loaded ||
+                            shared.loading ||
+                            hasExternalConsumer
                           ) {
-                            const hasExternalConsumer = shared.useIn.some(
+                            shared.useIn = shared.useIn.filter(
                               (usedHostName) =>
                                 usedHostName !== remoteInfo.name,
                             );
-                            if (
-                              shared.loaded ||
-                              shared.loading ||
-                              hasExternalConsumer
-                            ) {
-                              shared.useIn = shared.useIn.filter(
-                                (usedHostName) =>
-                                  usedHostName !== remoteInfo.name,
-                              );
-                              if (shared.useIn.length) {
-                                isAllSharedNotUsed = false;
-                                preserveRemoteRuntime = true;
-                                shared.providerState = 1;
-                              } else {
-                                needDeleteKeys.push([
-                                  instId,
-                                  shareScope,
-                                  shareName,
-                                  shareVersion,
-                                ]);
-                              }
+                            if (shared.useIn.length || shared.loading) {
+                              isAllSharedNotUsed = false;
+                              preserveRemoteRuntime = true;
+                              shared.providerState = 1;
                             } else {
                               needDeleteKeys.push([
                                 instId,
@@ -853,23 +849,32 @@ export class RemoteHandler {
                                 shareVersion,
                               ]);
                             }
+                          } else {
+                            needDeleteKeys.push([
+                              instId,
+                              shareScope,
+                              shareName,
+                              shareVersion,
+                            ]);
                           }
-                        });
-                    });
-                });
-            });
+                        }
+                      });
+                  });
+              });
+          });
 
-            if (isAllSharedNotUsed) {
-              remoteIns.shareScopeMap = {};
-              delete globalShareScopeMap[remoteInsId];
-            }
-            needDeleteKeys.forEach(
-              ([insId, shareScope, shareName, shareVersion]) => {
-                delete globalShareScopeMap[insId]?.[shareScope]?.[shareName]?.[
-                  shareVersion
-                ];
-              },
-            );
+          if (isAllSharedNotUsed && remoteIns) {
+            remoteIns.shareScopeMap = {};
+            delete globalShareScopeMap[remoteInsId];
+          }
+          needDeleteKeys.forEach(
+            ([insId, shareScope, shareName, shareVersion]) => {
+              delete globalShareScopeMap[insId]?.[shareScope]?.[shareName]?.[
+                shareVersion
+              ];
+            },
+          );
+          if (remoteInsIndex !== -1) {
             CurrentGlobal.__FEDERATION__.__INSTANCES__.splice(
               remoteInsIndex,
               1,
@@ -877,10 +882,9 @@ export class RemoteHandler {
           }
 
           if (preserveRemoteRuntime) {
-            // The shared record retains its loaded lib. The entry module cache
-            // should not keep unrelated exposed modules reachable.
-            clearRemoteEntryCache(loadedModule.remoteEntryExports);
-            clearRemoteEntryCache(loadedModule.lib);
+            // Keeping a shared factory without its execution cache can create a
+            // second singleton or break its later lazy dependencies. Until the
+            // provider supports safe selective cleanup, retain its runtime.
             host.moduleCache.delete(remote.name);
             return;
           }

--- a/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
+++ b/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
@@ -151,79 +151,105 @@ describe('clearCache', () => {
     expect((globalThis as any).remoteA).toBeUndefined();
   });
 
-  test('should retain a remote bundler runtime while another remote uses its shared module', async () => {
-    const { instance, webpackRequire } = createWebpackRequire();
-    const remoteEntryClear = jest.fn();
-    const previousFederation = (globalThis as any).__FEDERATION__;
-    const shared = {
-      from: 'remoteA',
-      loaded: true,
-      lib: () => ({ value: 'shared from remoteA' }),
-      useIn: ['remoteA', 'anotherRemote'],
-    };
+  test.each([false, true])(
+    'should invalidate host caches while preserving shared provider (loading: %s)',
+    async (loading) => {
+      const { instance, webpackRequire } = createWebpackRequire();
+      const remoteEntryClear = jest.fn();
+      const previousFederation = (globalThis as any).__FEDERATION__;
+      const shared = {
+        from: 'remoteA',
+        loaded: !loading,
+        loading: loading ? Promise.resolve() : undefined,
+        lib: loading ? undefined : () => ({ value: 'shared from remoteA' }),
+        useIn: ['remoteA', 'anotherRemote'],
+      };
 
-    instance.moduleCache.set('remoteA', {
-      remoteEntryExports: {
+      instance.moduleCache.set('remoteA', {
+        remoteEntryExports: {
+          __webpack_clear_cache__: remoteEntryClear,
+        },
+      });
+      (globalThis as any).remoteA = {
         __webpack_clear_cache__: remoteEntryClear,
-      },
-    });
-    (globalThis as any).remoteA = {
-      __webpack_clear_cache__: remoteEntryClear,
-    };
-    (globalThis as any).__FEDERATION__ = {
-      ...(previousFederation || {}),
-      __SHARE__: {
-        remoteA: {
-          default: {
-            'shared-from-remoteA': {
-              '1.0.0': shared,
+      };
+      (globalThis as any).__FEDERATION__ = {
+        ...(previousFederation || {}),
+        __SHARE__: {
+          remoteA: {
+            default: {
+              'shared-from-remoteA': {
+                '1.0.0': shared,
+              },
             },
           },
         },
-      },
-    };
-    webpackRequire.federation.bundlerRuntimeOptions.remotes.remoteInfos = {
-      remoteA: [
-        {
+      };
+      webpackRequire.federation.bundlerRuntimeOptions.remotes.remoteInfos = {
+        remoteA: [
+          {
+            name: 'remoteA',
+            entry: 'http://localhost:3001/remoteEntry.js',
+            entryGlobalName: 'remoteA',
+          },
+        ],
+      };
+      webpackRequire.remotesLoadingData = {
+        moduleIdToRemoteDataMapping: {
+          101: {
+            externalModuleId: 201,
+            remoteName: 'remoteA',
+          },
+        },
+        remoteKeyToRemoteModuleIds: {
+          remoteA: [101],
+        },
+        remoteKeyToExternalModuleIds: {
+          remoteA: [201],
+        },
+        remoteKeyToChunkIds: {
+          remoteA: [],
+        },
+      };
+
+      webpackRequire.remotesLoadingData.remoteModuleIdToConsumerModuleIds = {
+        101: [301],
+      };
+      webpackRequire.m[101] = () => null;
+      for (const id of [101, 201, 301, 302])
+        webpackRequire.c[id] = { exports: {} };
+      const previousWindow = globalThis.window;
+      const previousDocument = globalThis.document;
+      delete (globalThis as any).window;
+      delete (globalThis as any).document;
+      try {
+        await clearCache({
           name: 'remoteA',
-          entry: 'http://localhost:3001/remoteEntry.js',
-          entryGlobalName: 'remoteA',
-        },
-      ],
-    };
-    webpackRequire.remotesLoadingData = {
-      moduleIdToRemoteDataMapping: {
-        101: {
-          externalModuleId: 201,
-          remoteName: 'remoteA',
-        },
-      },
-      remoteKeyToRemoteModuleIds: {
-        remoteA: [101],
-      },
-      remoteKeyToExternalModuleIds: {
-        remoteA: [201],
-      },
-      remoteKeyToChunkIds: {
-        remoteA: [],
-      },
-    };
+          webpackRequire: webpackRequire as any,
+        });
 
-    try {
-      await clearCache({
-        name: 'remoteA',
-        webpackRequire: webpackRequire as any,
-      });
-
-      expect(remoteEntryClear).not.toHaveBeenCalled();
-      expect(instance.moduleCache.has('remoteA')).toBe(true);
-      expect((globalThis as any).remoteA).toBeDefined();
-      expect(shared.from).toBe('remoteA');
-    } finally {
-      (globalThis as any).__FEDERATION__ = previousFederation;
-      delete (globalThis as any).remoteA;
-    }
-  });
+        expect(remoteEntryClear).not.toHaveBeenCalled();
+        expect(instance.moduleCache.has('remoteA')).toBe(false);
+        expect(webpackRequire.m[101]).toBeUndefined();
+        expect(webpackRequire.c[101]).toBeUndefined();
+        expect(webpackRequire.c[201]).toBeUndefined();
+        expect(webpackRequire.c[301]).toBeUndefined();
+        expect(webpackRequire.c[302]).toBeDefined();
+        expect(
+          (globalThis as any).__FEDERATION__.__SHARE__.remoteA.default[
+            'shared-from-remoteA'
+          ]['1.0.0'],
+        ).toBe(shared);
+        expect((globalThis as any).remoteA).toBeDefined();
+        expect(shared.from).toBe('remoteA');
+      } finally {
+        (globalThis as any).__FEDERATION__ = previousFederation;
+        delete (globalThis as any).remoteA;
+        (globalThis as any).window = previousWindow;
+        (globalThis as any).document = previousDocument;
+      }
+    },
+  );
 
   test('should evict old caches before pending remote load settles', async () => {
     const { instance, webpackRequire } = createWebpackRequire();

--- a/packages/webpack-bundler-runtime/src/clearCache.ts
+++ b/packages/webpack-bundler-runtime/src/clearCache.ts
@@ -620,6 +620,7 @@ const invalidateRemoteEntryUrlGenerations = (
 const cleanupRemoteRuntimeCache = (
   webpackRequire: WebpackRequire,
   target: ClearCacheTarget,
+  preserveProvider = false,
 ) => {
   const instance = webpackRequire.federation.instance;
   if (!instance) {
@@ -629,13 +630,17 @@ const cleanupRemoteRuntimeCache = (
     const module = instance.moduleCache?.get(remoteName) as
       | Record<string, unknown>
       | undefined;
-    cleanupRemoteEntryInternalCache(module?.remoteEntryExports);
-    cleanupRemoteEntryInternalCache(module?.lib);
+    if (!preserveProvider) {
+      cleanupRemoteEntryInternalCache(module?.remoteEntryExports);
+      cleanupRemoteEntryInternalCache(module?.lib);
+    }
     instance.moduleCache?.delete(remoteName);
   }
-  for (const remoteInfo of target.remoteInfos) {
-    for (const globalKey of getRemoteEntryGlobalKeys(remoteInfo)) {
-      cleanupRemoteEntryInternalCache((globalThis as any)[globalKey]);
+  if (!preserveProvider) {
+    for (const remoteInfo of target.remoteInfos) {
+      for (const globalKey of getRemoteEntryGlobalKeys(remoteInfo)) {
+        cleanupRemoteEntryInternalCache((globalThis as any)[globalKey]);
+      }
     }
   }
   const idToRemoteMap = instance.remoteHandler?.idToRemoteMap;
@@ -648,6 +653,11 @@ const cleanupRemoteRuntimeCache = (
         delete idToRemoteMap[id];
       }
     }
+  }
+  // Shared factories (including later lazy dependencies) still close over the
+  // provider runtime. Host caches must be cleared independently of that lifetime.
+  if (preserveProvider) {
+    return;
   }
   const federationInstances = (globalThis as any).__FEDERATION__?.__INSTANCES__;
   if (Array.isArray(federationInstances)) {
@@ -697,7 +707,11 @@ const cleanupSharedCache = (
           ) {
             continue;
           }
-          if (shared.loaded || typeof shared.lib === 'function') {
+          if (
+            shared.loaded ||
+            shared.loading ||
+            typeof shared.lib === 'function'
+          ) {
             continue;
           }
           delete versions[shareVersion];
@@ -731,6 +745,9 @@ const hasActiveSharedConsumers = (target: ClearCacheTarget) => {
             !target.remoteNames.includes((shared as any).from)
           ) {
             continue;
+          }
+          if ((shared as any).loading) {
+            return true;
           }
           if (
             Array.isArray((shared as any).useIn) &&
@@ -892,9 +909,7 @@ const cleanupStaleRemoteCache = (
   target: ClearCacheTarget,
   consumerModuleIds: ModuleId[],
 ) => {
-  if (hasActiveSharedConsumers(target)) {
-    return;
-  }
+  const preserveProvider = hasActiveSharedConsumers(target);
   const idToExternalAndNameMapping =
     webpackRequire.federation.bundlerRuntimeOptions.remotes
       ?.idToExternalAndNameMapping ?? {};
@@ -918,8 +933,10 @@ const cleanupStaleRemoteCache = (
   deleteModuleCache(webpackRequire, target.remoteModuleIds);
   deleteModuleCache(webpackRequire, target.externalModuleIds);
   deleteModuleCache(webpackRequire, consumerModuleIds);
-  cleanupRemoteEntryCache(webpackRequire, target);
-  cleanupRemoteRuntimeCache(webpackRequire, target);
+  if (!preserveProvider) {
+    cleanupRemoteEntryCache(webpackRequire, target);
+  }
+  cleanupRemoteRuntimeCache(webpackRequire, target, preserveProvider);
 };
 
 export const runStaleRemoteCleanups = (

--- a/tools/ssr-cache/README.md
+++ b/tools/ssr-cache/README.md
@@ -36,21 +36,21 @@ A successful baseline run with TODOs is **not** production acceptance. When fixi
 a defect, remove its TODO and keep its desired-behavior assertion. These tests are
 an explicit development command; this change does not alter the CI workflows.
 
-| Case                 | What is exercised                                   | Current expectation                                                 |
-| -------------------- | --------------------------------------------------- | ------------------------------------------------------------------- |
-| plain                | Static multi-level consumers across emitted chunks  | Reacquired page remains stale: TODO                                 |
-| concat               | Same graph with module concatenation                | Page updates; saved function remains old                            |
-| parents              | Diagnostic JS plugin supplies missing parent edges  | Page updates; unrelated module executes once                        |
-| shared               | Real provider singleton consumed by host            | Host invalidation and shared strict identity: TODO                  |
-| all non-shared cases | Drop application CJS cache, then update again       | Dynamic reference refreshes; old adapter still called: TODO         |
-| Modern (opt-in)      | Real production resource plugin and one HTTP server | Recreate resource state to publish new manifest; PID/port unchanged |
+| Case                 | What is exercised                                   | Current expectation                                                                                      |
+| -------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| plain                | Static multi-level consumers across emitted chunks  | Reacquired page remains stale: TODO                                                                      |
+| concat               | Same graph with module concatenation                | Page updates; saved function remains old                                                                 |
+| parents              | Diagnostic JS plugin supplies missing parent edges  | Page updates; unrelated module executes once                                                             |
+| shared               | Real provider singleton consumed by host            | Host invalidation, shared strict identity and retained lazy dependency pass; parent closure remains TODO |
+| all non-shared cases | Drop application CJS cache, then update again       | Dynamic reference refreshes; old adapter still called: TODO                                              |
+| Modern (opt-in)      | Real production resource plugin and one HTTP server | Recreate resource state to publish new manifest; PID/port unchanged                                      |
 
 The `parents` plugin and manual page invalidation/hook rebinding in the fixture
 are diagnostic interventions, not the proposed production implementation. The
 fixture temporarily uses remove + register to exercise existing code; this does
 not specify atomic update semantics. No test here proves complete React streaming,
 HTTP remote transport, hydration compatibility, native ESM unloading, cyclic or
-multi-entry graph completeness, shared lazy dependency retention, or stable heap
+multi-entry graph completeness, general shared lazy dependency coverage, or stable heap
 usage. Those remain R1–R6 work.
 
 ## Cross-layer ownership
@@ -163,7 +163,12 @@ Thresholds are configurable and selected from R6 load measurements.
 
 ## Remaining stage gates
 
-R0 chooses the ownership and externally observable contracts above. R1 must prove
+R0 chooses the ownership and externally observable contracts above. The first R1
+fix separates host invalidation from provider cache retention, and covers shared
+identity plus a retained lazy dependency in real artifacts. It conservatively
+retains the provider execution cache while shared remains in use or loading; it
+does not claim selective provider GC. Parent closure and adapter disposal remain
+open. R1 must prove
 shared dependency retention and adapter disposal; R2 must prove stream termination;
 R3/R4 must implement Modern resource ownership and safe publication. None is marked
 implemented by this document. Arbitrary globals, unregistered tasks, native ESM

--- a/tools/ssr-cache/VALIDATION.md
+++ b/tools/ssr-cache/VALIDATION.md
@@ -57,3 +57,52 @@ covered by R0. They remain the explicit R1–R6 acceptance tasks. Other CI jobs 
 not run because this change adds a focused SSR baseline and contracts, not runtime
 behavior. No changeset or package publication is needed for these tooling/docs-only
 changes. The baseline is a documented explicit command, not yet a CI gate.
+
+## R1 shared-lifetime increment — 2026-09-10
+
+Base: merged R0 `bf33cf00f`. This increment fixes host/provider cleanup separation
+and shared identity; **R1 is not complete**. It does not change Rspack or implement
+adapter disposal. Provider-wide retention is a safe fallback, not selective GC.
+
+Commands executed:
+
+```sh
+pnpm exec turbo run build --filter=@module-federation/runtime-tools
+pnpm --filter @module-federation/webpack-bundler-runtime run test
+pnpm --filter @module-federation/runtime-core exec rstest run
+node --test tools/ssr-cache/baseline.test.cjs
+SSR_CACHE_RSPACK_ENTRY=/Users/bytedance/outter/rspack/packages/rspack/dist/index.js SSR_CACHE_MODERN_ENTRY=/Users/bytedance/work/modern.js/packages/server/core/dist/cjs/adapters/node/index.js node --test tools/ssr-cache/baseline.test.cjs
+pnpm run ci:local --only=e2e-modern-ssr
+pnpm exec prettier --check packages/runtime-core/src/remote/index.ts packages/runtime-core/__tests__/register-remotes.spec.ts packages/webpack-bundler-runtime/src/clearCache.ts packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts tools/ssr-cache .changeset/clean-host-retain-shared.md
+pnpm exec prettier --check .
+python3 .codex/skills/changeset-pr/scripts/run_changeset_status.py --output /tmp/mf-ssr-r1-changeset-status.json
+git diff --check
+```
+
+- Builds: 6/6 tasks pass. Bundler package: 109/109 tests pass. Runtime-core:
+  134/134 pass, including absent provider registration and pending shared loads.
+  Initial sandbox Rstest invocation could not listen; rerun with listener permission
+  passed after replacing existing undefined `vi.fn` usages with imported `rs.fn`
+  in the touched remote-registration tests. No snapshots were updated.
+- Installed-canary artifacts: 7 pass / 5 TODO / 1 explicit Modern skip. Local
+  Rspack + Modern: 8 pass / 5 TODO / 0 skip. Two previous shared TODOs now pass;
+  a new retained lazy-dependency identity assertion passes. The remaining TODOs
+  cover transitive parent metadata and stale adapter binding.
+- Modern SSR CI: remote-cache spec passes in this run, but shared-cache spec
+  **fails at line 40**: `nonSharedPayloadCollected` is false. Retaining provider
+  execution caches protects shared identity but also retains its unrelated
+  payload. The failing memory assertion is deliberately unchanged. Selective
+  provider cleanup is needed before declaring the production memory requirement
+  complete. R0's runtime-capture failure did not reproduce in this run; this
+  change does not claim to fix its cause.
+- Changed-file formatting and diff checks pass. Full-repo formatting still reports
+  683 existing/generated files, outside this patch.
+- Changeset status succeeds; the patch release entries are only runtime-core and
+  webpack-bundler-runtime. The repository fixed release group may expand the plan.
+  The scope helper requires Python 3.10+ annotations; on this machine it was run
+  with postponed annotations under Python 3.9, without modifying the helper.
+
+General shared lazy dependency graph coverage, selective provider reclamation,
+parent closure, adapter lifecycle and Modern production stream/serve/GC acceptance
+remain open. Other CI jobs were not run: the affected packages' complete tests and
+Modern SSR integration were selected. No publication was performed.

--- a/tools/ssr-cache/baseline.test.cjs
+++ b/tools/ssr-cache/baseline.test.cjs
@@ -92,15 +92,18 @@ for (const [variant, flags] of Object.entries({
         }
       }
       if (variant === 'shared') {
-        await knownFailure(
-          t,
-          'shared retention does not skip host invalidation',
-          () => assert.equal(result.static.withPageInvalidated, 'v2'),
+        await t.test('shared retention does not skip host invalidation', () =>
+          assert.equal(result.static.withPageInvalidated, 'v2'),
         );
-        await knownFailure(
-          t,
-          'consumed shared export retains strict identity',
-          () => assert.equal(result.shared.sameObject, true),
+        await t.test('consumed shared export retains strict identity', () =>
+          assert.equal(result.shared.sameObject, true),
+        );
+        await t.test(
+          'retained shared lazy dependency keeps identity after removal',
+          () => {
+            assert.equal(result.shared.lazySameObject, true);
+            assert.equal(result.shared.lazyValue, 'lazy-singleton');
+          },
         );
       } else {
         assert.equal(result.dynamic.savedHandler, 'v1');

--- a/tools/ssr-cache/fixture.cjs
+++ b/tools/ssr-cache/fixture.cjs
@@ -21,7 +21,11 @@ async function main() {
   write('v1.js', 'export default "v1";');
   write('v2.js', 'export default "v2";');
   if (process.env.SHARED === '1') {
-    write('shared.js', 'export default {identity:"shared-singleton"};');
+    write(
+      'shared.js',
+      'export default {identity:"shared-singleton",lazy:()=>import("./shared-lazy").then(m=>m.default)};',
+    );
+    write('shared-lazy.js', 'export default {identity:"lazy-singleton"};');
     for (const v of ['v1', 'v2'])
       write(
         v + '.js',
@@ -215,9 +219,11 @@ async function main() {
   assert.equal(beforePage(), 'v1');
   assert.equal(other(), 'unrelated');
   let sharedBefore;
+  let lazyBefore;
   if (host.share) {
     sharedBefore = (await host.share()).default;
     assert.equal((await host.share()).default, sharedBefore);
+    lazyBefore = await sharedBefore.lazy();
   }
   const mapping = JSON.parse(JSON.stringify(host.req.remotesLoadingData));
   const instance = host.req.federation.instance;
@@ -255,6 +261,8 @@ async function main() {
     const sharedAfter = (await host.share()).default;
     result.shared = {
       sameObject: sharedAfter === sharedBefore,
+      lazySameObject: (await sharedBefore.lazy()) === lazyBefore,
+      lazyValue: (await sharedAfter.lazy()).identity,
       before: sharedBefore,
       after: sharedAfter,
       records: Object.values(globalThis.__FEDERATION__.__SHARE__)


### PR DESCRIPTION
## Description

Remote removal previously either skipped host invalidation when a provider supplied shared modules, or cleared the provider execution cache and recreated its singleton. This patch invalidates host remote/consumer caches independently while retaining provider caches needed by external shared consumers or pending shared loads. Runtime-core now checks shared ownership even after the provider leaves the instance registry.

Tests cover host eviction, loaded/loading shares, absent provider registration, and strict shared/lazy dependency identity in real Rspack artifacts. Existing undefined `vi.fn` usages in the touched runtime-core tests were corrected to imported `rs.fn`. Adds patch changesets for runtime-core and webpack-bundler-runtime.

**Draft: R1 remains incomplete.** Conservative provider retention prevents collection of unrelated provider payload. Modern SSR CI fails `remove-remote-shared-cache.cy.js:40` (`nonSharedPayloadCollected` is false); this assertion is unchanged. Selective provider cleanup is required before the production memory requirement can pass. Parent metadata and adapter disposal are also still open.

Validation: builds passed; runtime-core 134/134 and bundler-runtime 109/109 tests passed. Local Rspack + Modern artifacts: 8 pass / 5 TODO; installed canary: 7 pass / 5 TODO / 1 explicit Modern skip. Two shared TODOs are now passing regressions. Modern remote-cache E2E passed in this run, shared-cache E2E failed as above. Changed files pass formatting; full-repo format still reports 683 existing/generated files. Changeset scope/status passed. Exact commands and skipped coverage are recorded in tools/ssr-cache/VALIDATION.md. No claim of production readiness or full provider GC.

## Related Issue

Continues the R0 baseline merged in #5048. No separate issue linked.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
