### PR TITLE
fix(runtime): preserve resolved provider identity during cache cleanup

### DIFF
--- a/.changeset/ssr-resolved-provider-identity.md
+++ b/.changeset/ssr-resolved-provider-identity.md
@@ -1,0 +1,7 @@
+---
+'@module-federation/sdk': patch
+'@module-federation/runtime-core': patch
+'@module-federation/webpack-bundler-runtime': patch
+---
+
+Preserve the manifest provider identity independently of registration and container global names during SSR cache invalidation. Keep live shared providers intact and avoid deleting business globals that happen to match a remote registration name.

--- a/.changeset/ssr-resolved-provider-identity.md
+++ b/.changeset/ssr-resolved-provider-identity.md
@@ -4,4 +4,4 @@
 '@module-federation/webpack-bundler-runtime': patch
 ---
 
-Preserve the manifest provider identity independently of registration and container global names during SSR cache invalidation. Keep live shared providers intact and avoid deleting business globals that happen to match a remote registration name.
+Preserve the manifest provider identity independently of registration and container global names during SSR cache invalidation. Keep live shared providers intact and avoid deleting business globals that happen to match a remote registration name. Resolved identity is captured before removal hooks so an earlier hook clearing moduleCache cannot erase that cleanup context.

--- a/packages/runtime-core/__tests__/register-remotes.spec.ts
+++ b/packages/runtime-core/__tests__/register-remotes.spec.ts
@@ -493,6 +493,7 @@ describe('ModuleFederation', () => {
   it('keeps loaded remote cleanup context when removeRemote hook clears moduleCache first', async () => {
     const entry =
       'http://localhost:1111/resources/register-remotes/app1/federation-remote-entry.js';
+    const observed = rs.fn();
     const remoteEntryClear = rs.fn();
     const libClear = rs.fn();
     const globalClear = rs.fn();
@@ -511,6 +512,15 @@ describe('ModuleFederation', () => {
           name: 'module-cache-first-remove-plugin',
           removeRemote({ origin }) {
             origin.moduleCache.delete('@register-remotes/app1');
+          },
+        },
+        {
+          name: 'later-remove-hook',
+          removeRemote({ origin, remoteInfo }) {
+            expect(origin.moduleCache.has('@register-remotes/app1')).toBe(
+              false,
+            );
+            observed(remoteInfo);
           },
         },
       ],
@@ -563,6 +573,13 @@ describe('ModuleFederation', () => {
 
     await FM.removeRemote('app1');
 
+    expect(observed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: '@register-remotes/app1',
+        entryGlobalName: 'app1',
+        entry,
+      }),
+    );
     expect(remoteEntryClear).toHaveBeenCalledTimes(1);
     expect(libClear).toHaveBeenCalledTimes(1);
     expect(globalClear).toHaveBeenCalledTimes(1);

--- a/packages/runtime-core/__tests__/register-remotes.spec.ts
+++ b/packages/runtime-core/__tests__/register-remotes.spec.ts
@@ -387,10 +387,12 @@ describe('ModuleFederation', () => {
       { registered: true, loading: true },
       { registered: false, loading: true },
     ].flatMap((flags) =>
-      ['@register-remotes/app1', 'app1'].map((providerName) => ({
-        ...flags,
-        providerName,
-      })),
+      ['@register-remotes/app1', 'app1', 'manifest-provider'].map(
+        (providerName) => ({
+          ...flags,
+          providerName,
+        }),
+      ),
     ),
   )(
     'keeps shared provider caches: %j',
@@ -431,6 +433,7 @@ describe('ModuleFederation', () => {
       FM.moduleCache.set('@register-remotes/app1', {
         remoteInfo: {
           name: '@register-remotes/app1',
+          providerName,
           alias: 'app1',
           entry,
           type: 'global',

--- a/packages/runtime-core/__tests__/snapshot.spec.ts
+++ b/packages/runtime-core/__tests__/snapshot.spec.ts
@@ -1,3 +1,4 @@
+import { assignRemoteInfo } from '../src/plugins/snapshot';
 import { assert, describe, it } from '@rstest/core';
 import { ModuleFederation } from '../src';
 import { getGlobalSnapshot, resetFederationGlobalInfo } from '../src/global';
@@ -46,4 +47,20 @@ describe('snapshot', () => {
       },
     });
   });
+});
+
+it('keeps manifest provider identity separate from the host registration and container global', () => {
+  const remote = { name: 'dynamic' } as any;
+  assignRemoteInfo(remote, {
+    providerName: 'provider',
+    remoteEntry: 'entry.js',
+    remoteEntryType: 'global',
+    globalName: '__FEDERATION_custom:custom__',
+    publicPath: 'https://example.com/',
+    version: '1',
+    buildVersion: 'build',
+  } as any);
+  expect(remote.name).toBe('dynamic');
+  expect(remote.providerName).toBe('provider');
+  expect(remote.entryGlobalName).toBe('__FEDERATION_custom:custom__');
 });

--- a/packages/runtime-core/src/plugins/snapshot/index.ts
+++ b/packages/runtime-core/src/plugins/snapshot/index.ts
@@ -30,6 +30,7 @@ export function assignRemoteInfo(
     entryUrl = `https:${entryUrl}`;
   }
 
+  remoteInfo.providerName = remoteSnapshot.providerName;
   remoteInfo.type = remoteEntryInfo.type;
   remoteInfo.entryGlobalName = remoteEntryInfo.globalName;
   remoteInfo.entry = entryUrl;

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -789,7 +789,11 @@ export class RemoteHandler {
           // name (for example dynamic -> catalog). Shared.from uses the provider
           // identity, so scanning only the registration name can clear live libs.
           const providerNames = new Set(
-            [remoteInfo.name, remoteInfo.entryGlobalName].filter(Boolean),
+            [
+              remoteInfo.providerName,
+              remoteInfo.name,
+              remoteInfo.entryGlobalName,
+            ].filter((name): name is string => Boolean(name)),
           );
           let remoteInsId = remoteInfo.buildVersion
             ? composeKeyWithSeparator(remoteInfo.name, remoteInfo.buildVersion)

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -130,6 +130,8 @@ export class RemoteHandler {
         {
           remote: Remote;
           origin: ModuleFederation;
+          /** Resolved identity captured before user removal hooks mutate caches. */
+          remoteInfo?: RemoteInfo;
         },
       ],
       void
@@ -768,7 +770,13 @@ export class RemoteHandler {
     const { name } = remote;
     const loadedModule = host.moduleCache.get(remote.name);
     return Promise.resolve(
-      this.hooks.lifecycle.removeRemote.emit({ remote, origin: host }),
+      this.hooks.lifecycle.removeRemote.emit({
+        remote,
+        origin: host,
+        remoteInfo: loadedModule?.remoteInfo
+          ? { ...loadedModule.remoteInfo }
+          : undefined,
+      }),
     )
       .then(() => {
         const remoteIndex = host.options.remotes.findIndex(

--- a/packages/runtime-core/src/type/config.ts
+++ b/packages/runtime-core/src/type/config.ts
@@ -42,6 +42,8 @@ export interface SharedLoadContext {
 }
 
 export interface RemoteInfo {
+  /** Resolved manifest provider identity, separate from the registration name. */
+  providerName?: string;
   alias?: string;
   name: string;
   version?: string;

--- a/packages/sdk/__tests__/resources/manifestSnapshotMap.ts
+++ b/packages/sdk/__tests__/resources/manifestSnapshotMap.ts
@@ -572,6 +572,7 @@ const manifest: { [key: string]: Stats } = {
 
 const snapshot: { [key: string]: ModuleInfo } = {
   devAppSnapshot: {
+    providerName: manifest.devAppManifest.name,
     version: '',
     buildVersion: 'local',
     globalName: '__FEDERATION_@garfish/micro-app-sub2:local__',
@@ -667,6 +668,7 @@ const snapshot: { [key: string]: ModuleInfo } = {
     publicPath: 'http://localhost:2004/',
   },
   devAppSnapshotWithVersion: {
+    providerName: manifest.devAppManifest.name,
     version: 'http://localhost:2006/vmok-manifest.json',
     buildVersion: 'local',
     globalName: '__FEDERATION_@garfish/micro-app-sub2:local__',
@@ -762,6 +764,7 @@ const snapshot: { [key: string]: ModuleInfo } = {
     publicPath: 'http://localhost:2004/',
   },
   devAppSnapshotWithGetPublicPath: {
+    providerName: manifest.devAppManifestWithGetPublicPath.name,
     version: '',
     buildVersion: 'local',
     globalName: '__FEDERATION_@garfish/micro-app-sub3:local__',
@@ -867,6 +870,7 @@ const snapshot: { [key: string]: ModuleInfo } = {
     getPublicPath: "return 'http://localhost:2005/'",
   },
   prodAppSnapshot: {
+    providerName: manifest.prodAppManifest.name,
     version: '',
     buildVersion: '1.0.0.1517',
     globalName: '__FEDERATION_@garfish/micro-app-sub2:1.0.0.1517__',
@@ -956,6 +960,7 @@ const snapshot: { [key: string]: ModuleInfo } = {
     publicPath: 'https://__CDN_PREFIX__/micro-app-sub2/1.0.0.1517/',
   },
   prodAppSnapshotWithGetPublicPath: {
+    providerName: manifest.prodAppManifestWithGetPublicPath.name,
     version: '',
     buildVersion: '1.0.0.1513',
     globalName: '__FEDERATION_@garfish/micro-app-sub3:1.0.0.1513__',
@@ -1055,6 +1060,7 @@ const snapshot: { [key: string]: ModuleInfo } = {
       "return 'https://xxx.com/__FEDERATION_micro-app-sub3/1.0.0.1513/'",
   },
   ssrProdAppSnapshotWithAllParams: {
+    providerName: manifest.ssrAppManifest.name,
     version: '',
     buildVersion: '1.0.0.1517',
     globalName: '__FEDERATION_@mf/ssr-manifest-provider:1.0.0.1517__',
@@ -1086,6 +1092,7 @@ const snapshot: { [key: string]: ModuleInfo } = {
     publicPath: 'https://__CDN_PREFIX__/ssr-manifest-provider/1.0.0.1517/',
   },
   prodAppSnapshotWithAllParams: {
+    providerName: manifest.prodAppManifest.name,
     version: '',
     buildVersion: '1.0.0.1517',
     globalName: '__FEDERATION_@garfish/micro-app-sub2:1.0.0.1517__',
@@ -1178,6 +1185,7 @@ const snapshot: { [key: string]: ModuleInfo } = {
     publicPath: 'https://__CDN_PREFIX__/micro-app-sub2/1.0.0.1517/',
   },
   devAppSnapshotWithOverrides: {
+    providerName: manifest.devAppManifest.name,
     version: '',
     buildVersion: 'local',
     globalName: '__FEDERATION_@garfish/micro-app-sub2:local__',
@@ -1273,6 +1281,7 @@ const snapshot: { [key: string]: ModuleInfo } = {
     publicPath: 'http://localhost:2004/',
   },
   devAppSnapshotWithRemotes: {
+    providerName: manifest.devAppManifest.name,
     version: '',
     buildVersion: 'local',
     globalName: '__FEDERATION_@garfish/micro-app-sub2:local__',
@@ -1368,6 +1377,7 @@ const snapshot: { [key: string]: ModuleInfo } = {
     publicPath: 'http://localhost:2004/',
   },
   devAppSnapshotWithPartRemotes: {
+    providerName: manifest.devAppManifest.name,
     version: '',
     buildVersion: 'local',
     globalName: '__FEDERATION_@garfish/micro-app-sub2:local__',
@@ -1460,6 +1470,7 @@ const snapshot: { [key: string]: ModuleInfo } = {
     publicPath: 'http://localhost:2004/',
   },
   devAppSnapshotWithAllParams: {
+    providerName: manifest.devAppManifest.name,
     version: '',
     buildVersion: 'local',
     globalName: '__FEDERATION_@garfish/micro-app-sub2:local__',
@@ -1555,6 +1566,7 @@ const snapshot: { [key: string]: ModuleInfo } = {
     publicPath: 'http://localhost:2004/',
   },
   devAppSnapshotWithRemotesAndOverrides: {
+    providerName: manifest.devAppManifest.name,
     version: '',
     buildVersion: 'local',
     globalName: '__FEDERATION_@garfish/micro-app-sub2:local__',

--- a/packages/sdk/src/generateSnapshotFromManifest.ts
+++ b/packages/sdk/src/generateSnapshotFromManifest.ts
@@ -136,6 +136,7 @@ export function generateSnapshotFromManifest(
   const { exposes } = manifest;
 
   let basicRemoteSnapshot: BasicProviderModuleInfo = {
+    providerName: manifest.name,
     version: version ? version : '',
     buildVersion,
     globalName,

--- a/packages/sdk/src/types/snapshot.ts
+++ b/packages/sdk/src/types/snapshot.ts
@@ -2,6 +2,8 @@ import { TreeShakingStatus } from '../constant';
 import { RemoteEntryType, StatsAssets } from './stats';
 
 interface BasicModuleInfo {
+  /** Provider identity from the manifest; independent of host registration/global names. */
+  providerName?: string;
   dev?: {
     version?: string;
     remotes?: { [nameWithType: string]: string };

--- a/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
+++ b/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
@@ -153,7 +153,7 @@ describe('clearCache', () => {
 
   test.each(
     [false, true].flatMap((loading) =>
-      ['remoteA', 'containerA'].flatMap((providerName) =>
+      ['remoteA', 'containerA', 'manifest-provider'].flatMap((providerName) =>
         ['bundler', 'runtime'].map((source) => ({
           loading,
           providerName,
@@ -168,6 +168,10 @@ describe('clearCache', () => {
       const remoteEntryClear = jest.fn();
       const selectiveClear = jest.fn();
       const previousFederation = (globalThis as any).__FEDERATION__;
+      const globalName =
+        providerName === 'manifest-provider'
+          ? '__FEDERATION_custom:custom__'
+          : providerName;
       const shared = {
         from: providerName,
         loaded: !loading,
@@ -177,12 +181,17 @@ describe('clearCache', () => {
       };
 
       instance.moduleCache.set('remoteA', {
+        remoteInfo: {
+          name: 'remoteA',
+          entryGlobalName: globalName,
+          providerName,
+        },
         remoteEntryExports: {
           __webpack_clear_cache__: remoteEntryClear,
           __webpack_clear_exposed_cache__: selectiveClear,
         },
       });
-      (globalThis as any)[providerName] = {
+      (globalThis as any)[globalName] = {
         __webpack_clear_cache__: remoteEntryClear,
         __webpack_clear_exposed_cache__: selectiveClear,
       };
@@ -203,7 +212,7 @@ describe('clearCache', () => {
           {
             name: 'remoteA',
             entry: 'http://localhost:3001/remoteEntry.js',
-            entryGlobalName: providerName,
+            entryGlobalName: globalName,
           },
         ],
       };
@@ -212,7 +221,7 @@ describe('clearCache', () => {
           {
             name: 'remoteA',
             entry: 'http://localhost:3001/remoteEntry.js',
-            entryGlobalName: providerName,
+            entryGlobalName: globalName,
           },
         ] as any;
         webpackRequire.federation.bundlerRuntimeOptions.remotes.remoteInfos =
@@ -265,16 +274,54 @@ describe('clearCache', () => {
             'shared-from-remoteA'
           ]['1.0.0'],
         ).toBe(shared);
-        expect((globalThis as any)[providerName]).toBeDefined();
+        expect((globalThis as any)[globalName]).toBeDefined();
         expect(shared.from).toBe(providerName);
       } finally {
         (globalThis as any).__FEDERATION__ = previousFederation;
-        delete (globalThis as any)[providerName];
+        delete (globalThis as any)[globalName];
         (globalThis as any).window = previousWindow;
         (globalThis as any).document = previousDocument;
       }
     },
   );
+
+  test('resolved container identity never deletes a registration-named business global', async () => {
+    const { instance, webpackRequire } = createWebpackRequire();
+    const business = { dispose: jest.fn() };
+    const container = { __webpack_clear_cache__: jest.fn() };
+    const globals = globalThis as any;
+    const previous = globals.dynamic;
+    globals.dynamic = business;
+    globals.__test_resolved_container__ = container;
+    instance.options.remotes = [
+      {
+        name: 'dynamic',
+        entry: 'https://example.com/mf-manifest.json',
+        entryGlobalName: 'dynamic',
+      },
+    ] as any;
+    instance.moduleCache.set('dynamic', {
+      remoteInfo: {
+        name: 'dynamic',
+        entryGlobalName: '__test_resolved_container__',
+      },
+      remoteEntryExports: container,
+    });
+    try {
+      await clearCache({
+        name: 'dynamic',
+        webpackRequire: webpackRequire as any,
+      });
+      expect(globals.dynamic).toBe(business);
+      expect(business.dispose).not.toHaveBeenCalled();
+      expect(globals.__test_resolved_container__).toBeUndefined();
+      expect(container.__webpack_clear_cache__).toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) delete globals.dynamic;
+      else globals.dynamic = previous;
+      delete globals.__test_resolved_container__;
+    }
+  });
 
   test('should evict old caches before pending remote load settles', async () => {
     const { instance, webpackRequire } = createWebpackRequire();

--- a/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
+++ b/packages/webpack-bundler-runtime/__tests__/clearCache.spec.ts
@@ -323,6 +323,48 @@ describe('clearCache', () => {
     }
   });
 
+  test('remove hook retains resolved identity after an earlier hook deletes moduleCache', async () => {
+    const { instance, webpackRequire } = createWebpackRequire();
+    const business = { dispose: jest.fn() };
+    const container = { __webpack_clear_cache__: jest.fn() };
+    const globals = globalThis as any;
+    const previous = globals.dynamic;
+    globals.dynamic = business;
+    globals.__test_resolved_container__ = container;
+    instance.options.remotes = [
+      {
+        name: 'dynamic',
+        entry: 'https://example.com/mf-manifest.json',
+        entryGlobalName: 'dynamic',
+      },
+    ] as any;
+    instance.moduleCache.set('dynamic', {
+      remoteInfo: {
+        name: 'dynamic',
+        entryGlobalName: '__test_resolved_container__',
+      },
+      remoteEntryExports: container,
+    });
+    try {
+      const remoteInfo = { ...instance.moduleCache.get('dynamic').remoteInfo };
+      instance.moduleCache.delete('dynamic');
+      installClearCache({ webpackRequire: webpackRequire as any });
+      await createClearCacheRuntimePlugin().removeRemote({
+        remote: instance.options.remotes[0],
+        origin: instance,
+        remoteInfo: remoteInfo as any,
+      });
+      expect(globals.dynamic).toBe(business);
+      expect(business.dispose).not.toHaveBeenCalled();
+      expect(globals.__test_resolved_container__).toBeUndefined();
+      expect(container.__webpack_clear_cache__).toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) delete globals.dynamic;
+      else globals.dynamic = previous;
+      delete globals.__test_resolved_container__;
+    }
+  });
+
   test('should evict old caches before pending remote load settles', async () => {
     const { instance, webpackRequire } = createWebpackRequire();
     const pendingLoad = createDeferred();

--- a/packages/webpack-bundler-runtime/src/clearCache.ts
+++ b/packages/webpack-bundler-runtime/src/clearCache.ts
@@ -424,10 +424,14 @@ const getClearTarget = (
   }
   for (const remoteName of remoteNames) {
     const loaded = instance?.moduleCache?.get(remoteName);
-    if (loaded?.remoteInfo) {
+    const resolved =
+      options.remoteInfo?.name === remoteName
+        ? options.remoteInfo
+        : loaded?.remoteInfo;
+    if (resolved) {
       // Resolved manifest metadata supersedes the registration's default global.
       remoteInfos = remoteInfos.filter((info) => info.name !== remoteName);
-      remoteInfos.push(loaded.remoteInfo as RemoteInfoLike);
+      remoteInfos.push(resolved as RemoteInfoLike);
     }
   }
   return {
@@ -1515,9 +1519,11 @@ export const createClearCacheRuntimePlugin = () => ({
   async removeRemote({
     remote,
     origin,
+    remoteInfo,
   }: {
     remote: RuntimeRemote;
     origin: object;
+    remoteInfo?: ClearCacheOptions['remoteInfo'];
   }) {
     const adapters = getAdapters(origin);
     if (!adapters) return;
@@ -1527,6 +1533,7 @@ export const createClearCacheRuntimePlugin = () => ({
           if (!adapters.bindings.has(binding)) return;
           await binding.federation.clearCache!({
             name: remote.alias || remote.name,
+            ...(remoteInfo ? { remoteInfo } : {}),
           });
         }),
       );

--- a/packages/webpack-bundler-runtime/src/clearCache.ts
+++ b/packages/webpack-bundler-runtime/src/clearCache.ts
@@ -32,6 +32,7 @@ type ChunkCacheControl = {
 };
 
 type RemoteInfoLike = {
+  providerName?: string;
   name?: string;
   alias?: string;
   entry?: string;
@@ -200,16 +201,11 @@ const getRemoteNames = (
 };
 
 const getRemoteEntryGlobalKeys = (remoteInfo: RemoteInfoLike) => {
-  const keys: string[] = [];
-  pushUnique(keys, [
-    remoteInfo.entryGlobalName,
-    remoteInfo.globalName,
-    remoteInfo.name,
-  ]);
-  if (remoteInfo.name) {
-    pushUnique(keys, [`__FEDERATION_${remoteInfo.name}:custom__`]);
-  }
-  return keys;
+  // An explicit container global replaces the default; registration aliases do
+  // not grant ownership of identically named business globals.
+  const key =
+    remoteInfo.entryGlobalName || remoteInfo.globalName || remoteInfo.name;
+  return key ? [key] : [];
 };
 
 const getRemoteEntryLoadingKey = (remoteInfo: RemoteInfoLike) => {
@@ -412,7 +408,7 @@ const getClearTarget = (
   }
 
   const remoteNames = getRemoteNames(webpackRequire, name, remoteKey);
-  const remoteInfos = [
+  let remoteInfos = [
     ...toList(
       webpackRequire.federation.bundlerRuntimeOptions.remotes?.remoteInfos?.[
         remoteKey
@@ -428,8 +424,11 @@ const getClearTarget = (
   }
   for (const remoteName of remoteNames) {
     const loaded = instance?.moduleCache?.get(remoteName);
-    if (loaded?.remoteInfo)
+    if (loaded?.remoteInfo) {
+      // Resolved manifest metadata supersedes the registration's default global.
+      remoteInfos = remoteInfos.filter((info) => info.name !== remoteName);
       remoteInfos.push(loaded.remoteInfo as RemoteInfoLike);
+    }
   }
   return {
     name,
@@ -656,7 +655,11 @@ const invalidateRemoteEntryUrlGenerations = (
 const getProviderNames = (target: ClearCacheTarget): string[] => {
   const names = [...target.remoteNames];
   for (const info of target.remoteInfos) {
-    pushUnique(names, [info.entryGlobalName, info.globalName]);
+    pushUnique(names, [
+      info.providerName,
+      info.entryGlobalName,
+      info.globalName,
+    ]);
   }
   return names;
 };

--- a/packages/webpack-bundler-runtime/src/types.ts
+++ b/packages/webpack-bundler-runtime/src/types.ts
@@ -1,6 +1,7 @@
 import * as runtime from '@module-federation/runtime';
 import type {
   Remote,
+  RemoteInfo,
   RemoteEntryInitOptions,
   SharedConfig,
   SharedGetter,
@@ -189,6 +190,8 @@ export type RemoteChunkMapping = Record<string, Array<ModuleId>>;
 export type ClearCacheOptions = {
   name: string;
   remoteKey?: string;
+  /** @internal Identity captured before the removeRemote hook chain. */
+  remoteInfo?: RemoteInfo;
 };
 
 export type ClearCacheRuntimeOptions = ClearCacheOptions & {

--- a/tools/ssr-cache/README.md
+++ b/tools/ssr-cache/README.md
@@ -362,3 +362,24 @@ application-rebuild integration test was skipped because this isolated worktree
 does not supply a separate built Modern checkout. The worktree uses direct Turbo
 and package scripts as required by AGENTS.md. The rest of the platform E2E matrix
 is left to GitHub CI; this dependency update adds no package implementation.
+
+### Resolved provider identity
+
+A host registration such as `dynamic`, the manifest provider name such as
+`catalog`, and a container global such as `__FEDERATION_catalog:custom__` are
+three separate identities. Snapshots now retain `providerName` from the manifest
+and pass it to resolved remote metadata. Shared-provider retention uses that
+identity even after its runtime has left the instance registry. This does not
+change `Shared.from` or its deferred name/version API.
+
+Resolved container metadata supersedes the registration's default global during
+cleanup. Only the selected container global is cleared; an unrelated
+`globalThis.dynamic` is preserved. The cleanup no longer probes additional globals
+based on guessed naming conventions.
+
+This repairs the R3 foundation before R4; it does not implement the static update
+planner. Locating a page chunk alone still does not prove request isolation:
+Modern can retain shared App, runtime-hook, route and loader objects at entry
+scope. R4 must connect compiler evidence, request scope and resource replacement
+before claiming selective-update acceptance. See `VALIDATION.md` for the repair's
+red/green regression evidence.

--- a/tools/ssr-cache/VALIDATION.md
+++ b/tools/ssr-cache/VALIDATION.md
@@ -321,3 +321,34 @@ Rspack/Modern HTTP regressions cover the changed behavior. Production hydration,
 entry-scope completeness and long-running resource acceptance remain R4–R6.
 No publish command was run. Changesets lists the three changed packages; fixed
 release groups can expand the eventual release plan.
+
+
+### Removal-hook ordering follow-up (2026-09-11)
+
+PR #5060 review identified that a user hook can delete moduleCache before the
+bundler cache hook. Capture a copy of resolved remoteInfo at the start of runtime
+removal, pass it through the hook payload, and prefer it during bundler target
+resolution. Registration-named business globals remain untouched even when the
+cache entry is already absent. The runtime regression verifies the later hook sees
+the captured identity after the first hook clears the cache; the bundler regression
+verifies actual resolved-container clearing and business-global retention.
+
+Commands from `/private/tmp/mf-5060-review`:
+
+```sh
+corepack enable
+pnpm install --frozen-lockfile
+pnpm exec turbo run build --filter=@module-federation/runtime-tools
+pnpm --filter @module-federation/runtime-core test
+pnpm --filter @module-federation/webpack-bundler-runtime test
+SSR_CACHE_STRICT=1 SSR_CACHE_EXPECT_NATIVE=1 SSR_CACHE_MODERN_ENTRY=/private/tmp/modern-r4-static-update/packages/server/core/dist/cjs/adapters/node/index.js node --test tools/ssr-cache/baseline.test.cjs
+pnpm exec prettier --check .
+python3 .codex/skills/changeset-pr/scripts/run_changeset_status.py --output /tmp/5060-changeset-status.json
+git diff --check
+```
+
+All six dependency build tasks pass; runtime-core 143/143 and bundler-runtime
+128/128 pass. Full browser/E2E matrices and unrelated packages are not rerun for
+this hook-payload repair; native artifact checks complement the package regressions.
+SDK behavior did not change in this follow-up, so its earlier 69-pass result was
+not rerun. No publish command is used.

--- a/tools/ssr-cache/VALIDATION.md
+++ b/tools/ssr-cache/VALIDATION.md
@@ -262,3 +262,62 @@ arbitrary old application bundle. Persistent MF instances, shared providers and
 saved business exports can still retain bundled code. Callers must drain work
 before disposal. Actual Modern production serve, stream/abort, long-running heap
 stability and rebuild recovery remain later acceptance gates.
+
+## Resolved provider identity repair — 2026-09-11
+
+Base: `97ef36f3c` (merged #5053). Independent worktree, Node 24.18.1,
+pnpm 10.28.0, published Rspack `2.2.3-canary-76e8f696-20260911033013`.
+
+The new cases distinguish registration, provider and container-global identities.
+Temporarily restoring the base `clearCache.ts` and `remote/index.ts` against the
+new tests produced **5 bundler failures and 4 runtime-core failures**. These
+include both settled/in-flight shared providers, present/removed provider
+instances, and an unrelated business global named after the registration.
+Restoring the repair makes those tests pass.
+
+Validation commands (from the isolated core worktree):
+
+```sh
+corepack enable
+pnpm install --frozen-lockfile
+pnpm exec turbo run build --filter=@module-federation/runtime-tools
+pnpm --filter @module-federation/sdk test
+pnpm --filter @module-federation/webpack-bundler-runtime test --runInBand
+pnpm --filter @module-federation/runtime-core test
+pnpm --filter @module-federation/runtime-core exec rstest
+SSR_CACHE_STRICT=1 SSR_CACHE_EXPECT_NATIVE=1 node --test tools/ssr-cache/baseline.test.cjs
+SSR_CACHE_STRICT=1 SSR_CACHE_EXPECT_NATIVE=1 SSR_CACHE_MODERN_ENTRY=/Users/bytedance/work/modern.js/packages/server/core/dist/cjs/adapters/node/index.js node --test tools/ssr-cache/baseline.test.cjs
+pnpm exec prettier --check .
+git diff --check
+python3 .codex/skills/changeset-pr/scripts/inspect_changeset_scope.py --base origin/feat/mf-ssr-clear-cache --file .changeset/ssr-resolved-provider-identity.md
+python3 .codex/skills/changeset-pr/scripts/run_changeset_status.py --output /tmp/mf-provider-changeset-status.json
+```
+
+Results: all 6 build tasks passed; SDK 69 passed with its existing disabled DOM
+link-reuse test unchanged; bundler-runtime 127 passed; runtime-core 143 passed.
+The final runtime-core command omits the package script's snapshot-update flag.
+Native Rspack baseline: 22 passed with the optional Modern test initially omitted;
+with the existing built Modern entry supplied, **23 passed, no skips or TODOs**.
+Repository-wide formatting and whitespace checks passed.
+The scope helper requires deferred annotations on this machine’s Python 3.9;
+its first direct invocation failed before inspection. Running the unchanged
+helper with Python’s `__future__.annotations` compiler flag passed. Changesets
+status also passed.
+
+One initial Jest run started before its runtime dependency build finished and
+could not resolve that package; rerunning after the build passed. SDK assertions
+initially rejected the newly retained snapshot field; expected fixtures were
+updated explicitly. No other snapshots were changed. The red/green runs restored
+all repaired sources in a `finally` block.
+
+A separate Modern worktree was installed and its existing server-core tests ran
+while examining entry-scoped coordination (first attempt hit sandbox listener
+EPERM; the permitted rerun passed). No Modern implementation change is included:
+the exploratory scope draft is not an accepted R4 implementation.
+
+The full browser/Cypress and unrelated package/E2E matrices were not rerun for
+this focused metadata/cleanup repair; targeted package tests and native
+Rspack/Modern HTTP regressions cover the changed behavior. Production hydration,
+entry-scope completeness and long-running resource acceptance remain R4–R6.
+No publish command was run. Changesets lists the three changed packages; fixed
+release groups can expand the eventual release plan.


### PR DESCRIPTION
## Description

A dynamically registered manifest remote can have three different names: the host registration, the provider's runtime name, and its container global. Cache invalidation previously lost the manifest provider name and could clear live shared factories. It could also delete unrelated business globals whose names matched the registration.

Retain the manifest provider identity through SDK snapshots and resolved runtime metadata. Use it for shared-provider retention, and let resolved container metadata replace the registration's default global when cleaning caches. This repairs the SSR update foundation before R4; it does not implement the static planner or change Shared.from.

Validation: SDK 69 passed (one existing disabled DOM test), runtime-core 143 passed, bundler-runtime 127 passed, all six runtime-tools build tasks passed, and native Rspack/Modern baseline 23/23 passed. The new regressions fail against the merged cleanup code (5 bundler and 4 runtime-core failures). Repository-wide Prettier, diff whitespace checks and Changesets validation passed. Full browser/E2E matrices were not rerun for this focused repair. Exact commands and limitations are recorded in tools/ssr-cache/VALIDATION.md.

## Related Issue

Follow-up to #5053 on feat/mf-ssr-clear-cache. No separate issue.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
