### PR TITLE
fix(runtime): selectively clear providers while retaining shared dependencies

### DIFF
--- a/.changeset/selective-provider-cache.md
+++ b/.changeset/selective-provider-cache.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/runtime-core': patch
+'@module-federation/webpack-bundler-runtime': patch
+---
+
+Use a provider's selective cache cleanup capability when preserving active shared dependencies, allowing unrelated exposed exports to be released. Providers without this capability retain their execution cache for compatibility.

--- a/.changeset/selective-provider-cache.md
+++ b/.changeset/selective-provider-cache.md
@@ -3,4 +3,4 @@
 '@module-federation/webpack-bundler-runtime': patch
 ---
 
-Use a provider's selective cache cleanup capability when preserving active shared dependencies, allowing unrelated exposed exports to be released. Providers without this capability retain their execution cache for compatibility.
+Require a provider's selective cache cleanup capability when preserving active shared dependencies, allowing unrelated exposed exports to be released. The provider must be built with the matching Rspack cache implementation.

--- a/packages/runtime-core/__tests__/register-remotes.spec.ts
+++ b/packages/runtime-core/__tests__/register-remotes.spec.ts
@@ -380,113 +380,104 @@ describe('ModuleFederation', () => {
     expect(FM.snapshotHandler.manifestCache.has(entry)).toBe(false);
   });
 
