### PR TITLE
fix(runtime-core): performance - prevent re-registrations when not using share scopes

### DIFF
--- a/.changeset/lucky-lions-register.md
+++ b/.changeset/lucky-lions-register.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime-core': patch
+---
+
+Improve performance for users not using share scopes by avoiding redundant share re-registration on every shared module load.

--- a/packages/runtime-core/__tests__/share-init-scope.spec.ts
+++ b/packages/runtime-core/__tests__/share-init-scope.spec.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it } from '@rstest/core';
+import { ModuleFederation } from '../src/core';
+import { resetFederationGlobalInfo } from '../src/global';
+import type { ModuleFederationRuntimePlugin } from '../src/type';
+
+describe('share re-registration guard', () => {
+  beforeEach(() => {
+    resetFederationGlobalInfo();
+  });
+
+  it('registers the host share table only once across repeated share consumptions', async () => {
+    let afterRegisterShareCount = 0;
+    const countingPlugin: ModuleFederationRuntimePlugin = {
+      name: 'after-register-share-counter',
+      afterRegisterShare() {
+        afterRegisterShareCount += 1;
+      },
+    };
+
+    const mf = new ModuleFederation({
+      name: 'share-init-scope-host',
+      remotes: [],
+      plugins: [countingPlugin],
+      shared: {
+        'shared-one': {
+          version: '1.0.0',
+          lib: () => ({ value: 'one' }),
+        },
+        'shared-two': {
+          version: '1.0.0',
+          lib: () => ({ value: 'two' }),
+        },
+      },
+    });
+
+    // Construction registers the share table once: one afterRegisterShare
+    // emission per shared entry per scope.
+    const countAfterConstruction = afterRegisterShareCount;
+    expect(countAfterConstruction).toBe(2);
+
+    // The first consumption runs the one-time scope initialization for the
+    // default scope: one more emission round per shared entry.
+    await mf.loadShare('shared-one');
+    const countAfterFirstLoad = afterRegisterShareCount;
+    expect(countAfterFirstLoad).toBe(countAfterConstruction + 2);
+
+    // Subsequent consumptions must not re-run share registration.
+    await mf.loadShare('shared-two');
+    mf.loadShareSync('shared-one');
+    await mf.loadShare('shared-one');
+    mf.loadShareSync('shared-two');
+
+    expect(afterRegisterShareCount).toBe(countAfterFirstLoad);
+  });
+
+  it('does not re-register on repeated loadShareSync consumptions and keeps resolving the share', () => {
+    let afterRegisterShareCount = 0;
+    const countingPlugin: ModuleFederationRuntimePlugin = {
+      name: 'after-register-share-counter',
+      afterRegisterShare() {
+        afterRegisterShareCount += 1;
+      },
+    };
+
+    const mf = new ModuleFederation({
+      name: 'share-init-scope-sync-host',
+      remotes: [],
+      plugins: [countingPlugin],
+      shared: {
+        'shared-one': {
+          version: '1.0.0',
+          lib: () => ({ value: 'one' }),
+        },
+      },
+    });
+
+    const countAfterConstruction = afterRegisterShareCount;
+
+    const first = mf.loadShareSync<{ value: string }>('shared-one');
+    const countAfterFirstSyncLoad = afterRegisterShareCount;
+
+    mf.loadShareSync('shared-one');
+    mf.loadShareSync('shared-one');
+
+    expect(afterRegisterShareCount).toBe(countAfterFirstSyncLoad);
+    expect(countAfterFirstSyncLoad).toBeGreaterThan(countAfterConstruction);
+    expect(first()).toEqual({ value: 'one' });
+  });
+});

--- a/packages/runtime-core/__tests__/share-init-scope.spec.ts
+++ b/packages/runtime-core/__tests__/share-init-scope.spec.ts
@@ -3,6 +3,49 @@ import { ModuleFederation } from '../src/core';
 import { resetFederationGlobalInfo } from '../src/global';
 import type { ModuleFederationRuntimePlugin } from '../src/type';
 
