### PR TITLE
fix(runtime): dispose and rebind bundler cache adapters

### DIFF
--- a/.changeset/dispose-bundler-cache-adapters.md
+++ b/.changeset/dispose-bundler-cache-adapters.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/webpack-bundler-runtime': patch
+---
+
+Dispose and reattach bundler cache adapters across application rebuilds without retaining stale removal hooks or stacking MF instance wrappers. Coordinate multiple live bundlers on one MF instance and restore owned methods and listeners when the last adapter detaches.

--- a/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
+++ b/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
@@ -16,6 +16,7 @@ function createWebpackRequire() {
       lifecycle: {
         createScript: {
           on: jest.fn(),
+          remove: jest.fn(),
         },
       },
     },
@@ -81,13 +82,12 @@ describe('clearCache', () => {
         cleared: true as const,
       }),
     );
+    installClearCache({ webpackRequire: webpackRequire as any });
     webpackRequire.federation.clearCache = clearCache;
 
-    await createClearCacheRuntimePlugin({
-      webpackRequire: webpackRequire as any,
-    }).removeRemote?.({
+    await createClearCacheRuntimePlugin().removeRemote?.({
       remote: { name: 'remoteA' },
-      origin: {},
+      origin: webpackRequire.federation.instance,
     } as any);
 
     expect(clearCache).toHaveBeenCalledWith({ name: 'remoteA' });
@@ -357,4 +357,225 @@ describe('clearCache', () => {
       }
     }
   });