-  it.each(
-    [
-      { registered: true, loading: false },
-      { registered: false, loading: false },
-      { registered: true, loading: true },
-      { registered: false, loading: true },
-    ].flatMap((value) =>
-      [false, true].map((selective) => ({ ...value, selective })),
-    ),
-  )(
-    'keeps shared provider caches: %j',
-    async ({ registered, loading, selective }) => {
-      const entry =
-        'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
-      const remoteEntryClear = rs.fn();
-      const selectiveClear = rs.fn();
-      const shared: any = {
-        version: '1.0.0',
-        from: '@register-remotes/app1',
-        get: rs.fn(),
-        shareConfig: { requiredVersion: false },
-        scope: ['default'],
-        useIn: loading
-          ? ['@register-remotes/app1']
-          : ['@register-remotes/app1', 'another-remote'],
-        deps: [],
-        lib: loading ? undefined : () => ({ value: 'shared from app1' }),
-        loaded: !loading,
-        loading: loading
-          ? Promise.resolve(() => ({ value: 'shared from app1' }))
-          : undefined,
-        strategy: 'version-first' as const,
-      };
-      const FM = new ModuleFederation({
-        name: '@federation/instance',
-        version: '1.0.1',
-        remotes: [
-          {
-            name: '@register-remotes/app1',
-            alias: 'app1',
-            entry,
-          },
-        ],
-      });
-      const previousInstances = [...Global.__FEDERATION__.__INSTANCES__];
-      const previousShareScope = Global.__FEDERATION__.__SHARE__;
-
-      FM.moduleCache.set('@register-remotes/app1', {
-        remoteInfo: {
+  it.each([
+    { registered: true, loading: false },
+    { registered: false, loading: false },
+    { registered: true, loading: true },
+    { registered: false, loading: true },
+  ])('keeps shared provider caches: %j', async ({ registered, loading }) => {
+    const entry =
+      'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
+    const remoteEntryClear = rs.fn();
+    const selectiveClear = rs.fn();
+    const shared: any = {
+      version: '1.0.0',
+      from: '@register-remotes/app1',
+      get: rs.fn(),
+      shareConfig: { requiredVersion: false },
+      scope: ['default'],
+      useIn: loading
+        ? ['@register-remotes/app1']
+        : ['@register-remotes/app1', 'another-remote'],
+      deps: [],
+      lib: loading ? undefined : () => ({ value: 'shared from app1' }),
+      loaded: !loading,
+      loading: loading
+        ? Promise.resolve(() => ({ value: 'shared from app1' }))
+        : undefined,
+      strategy: 'version-first' as const,
+    };
+    const FM = new ModuleFederation({
+      name: '@federation/instance',
+      version: '1.0.1',
+      remotes: [
+        {
           name: '@register-remotes/app1',
           alias: 'app1',
           entry,
-          type: 'global',
-          entryGlobalName: 'app1',
-          shareScope: 'default',
         },
-        remoteEntryExports: {
-          get: rs.fn(),
-          init: rs.fn(),
-          __webpack_clear_cache__: remoteEntryClear,
-          __webpack_clear_exposed_cache__: selective
-            ? selectiveClear
-            : undefined,
-        },
-      } as any);
-      (globalThis as any).app1 = {
+      ],
+    });
+    const previousInstances = [...Global.__FEDERATION__.__INSTANCES__];
+    const previousShareScope = Global.__FEDERATION__.__SHARE__;
+
+    FM.moduleCache.set('@register-remotes/app1', {
+      remoteInfo: {
+        name: '@register-remotes/app1',
+        alias: 'app1',
+        entry,
+        type: 'global',
+        entryGlobalName: 'app1',
+        shareScope: 'default',
+      },
+      remoteEntryExports: {
+        get: rs.fn(),
+        init: rs.fn(),
         __webpack_clear_cache__: remoteEntryClear,
-        __webpack_clear_exposed_cache__: selective ? selectiveClear : undefined,
-      };
-      if (registered)
-        Global.__FEDERATION__.__INSTANCES__.push({
-          name: '@register-remotes/app1',
-          options: { id: '@register-remotes/app1' },
-          shareScopeMap: {},
-        } as any);
-      Global.__FEDERATION__.__SHARE__ = {
-        '@register-remotes/app1': {
-          default: {
-            'shared-from-app1': {
-              '1.0.0': shared,
-            },
+        __webpack_clear_exposed_cache__: selectiveClear,
+      },
+    } as any);
+    (globalThis as any).app1 = {
+      __webpack_clear_cache__: remoteEntryClear,
+      __webpack_clear_exposed_cache__: selectiveClear,
+    };
+    if (registered)
+      Global.__FEDERATION__.__INSTANCES__.push({
+        name: '@register-remotes/app1',
+        options: { id: '@register-remotes/app1' },
+        shareScopeMap: {},
+      } as any);
+    Global.__FEDERATION__.__SHARE__ = {
+      '@register-remotes/app1': {
+        default: {
+          'shared-from-app1': {
+            '1.0.0': shared,
           },
         },
-      };
+      },
+    };
 
-      try {
-        await FM.removeRemote('app1');
+    try {
+      await FM.removeRemote('app1');
 
-        expect(FM.options.remotes).toHaveLength(0);
-        expect(remoteEntryClear).not.toHaveBeenCalled();
-        expect(selectiveClear).toHaveBeenCalledTimes(selective ? 2 : 0);
-        expect(FM.moduleCache.has('@register-remotes/app1')).toBe(false);
-        expect((globalThis as any).app1).toBeDefined();
-        expect(shared.from).toBe('@register-remotes/app1');
-        expect(shared.providerState).toBe(1);
-        expect(shared.useIn).toEqual(loading ? [] : ['another-remote']);
-      } finally {
-        Global.__FEDERATION__.__INSTANCES__.splice(
-          0,
-          Global.__FEDERATION__.__INSTANCES__.length,
-          ...previousInstances,
-        );
-        Global.__FEDERATION__.__SHARE__ = previousShareScope;
-        delete (globalThis as any).app1;
-      }
-    },
-  );
+      expect(FM.options.remotes).toHaveLength(0);
+      expect(remoteEntryClear).not.toHaveBeenCalled();
+      expect(selectiveClear).toHaveBeenCalledTimes(2);
+      expect(FM.moduleCache.has('@register-remotes/app1')).toBe(false);
+      expect((globalThis as any).app1).toBeDefined();
+      expect(shared.from).toBe('@register-remotes/app1');
+      expect(shared.providerState).toBe(1);
+      expect(shared.useIn).toEqual(loading ? [] : ['another-remote']);
+    } finally {
+      Global.__FEDERATION__.__INSTANCES__.splice(
+        0,
+        Global.__FEDERATION__.__INSTANCES__.length,
+        ...previousInstances,
+      );
+      Global.__FEDERATION__.__SHARE__ = previousShareScope;
+      delete (globalThis as any).app1;
+    }
+  });
 
   it('keeps loaded remote cleanup context when removeRemote hook clears moduleCache first', async () => {
     const entry =

--- a/packages/runtime-core/__tests__/register-remotes.spec.ts
+++ b/packages/runtime-core/__tests__/register-remotes.spec.ts
@@ -380,100 +380,113 @@ describe('ModuleFederation', () => {
     expect(FM.snapshotHandler.manifestCache.has(entry)).toBe(false);
   });
 
-  it.each([
-    { registered: true, loading: false },
-    { registered: false, loading: false },
-    { registered: true, loading: true },
-    { registered: false, loading: true },
-  ])('keeps shared provider caches: %j', async ({ registered, loading }) => {
-    const entry =
-      'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
-    const remoteEntryClear = rs.fn();
-    const shared: any = {
-      version: '1.0.0',
-      from: '@register-remotes/app1',
-      get: rs.fn(),
-      shareConfig: { requiredVersion: false },
-      scope: ['default'],
-      useIn: loading
-        ? ['@register-remotes/app1']
-        : ['@register-remotes/app1', 'another-remote'],
-      deps: [],
-      lib: loading ? undefined : () => ({ value: 'shared from app1' }),
-      loaded: !loading,
-      loading: loading
-        ? Promise.resolve(() => ({ value: 'shared from app1' }))
-        : undefined,
-      strategy: 'version-first' as const,
-    };
-    const FM = new ModuleFederation({
-      name: '@federation/instance',
-      version: '1.0.1',
-      remotes: [
-        {
+  it.each(
+    [
+      { registered: true, loading: false },
+      { registered: false, loading: false },
+      { registered: true, loading: true },
+      { registered: false, loading: true },
+    ].flatMap((value) =>
+      [false, true].map((selective) => ({ ...value, selective })),
+    ),
+  )(
+    'keeps shared provider caches: %j',
+    async ({ registered, loading, selective }) => {
+      const entry =
+        'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
+      const remoteEntryClear = rs.fn();
+      const selectiveClear = rs.fn();
+      const shared: any = {
+        version: '1.0.0',
+        from: '@register-remotes/app1',
+        get: rs.fn(),
+        shareConfig: { requiredVersion: false },
+        scope: ['default'],
+        useIn: loading
+          ? ['@register-remotes/app1']
+          : ['@register-remotes/app1', 'another-remote'],
+        deps: [],
+        lib: loading ? undefined : () => ({ value: 'shared from app1' }),
+        loaded: !loading,
+        loading: loading
+          ? Promise.resolve(() => ({ value: 'shared from app1' }))
+          : undefined,
+        strategy: 'version-first' as const,
+      };
+      const FM = new ModuleFederation({
+        name: '@federation/instance',
+        version: '1.0.1',
+        remotes: [
+          {
+            name: '@register-remotes/app1',
+            alias: 'app1',
+            entry,
+          },
+        ],
+      });
+      const previousInstances = [...Global.__FEDERATION__.__INSTANCES__];
+      const previousShareScope = Global.__FEDERATION__.__SHARE__;
+
+      FM.moduleCache.set('@register-remotes/app1', {
+        remoteInfo: {
           name: '@register-remotes/app1',
           alias: 'app1',
           entry,
+          type: 'global',
+          entryGlobalName: 'app1',
+          shareScope: 'default',
         },
-      ],
-    });
-    const previousInstances = [...Global.__FEDERATION__.__INSTANCES__];
-    const previousShareScope = Global.__FEDERATION__.__SHARE__;
-
-    FM.moduleCache.set('@register-remotes/app1', {
-      remoteInfo: {
-        name: '@register-remotes/app1',
-        alias: 'app1',
-        entry,
-        type: 'global',
-        entryGlobalName: 'app1',
-        shareScope: 'default',
-      },
-      remoteEntryExports: {
-        get: rs.fn(),
-        init: rs.fn(),
-        __webpack_clear_cache__: remoteEntryClear,
-      },
-    } as any);
-    (globalThis as any).app1 = {
-      __webpack_clear_cache__: remoteEntryClear,
-    };
-    if (registered)
-      Global.__FEDERATION__.__INSTANCES__.push({
-        name: '@register-remotes/app1',
-        options: { id: '@register-remotes/app1' },
-        shareScopeMap: {},
+        remoteEntryExports: {
+          get: rs.fn(),
+          init: rs.fn(),
+          __webpack_clear_cache__: remoteEntryClear,
+          __webpack_clear_exposed_cache__: selective
+            ? selectiveClear
+            : undefined,
+        },
       } as any);
-    Global.__FEDERATION__.__SHARE__ = {
-      '@register-remotes/app1': {
-        default: {
-          'shared-from-app1': {
-            '1.0.0': shared,
+      (globalThis as any).app1 = {
+        __webpack_clear_cache__: remoteEntryClear,
+        __webpack_clear_exposed_cache__: selective ? selectiveClear : undefined,
+      };
+      if (registered)
+        Global.__FEDERATION__.__INSTANCES__.push({
+          name: '@register-remotes/app1',
+          options: { id: '@register-remotes/app1' },
+          shareScopeMap: {},
+        } as any);
+      Global.__FEDERATION__.__SHARE__ = {
+        '@register-remotes/app1': {
+          default: {
+            'shared-from-app1': {
+              '1.0.0': shared,
+            },
           },
         },
-      },
-    };
+      };
 
-    try {
-      await FM.removeRemote('app1');
+      try {
+        await FM.removeRemote('app1');
 
-      expect(FM.options.remotes).toHaveLength(0);
-      expect(remoteEntryClear).not.toHaveBeenCalled();
-      expect(FM.moduleCache.has('@register-remotes/app1')).toBe(false);
-      expect((globalThis as any).app1).toBeDefined();
-      expect(shared.from).toBe('@register-remotes/app1');
-      expect(shared.providerState).toBe(1);
-      expect(shared.useIn).toEqual(loading ? [] : ['another-remote']);
-    } finally {
-      Global.__FEDERATION__.__INSTANCES__.splice(
-        0,
-        Global.__FEDERATION__.__INSTANCES__.length,
-        ...previousInstances,
-      );
-      Global.__FEDERATION__.__SHARE__ = previousShareScope;
-      delete (globalThis as any).app1;
-    }
-  });
+        expect(FM.options.remotes).toHaveLength(0);
+        expect(remoteEntryClear).not.toHaveBeenCalled();
+        expect(selectiveClear).toHaveBeenCalledTimes(selective ? 2 : 0);
+        expect(FM.moduleCache.has('@register-remotes/app1')).toBe(false);
+        expect((globalThis as any).app1).toBeDefined();
+        expect(shared.from).toBe('@register-remotes/app1');
+        expect(shared.providerState).toBe(1);
+        expect(shared.useIn).toEqual(loading ? [] : ['another-remote']);
+      } finally {
+        Global.__FEDERATION__.__INSTANCES__.splice(
+          0,
+          Global.__FEDERATION__.__INSTANCES__.length,
+          ...previousInstances,
+        );
+        Global.__FEDERATION__.__SHARE__ = previousShareScope;
+        delete (globalThis as any).app1;
+      }
+    },
+  );
 
   it('keeps loaded remote cleanup context when removeRemote hook clears moduleCache first', async () => {
     const entry =

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -885,6 +885,11 @@ export class RemoteHandler {
             // Keeping a shared factory without its execution cache can create a
             // second singleton or break its later lazy dependencies. Until the
             // provider supports safe selective cleanup, retain its runtime.
+            loadedModule.remoteEntryExports?.__webpack_clear_exposed_cache__?.();
+            loadedModule.lib?.__webpack_clear_exposed_cache__?.();
+            (
+              CurrentGlobal[key] as RemoteEntryExports | undefined
+            )?.__webpack_clear_exposed_cache__?.();
             host.moduleCache.delete(remote.name);
             return;
           }

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -883,13 +883,12 @@ export class RemoteHandler {
 
           if (preserveRemoteRuntime) {
             // Keeping a shared factory without its execution cache can create a
-            // second singleton or break its later lazy dependencies. Until the
-            // provider supports safe selective cleanup, retain its runtime.
-            loadedModule.remoteEntryExports?.__webpack_clear_exposed_cache__?.();
-            loadedModule.lib?.__webpack_clear_exposed_cache__?.();
-            (
-              CurrentGlobal[key] as RemoteEntryExports | undefined
-            )?.__webpack_clear_exposed_cache__?.();
+            // second singleton or break its later lazy dependencies. Retain
+            // the shared closure and clear unrelated execution caches.
+            loadedModule.remoteEntryExports?.__webpack_clear_exposed_cache__!();
+            loadedModule.lib?.__webpack_clear_exposed_cache__!();
+            (CurrentGlobal[key] as RemoteEntryExports | undefined)
+              ?.__webpack_clear_exposed_cache__!();
             host.moduleCache.delete(remote.name);
             return;
           }

--- a/packages/runtime-core/src/type/config.ts
+++ b/packages/runtime-core/src/type/config.ts
@@ -176,6 +176,6 @@ export type RemoteEntryExports = {
     remoteEntryInitOPtions?: RemoteEntryInitOptions,
   ) => void | Promise<void>;
   __webpack_clear_cache__?: () => void;
-  /** Clear unshared execution caches while preserving shared dependency closures. */
+  /** Required for shared-preserving cleanup; clears caches outside shared dependency closures. */
   __webpack_clear_exposed_cache__?: () => void;
 };

--- a/packages/runtime-core/src/type/config.ts
+++ b/packages/runtime-core/src/type/config.ts
@@ -176,4 +176,6 @@ export type RemoteEntryExports = {
     remoteEntryInitOPtions?: RemoteEntryInitOptions,
   ) => void | Promise<void>;
   __webpack_clear_cache__?: () => void;
+  /** Clear unshared execution caches while preserving shared dependency closures. */
+  __webpack_clear_exposed_cache__?: () => void;
 };

--- a/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
+++ b/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
@@ -151,11 +151,17 @@ describe('clearCache', () => {
     expect((globalThis as any).remoteA).toBeUndefined();
   });
 
-  test.each([false, true])(
-    'should invalidate host caches while preserving shared provider (loading: %s)',
-    async (loading) => {
+  test.each([
+    { loading: false, selective: false },
+    { loading: true, selective: false },
+    { loading: false, selective: true },
+    { loading: true, selective: true },
+  ])(
+    'should invalidate host caches while preserving shared provider: %j',
+    async ({ loading, selective }) => {
       const { instance, webpackRequire } = createWebpackRequire();
       const remoteEntryClear = jest.fn();
+      const selectiveClear = jest.fn();
       const previousFederation = (globalThis as any).__FEDERATION__;
       const shared = {
         from: 'remoteA',
@@ -168,10 +174,14 @@ describe('clearCache', () => {
       instance.moduleCache.set('remoteA', {
         remoteEntryExports: {
           __webpack_clear_cache__: remoteEntryClear,
+          __webpack_clear_exposed_cache__: selective
+            ? selectiveClear
+            : undefined,
         },
       });
       (globalThis as any).remoteA = {
         __webpack_clear_cache__: remoteEntryClear,
+        __webpack_clear_exposed_cache__: selective ? selectiveClear : undefined,
       };
       (globalThis as any).__FEDERATION__ = {
         ...(previousFederation || {}),
@@ -229,6 +239,7 @@ describe('clearCache', () => {
         });
 
         expect(remoteEntryClear).not.toHaveBeenCalled();
+        expect(selectiveClear.mock.calls.length > 0).toBe(selective);
         expect(instance.moduleCache.has('remoteA')).toBe(false);
         expect(webpackRequire.m[101]).toBeUndefined();
         expect(webpackRequire.c[101]).toBeUndefined();

--- a/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
+++ b/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
@@ -151,14 +151,9 @@ describe('clearCache', () => {
     expect((globalThis as any).remoteA).toBeUndefined();
   });
 
-  test.each([
-    { loading: false, selective: false },
-    { loading: true, selective: false },
-    { loading: false, selective: true },
-    { loading: true, selective: true },
-  ])(
+  test.each([{ loading: false }, { loading: true }])(
     'should invalidate host caches while preserving shared provider: %j',
-    async ({ loading, selective }) => {
+    async ({ loading }) => {
       const { instance, webpackRequire } = createWebpackRequire();
       const remoteEntryClear = jest.fn();
       const selectiveClear = jest.fn();
@@ -174,14 +169,12 @@ describe('clearCache', () => {
       instance.moduleCache.set('remoteA', {
         remoteEntryExports: {
           __webpack_clear_cache__: remoteEntryClear,
-          __webpack_clear_exposed_cache__: selective
-            ? selectiveClear
-            : undefined,
+          __webpack_clear_exposed_cache__: selectiveClear,
         },
       });
       (globalThis as any).remoteA = {
         __webpack_clear_cache__: remoteEntryClear,
-        __webpack_clear_exposed_cache__: selective ? selectiveClear : undefined,
+        __webpack_clear_exposed_cache__: selectiveClear,
       };
       (globalThis as any).__FEDERATION__ = {
         ...(previousFederation || {}),
@@ -239,7 +232,7 @@ describe('clearCache', () => {
         });
 
         expect(remoteEntryClear).not.toHaveBeenCalled();
-        expect(selectiveClear.mock.calls.length > 0).toBe(selective);
+        expect(selectiveClear).toHaveBeenCalled();
         expect(instance.moduleCache.has('remoteA')).toBe(false);
         expect(webpackRequire.m[101]).toBeUndefined();
         expect(webpackRequire.c[101]).toBeUndefined();

--- a/packages/webpack-bundler-runtime/src/clearCache.ts
+++ b/packages/webpack-bundler-runtime/src/clearCache.ts
@@ -576,9 +576,11 @@ const cleanupRemoteEntryInternalCache = (
       }
     | null
     | undefined;
-  const clear = preserveShared
-    ? entry?.__webpack_clear_exposed_cache__
-    : entry?.__webpack_clear_cache__;
+  if (preserveShared) {
+    entry?.__webpack_clear_exposed_cache__!();
+    return;
+  }
+  const clear = entry?.__webpack_clear_cache__;
   if (typeof clear === 'function') {
     clear();
   }

--- a/packages/webpack-bundler-runtime/src/clearCache.ts
+++ b/packages/webpack-bundler-runtime/src/clearCache.ts
@@ -565,13 +565,20 @@ const createClearSnapshot = (
   };
 };
 
-const cleanupRemoteEntryInternalCache = (remoteEntryExports: unknown) => {
-  const clear = (
-    remoteEntryExports as
-      | { __webpack_clear_cache__?: () => void }
-      | null
-      | undefined
-  )?.__webpack_clear_cache__;
+const cleanupRemoteEntryInternalCache = (
+  remoteEntryExports: unknown,
+  preserveShared = false,
+) => {
+  const entry = remoteEntryExports as
+    | {
+        __webpack_clear_cache__?: () => void;
+        __webpack_clear_exposed_cache__?: () => void;
+      }
+    | null
+    | undefined;
+  const clear = preserveShared
+    ? entry?.__webpack_clear_exposed_cache__
+    : entry?.__webpack_clear_cache__;
   if (typeof clear === 'function') {
     clear();
   }
@@ -630,17 +637,19 @@ const cleanupRemoteRuntimeCache = (
     const module = instance.moduleCache?.get(remoteName) as
       | Record<string, unknown>
       | undefined;
-    if (!preserveProvider) {
-      cleanupRemoteEntryInternalCache(module?.remoteEntryExports);
-      cleanupRemoteEntryInternalCache(module?.lib);
-    }
+    cleanupRemoteEntryInternalCache(
+      module?.remoteEntryExports,
+      preserveProvider,
+    );
+    cleanupRemoteEntryInternalCache(module?.lib, preserveProvider);
     instance.moduleCache?.delete(remoteName);
   }
-  if (!preserveProvider) {
-    for (const remoteInfo of target.remoteInfos) {
-      for (const globalKey of getRemoteEntryGlobalKeys(remoteInfo)) {
-        cleanupRemoteEntryInternalCache((globalThis as any)[globalKey]);
-      }
+  for (const remoteInfo of target.remoteInfos) {
+    for (const globalKey of getRemoteEntryGlobalKeys(remoteInfo)) {
+      cleanupRemoteEntryInternalCache(
+        (globalThis as any)[globalKey],
+        preserveProvider,
+      );
     }
   }
   const idToRemoteMap = instance.remoteHandler?.idToRemoteMap;

--- a/tools/ssr-cache/README.md
+++ b/tools/ssr-cache/README.md
@@ -173,3 +173,44 @@ shared dependency retention and adapter disposal; R2 must prove stream terminati
 R3/R4 must implement Modern resource ownership and safe publication. None is marked
 implemented by this document. Arbitrary globals, unregistered tasks, native ESM
 registry eviction and deployment-owned worker rotation remain explicit boundaries.
+
+## R1 selective provider cleanup and transitive parents
+
+With the companion Rspack branch `fix/mf-selective-cache`, enhanced containers
+export `__webpack_clear_exposed_cache__`. It removes execution-cache entries
+outside the forward dependency closure of declared and consumed shared modules,
+including async dependencies. MF calls this optional method when the provider
+must be retained for shared use. Older containers keep their execution cache.
+The existing full-cache method keeps its behavior.
+
+This is conservative: modules also reachable from shared cannot be released,
+module factories and the shared provider runtime remain, and arbitrary business
+references/global side effects are not removed. Clearing execution cache does
+not replace already-returned functions. The capability is compiler-owned, with
+no Modern-specific routing or request coordination in Rspack.
+
+The companion compiler also emits transitive static parent edges. Native tests
+cover cycles and multiple parents; the artifact matrix covers concatenation,
+deterministic numeric IDs and minification. Require these new capabilities with:
+
+```sh
+SSR_CACHE_EXPECT_NATIVE=1 SSR_CACHE_RSPACK_ENTRY=/absolute/path/to/rspack/packages/rspack/dist/index.js node --test tools/ssr-cache/baseline.test.cjs
+```
+
+This mode removes the parent-closure TODOs and requires non-shared payload GC,
+shared strict identity and retained lazy dependency identity. The three stale
+adapter TODOs remain. Without the native flag the installed older canary is still
+supported, and unsupported selective GC is explicitly skipped.
+
+For the existing full Modern SSR CI job, use the Node 24 resolver hook so both
+ESM and CJS toolchains load the local compiler (no lockfile or symlink changes):
+
+```sh
+SSR_CACHE_RSPACK_ENTRY=/absolute/path/to/rspack/packages/rspack/dist/index.js NODE_OPTIONS="--require=$PWD/tools/ssr-cache/local-rspack-hook.cjs" TURBO_ENV_MODE=loose pnpm run ci:local --only=e2e-modern-ssr
+```
+
+Verify the provider container exports the new method in the emitted artifact;
+merely finding its name inside bundled MF runtime call sites is insufficient.
+The Modern shared-cache spec now passes with this compiler. The separate
+remote-cache runtime-capture assertion still intermittently fails; the full CI
+job is not accepted as green. Adapter lifetime and R2–R6 are still open.

--- a/tools/ssr-cache/README.md
+++ b/tools/ssr-cache/README.md
@@ -9,10 +9,12 @@ From the repository root, with Node 24 and the lockfile's pnpm version:
 
 ```sh
 pnpm exec turbo run build --filter=@module-federation/runtime-tools
-node --test tools/ssr-cache/baseline.test.cjs
+SSR_CACHE_RSPACK_ENTRY=/absolute/path/to/rspack/packages/rspack/dist/index.js node --test tools/ssr-cache/baseline.test.cjs
 ```
 
-The default uses the installed `@rspack/core` (currently the lockfile's canary).
+Without an override the runner resolves the installed `@rspack/core`, but the
+current lockfile canary lacks the required selective cleanup method. Use the
+companion Rspack build for this unreleased implementation.
 To validate a local Rspack build, set `SSR_CACHE_RSPACK_ENTRY` to its absolute
 `packages/rspack/dist/index.js` path. The test reports the resolved path and
 version; a local build's version alone does not identify its commit.
@@ -91,9 +93,9 @@ accepted dynamic update. A failed rebuild may leave no serving generation; retai
 the control plane needed to retry. This ordering must be validated in R1/R3.
 
 Consumed shared exports must retain strict object identity, including dependencies
-needed for later lazy work. The implementation may retain a provider runtime when
-safe selective invalidation is unavailable; host consumer invalidation must still
-occur. Do not promise full provider GC or mutate an in-use shared singleton into a
+needed for later lazy work. The provider must supply selective invalidation of execution caches outside
+the shared dependency closure; host consumer invalidation must still occur.
+This unreleased implementation requires matching host/provider builds. Do not promise full provider GC or mutate an in-use shared singleton into a
 new version. Shared preservation is a correctness requirement, not just a loaded
 flag. Changes to an in-use shared dependency outside this contract must be reported
 as unsupported, not silently treated as an ordinary remote update.
@@ -179,8 +181,9 @@ registry eviction and deployment-owned worker rotation remain explicit boundarie
 With the companion Rspack branch `fix/mf-selective-cache`, enhanced containers
 export `__webpack_clear_exposed_cache__`. It removes execution-cache entries
 outside the forward dependency closure of declared and consumed shared modules,
-including async dependencies. MF calls this optional method when the provider
-must be retained for shared use. Older containers keep their execution cache.
+including async dependencies. MF requires this method when the provider
+must be retained for shared use. Host and provider must use the matching
+unreleased cache implementation; there is no legacy-provider fallback.
 The existing full-cache method keeps its behavior.
 
 This is conservative: modules also reachable from shared cannot be released,
@@ -199,8 +202,8 @@ SSR_CACHE_EXPECT_NATIVE=1 SSR_CACHE_RSPACK_ENTRY=/absolute/path/to/rspack/packag
 
 This mode removes the parent-closure TODOs and requires non-shared payload GC,
 shared strict identity and retained lazy dependency identity. The three stale
-adapter TODOs remain. Without the native flag the installed older canary is still
-supported, and unsupported selective GC is explicitly skipped.
+adapter TODOs remain. Selective cleanup is always required. The installed older canary predates this
+capability and is not a supported validation target for shared cleanup.
 
 For the existing full Modern SSR CI job, use the Node 24 resolver hook so both
 ESM and CJS toolchains load the local compiler (no lockfile or symlink changes):

--- a/tools/ssr-cache/VALIDATION.md
+++ b/tools/ssr-cache/VALIDATION.md
@@ -177,3 +177,40 @@ Full compiler suites and other CI jobs were skipped in favor of the two targeted
 compiler cases, affected packages' complete tests and Modern SSR integration.
 Streaming/drain/production-serve/long-running memory tests remain later roadmap
 gates, not skipped proof of implemented behavior. No package publication ran.
+
+## Unreleased-provider contract correction — 2026-09-10
+
+The user confirmed that this cache API has not shipped. The previous increment's
+legacy-provider fallback and compatibility test matrix are therefore removed.
+Shared-preserving cleanup directly calls the selective method; a missing method
+is an error, not successful cleanup with a retained full cache. Generic remote
+entry types remain optional because not every container participates in this
+cleanup path. Shared payload GC no longer skips for a missing capability.
+
+Commands rerun:
+
+```sh
+pnpm exec turbo run build --filter=@module-federation/runtime-tools
+pnpm --filter @module-federation/runtime-core exec rstest run
+pnpm --filter @module-federation/webpack-bundler-runtime run test
+SSR_CACHE_EXPECT_NATIVE=1 SSR_CACHE_RSPACK_ENTRY=/Users/bytedance/outter/rspack/packages/rspack/dist/index.js SSR_CACHE_MODERN_ENTRY=/Users/bytedance/work/modern.js/packages/server/core/dist/cjs/adapters/node/index.js node --test tools/ssr-cache/baseline.test.cjs
+node --test tools/ssr-cache/baseline.test.cjs
+SSR_CACHE_RSPACK_ENTRY=/Users/bytedance/outter/rspack/packages/rspack/dist/index.js NODE_OPTIONS="--require=$PWD/tools/ssr-cache/local-rspack-hook.cjs" TURBO_ENV_MODE=loose pnpm run ci:local --only=e2e-modern-ssr
+pnpm exec prettier --check .
+python3 .codex/skills/changeset-pr/scripts/run_changeset_status.py --output /tmp/mf-no-compat-changeset.json
+```
+
+Build: 6/6 successful; runtime-core 134/134; bundler runtime 109/109. The six
+removed cases tested the discarded compatibility path. New compiler/Modern
+artifact matrix remains 19 passes, 3 existing adapter TODOs, no skips/failures.
+The installed older canary negative check now exits 1 with a missing selective
+method error, confirming it is no longer silently accepted. Changeset planning
+passes. Full-repo formatting still reports 683 unrelated/generated files.
+
+Rspack changes in this correction are documentation only; its native suite was
+not repeated. Other CI jobs remain outside this focused correction. No publish.
+
+The full Modern SSR CI rerun passes both remote-cache and shared-cache specs.
+The previously recorded capture failure did not reproduce; this correction does
+not claim to fix its intermittent cause. Changed-file Prettier and
+`git diff --check` pass. Adapter lifecycle TODOs remain open.

--- a/tools/ssr-cache/VALIDATION.md
+++ b/tools/ssr-cache/VALIDATION.md
@@ -106,3 +106,74 @@ General shared lazy dependency graph coverage, selective provider reclamation,
 parent closure, adapter lifecycle and Modern production stream/serve/GC acceptance
 remain open. Other CI jobs were not run: the affected packages' complete tests and
 Modern SSR integration were selected. No publication was performed.
+
+## R1 selective provider increment — 2026-09-10
+
+Core base: merged #5049 (`2ed88f573`). Companion Rspack base:
+`8e63776c7a5fa47665fac96f16316f874a18b806`, branch `fix/mf-selective-cache`.
+This increment implements optional selective provider cleanup and transitive
+static parents, not adapter lifecycle or production acceptance.
+
+Commands executed in core:
+
+```sh
+pnpm exec turbo run build --filter=@module-federation/runtime-tools
+pnpm --filter @module-federation/webpack-bundler-runtime run test
+pnpm --filter @module-federation/runtime-core exec rstest run
+node --test tools/ssr-cache/baseline.test.cjs
+SSR_CACHE_EXPECT_NATIVE=1 SSR_CACHE_RSPACK_ENTRY=/Users/bytedance/outter/rspack/packages/rspack/dist/index.js node --test tools/ssr-cache/baseline.test.cjs
+SSR_CACHE_EXPECT_NATIVE=1 SSR_CACHE_RSPACK_ENTRY=/Users/bytedance/outter/rspack/packages/rspack/dist/index.js SSR_CACHE_MODERN_ENTRY=/Users/bytedance/work/modern.js/packages/server/core/dist/cjs/adapters/node/index.js node --test tools/ssr-cache/baseline.test.cjs
+NODE_OPTIONS='--require=/tmp/mf-selective-local-rspack.cjs' TURBO_ENV_MODE=loose pnpm run ci:local --only=e2e-modern-ssr
+pnpm exec prettier --check .
+python3 .codex/skills/changeset-pr/scripts/run_changeset_status.py --output /tmp/mf-selective-changeset-status.json
+git diff --check
+```
+
+The temporary Modern resolver hook used Node 24 `registerHooks` to resolve both
+`@rspack/core` and `@rspack-canary/core` to the local built entry. The equivalent,
+portable hook and invocation are now documented in README. An earlier CJS-only
+`Module._resolveFilename` hook did not affect Rslib ESM imports: its shared-cache
+failure was against the old compiler, not the new selective implementation.
+
+Commands executed in Rspack:
+
+```sh
+pnpm run build:binding:dev
+# From tests/rspack-test, separately (the filter matches literal text):
+pnpm run test:base -- -t configCases/container/mf-clear-cache-metadata
+pnpm run test:base -- -t configCases/container/mf-selective-provider-cache
+# From Rspack root:
+rustfmt --edition 2024 --check crates/rspack_plugin_mf/src/container/container_entry_module.rs crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+git diff --check
+```
+
+- Runtime-tools build: 6/6 tasks successful; bundler package 111/111 tests;
+  runtime-core 138/138 tests. An initial test matrix typo was corrected before
+  the full runtime-core rerun; no snapshots changed.
+- Installed old canary: 7 passes, 5 known TODOs, 2 explicit skips (selective
+  capability absent and Modern entry omitted), no failures.
+- New compiler artifact matrix: 18 passes, 3 stale-adapter TODOs, 1 Modern skip.
+  With the built Modern entry: 19 passes, 3 TODOs, no skips/failures. Covers
+  shared strict identity, retained lazy dependency identity, non-shared payload
+  WeakRef GC, concatenation and minified deterministic numeric IDs. Reacquired
+  static parents update without the diagnostic parent plugin.
+- Native Rspack targeted runs both pass (each runner reports 404 passes plus
+  filtered/skipped cases; this is not a claim that the full compiler suite ran).
+  Regressions include cyclic/multiple-parent metadata and first lazy execution
+  after cleanup, followed by another cleanup and identity check.
+- Full Modern SSR CI with the corrected hook: shared-cache spec **passes**,
+  including the unchanged `nonSharedPayloadCollected` assertion. Remote-cache
+  spec **fails at line 51**, `v1Runtime.captured === true`; the earlier replacement
+  and no-remove-error assertions pass. This same capture failure was recorded
+  in R0 and remains unresolved. No assertion was weakened; the CI job is not green.
+  Existing React/Helmet type/version warnings also remain.
+- Changeset parsing/planning passes; entries are patch releases only for
+  runtime-core and webpack-bundler-runtime (fixed groups may expand the plan).
+  Full-repo Prettier still fails on 683 pre-existing/generated files; only
+  changed files are formatted. Rspack has no local Prettier binary, so its
+  touched JS was formatted using the existing core binary.
+
+Full compiler suites and other CI jobs were skipped in favor of the two targeted
+compiler cases, affected packages' complete tests and Modern SSR integration.
+Streaming/drain/production-serve/long-running memory tests remain later roadmap
+gates, not skipped proof of implemented behavior. No package publication ran.

--- a/tools/ssr-cache/baseline.test.cjs
+++ b/tools/ssr-cache/baseline.test.cjs
@@ -110,22 +110,15 @@ for (const [variant, flags] of Object.entries({
         }
       }
       if (flags.SHARED === '1') {
-        if (process.env.SSR_CACHE_EXPECT_NATIVE === '1')
-          assert.equal(result.shared.selective, true);
+        assert.equal(result.shared.selective, true);
         await t.test('shared retention does not skip host invalidation', () =>
           assert.equal(result.static.withPageInvalidated, 'v2'),
         );
         await t.test('consumed shared export retains strict identity', () =>
           assert.equal(result.shared.sameObject, true),
         );
-        await t.test(
-          'unshared provider payload can be collected',
-          {
-            skip:
-              !result.shared.selective &&
-              'Provider lacks selective cleanup capability',
-          },
-          () => assert.equal(result.shared.payloadCollected, true),
+        await t.test('unshared provider payload can be collected', () =>
+          assert.equal(result.shared.payloadCollected, true),
         );
         await t.test(
           'retained shared lazy dependency keeps identity after removal',

--- a/tools/ssr-cache/baseline.test.cjs
+++ b/tools/ssr-cache/baseline.test.cjs
@@ -7,19 +7,23 @@ const { spawnSync } = require('node:child_process');
 
 // Each case owns a process: MF globals must not leak between compilations.
 function run(script, directory, flags = {}) {
-  const child = spawnSync(process.execPath, [path.join(__dirname, script)], {
-    env: {
-      ...process.env,
-      PARENTS: '0',
-      SHARED: '0',
-      CONCAT: '0',
-      ...flags,
-      SSR_CACHE_CASE_DIR: directory,
+  const child = spawnSync(
+    process.execPath,
+    ['--expose-gc', path.join(__dirname, script)],
+    {
+      env: {
+        ...process.env,
+        PARENTS: '0',
+        SHARED: '0',
+        CONCAT: '0',
+        ...flags,
+        SSR_CACHE_CASE_DIR: directory,
+      },
+      timeout: 120_000,
+      encoding: 'utf8',
+      maxBuffer: 8 * 1024 * 1024,
     },
-    timeout: 120_000,
-    encoding: 'utf8',
-    maxBuffer: 8 * 1024 * 1024,
-  });
+  );
   assert.ifError(child.error);
   assert.equal(child.status, 0, child.stderr + child.stdout);
 }
@@ -49,6 +53,16 @@ for (const [variant, flags] of Object.entries({
   concat: { CONCAT: '1' },
   parents: { PARENTS: '1' },
   shared: { SHARED: '1' },
+  ...(process.env.SSR_CACHE_EXPECT_NATIVE === '1'
+    ? {
+        'shared-concat': { SHARED: '1', CONCAT: '1' },
+        'shared-numeric': {
+          SHARED: '1',
+          MODULE_IDS: 'deterministic',
+          MINIMIZE: '1',
+        },
+      }
+    : {}),
 })) {
   test(`real Rspack artifacts: ${variant}`, async (t) => {
     const directory = fs.realpathSync(
@@ -78,7 +92,11 @@ for (const [variant, flags] of Object.entries({
         'unrelated exports retain identity',
       );
       assert.equal(result.static.executions.other, 1);
-      if (variant === 'plain' || variant === 'shared') {
+      if (
+        (variant === 'plain' || variant === 'shared') &&
+        !result.completeParents &&
+        process.env.SSR_CACHE_EXPECT_NATIVE !== '1'
+      ) {
         await knownFailure(t, 'reacquiring a static page returns v2', () =>
           assert.equal(result.static.reimport, 'v2'),
         );
@@ -91,12 +109,23 @@ for (const [variant, flags] of Object.entries({
           assert.equal(result.rebuild.afterRebindingHook.newClearCalls, 1);
         }
       }
-      if (variant === 'shared') {
+      if (flags.SHARED === '1') {
+        if (process.env.SSR_CACHE_EXPECT_NATIVE === '1')
+          assert.equal(result.shared.selective, true);
         await t.test('shared retention does not skip host invalidation', () =>
           assert.equal(result.static.withPageInvalidated, 'v2'),
         );
         await t.test('consumed shared export retains strict identity', () =>
           assert.equal(result.shared.sameObject, true),
+        );
+        await t.test(
+          'unshared provider payload can be collected',
+          {
+            skip:
+              !result.shared.selective &&
+              'Provider lacks selective cleanup capability',
+          },
+          () => assert.equal(result.shared.payloadCollected, true),
         );
         await t.test(
           'retained shared lazy dependency keeps identity after removal',

--- a/tools/ssr-cache/fixture.cjs
+++ b/tools/ssr-cache/fixture.cjs
@@ -26,6 +26,7 @@ async function main() {
       'export default {identity:"shared-singleton",lazy:()=>import("./shared-lazy").then(m=>m.default)};',
     );
     write('shared-lazy.js', 'export default {identity:"lazy-singleton"};');
+    write('payload.js', 'export default {items:new Array(200000).fill(42)};');
     for (const v of ['v1', 'v2'])
       write(
         v + '.js',
@@ -76,9 +77,9 @@ async function main() {
     mode: 'production',
     devtool: false,
     optimization: {
-      minimize: false,
+      minimize: process.env.MINIMIZE === '1',
       concatenateModules: process.env.CONCAT === '1',
-      moduleIds: 'named',
+      moduleIds: process.env.MODULE_IDS || 'named',
       chunkIds: 'named',
     },
     output: {
@@ -98,7 +99,12 @@ async function main() {
         implementation,
         filename: v + '.cjs',
         library: { type: 'commonjs-module' },
-        exposes: { './Value': './' + v + '.js' },
+        exposes: {
+          './Value': './' + v + '.js',
+          ...(process.env.SHARED === '1'
+            ? { './Payload': './payload.js' }
+            : {}),
+        },
         shared:
           process.env.SHARED === '1'
             ? {
@@ -227,6 +233,11 @@ async function main() {
   }
   const mapping = JSON.parse(JSON.stringify(host.req.remotesLoadingData));
   const instance = host.req.federation.instance;
+  let payloadRef;
+  if (host.share)
+    payloadRef = new WeakRef(
+      (await instance.loadRemote('remote/Payload')).default,
+    );
   const template = {
     ...instance.options.remotes.find(
       (r) => r.name === 'remote' || r.alias === 'remote',
@@ -242,6 +253,11 @@ async function main() {
     rspackEntry:
       process.env.SSR_CACHE_RSPACK_ENTRY || require.resolve('@rspack/core'),
     nodeVersion: process.version,
+    completeParents: Boolean(
+      mapping.consumerModuleIdToParentModuleIds?.['./middle.js']?.includes(
+        './page.js',
+      ),
+    ),
     mapping,
     static: {
       savedHandler: beforePage(),
@@ -259,7 +275,21 @@ async function main() {
   result.static.otherSame = (await host.other()) === other;
   if (host.share) {
     const sharedAfter = (await host.share()).default;
+    let payloadCollected = false;
+    for (let i = 0; i < 30; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      global.gc();
+      if (!payloadRef.deref()) {
+        payloadCollected = true;
+        break;
+      }
+    }
+    const selective =
+      typeof require(path.join(out, 'v1.cjs'))
+        .__webpack_clear_exposed_cache__ === 'function';
     result.shared = {
+      selective,
+      payloadCollected,
       sameObject: sharedAfter === sharedBefore,
       lazySameObject: (await sharedBefore.lazy()) === lazyBefore,
       lazyValue: (await sharedAfter.lazy()).identity,

--- a/tools/ssr-cache/local-rspack-hook.cjs
+++ b/tools/ssr-cache/local-rspack-hook.cjs
@@ -1,0 +1,19 @@
+// Node 24 hook for integration tools which import Rspack through either ESM or CJS.
+// Unlike patching Module._resolveFilename, this also covers Rslib's ESM imports.
+const { registerHooks } = require('node:module');
+const { pathToFileURL } = require('node:url');
+const { isAbsolute } = require('node:path');
+const entry = process.env.SSR_CACHE_RSPACK_ENTRY;
+if (!entry || !isAbsolute(entry)) {
+  throw new Error(
+    'SSR_CACHE_RSPACK_ENTRY must be an absolute built Rspack entry',
+  );
+}
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === '@rspack/core' || specifier === '@rspack-canary/core') {
+      return { url: pathToFileURL(entry).href, shortCircuit: true };
+    }
+    return nextResolve(specifier, context);
+  },
+});


### PR DESCRIPTION
## Description

When an active shared dependency keeps its provider alive, call `__webpack_clear_exposed_cache__` to release unrelated exposed execution-cache entries. This cache implementation has not shipped: host and provider must use matching builds. There is no missing-capability fallback that silently retains the full provider cache.

Rspack PR https://github.com/web-infra-dev/rspack/pull/15614 provides shared dependency closure retention and transitive static parent metadata. The artifact matrix covers concatenation, minified numeric IDs, shared/lazy strict identity and non-shared WeakRef GC. A Node 24 resolver hook supports local compiler integration through ESM and CJS.

Validation: runtime-tools build 6/6; runtime-core 134/134 and bundler runtime 109/109 tests. New compiler + Modern HTTP artifact matrix: 19 passes, 3 known stale-adapter TODOs, no skips. Removed six tests for the discarded legacy-provider fallback. The older installed canary now fails with a missing-method error, as expected. Latest full Modern SSR CI passes both remote-cache and shared-cache/GC specs; an earlier intermittent capture failure remains recorded and is not claimed fixed.

Changeset planning and changed-file formatting pass. Full-repo Prettier reports 683 existing/generated files. Other CI jobs were skipped in favor of affected packages and Modern SSR integration; exact commands and limitations are in tools/ssr-cache/VALIDATION.md. R1 remains incomplete pending adapter lifecycle. No publication.

## Related Issue

Continues #5049 and the SSR cache RFC. Companion compiler: https://github.com/web-infra-dev/rspack/pull/15614.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.