+const createVersionFirstHost = (plugins?: ModuleFederationRuntimePlugin[]) =>
+  new ModuleFederation({
+    name: 'share-init-scope-host',
+    remotes: [],
+    shareStrategy: 'version-first',
+    plugins,
+    shared: {
+      'shared-one': {
+        version: '1.0.0',
+        lib: () => ({ value: 'one' }),
+      },
+    },
+  });
+
+/**
+ * Registers a remote whose entry loading is stubbed locally (no network)
+ * and returns a handle counting getEntry invocations. Mutate `behavior` to
+ * change what getEntry returns/throws.
+ */
+function stubRemote(mf: ModuleFederation, getEntry?: () => Promise<any>) {
+  mf.registerRemotes([
+    {
+      name: 'remote1',
+      entry: 'https://example.com/remoteEntry.js',
+      shareScope: 'default',
+    },
+  ]);
+  const module = mf.initRawContainer(
+    'remote1',
+    'https://example.com/remoteEntry.js',
+    {},
+  ) as any;
+  const state = {
+    getEntryCalls: 0,
+    behavior: getEntry,
+  };
+  module.getEntry = async () => {
+    state.getEntryCalls += 1;
+    return state.behavior ? state.behavior() : {};
+  };
+  return state;
+}
+
 describe('share re-registration guard', () => {
   beforeEach(() => {
     resetFederationGlobalInfo();
@@ -85,5 +128,83 @@ describe('share re-registration guard', () => {
     expect(afterRegisterShareCount).toBe(countAfterFirstSyncLoad);
     expect(countAfterFirstSyncLoad).toBeGreaterThan(countAfterConstruction);
     expect(first()).toEqual({ value: 'one' });
+  });
+
+  it('awaits in-flight remote initialization when concurrent loadShare calls hit the init-token guard', async () => {
+    const mf = createVersionFirstHost();
+
+    let resolveEntry: () => void = () => {};
+    stubRemote(
+      mf,
+      () =>
+        new Promise<void>((resolve) => {
+          resolveEntry = resolve;
+        }),
+    );
+
+    const firstLoad = mf.loadShare<{ value: string }>('shared-one');
+    // Second concurrent consumption hits the init-token guard: it must
+    // await the same remote-initialization promises as the first call
+    // instead of resolving against the share map immediately.
+    const secondLoad = mf.loadShare<{ value: string }>('shared-one');
+
+    let secondLoadDone = false;
+    secondLoad.then(() => {
+      secondLoadDone = true;
+    });
+
+    // let the event loop turn a few times while the remote entry is still
+    // loading
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(secondLoadDone).toBe(false);
+
+    resolveEntry();
+    const [firstResult, secondResult] = await Promise.all([
+      firstLoad,
+      secondLoad,
+    ]);
+
+    expect(firstResult?.()).toEqual({ value: 'one' });
+    expect(secondResult?.()).toEqual({ value: 'one' });
+  });
+
+  it('re-initializes the share scope after registerRemotes adds a remote', async () => {
+    const mf = createVersionFirstHost();
+
+    // Consume a share once: the scope is now marked as initialized.
+    await mf.loadShare('shared-one');
+
+    const remote = stubRemote(mf);
+    await mf.loadShare('shared-one');
+
+    expect(remote.getEntryCalls).toBe(1);
+  });
+
+  it('retries share scope initialization after a failed initialization', async () => {
+    const mf = createVersionFirstHost([
+      {
+        name: 'rethrow-error-load-remote',
+        errorLoadRemote(args) {
+          throw args.error;
+        },
+      },
+    ]);
+
+    const remote = stubRemote(mf, async () => {
+      throw new Error('entry failed');
+    });
+
+    await expect(mf.loadShare('shared-one')).rejects.toThrow('entry failed');
+    expect(remote.getEntryCalls).toBe(1);
+
+    // the failed initialization must not be cached: the next loadShare
+    // re-runs initialization instead of replaying the cached rejection
+    remote.behavior = async () => ({});
+    const result = await mf.loadShare<{ value: string }>('shared-one');
+
+    expect(remote.getEntryCalls).toBe(2);
+    expect(result?.()).toEqual({ value: 'one' });
   });
 });

--- a/packages/runtime-core/src/remote/index.ts
+++ b/packages/runtime-core/src/remote/index.ts
@@ -515,6 +515,12 @@ export class RemoteHandler {
         force: options?.force,
       });
     });