+});
+
+describe('cache adapter lifecycle', () => {
+  test('attaches once and restores exact methods and its listener on disposal', () => {
+    const { instance, webpackRequire } = createWebpackRequire();
+    const originalLoad = instance.loadRemote;
+    const originalRegister = instance.registerRemotes;
+    const originalSet = instance.moduleCache.set;
+    const dispose = installClearCache({
+      webpackRequire: webpackRequire as any,
+    })!;
+    const load = instance.loadRemote;
+    expect(installClearCache({ webpackRequire: webpackRequire as any })).toBe(
+      dispose,
+    );
+    expect(instance.loadRemote).toBe(load);
+    const hook = instance.loaderHook.lifecycle.createScript;
+    expect(hook.on).toHaveBeenCalledTimes(1);
+    dispose();
+    dispose();
+    expect(instance.loadRemote).toBe(originalLoad);
+    expect(instance.registerRemotes).toBe(originalRegister);
+    expect(instance.moduleCache.set).toBe(originalSet);
+    expect(hook.remove).toHaveBeenCalledTimes(1);
+    expect(hook.remove).toHaveBeenCalledWith(hook.on.mock.calls[0][0]);
+    expect(Object.hasOwn(webpackRequire.federation, 'clearCache')).toBe(false);
+    expect(Object.hasOwn(webpackRequire.federation, 'disposeClearCache')).toBe(
+      false,
+    );
+  });
+
+  test('routes removal to every live binding, including a different bundled copy', async () => {
+    const { instance, webpackRequire: first } = createWebpackRequire();
+    const { webpackRequire: second } = createWebpackRequire();
+    second.federation.instance = instance;
+    const disposeFirst = installClearCache({ webpackRequire: first as any })!;
+    const wrappedLoad = instance.loadRemote;
+    let other: typeof import('../src/clearCache');
+    jest.isolateModules(() => {
+      other = require('../src/clearCache');
+    });
+    expect(other!.installClearCache({ webpackRequire: first as any })).toBe(
+      disposeFirst,
+    );
+    const disposeSecond = other!.installClearCache({
+      webpackRequire: second as any,
+    })!;
+    expect(instance.loadRemote).toBe(wrappedLoad);
+    const firstClear = jest.fn(async () => ({
+      name: 'remoteA',
+      cleared: true as const,
+    }));
+    const secondClear = jest.fn(async () => ({
+      name: 'remoteA',
+      cleared: true as const,
+    }));
+    first.federation.clearCache = firstClear;
+    second.federation.clearCache = secondClear;
+    const plugin = createClearCacheRuntimePlugin();
+    await plugin.removeRemote({
+      origin: instance,
+      remote: { name: 'remoteA' },
+    });
+    expect(firstClear).toHaveBeenCalledTimes(1);
+    expect(secondClear).toHaveBeenCalledTimes(1);
+    disposeFirst();
+    await plugin.removeRemote({
+      origin: instance,
+      remote: { name: 'remoteA' },
+    });
+    expect(firstClear).toHaveBeenCalledTimes(1);
+    expect(secondClear).toHaveBeenCalledTimes(2);
+    expect(instance.loadRemote).toBe(wrappedLoad);
+    disposeSecond();
+    await plugin.removeRemote({
+      origin: instance,
+      remote: { name: 'remoteA' },
+    });
+    expect(secondClear).toHaveBeenCalledTimes(2);
+  });
+
+  test('preserves later third-party wrappers without reviving a disposed registry', async () => {
+    const { instance, webpackRequire } = createWebpackRequire();
+    const original = instance.loadRemote;
+    const dispose = installClearCache({
+      webpackRequire: webpackRequire as any,
+    })!;
+    const ours = instance.loadRemote;
+    const thirdParty = jest.fn((...args: any[]) => (ours as any)(...args));
+    instance.loadRemote = thirdParty;
+    dispose();
+    expect(instance.loadRemote).toBe(thirdParty);
+    const again = installClearCache({ webpackRequire: webpackRequire as any })!;
+    await instance.loadRemote('remoteA/X', {});
+    expect(original).toHaveBeenCalledTimes(1);
+    expect(thirdParty).toHaveBeenCalledTimes(1);
+    again();
+    expect(instance.loadRemote).toBe(thirdParty);
+    await instance.loadRemote('remoteA/Y', {});
+    expect(original).toHaveBeenCalledTimes(2);
+  });
+
+  test('rejects disposal during cleanup and rejects saved entry points after disposal', async () => {
+    const { webpackRequire } = createWebpackRequire();
+    const dispose = installClearCache({
+      webpackRequire: webpackRequire as any,
+    })!;
+    const clear = webpackRequire.federation.clearCache!;
+    const pending = clear({ name: 'remoteA' });
+    expect(dispose).toThrow('cleanup is pending');
+    await pending;
+    dispose();
+    await expect(clear({ name: 'remoteA' })).rejects.toThrow('detached');
+  });
+});
+
+describe('cache adapter ownership and removal coordination', () => {
+  test('rejects changing the owner of a live binding', () => {
+    const { webpackRequire } = createWebpackRequire();
+    const dispose = installClearCache({
+      webpackRequire: webpackRequire as any,
+    })!;
+    const { instance: other } = createWebpackRequire();
+    expect(() =>
+      installClearCache({
+        webpackRequire: webpackRequire as any,
+        instance: other as any,
+      }),
+    ).toThrow('another MF instance');
+    dispose();
+  });
+
+  test('starts every live cleanup and waits for all outcomes before rejecting', async () => {
+    const { instance, webpackRequire: first } = createWebpackRequire();
+    const { webpackRequire: second } = createWebpackRequire();
+    second.federation.instance = instance;
+    const disposeFirst = installClearCache({ webpackRequire: first as any })!;
+    const disposeSecond = installClearCache({ webpackRequire: second as any })!;
+    const deferred = createDeferred();
+    const error = new Error('first cleanup failed');
+    first.federation.clearCache = jest.fn(async () => {
+      throw error;
+    });
+    second.federation.clearCache = jest.fn(() => deferred.promise as any);
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const pending = createClearCacheRuntimePlugin().removeRemote({
+        origin: instance,
+        remote: { name: 'remoteA' },
+      });
+      const observed = expect(pending).rejects.toBe(error);
+      let settled = false;
+      pending.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(first.federation.clearCache).toHaveBeenCalledTimes(1);
+      expect(second.federation.clearCache).toHaveBeenCalledTimes(1);
+      expect(settled).toBe(false);
+      deferred.resolve();
+      await observed;
+    } finally {
+      warn.mockRestore();
+      disposeFirst();
+      disposeSecond();
+    }
+  });
+});
+
+test('force registration updates every attached bundler once and leaves detached mappings alone', async () => {
+  const { instance, webpackRequire: first } = createWebpackRequire();
+  const { webpackRequire: second } = createWebpackRequire();
+  second.federation.instance = instance;
+  const remote = {
+    name: 'remoteA',
+    entry: 'https://example.test/old.js',
+    type: 'global',
+  };
+  instance.options.remotes.push(remote as never);
+  for (const binding of [first, second]) {
+    (
+      binding.federation.bundlerRuntimeOptions.remotes.remoteInfos as any
+    ).remoteA = [{ ...remote }];
+  }
+  const disposeFirst = installClearCache({ webpackRequire: first as any })!;
+  const disposeSecond = installClearCache({ webpackRequire: second as any })!;
+  try {
+    const entry = 'https://example.test/new.js';
+    await (instance.registerRemotes as any)([{ ...remote, entry }], {
+      force: true,
+    });
+    expect(instance.options.remotes).toHaveLength(1);
+    for (const binding of [first, second])
+      expect(
+        (binding.federation.bundlerRuntimeOptions.remotes.remoteInfos as any)
+          .remoteA[0].entry,
+      ).toBe(entry);
+    disposeFirst();
+    const finalEntry = 'https://example.test/final.js';
+    await (instance.registerRemotes as any)(
+      [{ ...remote, entry: finalEntry }],
+      { force: true },
+    );
+    expect(
+      (first.federation.bundlerRuntimeOptions.remotes.remoteInfos as any)
+        .remoteA[0].entry,
+    ).toBe(entry);
+    expect(
+      (second.federation.bundlerRuntimeOptions.remotes.remoteInfos as any)
+        .remoteA[0].entry,
+    ).toBe(finalEntry);
+  } finally {
+    disposeFirst();
+    disposeSecond();
+  }
 });

--- a/packages/webpack-bundler-runtime/src/clearCache.ts
+++ b/packages/webpack-bundler-runtime/src/clearCache.ts
@@ -61,10 +61,10 @@ type ClearCacheState = {
   remoteGenerations: Record<string, number>;
   remoteEntryUrlGenerations: Record<string, number>;
   staleRemoteCleanups: Record<string, { run: () => void; pending: number }>;
-  installed?: boolean;
+  dispose?: () => void;
 };
 
-const clearCacheStates = new WeakMap<WebpackRequire, ClearCacheState>();
+const cacheStateKey = Symbol.for('module-federation.clear-cache.state');
 
 const hasOwn = (obj: object, key: string | number) =>
   Object.prototype.hasOwnProperty.call(obj, key);
