### PR TITLE
fix(managers,rspack,enhanced): resolve canonical share keys for relative imports (#5042)

### DIFF
--- a/.changeset/canonical-shared-resolver.md
+++ b/.changeset/canonical-shared-resolver.md
@@ -1,0 +1,11 @@
+---
+'@module-federation/managers': patch
+'@module-federation/rspack': patch
+'@module-federation/enhanced': patch
+---
+
+feat: resolve canonical share keys for relative imports to prevent singleton duplication (#5042)
+
+In monorepos or multi-package repositories where packages use relative imports internally (e.g. `import { Context } from './FeatureTypeContext'`) while external consumers import via the canonical package specifier (e.g. `import { Context } from '@pkg/context-lib/FeatureTypeContext'`), Module Federation would previously bundle duplicate local instances because sharing was negotiated strictly by the raw import request specifier.
+
+This introduces `CanonicalSharedPlugin` in `@module-federation/managers` (applied automatically by `@module-federation/rspack` and `@module-federation/enhanced` when `shared` options are configured). It intercepts relative import requests in `normalModuleFactory.hooks.beforeResolve`, maps the target file to its package root via `package.json` (`main`, `module`, and `exports`), and normalizes matching relative requests to their canonical shared package specifiers before module factorization.

--- a/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
+++ b/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
@@ -26,6 +26,7 @@ import StartupChunkDependenciesPlugin from '../startup/MfStartupChunkDependencie
 import FederationModulesPlugin from './runtime/FederationModulesPlugin';
 import { createSchemaValidation } from '../../utils';
 import TreeShakingSharedPlugin from '../sharing/tree-shaking/TreeShakingSharedPlugin';
+import { CanonicalSharedPlugin } from '@module-federation/managers';
 
 const isValidExternalsType = require(
   normalizeWebpackPath(
@@ -274,6 +275,7 @@ class ModuleFederationPlugin implements WebpackPluginInstance {
         }).apply(compiler);
       }
       if (shared) {
+        new CanonicalSharedPlugin(shared).apply(compiler);
         new TreeShakingSharedPlugin({
           mfConfig: options,
         }).apply(compiler);

--- a/packages/managers/__tests__/resolveCanonicalShareKey.spec.ts
+++ b/packages/managers/__tests__/resolveCanonicalShareKey.spec.ts
@@ -1,0 +1,267 @@
+import path from 'path';
+import {
+  resolveCanonicalShareKey,
+  extractSharedKeys,
+  CanonicalSharedPlugin,
+  clearPackageJsonCache,
+  SharedKeysSet,
+} from '../src/resolveCanonicalShareKey';
+
+describe('resolveCanonicalShareKey', () => {
+  beforeEach(() => {
+    clearPackageJsonCache();
+  });
+
+  const managersDir = path.resolve(__dirname, '..');
+  const managersSrcDir = path.resolve(managersDir, 'src');
+
+  describe('extractSharedKeys', () => {
+    it('extracts keys from object form', () => {
+      const shared = {
+        react: { singleton: true },
+        'react-dom': { singleton: true },
+        '@pkg/foo/bar': { singleton: true },
+      };
+      const keys = extractSharedKeys(shared);
+      expect(keys).toBeInstanceOf(SharedKeysSet);
+      expect(Array.from(keys)).toEqual(
+        expect.arrayContaining(['react', 'react-dom', '@pkg/foo/bar']),
+      );
+    });
+
+    it('extracts keys from array form', () => {
+      const shared = ['react', 'lodash', { '@pkg/bar': { singleton: true } }];
+      const keys = extractSharedKeys(shared);
+      expect(Array.from(keys)).toEqual(
+        expect.arrayContaining(['react', 'lodash', '@pkg/bar']),
+      );
+    });
+
+    it('extracts configured request overrides', () => {
+      const shared = {
+        internal: {
+          request: '@scope/pkg/context',
+          import: '@scope/pkg/context',
+          singleton: true,
+        },
+      };
+      const keys = extractSharedKeys(shared);
+      expect(keys.has('internal')).toBe(true);
+      expect(keys.has('@scope/pkg/context')).toBe(true);
+    });
+
+    it('extracts trailing-slash prefixes into prefixes array', () => {
+      const shared = {
+        '@scope/pkg/': { singleton: true },
+        '@scope/pkg/deep/': { singleton: true },
+        'react/': { singleton: true },
+      };
+      const keys = extractSharedKeys(shared);
+      expect(keys.has('@scope/pkg/')).toBe(true);
+      expect(keys.prefixes).toEqual([
+        '@scope/pkg/deep/',
+        '@scope/pkg/',
+        'react/',
+      ]);
+    });
+
+    it('returns empty set for null or undefined', () => {
+      expect(extractSharedKeys(null).size).toBe(0);
+      expect(extractSharedKeys(undefined).size).toBe(0);
+    });
+  });
+
+  describe('resolveCanonicalShareKey with repro fixtures', () => {
+    it('returns null for non-relative requests', () => {
+      const sharedKeys = extractSharedKeys({
+        '@module-federation/managers': { singleton: true },
+      });
+      expect(
+        resolveCanonicalShareKey(managersSrcDir, 'lodash', sharedKeys),
+      ).toBeNull();
+      expect(
+        resolveCanonicalShareKey(
+          managersSrcDir,
+          '@module-federation/managers',
+          sharedKeys,
+        ),
+      ).toBeNull();
+    });
+
+    it('resolves relative import of root package when root package is shared', () => {
+      const sharedKeys = extractSharedKeys({
+        '@module-federation/managers': { singleton: true },
+      });
+      const result = resolveCanonicalShareKey(
+        managersSrcDir,
+        './index',
+        sharedKeys,
+      );
+      expect(result).toBe('@module-federation/managers');
+    });
+
+    it('resolves relative import of subpath when subpath is shared', () => {
+      const sharedKeys = extractSharedKeys({
+        '@module-federation/managers/SharedManager': { singleton: true },
+      });
+      const result = resolveCanonicalShareKey(
+        managersSrcDir,
+        './SharedManager',
+        sharedKeys,
+      );
+      expect(result).toBe('@module-federation/managers/SharedManager');
+    });
+
+    it('resolves relative import when configured via request override', () => {
+      const sharedKeys = extractSharedKeys({
+        internalManager: {
+          request: '@module-federation/managers/SharedManager',
+          singleton: true,
+        },
+      });
+      const result = resolveCanonicalShareKey(
+        managersSrcDir,
+        './SharedManager',
+        sharedKeys,
+      );
+      expect(result).toBe('@module-federation/managers/SharedManager');
+    });
+
+    it('resolves relative import matching trailing-slash prefix', () => {
+      const sharedKeys = extractSharedKeys({
+        '@module-federation/managers/': { singleton: true },
+      });
+      const result = resolveCanonicalShareKey(
+        managersSrcDir,
+        './SharedManager',
+        sharedKeys,
+      );
+      expect(result).toBe('@module-federation/managers/SharedManager');
+    });
+
+    it('returns null when relative import is not in sharedKeys', () => {
+      const sharedKeys = extractSharedKeys({
+        '@module-federation/managers/SharedManager': { singleton: true },
+      });
+      const result = resolveCanonicalShareKey(
+        managersSrcDir,
+        './ContainerManager',
+        sharedKeys,
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('CanonicalSharedPlugin', () => {
+    it('registers beforeResolve hook and rewrites relative requests matching sharedKeys', () => {
+      const plugin = new CanonicalSharedPlugin({
+        '@module-federation/managers/SharedManager': { singleton: true },
+      });
+
+      let tapCallback: any;
+      const mockCompiler = {
+        hooks: {
+          normalModuleFactory: {
+            tap: jest.fn((name, fn: any) => {
+              const mockNmf = {
+                hooks: {
+                  beforeResolve: {
+                    tap: jest.fn((_subName, subFn: any) => {
+                      tapCallback = subFn;
+                    }),
+                  },
+                },
+              };
+              fn(mockNmf);
+            }),
+          },
+        },
+      };
+
+      plugin.apply(mockCompiler);
+
+      expect(mockCompiler.hooks.normalModuleFactory.tap).toHaveBeenCalledWith(
+        'CanonicalSharedPlugin',
+        expect.any(Function),
+      );
+      expect(tapCallback).toBeDefined();
+
+      const resolveData = {
+        context: managersSrcDir,
+        request: './SharedManager',
+      };
+      tapCallback(resolveData);
+      expect(resolveData.request).toBe(
+        '@module-federation/managers/SharedManager',
+      );
+
+      const nonMatchingData = {
+        context: managersSrcDir,
+        request: './ContainerManager',
+      };
+      tapCallback(nonMatchingData);
+      expect(nonMatchingData.request).toBe('./ContainerManager');
+    });
+
+    it('rewrites relative requests when shared with request override or prefix', () => {
+      const plugin = new CanonicalSharedPlugin({
+        customAlias: {
+          request: '@module-federation/managers/SharedManager',
+        },
+        '@module-federation/managers/utils/': {
+          singleton: true,
+        },
+      });
+
+      let tapCallback: any;
+      const mockCompiler = {
+        hooks: {
+          normalModuleFactory: {
+            tap: jest.fn((_name, fn: any) => {
+              fn({
+                hooks: {
+                  beforeResolve: {
+                    tap: jest.fn((_subName, subFn: any) => {
+                      tapCallback = subFn;
+                    }),
+                  },
+                },
+              });
+            }),
+          },
+        },
+      };
+
+      plugin.apply(mockCompiler);
+
+      const requestOverrideData = {
+        context: managersSrcDir,
+        request: './SharedManager',
+      };
+      tapCallback(requestOverrideData);
+      expect(requestOverrideData.request).toBe(
+        '@module-federation/managers/SharedManager',
+      );
+
+      const prefixData = {
+        context: managersSrcDir,
+        request: './utils',
+      };
+      tapCallback(prefixData);
+      expect(prefixData.request).toBe('@module-federation/managers/utils');
+    });
+
+    it('does not register hooks when shared is empty', () => {
+      const plugin = new CanonicalSharedPlugin({});
+      const mockCompiler = {
+        hooks: {
+          normalModuleFactory: {
+            tap: jest.fn(),
+          },
+        },
+      };
+      plugin.apply(mockCompiler);
+      expect(mockCompiler.hooks.normalModuleFactory.tap).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/managers/src/index.ts
+++ b/packages/managers/src/index.ts
@@ -3,6 +3,14 @@ export { ContainerManager } from './ContainerManager';
 export { PKGJsonManager } from './PKGJsonManager';
 export { RemoteManager } from './RemoteManager';
 export { SharedManager } from './SharedManager';
+export {
+  CanonicalSharedPlugin,
+  SharedKeysSet,
+  isSharedKeyMatch,
+  resolveCanonicalShareKey,
+  extractSharedKeys,
+  clearPackageJsonCache,
+} from './resolveCanonicalShareKey';
 
 export { UNKNOWN_MODULE_NAME } from './constant';
 

--- a/packages/managers/src/resolveCanonicalShareKey.ts
+++ b/packages/managers/src/resolveCanonicalShareKey.ts
@@ -1,0 +1,293 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { findPackageJson } from './findPackageJson';
+
+interface PkgInfo {
+  dir: string;
+  name?: string;
+  main?: string;
+  module?: string;
+  exports?: Record<string, any> | string;
+}
+
+const pkgCache = new Map<string, PkgInfo | null>();
+
+export function clearPackageJsonCache(): void {
+  pkgCache.clear();
+}
+
+export function getPackageJsonInfo(startDir: string): PkgInfo | null {
+  const pkgJsonPath = findPackageJson(startDir);
+  if (!pkgJsonPath) {
+    return null;
+  }
+  if (pkgCache.has(pkgJsonPath)) {
+    return pkgCache.get(pkgJsonPath)!;
+  }
+  try {
+    const raw = fs.readFileSync(pkgJsonPath, 'utf-8');
+    const data = JSON.parse(raw);
+    const info: PkgInfo = {
+      dir: path.dirname(pkgJsonPath),
+      name: data.name,
+      main: data.main,
+      module: data.module,
+      exports: data.exports,
+    };
+    pkgCache.set(pkgJsonPath, info);
+    return info;
+  } catch {
+    pkgCache.set(pkgJsonPath, null);
+    return null;
+  }
+}
+
+export class SharedKeysSet extends Set<string> {
+  prefixes: string[] = [];
+
+  isMatch(candidate: string): boolean {
+    if (this.has(candidate)) {
+      return true;
+    }
+    for (const prefix of this.prefixes) {
+      if (candidate.startsWith(prefix) || candidate === prefix.slice(0, -1)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+export function isSharedKeyMatch(
+  candidate: string,
+  sharedKeys: SharedKeysSet | Set<string>,
+): boolean {
+  if (sharedKeys instanceof SharedKeysSet) {
+    return sharedKeys.isMatch(candidate);
+  }
+  if (sharedKeys.has(candidate)) {
+    return true;
+  }
+  for (const key of sharedKeys) {
+    if (
+      key.endsWith('/') &&
+      (candidate.startsWith(key) || candidate === key.slice(0, -1))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Extracts all unique shared package/module keys from the user's `shared` configuration,
+ * including configured `request` overrides and trailing-slash prefixes.
+ */
+export function extractSharedKeys(shared: unknown): SharedKeysSet {
+  const result = new SharedKeysSet();
+
+  const addKey = (k: string) => {
+    if (!k || typeof k !== 'string') return;
+    result.add(k);
+    if (k.endsWith('/') && !result.prefixes.includes(k)) {
+      result.prefixes.push(k);
+    }
+  };
+
+  const processEntry = (key: string, val: unknown) => {
+    addKey(key);
+    if (val && typeof val === 'object') {
+      const req = (val as { request?: unknown }).request;
+      if (typeof req === 'string') {
+        addKey(req);
+      }
+    }
+  };
+
+  if (Array.isArray(shared)) {
+    for (const item of shared) {
+      if (typeof item === 'string') {
+        addKey(item);
+      } else if (item && typeof item === 'object') {
+        for (const [k, val] of Object.entries(item)) {
+          processEntry(k, val);
+        }
+      }
+    }
+  } else if (shared && typeof shared === 'object') {
+    for (const [k, val] of Object.entries(shared as Record<string, unknown>)) {
+      processEntry(k, val);
+    }
+  }
+
+  // Sort prefixes descending by length so more specific prefixes match first
+  result.prefixes.sort((a, b) => b.length - a.length);
+
+  return result;
+}
+
+const STRIP_EXT_REGEX = /\.[^/.]+$/;
+const STRIP_SRC_PREFIX_REGEX = /^(src|lib)\//;
+
+/**
+ * Resolves a relative import request (e.g. `./FeatureTypeContext` or `../context-lib/FeatureTypeContext`)
+ * to its canonical shared package specifier (e.g. `@repro/context-lib/FeatureTypeContext`)
+ * if the resolved target matches any key in `sharedKeys`.
+ */
+export function resolveCanonicalShareKey(
+  context: string,
+  request: string,
+  sharedKeys: SharedKeysSet | Set<string>,
+): string | null {
+  if (!request || !request.startsWith('.') || !sharedKeys.size) {
+    return null;
+  }
+
+  const targetPath = path.resolve(context, request);
+
+  // Determine starting directory to look up package.json
+  let startDir = targetPath;
+  try {
+    if (!fs.existsSync(targetPath) || !fs.statSync(targetPath).isDirectory()) {
+      startDir = path.dirname(targetPath);
+    }
+  } catch {
+    startDir = path.dirname(targetPath);
+  }
+
+  const pkg = getPackageJsonInfo(startDir);
+  if (!pkg || !pkg.name) {
+    return null;
+  }
+
+  const pkgName = pkg.name;
+  const rel = path.relative(pkg.dir, targetPath).replace(/\\/g, '/');
+  const relNoExt = rel.replace(STRIP_EXT_REGEX, '');
+  const relNoPrefix = relNoExt.replace(STRIP_SRC_PREFIX_REGEX, '');
+
+  const candidates = new Set<string>();
+
+  // 1. Root / main package match
+  if (isSharedKeyMatch(pkgName, sharedKeys)) {
+    if (
+      rel === '' ||
+      rel === 'index' ||
+      relNoExt === 'index' ||
+      relNoPrefix === 'index' ||
+      (pkg.main &&
+        path.resolve(pkg.dir, pkg.main).replace(STRIP_EXT_REGEX, '') ===
+          targetPath.replace(STRIP_EXT_REGEX, '')) ||
+      (pkg.module &&
+        path.resolve(pkg.dir, pkg.module).replace(STRIP_EXT_REGEX, '') ===
+          targetPath.replace(STRIP_EXT_REGEX, ''))
+    ) {
+      candidates.add(pkgName);
+    }
+  }
+
+  // 2. Direct subpath match: prefer canonical extensionless and un-prefixed form
+  if (rel && rel !== '.') {
+    if (relNoPrefix && relNoPrefix !== relNoExt) {
+      candidates.add(`${pkgName}/${relNoPrefix}`);
+    }
+    candidates.add(`${pkgName}/${relNoExt}`);
+    candidates.add(`${pkgName}/${rel}`);
+  }
+
+  // 3. Match against package.json "exports" field
+  if (pkg.exports && typeof pkg.exports === 'object') {
+    for (const [exportKey, exportVal] of Object.entries(pkg.exports)) {
+      const cleanExportKey = exportKey.replace(/^\.\/?/, '');
+      const candidate = cleanExportKey
+        ? `${pkgName}/${cleanExportKey}`
+        : pkgName;
+
+      if (!isSharedKeyMatch(candidate, sharedKeys)) {
+        continue;
+      }
+
+      if (cleanExportKey === relNoExt || cleanExportKey === relNoPrefix) {
+        candidates.add(candidate);
+        continue;
+      }
+
+      if (typeof exportVal === 'string') {
+        const fullExport = path.resolve(pkg.dir, exportVal);
+        const fullExportNoExt = fullExport.replace(STRIP_EXT_REGEX, '');
+        const targetPathNoExt = targetPath.replace(STRIP_EXT_REGEX, '');
+        if (fullExport === targetPath || fullExportNoExt === targetPathNoExt) {
+          candidates.add(candidate);
+        }
+      } else if (exportVal && typeof exportVal === 'object') {
+        for (const subVal of Object.values(exportVal)) {
+          if (typeof subVal === 'string') {
+            const fullExport = path.resolve(pkg.dir, subVal);
+            const fullExportNoExt = fullExport.replace(STRIP_EXT_REGEX, '');
+            const targetPathNoExt = targetPath.replace(STRIP_EXT_REGEX, '');
+            if (
+              fullExport === targetPath ||
+              fullExportNoExt === targetPathNoExt
+            ) {
+              candidates.add(candidate);
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  for (const c of candidates) {
+    if (isSharedKeyMatch(c, sharedKeys)) {
+      return c;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Compiler plugin that rewrites relative import requests to their canonical shared specifiers
+ * before module factorization, ensuring relative imports inside a shared library negotiate
+ * the shared singleton instance instead of bundling duplicate local instances.
+ */
+export class CanonicalSharedPlugin {
+  readonly name = 'CanonicalSharedPlugin';
+  private _sharedKeys: SharedKeysSet;
+
+  constructor(shared: unknown) {
+    this._sharedKeys = extractSharedKeys(shared);
+  }
+
+  apply(compiler: any): void {
+    if (!this._sharedKeys.size) {
+      return;
+    }
+
+    compiler.hooks.normalModuleFactory.tap(
+      'CanonicalSharedPlugin',
+      (nmf: any) => {
+        nmf.hooks.beforeResolve.tap(
+          'CanonicalSharedPlugin',
+          (resolveData: any) => {
+            if (
+              !resolveData ||
+              !resolveData.request ||
+              !resolveData.request.startsWith('.')
+            ) {
+              return;
+            }
+            const canonical = resolveCanonicalShareKey(
+              resolveData.context,
+              resolveData.request,
+              this._sharedKeys,
+            );
+            if (canonical) {
+              resolveData.request = canonical;
+            }
+          },
+        );
+      },
+    );
+  }
+}

--- a/packages/rspack/__tests__/ModuleFederationPlugin.spec.ts
+++ b/packages/rspack/__tests__/ModuleFederationPlugin.spec.ts
@@ -133,3 +133,61 @@ describe('runtime capability optimization defines', () => {
     });
   });
 });
+
+describe('canonical shared plugin integration', () => {
+  it('applies CanonicalSharedPlugin when shared options are configured', () => {
+    const plugin = new ModuleFederationPlugin({
+      name: 'host',
+      dts: false,
+      manifest: false,
+      shared: {
+        react: { singleton: true },
+        '@repro/context-lib/FeatureTypeContext': { singleton: true },
+      },
+    });
+
+    let beforeResolveHook: any;
+    const compiler = {
+      options: {
+        plugins: [],
+        optimization: { splitChunks: {} },
+        resolve: { alias: {} },
+      },
+      hooks: {
+        afterPlugins: { tap: jest.fn() },
+        normalModuleFactory: {
+          tap: jest.fn((name: string, fn: any) => {
+            const nmf = {
+              hooks: {
+                beforeResolve: {
+                  tap: jest.fn((_subName: string, subFn: any) => {
+                    beforeResolveHook = subFn;
+                  }),
+                },
+              },
+            };
+            fn(nmf);
+          }),
+        },
+      },
+      webpack: {
+        DefinePlugin: class {
+          apply() {}
+        },
+        container: {
+          ModuleFederationPlugin: class {
+            apply() {}
+          },
+        },
+      },
+    } as any;
+
+    plugin.apply(compiler);
+
+    expect(compiler.hooks.normalModuleFactory.tap).toHaveBeenCalledWith(
+      'CanonicalSharedPlugin',
+      expect.any(Function),
+    );
+    expect(beforeResolveHook).toBeDefined();
+  });
+});

--- a/packages/rspack/src/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/ModuleFederationPlugin.ts
@@ -12,7 +12,11 @@ import {
 } from '@module-federation/sdk';
 
 import { StatsPlugin } from '@module-federation/manifest';
-import { ContainerManager, utils } from '@module-federation/managers';
+import {
+  ContainerManager,
+  utils,
+  CanonicalSharedPlugin,
+} from '@module-federation/managers';
 import { DtsPlugin } from '@module-federation/dts-plugin';
 import ReactBridgePlugin from '@module-federation/bridge-react-webpack-plugin';
 import path from 'node:path';
@@ -230,6 +234,10 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
         logger.warn(err);
         disableManifest = true;
       }
+    }
+
+    if (options.shared) {
+      new CanonicalSharedPlugin(options.shared).apply(compiler);
     }
 
     new compiler.webpack.container.ModuleFederationPlugin(


### PR DESCRIPTION
## Description

### Problem
In monorepos or multi-package repositories where packages use relative imports internally (e.g. `import { Context } from './FeatureTypeContext'`) while external consumers import via the canonical package specifier (e.g. `import { Context } from '@pkg/context-lib/FeatureTypeContext'`), Module Federation previously bundled duplicate local instances because sharing was negotiated strictly by the raw import request specifier.

The existing `allowNodeModulesSuffixMatch` option (`extractPathAfterNodeModules`) only checks for the substring `node_modules` in the file path. In modern monorepos (pnpm workspaces, npm workspaces, Lerna), workspace packages live under repository subdirectories (such as `packages/*`) and do not contain `node_modules/` in their path, leaving relative imports unshared and splitting singleton contexts across host and remote compilations.

### Solution
This introduces `CanonicalSharedPlugin` in `@module-federation/managers`, which is applied automatically by `@module-federation/rspack` and `@module-federation/enhanced` when `shared` options are configured:
1. Intercepts relative import requests in `normalModuleFactory.hooks.beforeResolve`.
2. Locates the nearest `package.json` for the resolved target path (with memoized `pkgCache` for build performance).
3. Matches root packages, `package.json` `exports` entries, and relative subpaths against configured `sharedKeys`.
4. Rewrites matching relative requests to their canonical shared package specifiers before module factorization.

### Result
Relative imports within a shared package/subpath now cleanly delegate to the federated shared scope (`webpack/sharing/consume/...`) instead of embedding private local duplicates in chunks, resolving singleton fragmentation across host and remote builds.

## Related Issue

Fixes #5042
Related: module-federation/vite#329, #4283

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation / changeset.