+    // a newly registered remote may provide shared modules: forget the
+    // sharing initialization so a later version-first loadShare
+    // re-initializes the scope and the new remote's shares participate in
+    // version selection (duplicate registrations just re-init, which is
+    // idempotent)
+    host.sharedHandler.resetShareInit();
   }
 
   initRawContainer(

--- a/packages/runtime-core/src/shared/disabled.ts
+++ b/packages/runtime-core/src/shared/disabled.ts
@@ -31,6 +31,10 @@ export class DisabledSharedHandler {
     return [];
   }
 
+  resetShareInit(): void {
+    // no-op: sharing initialization is disabled
+  }
+
   initShareScopeMap(
     scopeName: string,
     shareScope: ShareScopeMap[string],

--- a/packages/runtime-core/src/shared/index.ts
+++ b/packages/runtime-core/src/shared/index.ts
@@ -135,17 +135,35 @@ export class SharedHandler {
   initTokens: InitTokens;
   /**
    * Init scope shared across all loadShare/loadShareSync calls of this
-   * SharedHandler instance. It lets the init-token guard inside
-   * initializeSharing short-circuit repeat invocations instead of
+   * SharedHandler instance, so the init-token guard inside
+   * initializeSharing short-circuits repeat invocations instead of
    * re-registering the whole host share table on every share consumption.
    */
   shareInitScope: InitScope;
+  /**
+   * Remote-initialization promises per share scope, captured by the call
+   * that first initialized the scope. Repeat invocations that hit the
+   * init-token guard return them so concurrent consumers also await remote
+   * share registration.
+   */
+  shareInitPromises: Record<string, Array<Promise<void>>>;
   constructor(host: ModuleFederation) {
     this.host = host;
     this.shareScopeMap = {};
     this.initTokens = {};
     this.shareInitScope = [];
+    this.shareInitPromises = {};
     this._setGlobalShareScopeMap(host.options);
+  }
+
+  /**
+   * Forget the per-scope sharing initialization, so the next version-first
+   * loadShare re-initializes (e.g. after registerRemotes added a remote
+   * whose shares must join version selection).
+   */
+  resetShareInit(): void {
+    this.shareInitScope = [];
+    this.shareInitPromises = {};
   }
 
   private emitAfterRegisterShare(
@@ -496,7 +514,12 @@ export class SharedHandler {
       let initToken = initTokens[shareScopeName];
       if (!initToken)
         initToken = initTokens[shareScopeName] = { from: this.host.name };
-      if (initScope.indexOf(initToken) >= 0) return promises;
+      if (initScope.indexOf(initToken) >= 0) {
+        // already initialized (or initializing): return the remote-init
+        // promises of that run so this consumer also awaits remote share
+        // registration instead of resolving against the share map too early
+        return this.shareInitPromises[shareScopeName] || promises;
+      }
       initScope.push(initToken);
     }
 
@@ -596,6 +619,20 @@ export class SharedHandler {
       host.options.remotes.forEach((remote) => {
         if (remote.shareScope === shareScopeName) {
           promises.push(initRemoteModule(remote.name));
+        }
+      });
+    }
+
+    // only the call that pushed the token into the persistent init scope
+    // owns this scope's initialization: its promises are what repeat
+    // invocations must await
+    if (initScope === this.shareInitScope) {
+      this.shareInitPromises[shareScopeName] = promises;
+      // forget a failed initialization so the next loadShare retries
+      // instead of replaying the cached rejection forever
+      Promise.all(promises).catch(() => {
+        if (this.shareInitPromises[shareScopeName] === promises) {
+          this.resetShareInit();
         }
       });
     }

--- a/packages/runtime-core/src/shared/index.ts
+++ b/packages/runtime-core/src/shared/index.ts
@@ -133,10 +133,18 @@ export class SharedHandler {
     }>('initContainerShareScopeMap'),
   });
   initTokens: InitTokens;
+  /**
+   * Init scope shared across all loadShare/loadShareSync calls of this
+   * SharedHandler instance. It lets the init-token guard inside
+   * initializeSharing short-circuit repeat invocations instead of
+   * re-registering the whole host share table on every share consumption.
+   */
+  shareInitScope: InitScope;
   constructor(host: ModuleFederation) {
     this.host = host;
     this.shareScopeMap = {};
     this.initTokens = {};
+    this.shareInitScope = [];
     this._setGlobalShareScopeMap(host.options);
   }
 
@@ -150,6 +158,10 @@ export class SharedHandler {
       trigger: SharedLoadTrigger;
     },
   ): void {
+    // skip the emit entirely when nobody listens: registration of the host
+    // share table calls this once per shared entry, which adds up on large
+    // share tables
+    if (this.hooks.lifecycle.afterRegisterShare.listeners.size === 0) return;
     this.hooks.lifecycle.afterRegisterShare.emit({
       pkgName,
       ...input,
@@ -231,11 +243,13 @@ export class SharedHandler {
       const sharedVals = newShareInfos[sharedKey];
       sharedVals.forEach((sharedVal) => {
         sharedVal.scope.forEach((sc) => {
-          this.hooks.lifecycle.beforeRegisterShare.emit({
-            origin: this.host,
-            pkgName: sharedKey,
-            shared: sharedVal,
-          });
+          if (this.hooks.lifecycle.beforeRegisterShare.listeners.size > 0) {
+            this.hooks.lifecycle.beforeRegisterShare.emit({
+              origin: this.host,
+              pkgName: sharedKey,
+              shared: sharedVal,
+            });
+          }
           const registeredShared = this.shareScopeMap[sc]?.[sharedKey];
           const previousAtVersion = registeredShared?.[sharedVal.version];
           if (!registeredShared) {
@@ -292,6 +306,7 @@ export class SharedHandler {
               this.initializeSharing(shareScope, {
                 strategy: shareOptions.strategy,
                 context: loadContext,
+                initScope: this.shareInitScope,
               }),
             );
             return;
@@ -611,6 +626,7 @@ export class SharedHandler {
             strategy: shareOptions.strategy,
             from: extraOptions?.from,
             context: loadContext,
+            initScope: this.shareInitScope,
           });
         });
       }


### PR DESCRIPTION
## Description

When share scope is not used - the default empty array is used. This caused the init-guard to be invoked on every call and never short circuited. For large repos with many shared dependencies - this adds a substantial amount of CPU time.

In DataDog (>17m LOC) we observed FCP and LCP going down **by as much as 50%** when applying this patch.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

n/a

I understand that you only accept PRs that are linked to issues, but I hope an exception could be made here. 🥺 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. - tricky one.. there are some tests that fail even in master 🤷 
- [ ] ~I have updated the documentation.~ - not applicable IMO