@@ -98,7 +98,9 @@ const pushUnique = <T>(target: T[], values: Array<T | undefined | null>) => {
 };
 
 const getState = (webpackRequire: WebpackRequire): ClearCacheState => {
-  let state = clearCacheStates.get(webpackRequire);
+  let state = (webpackRequire as any)[cacheStateKey] as
+    | ClearCacheState
+    | undefined;
   if (!state) {
     state = {
       remoteClearBarriers: {},
@@ -106,7 +108,7 @@ const getState = (webpackRequire: WebpackRequire): ClearCacheState => {
       remoteEntryUrlGenerations: {},
       staleRemoteCleanups: {},
     };
-    clearCacheStates.set(webpackRequire, state);
+    Object.defineProperty(webpackRequire, cacheStateKey, { value: state });
   }
   return state;
 };
@@ -1219,33 +1221,31 @@ const replaceRemoteRegistration = (instance: any, remote: RuntimeRemote) => {
 };
 
 const registerRemotesWithForce = (
-  webpackRequire: WebpackRequire,
+  bindings: WebpackRequire[],
   instance: any,
   remotes: RuntimeRemote[],
 ) => {
   const remoteList = toList(remotes);
   const registrationSnapshot = captureRemoteRegistrationSnapshot(instance);
   const bundlerSnapshots: Array<{ restore: () => void }> = [];
-  const clearTargets: Array<ClearCacheTarget | undefined> = [];
+  const clearTargets: Array<{
+    target: ClearCacheTarget;
+    binding: WebpackRequire;
+  }> = [];
   try {
     for (const remote of remoteList) {
-      let clearTarget: ClearCacheTarget | undefined;
-      try {
-        clearTarget = getClearTarget({
-          name: remote.name,
-          webpackRequire,
-        });
-      } catch {
-        clearTarget = undefined;
-      }
+      const targets = bindings.map((binding) => ({
+        binding,
+        target: getClearTarget({ name: remote.name, webpackRequire: binding }),
+      }));
       const normalizedRemote = replaceRemoteRegistration(instance, remote);
-      if (clearTarget) {
+      for (const { binding, target } of targets) {
         bundlerSnapshots.push(
-          captureBundlerRemoteInfoSnapshot(webpackRequire, clearTarget),
+          captureBundlerRemoteInfoSnapshot(binding, target),
         );
-        updateBundlerRemoteInfo(webpackRequire, clearTarget, normalizedRemote);
+        updateBundlerRemoteInfo(binding, target, normalizedRemote);
+        clearTargets.push({ binding, target });
       }
-      clearTargets.push(clearTarget);
     }
   } catch (error) {
     for (let i = bundlerSnapshots.length - 1; i >= 0; i--) {
@@ -1254,14 +1254,15 @@ const registerRemotesWithForce = (
     registrationSnapshot.restore();
     return Promise.reject(error);
   }
-  return clearTargets
-    .reduce(
-      (promise, target) =>
-        promise.then(() =>
-          target ? clearRemoteTarget(target, webpackRequire) : undefined,
-        ),
-      Promise.resolve<unknown>(undefined),
-    )
+  return Promise.allSettled(
+    clearTargets.map(({ target, binding }) =>
+      clearRemoteTarget(target, binding),
+    ),
+  )
+    .then((results) => {
+      const failure = results.find((result) => result.status === 'rejected');
+      if (failure?.status === 'rejected') throw failure.reason;
+    })
     .catch((error) => {
       for (let i = bundlerSnapshots.length - 1; i >= 0; i--) {
         bundlerSnapshots[i].restore();
@@ -1271,121 +1272,230 @@ const registerRemotesWithForce = (
     });
 };
 
-const markRemoteModuleGeneration = (
-  webpackRequire: WebpackRequire,
-  remoteName: string,
-  module: Record<string, any> | undefined,
-) => {
-  if (module && typeof module === 'object') {
-    module['__rspack_remote_generation__'] = getRemoteGeneration(
-      webpackRequire,
-      remoteName,
-    );
-  }
+type CacheAdapters = {
+  bindings: Set<WebpackRequire>;
+  restore: () => void;
 };
 
+// Bundled copies must coordinate through the logical MF instance. A module-local
+// WeakMap would create separate registries after rebuilding an application.
+const adaptersKey = Symbol.for('module-federation.clear-cache.adapters');
+const getAdapters = (instance: any): CacheAdapters | undefined =>
+  instance?.[adaptersKey];
+
+const wrapMethod = (
+  target: any,
+  key: string,
+  wrapper: (original: any) => any,
+) => {
+  const descriptor = Object.getOwnPropertyDescriptor(target, key);
+  const original = target[key];
+  const wrapped = wrapper(original);
+  target[key] = wrapped;
+  return () => {
+    // Do not replace a wrapper installed later by another owner.
+    if (target[key] !== wrapped) return;
+    if (descriptor) Object.defineProperty(target, key, descriptor);
+    else delete target[key];
+  };
+};
+
+const createAdapters = (instance: any): CacheAdapters => {
+  const bindings = new Set<WebpackRequire>();
+  const restorers: Array<() => void> = [];
+  const adapters = {
+    bindings,
+    restore: () => {
+      for (const restore of restorers.splice(0).reverse()) restore();
+      if (instance[adaptersKey] === adapters) delete instance[adaptersKey];
+    },
+  };
+  Object.defineProperty(instance, adaptersKey, {
+    value: adapters,
+    configurable: true,
+  });
+  if (typeof instance.loadRemote === 'function') {
+    restorers.push(
+      wrapMethod(
+        instance,
+        'loadRemote',
+        (original) =>
+          function (this: any, id: string, options?: Record<string, any>) {
+            const active: WebpackRequire[] = [];
+            const waits: Promise<unknown>[] = [];
+            for (const binding of bindings) {
+              const remoteKeys = getRemoteKeysForRequest(binding, id);
+              if (remoteKeys.length === 0) continue;
+              active.push(binding);
+              runStaleRemoteCleanups(binding, remoteKeys);
+              const wait = waitForRemoteClear(binding, remoteKeys);
+              if (wait) waits.push(wait);
+            }
+            const load = () => {
+              if (active.some((binding) => !bindings.has(binding)))
+                throw new Error(
+                  'Cache adapter detached while waiting to load a remote',
+                );
+              return original.call(this, id, options);
+            };
+            return waits.length ? Promise.all(waits).then(load) : load();
+          },
+      ),
+    );
+  }
+  if (typeof instance.registerRemotes === 'function') {
+    restorers.push(
+      wrapMethod(
+        instance,
+        'registerRemotes',
+        (original) =>
+          function (
+            this: any,
+            remotes: RuntimeRemote[],
+            options?: { force?: boolean },
+          ) {
+            if (!options?.force || bindings.size === 0)
+              return original.call(this, remotes, options);
+            return registerRemotesWithForce(
+              Array.from(bindings),
+              instance,
+              remotes,
+            );
+          },
+      ),
+    );
+  }
+  const createScript = instance.loaderHook?.lifecycle?.createScript;
+  const listener = ({
+    url,
+    remoteInfo,
+  }: {
+    url: string;
+    remoteInfo?: RemoteInfoLike;
+  }) => {
+    if (!remoteInfo) return;
+    const key = getRemoteEntryUrlGenerationKey(remoteInfo);
+    if (!key) return;
+    let generation = 0;
+    for (const binding of bindings)
+      generation = Math.max(
+        generation,
+        getState(binding).remoteEntryUrlGenerations[key] ?? 0,
+      );
+    if (generation)
+      return { url: withRemoteEntryUrlGeneration(url, generation) };
+  };
+  createScript?.on?.(listener);
+  restorers.push(() => createScript?.remove?.(listener));
+  return adapters;
+};
+
+// Keep the disposable handle independent of the runtime it used to own: even a
+// retained, already-called disposer must not keep the old bundler alive.
+const attachCacheAdapter = (
+  binding: WebpackRequire | undefined,
+  instance: any,
+): (() => void) => {
+  const runtime = binding!;
+  let state: ClearCacheState | undefined = getState(runtime);
+  let adapters: CacheAdapters | undefined =
+    getAdapters(instance) ?? createAdapters(instance);
+  adapters.bindings.add(runtime);
+  let restoreClear: (() => void) | undefined = wrapMethod(
+    runtime.federation,
+    'clearCache',
+    () => (options: ClearCacheOptions) => {
+      if (!binding)
+        return Promise.reject(new Error('Cache adapter is detached'));
+      return clearCache({ ...options, webpackRequire: binding });
+    },
+  );
+  let previousDispose = Object.getOwnPropertyDescriptor(
+    runtime.federation,
+    'disposeClearCache',
+  );
+  const dispose = () => {
+    if (!binding) return;
+    if (
+      Object.keys(state!.remoteClearBarriers).length ||
+      Object.keys(state!.staleRemoteCleanups).length
+    )
+      throw new Error(
+        'Cannot detach cache adapter while cache cleanup is pending',
+      );
+    const federation = binding.federation;
+    restoreClear!();
+    restoreClear = undefined;
+    adapters!.bindings.delete(binding);
+    binding = undefined;
+    state!.dispose = undefined;
+    state = undefined;
+    if (federation.disposeClearCache === dispose) {
+      if (previousDispose)
+        Object.defineProperty(federation, 'disposeClearCache', previousDispose);
+      else delete federation.disposeClearCache;
+    }
+    previousDispose = undefined;
+    if (adapters!.bindings.size === 0) adapters!.restore();
+    adapters = undefined;
+  };
+  runtime.federation.disposeClearCache = dispose;
+  state.dispose = dispose;
+  return dispose;
+};
+
+/** Attach after initialization; callers must drain old work before disposal. */
 export const installClearCache = ({
   webpackRequire,
   instance,
 }: InstallClearCacheOptions) => {
   const state = getState(webpackRequire);
-  if (state.installed) {
-    return;
-  }
-  const federation = webpackRequire.federation;
-  instance ??= federation.instance;
-  if (!instance) {
-    return;
-  }
-  state.installed = true;
-
-  federation.clearCache = (options: ClearCacheOptions) =>
-    clearCache({ ...options, webpackRequire });
-
-  const moduleCache = instance.moduleCache;
-  if (moduleCache && typeof moduleCache.set === 'function') {
-    const originalSet = moduleCache.set.bind(moduleCache);
-    (moduleCache as any).set = (
-      remoteName: string,
-      module: Record<string, any>,
-    ) => {
-      markRemoteModuleGeneration(webpackRequire, remoteName, module);
-      return originalSet(remoteName, module as any);
-    };
-  }
-
-  if (typeof instance.loadRemote === 'function') {
-    const originalLoadRemote = instance.loadRemote.bind(instance);
-    (instance as any).loadRemote = (
-      id: string,
-      options?: Record<string, any>,
-    ) => {
-      const remoteKeys = getRemoteKeysForRequest(webpackRequire, id);
-      runStaleRemoteCleanups(webpackRequire, remoteKeys);
-      const load = () => originalLoadRemote(id, options as any);
-      return (
-        waitForRemoteClear(webpackRequire, remoteKeys)?.then(load) ?? load()
+  instance ??= webpackRequire.federation.instance;
+  if (!instance) return;
+  if (state.dispose) {
+    if (!getAdapters(instance)?.bindings.has(webpackRequire))
+      throw new Error(
+        'Cache adapter is already attached to another MF instance',
       );
-    };
+    return state.dispose;
   }
-
-  if (typeof instance.registerRemotes === 'function') {
-    const originalRegisterRemotes = instance.registerRemotes.bind(instance);
-    (instance as any).registerRemotes = (
-      remotes: RuntimeRemote[],
-      options?: { force?: boolean },
-    ) => {
-      if (!options?.force) {
-        return originalRegisterRemotes(remotes as any, options as any);
-      }
-      return registerRemotesWithForce(webpackRequire, instance, remotes);
-    };
-  }
-
-  instance.loaderHook?.lifecycle?.createScript?.on?.(
-    ({ url, remoteInfo }: { url: string; remoteInfo?: RemoteInfoLike }) => {
-      if (!remoteInfo) {
-        return;
-      }
-      const key = getRemoteEntryUrlGenerationKey(remoteInfo);
-      const generation = key ? state.remoteEntryUrlGenerations[key] : undefined;
-      if (!generation) {
-        return;
-      }
-      return {
-        url: withRemoteEntryUrlGeneration(url, generation),
-      };
-    },
-  );
+  return attachCacheAdapter(webpackRequire, instance);
 };
 
 const reportRemoveRemoteClearCacheError = (error: unknown) => {
-  if (typeof console === 'undefined' || typeof console.warn !== 'function') {
+  if (typeof console === 'undefined' || typeof console.warn !== 'function')
     return;
-  }
   console.warn(
-    `clearCache after removeRemote failed: ${
-      error instanceof Error ? error.message : String(error)
-    }`,
+    `clearCache after removeRemote failed: ${error instanceof Error ? error.message : String(error)}`,
   );
 };
 
-export const createClearCacheRuntimePlugin = ({
-  webpackRequire,
-}: {
-  webpackRequire: WebpackRequire;
-}) => ({
+// This plugin may outlive many application generations. Never capture a bundler.
+export const createClearCacheRuntimePlugin = () => ({
   name: 'bundler-runtime-clear-cache-plugin',
-  removeRemote({ remote }: { remote: RuntimeRemote }) {
-    const clear =
-      webpackRequire.federation.clearCache ||
-      ((options: ClearCacheOptions) =>
-        clearCache({ ...options, webpackRequire }));
-    return clear({ name: remote.alias || remote.name })
-      .then(() => undefined)
-      .catch((error) => {
-        reportRemoveRemoteClearCacheError(error);
-        throw error;
-      });
+  async removeRemote({
+    remote,
+    origin,
+  }: {
+    remote: RuntimeRemote;
+    origin: object;
+  }) {
+    const adapters = getAdapters(origin);
+    if (!adapters) return;
+    try {
+      const results = await Promise.allSettled(
+        Array.from(adapters.bindings, async (binding) => {
+          if (!adapters.bindings.has(binding)) return;
+          await binding.federation.clearCache!({
+            name: remote.alias || remote.name,
+          });
+        }),
+      );
+      const failure = results.find((result) => result.status === 'rejected');
+      if (failure?.status === 'rejected') throw failure.reason;
+    } catch (error) {
+      reportRemoveRemoteClearCacheError(error);
+      throw error;
+    }
   },
 });

--- a/packages/webpack-bundler-runtime/src/init.ts
+++ b/packages/webpack-bundler-runtime/src/init.ts
@@ -137,7 +137,7 @@ export function init({ webpackRequire }: { webpackRequire: WebpackRequire }) {
     plugins.push(treeShakingSharePlugin());
   }
   const plugins = (initOptions.plugins ||= []);
-  plugins.push(createClearCacheRuntimePlugin({ webpackRequire }));
+  plugins.push(createClearCacheRuntimePlugin());
 
   const instance = runtime!.init(initOptions);
   installClearCache({ webpackRequire, instance });

--- a/packages/webpack-bundler-runtime/src/types.ts
+++ b/packages/webpack-bundler-runtime/src/types.ts
@@ -280,9 +280,13 @@ export interface Federation {
     clearCache: (
       options: ClearCacheRuntimeOptions,
     ) => Promise<ClearCacheResult>;
-    installClearCache: (options: InstallClearCacheOptions) => void;
+    installClearCache: (
+      options: InstallClearCacheOptions,
+    ) => (() => void) | undefined;
   };
   clearCache?: (options: ClearCacheOptions) => Promise<ClearCacheResult>;
+  /** Detach this bundler after draining application work. Idempotent. */
+  disposeClearCache?: () => void;
   bundlerRuntimeOptions: {
     remotes?: Exclude<RemotesOptions, 'chunkId' | 'promises'> & {
       remoteInfos?: RemoteInfos;

--- a/tools/ssr-cache/README.md
+++ b/tools/ssr-cache/README.md
@@ -38,16 +38,16 @@ A successful baseline run with TODOs is **not** production acceptance. When fixi
 a defect, remove its TODO and keep its desired-behavior assertion. These tests are
 an explicit development command; this change does not alter the CI workflows.
 
-| Case                 | What is exercised                                   | Current expectation                                                                                      |
-| -------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| plain                | Static multi-level consumers across emitted chunks  | Reacquired page remains stale: TODO                                                                      |
-| concat               | Same graph with module concatenation                | Page updates; saved function remains old                                                                 |
-| parents              | Diagnostic JS plugin supplies missing parent edges  | Page updates; unrelated module executes once                                                             |
-| shared               | Real provider singleton consumed by host            | Host invalidation, shared strict identity and retained lazy dependency pass; parent closure remains TODO |
-| all non-shared cases | Drop application CJS cache, then update again       | Dynamic reference refreshes; old adapter still called: TODO                                              |
-| Modern (opt-in)      | Real production resource plugin and one HTTP server | Recreate resource state to publish new manifest; PID/port unchanged                                      |
+| Case                 | What is exercised                                   | Current expectation                                                            |
+| -------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------ |
+| plain                | Static multi-level consumers across emitted chunks  | Page updates with the companion Rspack parent metadata                         |
+| concat               | Same graph with module concatenation                | Page updates; saved function remains old                                       |
+| parents              | Diagnostic JS plugin supplies missing parent edges  | Page updates; unrelated module executes once                                   |
+| shared               | Real provider singleton consumed by host            | Host invalidation, shared strict identity and retained lazy dependency pass    |
+| all non-shared cases | Drop application CJS cache, then update again       | Dynamic reference refreshes; disposed adapter is not called on the next update |
+| Modern (opt-in)      | Real production resource plugin and one HTTP server | Recreate resource state to publish new manifest; PID/port unchanged            |
 
-The `parents` plugin and manual page invalidation/hook rebinding in the fixture
+The `parents` plugin and manual page invalidation in the fixture
 are diagnostic interventions, not the proposed production implementation. The
 fixture temporarily uses remove + register to exercise existing code; this does
 not specify atomic update semantics. No test here proves complete React streaming,
@@ -165,16 +165,13 @@ Thresholds are configurable and selected from R6 load measurements.
 
 ## Remaining stage gates
 
-R0 chooses the ownership and externally observable contracts above. The first R1
-fix separates host invalidation from provider cache retention, and covers shared
-identity plus a retained lazy dependency in real artifacts. It conservatively
-retains the provider execution cache while shared remains in use or loading; it
-does not claim selective provider GC. Parent closure and adapter disposal remain
-open. R1 must prove
-shared dependency retention and adapter disposal; R2 must prove stream termination;
-R3/R4 must implement Modern resource ownership and safe publication. None is marked
-implemented by this document. Arbitrary globals, unregistered tasks, native ESM
-registry eviction and deployment-owned worker rotation remain explicit boundaries.
+R0 chooses the ownership and externally observable contracts above. Shared
+identity, selective provider reclamation, static parent closure and explicit
+adapter disposal now pass the local artifact baseline. This does not implement
+Modern admission/drain or its application-generation owner. R2 must establish
+stream termination; R3/R4 must integrate resource ownership and safe publication.
+Arbitrary globals, unregistered tasks, native ESM registry eviction and
+deployment-owned worker rotation remain explicit boundaries.
 
 ## R1 selective provider cleanup and transitive parents
 
@@ -202,7 +199,7 @@ SSR_CACHE_EXPECT_NATIVE=1 SSR_CACHE_RSPACK_ENTRY=/absolute/path/to/rspack/packag
 
 This mode removes the parent-closure TODOs and requires non-shared payload GC,
 shared strict identity and retained lazy dependency identity. The three stale
-adapter TODOs remain. Selective cleanup is always required. The installed older canary predates this
+adapter assertions now pass with explicit disposal before application rebuild. Selective cleanup is always required. The installed older canary predates this
 capability and is not a supported validation target for shared cleanup.
 
 For the existing full Modern SSR CI job, use the Node 24 resolver hook so both
@@ -216,4 +213,44 @@ Verify the provider container exports the new method in the emitted artifact;
 merely finding its name inside bundled MF runtime call sites is insufficient.
 The Modern shared-cache spec now passes with this compiler. The separate
 remote-cache runtime-capture assertion still intermittently fails; the full CI
-job is not accepted as green. Adapter lifetime and R2–R6 are still open.
+job is not accepted as green. The explicit adapter lifecycle below closes the stale-binding baseline; Modern
+ownership and R2–R6 remain open.
+
+## R1 adapter lifecycle
+
+`installClearCache({ webpackRequire, instance })` returns an idempotent disposer
+when an instance is available. The same handle is also exposed as
+`webpackRequire.federation.disposeClearCache`. Repeated installation of the same
+live bundler/instance returns the same handle; attempting to change its owner
+without detaching fails. Bootstrap still installs the adapter automatically.
+
+The application owner must drain old work before calling the disposer, then
+release its old application references, rebuild and validate before publication.
+Disposal rejects while known cache cleanup/barriers are pending. It does not
+claim to drain arbitrary renders, loaders or business tasks. Saved clear entry
+points reject after disposal; saved idempotent disposers do not retain a bundler.
+
+A symbol-keyed registry on each MF instance coordinates every attached bundler,
+including adapters installed by separate bundled copies. The removal plugin
+captures no bundler and dispatches to that instance's live bindings. It starts
+all cleanups and waits for all outcomes before propagating a failure. Removal of
+one binding does not detach another owner. The temporary force-registration path
+also updates all live mappings; its API replacement remains a later task.
+
+Instance load/register wrappers and the createScript listener are installed once
+per registry. The last detach restores exact original methods/descriptors and
+removes its listener. A subsequently installed third-party wrapper is preserved;
+an old empty registry remains a pass-through if such a wrapper still references
+it. The unused moduleCache.set generation marker/wrapper was removed.
+
+The baseline now uses the production disposer before dropping CJS cache. It no
+longer manually replaces the removeRemote plugin. With the companion compiler
+and Modern entry, strict mode passes all 23 checks with zero TODOs/skips. These
+include repeated installation, cross-copy/multiple-binding unit coverage and a
+separate WeakRef check retaining the disposer and saved clear function.
+
+The WeakRef test proves adapter-owned references are released, not that all
+application bundles are collectable: the retained MF control plane, active shared
+providers and business exports may still reference bundled code. Modern must
+supply application ownership and request/stream drain; production serve,
+long-running memory stability and end-to-end recovery remain later stage gates.

--- a/tools/ssr-cache/VALIDATION.md
+++ b/tools/ssr-cache/VALIDATION.md
@@ -214,3 +214,51 @@ The full Modern SSR CI rerun passes both remote-cache and shared-cache specs.
 The previously recorded capture failure did not reproduce; this correction does
 not claim to fix its intermittent cause. Changed-file Prettier and
 `git diff --check` pass. Adapter lifecycle TODOs remain open.
+
+## R1 adapter lifecycle — 2026-09-10
+
+Core base: `3b53e9619` (merged #5051). The adapter is explicitly disposed before
+application CJS cache is dropped; no diagnostic replacement of the runtime plugin
+is used. Actual Modern request draining and rebuilding remain framework work.
+
+Commands executed:
+
+```sh
+pnpm exec turbo run build --filter=@module-federation/runtime-tools
+pnpm --filter @module-federation/webpack-bundler-runtime run test
+SSR_CACHE_STRICT=1 SSR_CACHE_EXPECT_NATIVE=1 SSR_CACHE_RSPACK_ENTRY=/Users/bytedance/outter/rspack/packages/rspack/dist/index.js SSR_CACHE_MODERN_ENTRY=/Users/bytedance/work/modern.js/packages/server/core/dist/cjs/adapters/node/index.js node --test tools/ssr-cache/baseline.test.cjs
+SSR_CACHE_RSPACK_ENTRY=/Users/bytedance/outter/rspack/packages/rspack/dist/index.js NODE_OPTIONS="--require=$PWD/tools/ssr-cache/local-rspack-hook.cjs" TURBO_ENV_MODE=loose pnpm run ci:local --only=e2e-modern-ssr
+pnpm exec prettier --check .
+pnpm exec prettier --check packages/webpack-bundler-runtime/src/clearCache.ts packages/webpack-bundler-runtime/src/init.ts packages/webpack-bundler-runtime/src/types.ts packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts tools/ssr-cache .changeset/dispose-bundler-cache-adapters.md
+python3 .codex/skills/changeset-pr/scripts/run_changeset_status.py --output /tmp/mf-adapter-changeset.json
+git diff --check
+```
+
+- Build: 6/6 tasks successful. An intermediate const/let edit error was corrected
+  before final build/test runs. Full bundler suite: 116/116 tests, 10 suites.
+- Strict native/Modern artifact baseline: **23/23 pass, no TODOs, skips or
+  failures**. The three previous stale-adapter assertions now pass for plain,
+  concatenated and diagnostic-parent variants. Shared identity/GC continues to
+  pass. A new child-process WeakRef test retains the disposer and saved clear
+  function while proving the disposed adapter no longer retains its runtime.
+- Unit coverage includes repeated attach/dispose, exact method restoration,
+  listener removal, separate bundled copies, multiple owners, preserving later
+  third-party wrappers, pending-cleanup detach rejection, starting all live
+  cleanups and waiting for errors, and updating only live registration mappings.
+- Full Modern SSR CI passes both existing remote-cache and shared-cache specs.
+  The emitted host was checked for the final all-binding cleanup and request-key
+  filtering logic. Earlier capture instability did not reproduce and is not
+  claimed fixed. Existing React/Helmet warnings remain.
+- Changed-file formatting, changeset planning and diff checks pass. Full-repo
+  Prettier still fails on 683 pre-existing/generated files. The new changeset
+  lists only webpack-bundler-runtime; fixed groups may broaden the release plan.
+- No Rust/compiler change in this increment, so native Rspack suites were not
+  repeated. Runtime-core sources are unchanged; its standalone suite was not
+  repeated. Other CI jobs were skipped in favor of the affected package's full
+  tests and Modern SSR integration. No package publication was performed.
+
+The GC check concerns adapter-owned references, not complete collection of an
+arbitrary old application bundle. Persistent MF instances, shared providers and
+saved business exports can still retain bundled code. Callers must drain work
+before disposal. Actual Modern production serve, stream/abort, long-running heap
+stability and rebuild recovery remain later acceptance gates.

--- a/tools/ssr-cache/adapter-fixture.cjs
+++ b/tools/ssr-cache/adapter-fixture.cjs
@@ -1,0 +1,48 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { installClearCache } = require(
+  path.join(
+    __dirname,
+    '../../packages/webpack-bundler-runtime/dist/clearCache.cjs',
+  ),
+);
+const instance = {
+  moduleCache: new Map(),
+  loadRemote: async () => null,
+  registerRemotes() {},
+  options: { remotes: [] },
+  loaderHook: { lifecycle: { createScript: { on() {}, remove() {} } } },
+};
+function attach() {
+  const runtime = {
+    federation: { instance, bundlerRuntimeOptions: {} },
+    m: {},
+    c: {},
+  };
+  const weak = new WeakRef(runtime);
+  const dispose = installClearCache({ webpackRequire: runtime });
+  const savedClear = runtime.federation.clearCache;
+  dispose();
+  return { weak, dispose, savedClear };
+}
+(async () => {
+  const retained = attach();
+  for (let n = 0; n < 30; n++) {
+    await new Promise((r) => setTimeout(r, 10));
+    global.gc();
+    if (!retained.weak.deref()) break;
+  }
+  assert.equal(
+    retained.weak.deref(),
+    undefined,
+    'retained disposer retains old runtime',
+  );
+  retained.dispose();
+  await assert.rejects(retained.savedClear({ name: 'remote' }), /detached/);
+  console.log(
+    'disposed runtime collected with handle and clear function retained',
+  );
+})().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/tools/ssr-cache/baseline.test.cjs
+++ b/tools/ssr-cache/baseline.test.cjs
@@ -105,8 +105,6 @@ for (const [variant, flags] of Object.entries({
         if (variant === 'parents') {
           for (const module of ['page', 'middle', 'leaf'])
             assert.equal(result.static.executions[module], 2);
-          assert.equal(result.rebuild.afterRebindingHook.result, 'v1');
-          assert.equal(result.rebuild.afterRebindingHook.newClearCalls, 1);
         }
       }
       if (flags.SHARED === '1') {
@@ -134,15 +132,11 @@ for (const [variant, flags] of Object.entries({
         assert.equal(result.rebuild.dynamicResult, 'v2');
         assert.equal(result.rebuild.newBundler, true);
         assert.equal(result.rebuild.hostChanged, false);
-        await knownFailure(
-          t,
-          'second update clears the current bundler',
-          () => {
-            assert.equal(result.rebuild.secondUpdate.oldClearCalls, 0);
-            assert.equal(result.rebuild.secondUpdate.newClearCalls, 1);
-            assert.equal(result.rebuild.secondUpdate.result, 'v1');
-          },
-        );
+        await t.test('second update clears the current bundler', () => {
+          assert.equal(result.rebuild.secondUpdate.oldClearCalls, 0);
+          assert.equal(result.rebuild.secondUpdate.newClearCalls, 1);
+          assert.equal(result.rebuild.secondUpdate.result, 'v1');
+        });
       }
       if (variant === 'plain') {
         await t.test(
@@ -176,3 +170,7 @@ for (const [variant, flags] of Object.entries({
     }
   });
 }
+
+test('disposed adapter releases its runtime with handles retained', () => {
+  run('adapter-fixture.cjs', process.cwd());
+});

--- a/tools/ssr-cache/fixture.cjs
+++ b/tools/ssr-cache/fixture.cjs
@@ -348,6 +348,10 @@ async function main() {
   // Same process: drop all emitted CJS modules then reacquire the application.
   const oldInstance = host.req.federation.instance;
   const oldRequire = host.req;
+  const disposeOld = oldRequire.federation.disposeClearCache;
+  assert.equal(typeof disposeOld, 'function');
+  disposeOld();
+  disposeOld();
   for (const key of Object.keys(require.cache))
     if (key.startsWith(out + path.sep)) delete require.cache[key];
   host = require(path.join(out, 'host.cjs'));
@@ -393,33 +397,6 @@ async function main() {
   assert.equal(result.dynamic.reimport, 'v1');
   assert.equal(result.rebuild.dynamicResult, 'v2');
 
-  if (process.env.PARENTS === '1') {
-    // Diagnostic intervention only: replace stale removal callback with current bundler.
-    const current = host.req.federation.instance;
-    current.remoteHandler.hooks.removePlugin(
-      'bundler-runtime-clear-cache-plugin',
-    );
-    current.remoteHandler.hooks.applyPlugin({
-      name: 'bundler-runtime-clear-cache-plugin',
-      removeRemote({ remote }) {
-        return host.req.federation.clearCache({
-          name: remote.alias || remote.name,
-        });
-      },
-    });
-    const next = {
-      ...current.options.remotes.find(
-        (r) => r.alias === 'remote' || r.name === 'remote',
-      ),
-    };
-    await current.removeRemote('remote');
-    current.registerRemotes([next]);
-    result.rebuild.afterRebindingHook = {
-      oldClearCalls,
-      newClearCalls,
-      result: (await host.page())(),
-    };
-  }
   fs.writeFileSync(
     path.join(root, 'result.json'),
     JSON.stringify(result, null, 2),


### PR DESCRIPTION
## Description

After an application rebuild reused its MF instance, the removal plugin still called the first bundler and installation stacked instance wrappers/listeners. Make the plugin query live bindings from the instance and return an idempotent disposer from `installClearCache`, also available as `federation.disposeClearCache`.

A shared per-instance registry coordinates multiple bundlers and separately bundled copies. The last detach restores owned methods and removes its listener, preserves later third-party wrappers, and releases captured runtime references. Pending cache cleanup prevents detachment; saved clear functions reject after disposal. Remove/force-registration cleanup reaches all live bindings and waits for their outcomes. The unused moduleCache.set generation wrapper is removed.

The application owner must drain work before disposal. This is an adapter primitive, not Modern admission/drain or full application GC. Persistent MF/shared/business references can still retain code.

Validation: runtime-tools build 6/6; complete bundler package 116/116 tests; strict real Rspack + Modern HTTP artifact baseline 23/23, zero TODOs/skips, including the three previously stale-adapter cases and a retained-handle WeakRef check. Full Modern SSR CI passes both remote-cache and shared-cache/GC specs. Existing intermittent capture failure did not reproduce and is not claimed fixed. Changed-file formatting, diff checks and changeset planning pass; full-repo Prettier still reports 683 pre-existing/generated files. Unchanged runtime-core/native Rspack suites and unrelated CI jobs were not rerun. Exact commands and limits: tools/ssr-cache/VALIDATION.md. No publication.

## Related Issue

Continues merged #5051 and the SSR cache RFC R1 adapter lifecycle work.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.