### PR TITLE
fix(runtime-core): skip import:false stubs when selecting shared providers

### DIFF
--- a/.changeset/skip-import-false-share-stubs.md
+++ b/.changeset/skip-import-false-share-stubs.md
@@ -2,4 +2,4 @@
 '@module-federation/runtime-core': patch
 ---
 
-Skip consume-only `import: false` share-scope stubs when selecting a provider if a real shared module exists for the package.
+Skip consume-only `import: false` share-scope stubs when selecting a provider if a real shared module exists, while still applying the stub's requiredVersion and strictVersion.

--- a/.changeset/skip-import-false-share-stubs.md
+++ b/.changeset/skip-import-false-share-stubs.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime-core': patch
+---
+
+Skip consume-only `import: false` share-scope stubs when selecting a provider if a real shared module exists for the package.

--- a/packages/runtime-core/__tests__/get-registered-share.spec.ts
+++ b/packages/runtime-core/__tests__/get-registered-share.spec.ts
@@ -124,10 +124,63 @@ describe('getRegisteredShare import:false consume-only stubs', () => {
       };
 
       const selected = selectShare(shareScopeMap, real);
-      expect(selected?.shared).not.toBe(stub);
-      expect(selected?.shared?.shareConfig?.import).not.toBe(false);
+      expect(selected?.shared).toBe(real);
+      expect(shareScopeMap.default.react['18.3.1']).toBe(real);
     },
   );
+
+  it('promotes a real requester into a same-version slot occupied by a loaded import:false stub', () => {
+    const stub = createConsumeOnlyStub({
+      version: '19.2.7',
+      from: 'host-stub',
+      loaded: true,
+      strategy: 'version-first',
+      shareConfig: {
+        requiredVersion: '^19.0.0',
+        singleton: true,
+        eager: false,
+        strictVersion: false,
+        import: false,
+      },
+    });
+    const real = createRealProvider({
+      version: '19.2.7',
+      from: 'provider',
+      strategy: 'version-first',
+      shareConfig: {
+        requiredVersion: '^19.0.0',
+        singleton: true,
+        eager: false,
+        strictVersion: false,
+      },
+    });
+    const shareScopeMap: ShareScopeMap = {
+      default: {
+        react: {
+          '19.2.7': stub,
+        },
+      },
+    };
+
+    const selected = selectShare(shareScopeMap, real);
+    expect(selected?.shared).toBe(real);
+    expect(shareScopeMap.default.react['19.2.7']).toBe(real);
+
+    const consumer = createConsumeOnlyStub({
+      version: '19.2.7',
+      from: 'nested-consumer',
+      shareConfig: {
+        requiredVersion: '^19.0.0',
+        singleton: true,
+        eager: false,
+        strictVersion: false,
+        import: false,
+      },
+    });
+    const later = selectShare(shareScopeMap, consumer);
+    expect(later?.shared).toBe(real);
+    expect(later?.shared?.shareConfig?.import).not.toBe(false);
+  });
 
   it.each<ShareStrategy>(['version-first', 'loaded-first'])(
     'prefers a runtime-only host sentinel "0" over a higher import:false stub (%s)',
@@ -409,6 +462,26 @@ describe('loadShare import:false consume-only stubs', () => {
 
     const factory = await host.loadShare<{ name: string }>('react');
     expect(factory?.()).toEqual({ name: 'real-react-19.2.7' });
+    expect(
+      host.shareScopeMap.default.react['19.2.7'].shareConfig.import,
+    ).not.toBe(false);
+
+    const later = selectShare(
+      host.shareScopeMap,
+      createConsumeOnlyStub({
+        version: '19.2.7',
+        from: 'nested-consumer',
+        shareConfig: {
+          requiredVersion: '^19.0.0',
+          singleton: true,
+          eager: false,
+          strictVersion: false,
+          import: false,
+        },
+      }),
+    );
+    expect(later?.shared?.shareConfig?.import).not.toBe(false);
+    expect(later?.shared).toBe(host.shareScopeMap.default.react['19.2.7']);
   });
 
   it('still throws must-be-provided-by-host when only an import:false stub exists', async () => {

--- a/packages/runtime-core/__tests__/get-registered-share.spec.ts
+++ b/packages/runtime-core/__tests__/get-registered-share.spec.ts
@@ -335,3 +335,175 @@ describe('getRegisteredShare import:false consume-only stubs', () => {
     expect(factory?.()).toEqual({ marker: 'real-provider' });
   });
 });
+
+describe('loadShare import:false consume-only stubs', () => {
+  beforeEach(() => {
+    resetFederationGlobalInfo();
+  });
+
+  it('selects a lower-version real provider over a higher import:false stub (19.2.8 vs 19.2.7)', async () => {
+    const host = new ModuleFederation({
+      name: 'repro-host',
+      remotes: [],
+      shareStrategy: 'version-first',
+      shared: {
+        react: [
+          {
+            version: '19.2.8',
+            shareConfig: {
+              singleton: true,
+              requiredVersion: '^19.0.0',
+              import: false,
+            },
+            get: () => () => {
+              throw new Error(HOST_PROVIDED_ERROR);
+            },
+          },
+          {
+            version: '19.2.7',
+            shareConfig: {
+              singleton: true,
+              requiredVersion: '^19.0.0',
+            },
+            get: () => () => ({ name: 'real-react-19.2.7' }),
+          },
+        ],
+      },
+    });
+
+    const factory = await host.loadShare<{ name: string }>('react');
+    expect(factory?.()).toEqual({ name: 'real-react-19.2.7' });
+  });
+
+  it('selects a later real provider over a same-version import:false stub', async () => {
+    const host = new ModuleFederation({
+      name: 'same-version-host',
+      remotes: [],
+      shareStrategy: 'version-first',
+      shared: {
+        react: {
+          version: '19.2.7',
+          shareConfig: {
+            singleton: true,
+            requiredVersion: '^19.0.0',
+          },
+          get: () => () => ({ name: 'real-react-19.2.7' }),
+        },
+      },
+    });
+
+    host.shareScopeMap.default.react = {
+      '19.2.7': createConsumeOnlyStub({
+        version: '19.2.7',
+        from: 'zzz-host-stub',
+        loaded: true,
+        shareConfig: {
+          requiredVersion: '^19.0.0',
+          singleton: true,
+          eager: false,
+          strictVersion: false,
+          import: false,
+        },
+      }),
+    };
+
+    const factory = await host.loadShare<{ name: string }>('react');
+    expect(factory?.()).toEqual({ name: 'real-react-19.2.7' });
+  });
+
+  it('still throws must-be-provided-by-host when only an import:false stub exists', async () => {
+    const host = new ModuleFederation({
+      name: 'stub-only-host',
+      remotes: [],
+      shareStrategy: 'version-first',
+      shared: {
+        react: {
+          version: '19.2.8',
+          shareConfig: {
+            singleton: true,
+            requiredVersion: '^19.0.0',
+            import: false,
+          },
+          get: () => () => {
+            throw new Error(HOST_PROVIDED_ERROR);
+          },
+        },
+      },
+    });
+
+    const factory = await host.loadShare('react');
+    expect(factory).toEqual(expect.any(Function));
+    expect(() => factory?.()).toThrow(HOST_PROVIDED_ERROR);
+  });
+
+  it('keeps the consume-only stub requiredVersion when selecting a real provider', () => {
+    const stub = createConsumeOnlyStub({
+      version: '19.2.8',
+      from: 'consumer-stub',
+      shareConfig: {
+        requiredVersion: '^19.0.0',
+        singleton: true,
+        eager: false,
+        strictVersion: true,
+        import: false,
+      },
+    });
+    const real = createRealProvider({
+      version: '19.2.7',
+      from: 'provider',
+      loaded: false,
+      lib: undefined,
+      get: () => () => ({ name: 'real-react-19.2.7' }),
+    });
+
+    const selected = selectShare(
+      {
+        default: {
+          react: {
+            '19.2.8': stub,
+            '19.2.7': real,
+          },
+        },
+      },
+      stub,
+    );
+
+    expect(selected?.shared).toBe(real);
+    expect(stub.shareConfig.requiredVersion).toBe('^19.0.0');
+    expect(stub.shareConfig.strictVersion).toBe(true);
+  });
+
+  it('uses the consume-only stub strictVersion against the selected real provider', () => {
+    const stub = createConsumeOnlyStub({
+      version: '19.2.8',
+      from: 'consumer-stub',
+      shareConfig: {
+        requiredVersion: '^19.2.8',
+        singleton: true,
+        eager: false,
+        strictVersion: true,
+        import: false,
+      },
+    });
+    const real = createRealProvider({
+      version: '19.2.7',
+      from: 'provider',
+      loaded: false,
+      lib: undefined,
+    });
+
+    expect(() =>
+      selectShare(
+        {
+          default: {
+            react: {
+              '19.2.8': stub,
+              '19.2.7': real,
+            },
+          },
+        },
+        stub,
+      ),
+    ).toThrow(/does not satisfy the requirement/);
+  });
+});

--- a/packages/runtime-core/__tests__/get-registered-share.spec.ts
+++ b/packages/runtime-core/__tests__/get-registered-share.spec.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, beforeEach } from '@rstest/core';
+import { ModuleFederation } from '../src/core';
+import { resetFederationGlobalInfo } from '../src/global';
+import { getRegisteredShare } from '../src/utils/share';
+import type { ShareScopeMap, Shared, ShareStrategy } from '../src/type';
+
+const HOST_PROVIDED_ERROR = "Shared module 'react' must be provided by host";
+const resolveShare = {
+  emit: () => undefined,
+};
+
+const throwingGet: Shared['get'] = () => {
+  throw new Error(HOST_PROVIDED_ERROR);
+};
+
+const createShared = (overrides: Partial<Shared> = {}): Shared => {
+  const version = overrides.version ?? '18.3.1';
+  return {
+    version,
+    get: overrides.get ?? throwingGet,
+    shareConfig: {
+      requiredVersion: '*',
+      singleton: true,
+      eager: false,
+      strictVersion: false,
+      ...overrides.shareConfig,
+    },
+    scope: overrides.scope ?? ['default'],
+    useIn: overrides.useIn ?? [],
+    from: overrides.from ?? 'host',
+    deps: overrides.deps ?? [],
+    strategy: overrides.strategy ?? 'version-first',
+    ...overrides,
+  };
+};
+
+const createConsumeOnlyStub = (overrides: Partial<Shared> = {}): Shared =>
+  createShared({
+    from: 'host-stub',
+    loaded: false,
+    loading: null,
+    get: throwingGet,
+    shareConfig: {
+      requiredVersion: '*',
+      singleton: true,
+      eager: false,
+      strictVersion: false,
+      import: false,
+      ...overrides.shareConfig,
+    },
+    ...overrides,
+  });
+
+const createRealProvider = (overrides: Partial<Shared> = {}): Shared => {
+  const marker = overrides.from ?? 'provider';
+  const lib = overrides.lib ?? (() => ({ marker }));
+  return createShared({
+    from: marker,
+    loaded: true,
+    lib,
+    get: () => Promise.resolve(lib),
+    shareConfig: {
+      requiredVersion: '*',
+      singleton: true,
+      eager: false,
+      strictVersion: false,
+      ...overrides.shareConfig,
+    },
+    ...overrides,
+  });
+};
+
+const selectShare = (
+  shareScopeMap: ShareScopeMap,
+  shareInfo: Shared,
+  pkgName = 'react',
+) =>
+  getRegisteredShare(
+    shareScopeMap,
+    pkgName,
+    shareInfo,
+    // @ts-expect-error test double for resolveShare hook
+    resolveShare,
+  );
+
+describe('getRegisteredShare import:false consume-only stubs', () => {
+  beforeEach(() => {
+    resetFederationGlobalInfo();
+  });
+
+  it.each<ShareStrategy>(['version-first', 'loaded-first'])(
+    'prefers a later real provider over a same-version import:false stub (%s)',
+    (strategy) => {
+      const stub = createConsumeOnlyStub({
+        version: '18.3.1',
+        from: 'host-stub',
+        strategy,
+        shareConfig: {
+          requiredVersion: '^18.3.1',
+          singleton: true,
+          eager: false,
+          strictVersion: false,
+          import: false,
+        },
+      });
+      const real = createRealProvider({
+        version: '18.3.1',
+        from: 'provider',
+        strategy,
+        shareConfig: {
+          requiredVersion: '^18.3.1',
+          singleton: true,
+          eager: false,
+          strictVersion: false,
+        },
+      });
+
+      const shareScopeMap: ShareScopeMap = {
+        default: {
+          react: {
+            '18.3.1': stub,
+          },
+        },
+      };
+
+      const selected = selectShare(shareScopeMap, real);
+      expect(selected?.shared).not.toBe(stub);
+      expect(selected?.shared?.shareConfig?.import).not.toBe(false);
+    },
+  );
+
+  it.each<ShareStrategy>(['version-first', 'loaded-first'])(
+    'prefers a runtime-only host sentinel "0" over a higher import:false stub (%s)',
+    (strategy) => {
+      const stub = createConsumeOnlyStub({
+        version: '1.2.3',
+        from: 'remote-stub',
+        loaded: false,
+        loading: strategy === 'loaded-first' ? Promise.resolve() : null,
+        strategy,
+        shareConfig: {
+          requiredVersion: '*',
+          singleton: true,
+          eager: false,
+          strictVersion: false,
+          import: false,
+        },
+      });
+      const hostProvider = createRealProvider({
+        version: '0',
+        from: 'runtime-host',
+        strategy,
+        shareConfig: {
+          requiredVersion: false,
+          singleton: true,
+          eager: false,
+          strictVersion: false,
+        },
+      });
+
+      const shareScopeMap: ShareScopeMap = {
+        default: {
+          react: {
+            '1.2.3': stub,
+            '0': hostProvider,
+          },
+        },
+      };
+
+      const selected = selectShare(shareScopeMap, stub);
+      expect(selected?.shared).toBe(hostProvider);
+      expect(selected?.shared?.from).toBe('runtime-host');
+    },
+  );
+
+  it('keeps the import:false stub when no real provider exists', async () => {
+    const stub = createConsumeOnlyStub({
+      version: '18.3.1',
+      from: 'host-stub',
+      shareConfig: {
+        requiredVersion: '^18.3.1',
+        singleton: true,
+        eager: false,
+        strictVersion: false,
+        import: false,
+      },
+    });
+    const shareScopeMap: ShareScopeMap = {
+      default: {
+        react: {
+          '18.3.1': stub,
+        },
+      },
+    };
+
+    const selected = selectShare(shareScopeMap, stub);
+    expect(selected?.shared).toBe(stub);
+
+    await expect(Promise.resolve().then(() => stub.get())).rejects.toThrow(
+      HOST_PROVIDED_ERROR,
+    );
+  });
+
+  it('still applies version-first among real providers after skipping stubs', () => {
+    const oldReal = createRealProvider({
+      version: '17.0.2',
+      from: 'old-provider',
+      loaded: false,
+      lib: undefined,
+      strategy: 'version-first',
+    });
+    const midReal = createRealProvider({
+      version: '18.0.0',
+      from: 'mid-provider',
+      loaded: false,
+      lib: undefined,
+      strategy: 'version-first',
+    });
+    const stub = createConsumeOnlyStub({
+      version: '19.0.0',
+      from: 'stub',
+      strategy: 'version-first',
+    });
+
+    const shareScopeMap: ShareScopeMap = {
+      default: {
+        react: {
+          '17.0.2': oldReal,
+          '19.0.0': stub,
+          '18.0.0': midReal,
+        },
+      },
+    };
+
+    const selected = selectShare(
+      shareScopeMap,
+      createShared({
+        version: '18.0.0',
+        strategy: 'version-first',
+        shareConfig: {
+          requiredVersion: '*',
+          singleton: true,
+          eager: false,
+          strictVersion: false,
+        },
+      }),
+    );
+    expect(selected?.shared).toBe(midReal);
+  });
+
+  it('still applies loaded-first among real providers after skipping stubs', () => {
+    const loadedReal = createRealProvider({
+      version: '17.0.2',
+      from: 'loaded-host',
+      loaded: true,
+      strategy: 'loaded-first',
+    });
+    const newerUnloaded = createRealProvider({
+      version: '18.3.1',
+      from: 'newer-unloaded',
+      loaded: false,
+      lib: undefined,
+      loading: null,
+      strategy: 'loaded-first',
+    });
+    const stub = createConsumeOnlyStub({
+      version: '19.0.0',
+      from: 'stub',
+      loaded: false,
+      loading: Promise.resolve(),
+      strategy: 'loaded-first',
+    });
+
+    const shareScopeMap: ShareScopeMap = {
+      default: {
+        react: {
+          '19.0.0': stub,
+          '17.0.2': loadedReal,
+          '18.3.1': newerUnloaded,
+        },
+      },
+    };
+
+    const selected = selectShare(
+      shareScopeMap,
+      createShared({
+        version: '18.3.1',
+        strategy: 'loaded-first',
+        shareConfig: {
+          requiredVersion: '*',
+          singleton: true,
+          eager: false,
+          strictVersion: false,
+        },
+      }),
+    );
+    expect(selected?.shared).toBe(loadedReal);
+  });
+
+  it('uses a later real provider from loadShare when a same-version stub occupies the slot', async () => {
+    const federation = new ModuleFederation({
+      name: 'provider',
+      remotes: [],
+      shareStrategy: 'version-first',
+      shared: {
+        react: {
+          version: '18.3.1',
+          lib: () => ({ marker: 'real-provider' }),
+          shareConfig: {
+            singleton: true,
+            requiredVersion: '^18.3.1',
+          },
+        },
+      },
+    });
+
+    // Occupy the same version slot with a loaded consume-only stub so
+    // initializeSharing will not replace it. Selection must still skip it.
+    federation.shareScopeMap.default.react = {
+      '18.3.1': createConsumeOnlyStub({
+        version: '18.3.1',
+        from: 'zzz-host-stub',
+        loaded: true,
+        shareConfig: {
+          requiredVersion: '^18.3.1',
+          singleton: true,
+          eager: false,
+          strictVersion: false,
+          import: false,
+        },
+      }),
+    };
+
+    const factory = await federation.loadShare<{ marker: string }>('react');
+    expect(factory?.()).toEqual({ marker: 'real-provider' });
+  });
+});

--- a/packages/runtime-core/src/type/config.ts
+++ b/packages/runtime-core/src/type/config.ts
@@ -63,6 +63,11 @@ export interface SharedConfig {
   eager?: boolean;
   strictVersion?: boolean;
   layer?: string | null;
+  /**
+   * Consume-only marker. `false` means this share-scope entry is not a real
+   * provider and must not win selection when a usable provider exists.
+   */
+  import?: false;
 }
 
 export type TreeShakingArgs = {

--- a/packages/runtime-core/src/utils/share.ts
+++ b/packages/runtime-core/src/utils/share.ts
@@ -166,17 +166,57 @@ export function versionLt(a: string, b: string): boolean {
   }
 }
 
+function isConsumeOnlyStub(shared?: {
+  shareConfig?: { import?: unknown };
+}): boolean {
+  return shared?.shareConfig?.import === false;
+}
+
+function preferRealShareProviders(
+  shareVersionMap: ShareScopeMap[string][string],
+): ShareScopeMap[string][string] {
+  const realEntries = Object.entries(shareVersionMap).filter(
+    ([, shared]) => !isConsumeOnlyStub(shared),
+  );
+  if (realEntries.length > 0) {
+    return Object.fromEntries(realEntries);
+  }
+  return shareVersionMap;
+}
+
+function getShareVersionMapForSelection(
+  shareVersionMap: ShareScopeMap[string][string],
+  shareInfo: Shared,
+): ShareScopeMap[string][string] {
+  const preferred = preferRealShareProviders(shareVersionMap);
+  if (preferred !== shareVersionMap) {
+    return preferred;
+  }
+  // Scope has no real provider. Keep consume-only stubs only when the
+  // requester is also consume-only, preserving "must be provided by host".
+  if (!isConsumeOnlyStub(shareInfo)) {
+    return {};
+  }
+  return shareVersionMap;
+}
+
 export const findVersion = (
   shareVersionMap: ShareScopeMap[string][string],
   cb?: (prev: string, cur: string) => boolean,
 ): string => {
+  const versionMap = preferRealShareProviders(shareVersionMap);
   const callback =
     cb ||
     function (prev: string, cur: string): boolean {
       return versionLt(prev, cur);
     };
 
-  return Object.keys(shareVersionMap).reduce((prev: number | string, cur) => {
+  const versionKeys = Object.keys(versionMap);
+  if (!versionKeys.length) {
+    return '';
+  }
+
+  return versionKeys.reduce((prev: number | string, cur) => {
     if (!prev) {
       return cur;
     }
@@ -386,12 +426,30 @@ export function getRegisteredShare(
       localShareScopeMap[sc][pkgName]
     ) {
       const { requiredVersion } = shareConfig;
+      const pkgVersions = localShareScopeMap[sc][pkgName];
+      const versionsForSelection = getShareVersionMapForSelection(
+        pkgVersions,
+        shareInfo,
+      );
+      if (!Object.keys(versionsForSelection).length) {
+        continue;
+      }
+      const selectionShareScopeMap: ShareScopeMap = {
+        ...localShareScopeMap,
+        [sc]: {
+          ...localShareScopeMap[sc],
+          [pkgName]: versionsForSelection,
+        },
+      };
       const findShareFunction = getFindShareFunction(strategy);
       const { version: maxOrSingletonVersion, useTreesShaking } =
-        findShareFunction(localShareScopeMap, sc, pkgName, treeShaking);
+        findShareFunction(selectionShareScopeMap, sc, pkgName, treeShaking);
 
       const defaultResolver = () => {
-        const shared = localShareScopeMap[sc][pkgName][maxOrSingletonVersion];
+        const shared = versionsForSelection[maxOrSingletonVersion];
+        if (!shared) {
+          return;
+        }
         if (shareConfig.singleton) {
           if (
             typeof requiredVersion === 'string' &&
@@ -430,7 +488,7 @@ export function getRegisteredShare(
           const _usedTreeShaking = shouldUseTreeShaking(treeShaking);
           if (_usedTreeShaking) {
             for (const [versionKey, versionValue] of Object.entries(
-              localShareScopeMap[sc][pkgName],
+              versionsForSelection,
             )) {
               if (
                 !shouldUseTreeShaking(
@@ -450,7 +508,7 @@ export function getRegisteredShare(
             }
           }
           for (const [versionKey, versionValue] of Object.entries(
-            localShareScopeMap[sc][pkgName],
+            versionsForSelection,
           )) {
             if (satisfy(versionKey, requiredVersion)) {
               return {

--- a/packages/runtime-core/src/utils/share.ts
+++ b/packages/runtime-core/src/utils/share.ts
@@ -192,10 +192,14 @@ function getShareVersionMapForSelection(
   if (preferred !== shareVersionMap) {
     return preferred;
   }
-  // Scope has no real provider. Keep consume-only stubs only when the
-  // requester is also consume-only, preserving "must be provided by host".
+  // Scope has no real provider. If the requester is a real provider, register
+  // it as the candidate so later consume-only loadShare does not keep hitting
+  // a throwing stub, and so resolveShare still runs.
   if (!isConsumeOnlyStub(shareInfo)) {
-    return {};
+    shareVersionMap[shareInfo.version] = shareInfo;
+    return {
+      [shareInfo.version]: shareInfo,
+    };
   }
   return shareVersionMap;
 }

--- a/packages/runtime-core/src/utils/share.ts
+++ b/packages/runtime-core/src/utils/share.ts
@@ -204,14 +204,13 @@ export const findVersion = (
   shareVersionMap: ShareScopeMap[string][string],
   cb?: (prev: string, cur: string) => boolean,
 ): string => {
-  const versionMap = preferRealShareProviders(shareVersionMap);
   const callback =
     cb ||
     function (prev: string, cur: string): boolean {
       return versionLt(prev, cur);
     };
 
-  const versionKeys = Object.keys(versionMap);
+  const versionKeys = Object.keys(shareVersionMap);
   if (!versionKeys.length) {
     return '';
   }
@@ -427,6 +426,8 @@ export function getRegisteredShare(
     ) {
       const { requiredVersion } = shareConfig;
       const pkgVersions = localShareScopeMap[sc][pkgName];
+      // Skip consume-only stubs for get/lib selection, but keep using
+      // shareInfo.shareConfig (requiredVersion / strictVersion / singleton).
       const versionsForSelection = getShareVersionMapForSelection(
         pkgVersions,
         shareInfo,


### PR DESCRIPTION
## Description

Share-scope provider selection in `@module-federation/runtime-core` treated consume-only `import: false` stubs as first-class providers. Those stubs can win version or singleton selection (same version / first registrant, or a higher declared version than a real provider), so `loadShare` calls a `get()` that throws `Shared module '…' must be provided by host` even when a real host/provider is already in the scope.

This is the portable fix in `getRegisteredShare`. Vite generated helpers ([#953](https://github.com/module-federation/vite/pull/953), [#1178](https://github.com/module-federation/vite/pull/1178), [#1184](https://github.com/module-federation/vite/pull/1184), [#1230](https://github.com/module-federation/vite/pull/1230)) only paper over the symptom for Vite-generated paths; nested remotes that call `loadShare` directly stay unprotected without this core change.

Fixes #5058

## Changes Made

- Skip `shareConfig.import === false` candidates in `getRegisteredShare` when at least one real provider exists
- Keep stub metadata available for `requiredVersion` / `strictVersion` checks on the requester
- Type `import?: false` on `SharedConfig`
- Unit coverage including stub `19.2.8` vs real provider `19.2.7`

## Testing

**FAIL (unfixed):** `loadShare('react')` with stub@19.2.8 (`import: false`) + provider@19.2.7 invoked the stub and threw `must be provided by host`.

**PASS (fixed):** same test selects the real 19.2.7 provider.

Full `@module-federation/runtime-core` suite: **139 passed**.

Also validated independently against published `2.9.0` with the same stub-vs-provider setup (see #5058 comment).
